### PR TITLE
for single prec. float, use log2f, not log2

### DIFF
--- a/kernels/volk/volk_32f_log2_32f.h
+++ b/kernels/volk/volk_32f_log2_32f.h
@@ -113,7 +113,7 @@ volk_32f_log2_32f_generic(float* bVector, const float* aVector, unsigned int num
   unsigned int number = 0;
 
   for(number = 0; number < num_points; number++) {
-    *bPtr++ = log2(*aPtr++);
+    *bPtr++ = log2f(*aPtr++);
   }
 
 }
@@ -167,7 +167,7 @@ volk_32f_log2_32f_a_sse4_1(float* bVector, const float* aVector, unsigned int nu
 
   number = quarterPoints * 4;
   for(;number < num_points; number++){
-    *bPtr++ = log2(*aPtr++);
+    *bPtr++ = log2f(*aPtr++);
   }
 }
 
@@ -262,7 +262,7 @@ volk_32f_log2_32f_neon(float* bVector, const float* aVector, unsigned int num_po
   }
 
   for(number = quarterPoints * 4; number < num_points; number++){
-    *bPtr++ = log2(*aPtr++);
+    *bPtr++ = log2f(*aPtr++);
   }
 }
 
@@ -285,7 +285,7 @@ volk_32f_log2_32f_u_generic(float* bVector, const float* aVector, unsigned int n
   unsigned int number = 0;
 
   for(number = 0; number < num_points; number++){
-    *bPtr++ = log2(*aPtr++);
+    *bPtr++ = log2f(*aPtr++);
   }
 }
 
@@ -339,7 +339,7 @@ volk_32f_log2_32f_u_sse4_1(float* bVector, const float* aVector, unsigned int nu
 
   number = quarterPoints * 4;
   for(;number < num_points; number++){
-    *bPtr++ = log2(*aPtr++);
+    *bPtr++ = log2f(*aPtr++);
   }
 }
 


### PR DESCRIPTION
This gives a ~10% performance increase on my x86 machine; haven't tested on ARM.
