### PR TITLE
Fix: remove compiler flags from MSVC builds

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -383,7 +383,7 @@ foreach(machine_name ${available_machines})
     )
     MESSAGE(STATUS "BUILD INFO ::: ${machine_name} ::: ${COMPILER_NAME} ::: ${CMAKE_C_FLAGS_${CBTU}} ${CMAKE_C_FLAGS} ${${machine_name}_flags}")
     set(COMPILER_INFO "${COMPILER_INFO}${machine_name}:::${COMPILER_NAME}:::${CMAKE_C_FLAGS_${CBTU}} ${CMAKE_C_FLAGS} ${${machine_name}_flags}\n" )
-    if(${machine_name}_flags)
+    if(${machine_name}_flags AND NOT MSVC)
         set_source_files_properties(${machine_source} PROPERTIES COMPILE_FLAGS "${${machine_name}_flags}")
     endif()
 


### PR DESCRIPTION
Unlike GCC, MSVC does not require /arch flags to generate intrinsics for an instruction set.  However, if the flag is present, it will attempt to optimize _all_ the code for that .c file.  Unfortunately, it will even optimize code in the dynamic initializer of the class (at least MSVC 2015 will).

This will cause volk to crash when running on a machine without AVX as the initializer appears to be called outside of CPU guard checks.

Tested removal of the flags and found only a minor difference in performance on an AVX2 CPU. 
As well, tested volk_profile built on an AVX2 machine on a SSE4.1 CPU (which it crashed on previously), and it ran successfully and used up to SSE4.1 as expected.

volk_profile time to execute using default settings:

i7-5930X:  [AVX2]
- MSVC 2015 64-bit Original: 62.4s
- MSVC 2015 64-bit Patched: 66.3s
- MSVC 2015 Patched (only generic machine): 118.7s
- GCC Linux Mint 64-bit Original: 59.7s

i5-760:  [SSE4.1]
- MSVC 2015 64-bit Patched: 143.0sec
- All others: Crash
