### PR TITLE
Don't override the BOOST_ROOT environment variable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ include(VolkVersion) #setup version info
 ########################################################################
 # Environment setup
 ########################################################################
-IF(NOT DEFINED BOOST_ROOT)
+IF(NOT DEFINED BOOST_ROOT AND NOT DEFINED ENV{BOOST_ROOT})
     SET(BOOST_ROOT ${CMAKE_INSTALL_PREFIX})
 ENDIF()
 


### PR DESCRIPTION
No reason to override the BOOST_ROOT environment variable when building.
