### PR TITLE
Silence debug messages on standard out

### DIFF
--- a/lib/volk_rank_archs.c
+++ b/lib/volk_rank_archs.c
@@ -38,7 +38,7 @@ int volk_get_index(
     }
     //TODO return -1;
     //something terrible should happen here
-    printf("Volk warning: no arch found, returning generic impl\n");
+    fprintf(stderr, "Volk warning: no arch found, returning generic impl\n");
     return volk_get_index(impl_names, n_impls, "generic"); //but we'll fake it for now
 }
 

--- a/tmpl/volk.tmpl.c
+++ b/tmpl/volk.tmpl.c
@@ -53,7 +53,7 @@ struct volk_machine *get_machine(void)
       }
     }
     machine = max_machine;
-    printf("Using Volk machine: %s\n", machine->name);
+    //printf("Using Volk machine: %s\n", machine->name);
     __alignment = machine->alignment;
     __alignment_mask = (intptr_t)(__alignment-1);
     return machine;


### PR DESCRIPTION
The first commit comments out the "Using Volk machine: <machine>" debug
message on standard out, which interferes with programs trying to use
standard out for legitimate purposes.

This modification is consistent with other commented out debug printf()
calls in the volk codebase, and should be superseded by a proper
compile-time configurable logging system for the library.

The second commit moves the "no arch found" warning message from stdout to stderr, thereby eliminating all library output on stdout.

This PR fixes #66.
