### PR TITLE
sort input files

### DIFF
--- a/gen/volk_kernel_defs.py
+++ b/gen/volk_kernel_defs.py
@@ -204,7 +204,7 @@ class kernel_class:
 ########################################################################
 __file__ = os.path.abspath(__file__)
 srcdir = os.path.dirname(os.path.dirname(__file__))
-kernel_files = glob.glob(os.path.join(srcdir, "kernels", "volk", "*.h"))
+kernel_files = sorted(glob.glob(os.path.join(srcdir, "kernels", "volk", "*.h")))
 kernels = list(map(kernel_class, kernel_files))
 
 if __name__ == '__main__':

--- a/python/volk_modtool/volk_modtool_generate.py
+++ b/python/volk_modtool/volk_modtool_generate.py
@@ -60,10 +60,10 @@ class volk_modtool:
         else:
             name = self.get_basename(base)
         if name == '':
-            hdr_files = glob.glob(os.path.join(base, "kernels/volk/*.h"))
+            hdr_files = sorted(glob.glob(os.path.join(base, "kernels/volk/*.h")))
             begins = re.compile("(?<=volk_).*")
         else:
-            hdr_files = glob.glob(os.path.join(base, "kernels/volk_" + name + "/*.h"))
+            hdr_files = sorted(glob.glob(os.path.join(base, "kernels/volk_" + name + "/*.h")))
             begins = re.compile("(?<=volk_" + name + "_).*")
 
         datatypes = []
@@ -158,7 +158,7 @@ class volk_modtool:
         open(dest, 'w+').write(outstring)
 
         # copy orc proto-kernels if they exist
-        for orcfile in glob.glob(inpath + '/kernels/volk/asm/orc/' + top + name + '*.orc'):
+        for orcfile in sorted(glob.glob(inpath + '/kernels/volk/asm/orc/' + top + name + '*.orc')):
             if os.path.isfile(orcfile):
                 instring = open(orcfile, 'r').read()
                 outstring = re.sub(oldvolk, 'volk_' + self.my_dict['name'], instring)


### PR DESCRIPTION
when building packages (e.g. for openSUSE Linux)
(random) filesystem order of input files
influences ordering of entries in the output,
thus without the patch, builds (in disposable VMs) would usually differ.

See https://reproducible-builds.org/ for why this matters.

Note: I'm not 100% sure it needs all of those (because gnuradio compilation takes 100 minutes), but they should not hurt anyway.