### PR TITLE
python3: mako template doesn't seem to understand map generator

### DIFF
--- a/gen/volk_kernel_defs.py
+++ b/gen/volk_kernel_defs.py
@@ -205,7 +205,7 @@ class kernel_class:
 __file__ = os.path.abspath(__file__)
 srcdir = os.path.dirname(os.path.dirname(__file__))
 kernel_files = glob.glob(os.path.join(srcdir, "kernels", "volk", "*.h"))
-kernels = map(kernel_class, kernel_files)
+kernels = list(map(kernel_class, kernel_files))
 
 if __name__ == '__main__':
     print(kernels)


### PR DESCRIPTION
My previous PR contained a regression when run with py3 that I just caught:

At the line: https://github.com/gnuradio/volk/blob/master/tmpl/volk_machine_xxx.tmpl.c#L46

it appears that if `kernels` is any iterator it should work, but for some reason the map iterator returned by python3's `map` function is not iterated by mako.

This commit forces both py2 and py3 to evaluate to a list.