### PR TITLE
Volk snaps

### DIFF
--- a/include/volk/constants.h
+++ b/include/volk/constants.h
@@ -27,11 +27,11 @@
 
 __VOLK_DECL_BEGIN
 
-VOLK_API char* volk_prefix();
-VOLK_API char* volk_version();
-VOLK_API char* volk_c_compiler();
-VOLK_API char* volk_compiler_flags();
-VOLK_API char* volk_available_machines();
+VOLK_API const char* volk_prefix();
+VOLK_API const char* volk_version();
+VOLK_API const char* volk_c_compiler();
+VOLK_API const char* volk_compiler_flags();
+VOLK_API const char* volk_available_machines();
 
 __VOLK_DECL_END
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -489,7 +489,7 @@ endif()
 message(STATUS "Loading version ${VERSION} into constants...")
 
 #double escape for windows backslash path separators
-string(REPLACE "\\" "\\\\" prefix ${prefix})
+string(REPLACE "\\" "\\\\" prefix "${prefix}")
 
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/constants.c.in

--- a/lib/constants.c.in
+++ b/lib/constants.c.in
@@ -27,33 +27,33 @@
 #include <stdlib.h>
 #include <volk/constants.h>
 
-char*
+const char*
 volk_prefix()
 {
   const char *prefix = getenv("VOLK_PREFIX");
-  if (prefix != NULL) return (char *)prefix;
+  if (prefix != NULL) return prefix;
   return "@prefix@";
 }
 
-char*
+const char*
 volk_version()
 {
   return "@VERSION@";
 }
 
-char*
+const char*
 volk_c_compiler()
 {
   return "@cmake_c_compiler_version@";
 }
 
-char*
+const char*
 volk_compiler_flags()
 {
   return "@COMPILER_INFO@";
 }
 
-char*
+const char*
 volk_available_machines()
 {
   return "@available_machines@";

--- a/lib/constants.c.in
+++ b/lib/constants.c.in
@@ -24,11 +24,14 @@
 #include <config.h>
 #endif
 
+#include <stdlib.h>
 #include <volk/constants.h>
 
 char*
 volk_prefix()
 {
+  const char *prefix = getenv("VOLK_PREFIX");
+  if (prefix != NULL) return (char *)prefix;
   return "@prefix@";
 }
 


### PR DESCRIPTION
I needed to make some minor changes to package volk into a snap package.
- The cmake-based build module sets a blank CMAKE_INSTALL_PREFIX (it does destdir installs). The fix was to quote the prefix escape code so it always sees the same number of arguments. My personal preference would have been to use `file(TO_CMAKE_PATH prefix "${prefix}")` to keep the paths unix-style inside the code, anyway you would still need the quotes in this case.
- Snaps are relocatable, we we need a dynamic install prefix. I added support for a "VOLK_PREFIX" environment variable. I think the use of this prefix is limited at the moment, but at least it will be correct and future-proofed. This is also helpful for the PothosSDR windows installer which also has relocatable installs based on the user's selection.
- Const correctness: The constants functions should really be retuning `const char*`, and also because we would have to cast the result of getenv() to `char *` to avoid the compiler warning/error.
