### PR TITLE
Make builds reproducible by getting rid of the builddate.

### DIFF
--- a/apps/volk-config-info.cc
+++ b/apps/volk-config-info.cc
@@ -40,7 +40,6 @@ main(int argc, char **argv)
   desc.add_options()
     ("help,h", "print help message")
     ("prefix", "print VOLK installation prefix")
-    ("builddate", "print VOLK build date (RFC2822 format)")
     ("cc", "print VOLK C compiler version")
     ("cflags", "print VOLK CFLAGS")
     ("all-machines", "print VOLK machines built into library")
@@ -66,9 +65,6 @@ main(int argc, char **argv)
 
   if(vm.count("prefix"))
     std::cout << volk_prefix() << std::endl;
-
-  if(vm.count("builddate"))
-    std::cout << volk_build_date() << std::endl;
 
   if(vm.count("version"))
     std::cout << volk_version() << std::endl;

--- a/include/volk/constants.h
+++ b/include/volk/constants.h
@@ -28,7 +28,6 @@
 __VOLK_DECL_BEGIN
 
 VOLK_API char* volk_prefix();
-VOLK_API char* volk_build_date();
 VOLK_API char* volk_version();
 VOLK_API char* volk_c_compiler();
 VOLK_API char* volk_compiler_flags();

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -469,11 +469,6 @@ endif()
 # Handle the generated constants
 ########################################################################
 
-execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
-    "import time;print time.strftime('%a, %d %b %Y %H:%M:%S', time.gmtime())"
-    OUTPUT_VARIABLE BUILD_DATE OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-message(STATUS "Loading build date ${BUILD_DATE} into constants...")
 message(STATUS "Loading version ${VERSION} into constants...")
 
 #double escape for windows backslash path separators

--- a/lib/constants.c.in
+++ b/lib/constants.c.in
@@ -33,12 +33,6 @@ volk_prefix()
 }
 
 char*
-volk_build_date()
-{
-  return "@BUILD_DATE@";
-}
-
-char*
 volk_version()
 {
   return "@VERSION@";


### PR DESCRIPTION
No one uses the build date anyway and this fix will make the Debian people happy.
