### PR TITLE
CMake: Generate VolkConfig.cmake with a hardcoded install path hint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,11 @@ endif()
 ########################################################################
 
 configure_file(
+  ${CMAKE_SOURCE_DIR}/cmake/Modules/VolkConfig.cmake.in
+  ${CMAKE_BINARY_DIR}/cmake/Modules/VolkConfig.cmake
+@ONLY)
+
+configure_file(
   ${CMAKE_SOURCE_DIR}/cmake/Modules/VolkConfigVersion.cmake.in
   ${CMAKE_BINARY_DIR}/cmake/Modules/VolkConfigVersion.cmake
 @ONLY)
@@ -230,7 +235,7 @@ endif(NOT CMAKE_MODULES_DIR)
 
 install(
     FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/VolkConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake/Modules/VolkConfig.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/cmake/Modules/VolkConfigVersion.cmake
     DESTINATION ${CMAKE_MODULES_DIR}/volk
     COMPONENT "volk_devel"

--- a/cmake/Modules/VolkConfig.cmake.in
+++ b/cmake/Modules/VolkConfig.cmake.in
@@ -8,6 +8,7 @@ FIND_PATH(
         ${PC_VOLK_INCLUDEDIR}
     PATHS /usr/local/include
           /usr/include
+          "@CMAKE_INSTALL_PREFIX@/include"
 )
 
 FIND_LIBRARY(
@@ -19,6 +20,7 @@ FIND_LIBRARY(
           /usr/local/lib64
           /usr/lib
           /usr/lib64
+          "@CMAKE_INSTALL_PREFIX@/lib"
 )
 
 INCLUDE(FindPackageHandleStandardArgs)


### PR DESCRIPTION
This allows the Volk headers and libraries to be properly found when
Volk was built with a prefix that differs from the expected paths.

Signed-off-by: Paul Cercueil paul.cercueil@analog.com
