### PR TITLE
Allow volk-config file redirection and option to build config file from cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,31 @@ endif()
 message(STATUS "  Modify using: -DENABLE_TESTING=ON/OFF")
 
 ########################################################################
+# Option to enable post-build profiling using volk_profile, off by default
+########################################################################
+OPTION(ENABLE_PROFILING "Launch system profiler after build" OFF)
+if(ENABLE_PROFILING)
+  if(DEFINED VOLK_CONFIGPATH)
+    get_filename_component(VOLK_CONFIGPATH ${VOLK_CONFIGPATH} ABSOLUTE)
+    set(VOLK_CONFIGPATH "${VOLK_CONFIGPATH}/volk")
+    message(STATUS "System profiling is enabled, using path: ${VOLK_CONFIGPATH}")
+  elseif(DEFINED ENV{VOLK_CONFIGPATH})
+    set(VOLK_CONFIGPATH "$ENV{VOLK_CONFIGPATH}/volk")
+    message(STATUS "System profiling is enabled, using env path: $ENV{VOLK_CONFIGPATH}")
+  else()
+    message(STATUS "System profiling is enabled with default paths.")
+    if(DEFINED ENV{HOME})
+        set(VOLK_CONFIGPATH "$ENV{HOME}/.volk")
+    elseif(DEFINED ENV{APPDATA})
+        set(VOLK_CONFIGPATH "$ENV{APPDATA}/.volk")
+    endif()
+  endif()
+else()
+  message(STATUS "System profiling is disabled.")
+endif()
+message(STATUS "  Modify using: -DENABLE_PROFILING=ON/OFF")
+
+########################################################################
 # Setup the library
 ########################################################################
 add_subdirectory(lib)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -67,3 +67,19 @@ install(
     DESTINATION bin
     COMPONENT "volk"
 )
+
+# Launch volk_profile if requested to do so
+if(ENABLE_PROFILING)
+   if(DEFINED VOLK_CONFIGPATH)
+        set( VOLK_CONFIG_ARG "-p${VOLK_CONFIGPATH}" )
+        set( VOLK_CONFIG "${VOLK_CONFIGPATH}/volk_config" )
+   endif()
+
+   add_custom_command(OUTPUT ${VOLK_CONFIG}
+        COMMAND volk_profile "${VOLK_CONFIG_ARG}"
+        DEPENDS volk_profile
+        COMMENT "Launching profiler, this may take a few minutes..."
+    )
+    add_custom_target(volk-profile-run ALL DEPENDS ${VOLK_CONFIG})
+
+endif()

--- a/apps/volk_profile.cc
+++ b/apps/volk_profile.cc
@@ -71,6 +71,9 @@ int main(int argc, char *argv[]) {
       ("json,j",
             boost::program_options::value<std::string>(),
             "JSON output file")
+      ("path,p",
+            boost::program_options::value<std::string>(),
+            "Specify volk_config path.")
       ;
 
     // Handle the options that were given
@@ -86,6 +89,7 @@ int main(int argc, char *argv[]) {
     std::string def_kernel_regex;
     bool update_mode = false;
     bool dry_run = false;
+    std::string config_file;
 
     // Handle the provided options
     try {
@@ -133,13 +137,24 @@ int main(int argc, char *argv[]) {
         json_file.open( filename.c_str() );
     }
 
+    if ( vm.count("path") ) {
+        try {
+             config_file = vm["path"].as<std::string>() + "/volk_config";
+        }
+        catch (boost::bad_any_cast& error) {
+            std::cerr << error.what() << std::endl;
+            return 1;
+        }
+    }
+
     volk_test_params_t test_params(def_tol, def_scalar, def_vlen, def_iter,
         def_benchmark_mode, def_kernel_regex);
 
     // Run tests
     std::vector<volk_test_results_t> results;
     if(update_mode) {
-        read_results(&results);
+        if( vm.count("path") ) read_results(&results, config_file);
+        else read_results(&results);
     }
 
 
@@ -201,7 +216,8 @@ int main(int argc, char *argv[]) {
     }
 
     if(!dry_run) {
-        write_results(&results, false);
+        if(vm.count("path")) write_results(&results, false, config_file);
+        else write_results(&results, false);
     }
     else {
         std::cout << "Warning: this was a dry-run. Config not generated" << std::endl;

--- a/apps/volk_profile.cc
+++ b/apps/volk_profile.cc
@@ -212,6 +212,12 @@ void read_results(std::vector<volk_test_results_t> *results)
 {
     char path[1024];
     volk_get_config_path(path);
+
+    read_results(results, std::string(path));
+}
+
+void read_results(std::vector<volk_test_results_t> *results, std::string path)
+{
     const fs::path config_path(path);
 
     if(fs::exists(config_path)) {
@@ -264,6 +270,11 @@ void write_results(const std::vector<volk_test_results_t> *results, bool update_
     char path[1024];
     volk_get_config_path(path);
 
+    write_results( results, update_result, std::string(path));
+}
+
+void write_results(const std::vector<volk_test_results_t> *results, bool update_result, const std::string path)
+{
     const fs::path config_path(path);
 
     // Until we can update the config on a kernel by kernel basis

--- a/apps/volk_profile.h
+++ b/apps/volk_profile.h
@@ -1,5 +1,7 @@
 
 
 void read_results(std::vector<volk_test_results_t> *results);
+void read_results(std::vector<volk_test_results_t> *results, std::string path);
 void write_results(const std::vector<volk_test_results_t> *results, bool update_result);
+void write_results(const std::vector<volk_test_results_t> *results, bool update_result, const std::string path);
 void write_json(std::ofstream &json_file, std::vector<volk_test_results_t> results);

--- a/lib/volk_prefs.c
+++ b/lib/volk_prefs.c
@@ -6,14 +6,26 @@
 void volk_get_config_path(char *path)
 {
     if (!path) return;
+
     const char *suffix = "/.volk/volk_config";
+    const char *suffix2 = "/volk/volk_config"; //non-hidden
     char *home = NULL;
+
+    //allows config redirection via env variable
+    home = getenv("VOLK_CONFIGPATH");
+    if(home!=NULL){
+        strncpy(path,home,512);
+        strcat(path,suffix2);
+        return;
+    }
+
     if (home == NULL) home = getenv("HOME");
     if (home == NULL) home = getenv("APPDATA");
     if (home == NULL){
         path[0] = 0;
         return;
     }
+
     strncpy(path, home, 512);
     strcat(path, suffix);
 }


### PR DESCRIPTION
Changes to allow volk-config file redirection to be able to store the file elsewhere in a system rather than have it go to the home path (for example, have it go to [install_path]/etc/volk/volk_config). The option can be passed to volk_profile via command line argument and can be used at run-time using the VOLK_CONFIGPATH environment variable.

Changes should work well with volk-modtool ([install_path]/etc/volk_[libname]/volk_[libname]_config) as well.

While I was at it, I did also add an option to launch volk_profile directly from cmake using the argument ENABLE_PROFILING=ON (OFF by default). This change should also translate well with volk-modtool.
