### PR TITLE
Fix add test

### DIFF
--- a/cmake/Modules/VolkAddTest.cmake
+++ b/cmake/Modules/VolkAddTest.cmake
@@ -70,7 +70,7 @@ function(VOLK_ADD_TEST test_name)
     endforeach()
 
     #augment the PATH to start with the directory of the test
-    set(binpath "$1:\$PATH")
+    set(binpath "\"$1:\$PATH\"")
     list(APPEND environs "PATH=${binpath}")
 
     #set the shell to use
@@ -106,7 +106,7 @@ function(VOLK_ADD_TEST test_name)
       #"$*" expands in the shell into a list of all of the arguments
       #to the shell script, concatenated using the character provided
       #in ${IFS}.
-      list(APPEND testlibpath "\"$*\"")
+      list(APPEND testlibpath "$*")
     else()
       #shell does not support IFS expansion; use a loop instead
       list(APPEND testlibpath "\${LL}")
@@ -118,7 +118,7 @@ function(VOLK_ADD_TEST test_name)
 
     #replace list separator with the path separator
     string(REPLACE ";" ":" libpath "${libpath}")
-    list(APPEND environs "${LD_PATH_VAR}=${libpath}")
+    list(APPEND environs "${LD_PATH_VAR}=\"${libpath}\"")
 
     #generate a shell script file that sets the environment and runs the test
     set(sh_file ${CMAKE_CURRENT_BINARY_DIR}/${test_name}_test.sh)
@@ -126,7 +126,7 @@ function(VOLK_ADD_TEST test_name)
     if(SHELL_SUPPORTS_IFS)
       file(APPEND ${sh_file} "export IFS=:\n")
     else()
-      file(APPEND ${sh_file} "LL=$1 && for tf in \"\$@\"; do LL=\${LL}:\${tf}; done\n")
+      file(APPEND ${sh_file} "LL=\"$1\" && for tf in \"\$@\"; do LL=\"\${LL}:\${tf}\"; done\n")
     endif()
 
     #each line sets an environment variable

--- a/cmake/Modules/VolkAddTest.cmake
+++ b/cmake/Modules/VolkAddTest.cmake
@@ -140,12 +140,6 @@ function(VOLK_ADD_TEST test_name)
     #finally: append the test name to execute
     file(APPEND ${sh_file} ${test_name} " " ${VOLK_TEST_ARGS} "\n")
 
-    #load the command to run with its arguments
-    #foreach(arg ${ARGN})
-    #  file(APPEND ${sh_file} "${arg} ")
-    #endforeach(arg)
-    #file(APPEND ${sh_file} "\n")
-
     #make the shell file executable
     execute_process(COMMAND chmod +x ${sh_file})
 


### PR DESCRIPTION
Properly quoting $PATH and $X_LIBRARY_PATH allows this script to work on more Linux distros :) Does not hurt on OSX. No idea about other _UNIX_ or _BSD_.
