### PR TITLE
Cmake tweaks

### DIFF
--- a/cmake/Modules/VolkPython.cmake
+++ b/cmake/Modules/VolkPython.cmake
@@ -97,11 +97,13 @@ endmacro(VOLK_PYTHON_CHECK_MODULE)
 ########################################################################
 # Sets the python installation directory VOLK_PYTHON_DIR
 ########################################################################
+if(NOT DEFINED VOLK_PYTHON_DIR)
 execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "
 from distutils import sysconfig
 print sysconfig.get_python_lib(plat_specific=True, prefix='')
 " OUTPUT_VARIABLE VOLK_PYTHON_DIR OUTPUT_STRIP_TRAILING_WHITESPACE
 )
+endif()
 file(TO_CMAKE_PATH ${VOLK_PYTHON_DIR} VOLK_PYTHON_DIR)
 
 ########################################################################

--- a/cmake/Modules/VolkVersion.cmake
+++ b/cmake/Modules/VolkVersion.cmake
@@ -41,7 +41,15 @@ if(GIT_FOUND AND EXISTS ${CMAKE_SOURCE_DIR}/.git)
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
 else()
-    set(GIT_DESCRIBE "v${MAJOR_VERSION}.${API_COMPAT}.x-xxx-xunknown")
+  if(NOT VOLK_GIT_COUNT)
+    set(VOLK_GIT_COUNT "0")
+  endif()
+
+  if(NOT VOLK_GIT_HASH)
+    set(VOLK_GIT_HASH "unknown")
+  endif()
+
+  set(GIT_DESCRIBE "v${MAJOR_VERSION}.${API_COMPAT}.${MINOR_VERSION}-${VOLK_GIT_COUNT}-${VOLK_GIT_HASH}")
 endif()
 
 ########################################################################


### PR DESCRIPTION
a couple small tweaks for added flexibility in defining internal variables.

1) the VOLK_PYTHON_DIR should be OK as is; it just replicates what GR does.

2) if you want to tweak the VOLK_VERSION string settings, that's fine. I just think it's important to allow for more robust settings of this string.
