### PR TITLE
kernels: fix bit shift error in volk_64u_popcnt_generic

### DIFF
--- a/kernels/volk/volk_64u_popcnt.h
+++ b/kernels/volk/volk_64u_popcnt.h
@@ -84,7 +84,7 @@ volk_64u_popcnt_generic(uint64_t* ret, const uint64_t value)
   uint64_t retVal64  = retVal;
 
   //retVal = valueVector[1];
-  retVal = (uint32_t)((value & 0xFFFFFFFF00000000ull) >> 31);
+  retVal = (uint32_t)((value & 0xFFFFFFFF00000000ull) >> 32);
   retVal = (retVal & 0x55555555) + (retVal >> 1 & 0x55555555);
   retVal = (retVal & 0x33333333) + (retVal >> 2 & 0x33333333);
   retVal = (retVal + (retVal >> 4)) & 0x0F0F0F0F;


### PR DESCRIPTION
Fixes https://github.com/gnuradio/volk/issues/106