### PR TITLE
Build on python3 system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,16 +68,22 @@ SET(CROSSCOMPILE_MULTILIB ${CROSSCOMPILE_MULTILIB} CACHE STRING "Define \"true\"
 
 # Python
 include(VolkPython) #sets PYTHON_EXECUTABLE and PYTHON_DASH_B
-VOLK_PYTHON_CHECK_MODULE("python >= 2.5" sys "sys.version.split()[0] >= '2.5'" PYTHON_MIN_VER_FOUND)
+VOLK_PYTHON_CHECK_MODULE("python >= 2.7" sys "sys.version.split()[0] >= '2.7'" PYTHON_MIN_VER_FOUND)
 VOLK_PYTHON_CHECK_MODULE("mako >= 0.4.2" mako "mako.__version__ >= '0.4.2'" MAKO_FOUND)
+VOLK_PYTHON_CHECK_MODULE("six - python 2 and 3 compatibility library" six "True" SIX_FOUND)
 
 if(NOT PYTHON_MIN_VER_FOUND)
-    message(FATAL_ERROR "Python 2.5 or greater required to build VOLK")
+    message(FATAL_ERROR "Python 2.7 or greater required to build VOLK")
 endif()
 
 # Mako
 if(NOT MAKO_FOUND)
     message(FATAL_ERROR "Mako templates required to build VOLK")
+endif()
+
+# Six
+if(NOT SIX_FOUND)
+    message(FATAL_ERROR "six - python 2 and 3 compatibility library required to build VOLK")
 endif()
 
 # Boost

--- a/cmake/Modules/VolkPython.cmake
+++ b/cmake/Modules/VolkPython.cmake
@@ -41,7 +41,7 @@ else(PYTHON_EXECUTABLE)
 
     #and if that fails use the find program routine
     if(NOT PYTHONINTERP_FOUND)
-        find_program(PYTHON_EXECUTABLE NAMES python python2 python2.7 python2.6 python3)
+        find_program(PYTHON_EXECUTABLE NAMES python python2 python2.7 python3)
         if(PYTHON_EXECUTABLE)
             set(PYTHONINTERP_FOUND TRUE)
         endif(PYTHON_EXECUTABLE)

--- a/cmake/Modules/VolkPython.cmake
+++ b/cmake/Modules/VolkPython.cmake
@@ -36,11 +36,12 @@ if(PYTHON_EXECUTABLE)
 else(PYTHON_EXECUTABLE)
 
     #use the built-in find script
+    set(Python_ADDITIONAL_VERSIONS 3.4 3.5 3.6)
     find_package(PythonInterp 2)
 
     #and if that fails use the find program routine
     if(NOT PYTHONINTERP_FOUND)
-        find_program(PYTHON_EXECUTABLE NAMES python python2 python2.7 python2.6 python2.5)
+        find_program(PYTHON_EXECUTABLE NAMES python python2 python2.7 python2.6 python3)
         if(PYTHON_EXECUTABLE)
             set(PYTHONINTERP_FOUND TRUE)
         endif(PYTHON_EXECUTABLE)
@@ -100,7 +101,7 @@ endmacro(VOLK_PYTHON_CHECK_MODULE)
 if(NOT DEFINED VOLK_PYTHON_DIR)
 execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "
 from distutils import sysconfig
-print sysconfig.get_python_lib(plat_specific=True, prefix='')
+print(sysconfig.get_python_lib(plat_specific=True, prefix=''))
 " OUTPUT_VARIABLE VOLK_PYTHON_DIR OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 endif()
@@ -113,7 +114,7 @@ file(TO_CMAKE_PATH ${VOLK_PYTHON_DIR} VOLK_PYTHON_DIR)
 function(VOLK_UNIQUE_TARGET desc)
     file(RELATIVE_PATH reldir ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR})
     execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import re, hashlib
-unique = hashlib.md5('${reldir}${ARGN}').hexdigest()[:5]
+unique = hashlib.md5(b'${reldir}${ARGN}').hexdigest()[:5]
 print(re.sub('\\W', '_', '${desc} ${reldir} ' + unique))"
     OUTPUT_VARIABLE _target OUTPUT_STRIP_TRAILING_WHITESPACE)
     add_custom_target(${_target} ALL DEPENDS ${ARGN})
