### PR TITLE
Use 'powf' instead of 'pow'

### DIFF
--- a/kernels/volk/volk_32f_x2_pow_32f.h
+++ b/kernels/volk/volk_32f_x2_pow_32f.h
@@ -190,7 +190,7 @@ volk_32f_x2_pow_32f_a_sse4_1(float* cVector, const float* bVector,
 
   number = quarterPoints * 4;
   for(;number < num_points; number++){
-    *cPtr++ = pow(*aPtr++, *bPtr++);
+    *cPtr++ = powf(*aPtr++, *bPtr++);
   }
 }
 
@@ -215,7 +215,7 @@ volk_32f_x2_pow_32f_generic(float* cVector, const float* bVector,
   unsigned int number = 0;
 
   for(number = 0; number < num_points; number++){
-    *cPtr++ = pow(*aPtr++, *bPtr++);
+    *cPtr++ = powf(*aPtr++, *bPtr++);
   }
 }
 #endif /* LV_HAVE_GENERIC */
@@ -326,7 +326,7 @@ volk_32f_x2_pow_32f_u_sse4_1(float* cVector, const float* bVector,
 
   number = quarterPoints * 4;
   for(;number < num_points; number++){
-    *cPtr++ = pow(*aPtr++, *bPtr++);
+    *cPtr++ = powf(*aPtr++, *bPtr++);
   }
 }
 


### PR DESCRIPTION
... to match variables and avoid implicit type conversion. Makes some older compilers happy, allowing 'make test' to pass.