@@ -230,7 +231,7 @@ endfunction(VOLK_PYTHON_INSTALL)
 file(WRITE ${CMAKE_BINARY_DIR}/python_compile_helper.py "
 import sys, py_compile
 files = sys.argv[1:]
-srcs, gens = files[:len(files)/2], files[len(files)/2:]
+srcs, gens = files[:len(files)//2], files[len(files)//2:]
 for src, gen in zip(srcs, gens):
     py_compile.compile(file=src, cfile=gen, doraise=True)
 ")

--- a/gen/volk_arch_defs.py
+++ b/gen/volk_arch_defs.py
@@ -15,6 +15,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import print_function
+
+import six
+
 archs = list()
 arch_dict = dict()
 
@@ -75,11 +79,11 @@ for arch_xml in archs_xml:
     flags = dict()
     for flag_xml in arch_xml.getElementsByTagName("flag"):
         name = flag_xml.attributes["compiler"].value
-        if not flags.has_key(name): flags[name] = list()
+        if name not in flags: flags[name] = list()
         flags[name].append(flag_xml.firstChild.data)
     #force kwargs keys to be of type str, not unicode for py25
-    kwargs = dict((str(k), v) for k, v in kwargs.iteritems())
+    kwargs = dict((str(k), v) for k, v in six.iteritems(kwargs))
     register_arch(flags=flags, checks=checks, **kwargs)
 
 if __name__ == '__main__':
-    print archs
+    print(archs)

--- a/gen/volk_compile_utils.py
+++ b/gen/volk_compile_utils.py
@@ -16,6 +16,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import print_function
+
 import optparse
 import volk_arch_defs
 import volk_machine_defs
@@ -26,7 +28,7 @@ def do_arch_flags_list(compiler):
         if not arch.is_supported(compiler): continue
         fields = [arch.name] + arch.get_flags(compiler)
         output.append(','.join(fields))
-    print ';'.join(output)
+    print(';'.join(output))
 
 def do_machines_list(arch_names):
     output = list()
@@ -34,14 +36,14 @@ def do_machines_list(arch_names):
         machine_arch_set = set(machine.arch_names)
         if set(arch_names).intersection(machine_arch_set) == machine_arch_set:
             output.append(machine.name)
-    print ';'.join(output)
+    print(';'.join(output))
 
 def do_machine_flags_list(compiler, machine_name):
     output = list()
     machine = volk_machine_defs.machine_dict[machine_name]
     for arch in machine.archs:
         output.extend(arch.get_flags(compiler))
-    print ' '.join(output)
+    print(' '.join(output))
 
 def main():
     parser = optparse.OptionParser()

--- a/gen/volk_kernel_defs.py
+++ b/gen/volk_kernel_defs.py
@@ -19,6 +19,8 @@
 # Boston, MA 02110-1301, USA.
 #
 
+from __future__ import print_function
+
 import os
 import re
 import sys
@@ -98,9 +100,9 @@ def split_into_nested_ifdef_sections(code):
 def print_sections(sections, indent = '  '):
     for header, body in sections:
         if header == 'text':
-            print indent, ('\n'+indent).join(body.splitlines())
+            print(indent, ('\n'+indent).join(body.splitlines()))
             continue
-        print indent.replace(' ', '-') + '>', header
+        print(indent.replace(' ', '-') + '>', header)
         print_sections(body, indent + '  ')
 
 ########################################################################
@@ -136,7 +138,7 @@ class impl_class:
                 arg_type, arg_name = m.groups()
                 self.args.append((arg_type, arg_name))
         except Exception as ex:
-            raise Exception, 'I cant parse the function prototype from: %s in %s\n%s'%(kern_name, body, ex)
+            raise Exception('I cant parse the function prototype from: %s in %s\n%s'%(kern_name, body, ex))
 
         assert self.name
         self.is_aligned = self.name.startswith('a_')
@@ -206,4 +208,4 @@ kernel_files = glob.glob(os.path.join(srcdir, "kernels", "volk", "*.h"))
 kernels = map(kernel_class, kernel_files)
 
 if __name__ == '__main__':
-    print kernels
+    print(kernels)

--- a/gen/volk_machine_defs.py
+++ b/gen/volk_machine_defs.py
@@ -15,6 +15,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+from __future__ import print_function
+
+import six
+
 from volk_arch_defs import arch_dict
 
 machines = list()
@@ -67,8 +71,8 @@ for machine_xml in machines_xml:
         except: pass
     kwargs['archs'] = kwargs['archs'].split()
     #force kwargs keys to be of type str, not unicode for py25
-    kwargs = dict((str(k), v) for k, v in kwargs.iteritems())
+    kwargs = dict((str(k), v) for k, v in six.iteritems(kwargs))
     register_machine(**kwargs)
 
 if __name__ == '__main__':
-    print machines
+    print(machines)

--- a/gen/volk_tmpl_utils.py
+++ b/gen/volk_tmpl_utils.py
@@ -20,6 +20,8 @@
 # Boston, MA 02110-1301, USA.
 #
 
+from __future__ import print_function
+
 import os
 import re
 import sys
@@ -53,6 +55,6 @@ def main():
 
     output = __parse_tmpl(open(opts.input).read(), args=args)
     if opts.output: open(opts.output, 'w').write(output)
-    else: print output
+    else: print(output)
 
 if __name__ == '__main__': main()

--- a/python/volk_modtool/cfg.py
+++ b/python/volk_modtool/cfg.py
@@ -20,6 +20,8 @@
 # Boston, MA 02110-1301, USA.
 #
 
+from __future__ import print_function
+
 import ConfigParser
 import sys
 import os
@@ -71,7 +73,7 @@ class volk_modtool_config:
         elif os.path.exists(default):
             icfg.read(default)
         else:
-            print "Initializing config file..."
+            print("Initializing config file...")
             icfg.add_section(self.config_name)
             for kn in self.config_defaults:
                 rv = raw_input("%s: "%(kn))
@@ -95,10 +97,3 @@ class volk_modtool_config:
         for i in stuff:
             retval[i[0]] = i[1]
         return retval
-
-
-
-
-
-
-

--- a/python/volk_modtool/volk_modtool_generate.py
+++ b/python/volk_modtool/volk_modtool_generate.py
@@ -19,6 +19,8 @@
 # Boston, MA 02110-1301, USA.
 #
 
+from __future__ import print_function
+
 import os
 import re
 import glob
@@ -214,14 +216,14 @@ class volk_modtool:
 
         for kernel in search_kernels:
             infile = os.path.join(inpath, 'kernels/' + top[:-1] + '/' + top + kernel.pattern + '.h')
-            print "Removing kernel %s" % kernel.pattern
+            print("Removing kernel %s" % kernel.pattern)
             if os.path.exists(infile):
                 os.remove(infile)
         # remove the orc proto-kernels if they exist. There are no puppets here
         # so just need to glob for files matching kernel name
-        print glob.glob(inpath + '/kernel/volk/asm/orc/' + top + name + '*.orc')
+        print(glob.glob(inpath + '/kernel/volk/asm/orc/' + top + name + '*.orc'))
         for orcfile in glob.glob(inpath + '/kernel/volk/asm/orc/' + top + name + '*.orc'):
-            print orcfile
+            print(orcfile)
             if os.path.exists(orcfile):
                 os.remove(orcfile)
 
@@ -283,7 +285,7 @@ class volk_modtool:
                 open(dest, 'a').write(otherline)
 
         for kernel in search_kernels:
-            print "Adding kernel %s from module %s" % (kernel.pattern, base)
+            print("Adding kernel %s from module %s" % (kernel.pattern, base))
 
         infile = open(os.path.join(inpath, 'lib/testqa.cc'))
         otherinfile = open(os.path.join(self.my_dict['destination'], 'volk_' + self.my_dict['name'], 'lib/testqa.cc'))


### PR DESCRIPTION
This pull request adds support for systems whose default python is python3.
It retains backwards compatibility with Python 2.7.

In a few places, I used "six" to maintain compatibility. This is the same tool that will be required in gnuradio's 3.8 branch to add python3 support.