### PR TITLE
protokernels: Adding AVX intrinsics in 64f kernels

### DIFF
--- a/kernels/volk/volk_64f_convert_32f.h
+++ b/kernels/volk/volk_64f_convert_32f.h
@@ -67,6 +67,41 @@
 #include <inttypes.h>
 #include <stdio.h>
 
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void volk_64f_convert_32f_u_avx(float* outputVector, const double* inputVector, unsigned int num_points){
+  unsigned int number = 0;
+
+  const unsigned int oneEightPoints = num_points / 8;
+
+  const double* inputVectorPtr = (const double*)inputVector;
+  float* outputVectorPtr = outputVector;
+  __m128 ret1, ret2;
+  __m256d inputVal1, inputVal2;
+
+  for(;number < oneEightPoints; number++){
+    inputVal1 = _mm256_loadu_pd(inputVectorPtr); inputVectorPtr += 4;
+    inputVal2 = _mm256_loadu_pd(inputVectorPtr); inputVectorPtr += 4;
+
+    ret1 = _mm256_cvtpd_ps(inputVal1);
+    ret2 = _mm256_cvtpd_ps(inputVal2);
+
+    _mm_storeu_ps(outputVectorPtr, ret1);
+    outputVectorPtr += 4;
+
+    _mm_storeu_ps(outputVectorPtr, ret2);
+    outputVectorPtr += 4;
+  }
+
+  number = oneEightPoints * 8;
+  for(; number < num_points; number++){
+    outputVector[number] = (float)(inputVector[number]);
+  }
+}
+#endif /* LV_HAVE_AVX */
+
+
 #ifdef LV_HAVE_SSE2
 #include <emmintrin.h>
 
@@ -123,6 +158,41 @@ static inline void volk_64f_convert_32f_generic(float* outputVector, const doubl
 
 #include <inttypes.h>
 #include <stdio.h>
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void volk_64f_convert_32f_a_avx(float* outputVector, const double* inputVector, unsigned int num_points){
+  unsigned int number = 0;
+
+  const unsigned int oneEightPoints = num_points / 8;
+
+  const double* inputVectorPtr = (const double*)inputVector;
+  float* outputVectorPtr = outputVector;
+  __m128 ret1, ret2;
+  __m256d inputVal1, inputVal2;
+
+  for(;number < oneEightPoints; number++){
+    inputVal1 = _mm256_load_pd(inputVectorPtr); inputVectorPtr += 4;
+    inputVal2 = _mm256_load_pd(inputVectorPtr); inputVectorPtr += 4;
+
+    ret1 = _mm256_cvtpd_ps(inputVal1);
+    ret2 = _mm256_cvtpd_ps(inputVal2);
+
+    _mm_store_ps(outputVectorPtr, ret1);
+    outputVectorPtr += 4;
+
+    _mm_store_ps(outputVectorPtr, ret2);
+    outputVectorPtr += 4;
+  }
+
+  number = oneEightPoints * 8;
+  for(; number < num_points; number++){
+    outputVector[number] = (float)(inputVector[number]);
+  }
+}
+#endif /* LV_HAVE_AVX */
+
 
 #ifdef LV_HAVE_SSE2
 #include <emmintrin.h>

--- a/kernels/volk/volk_64f_x2_max_64f.h
+++ b/kernels/volk/volk_64f_x2_max_64f.h
@@ -74,6 +74,45 @@
 #include <inttypes.h>
 #include <stdio.h>
 
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void
+volk_64f_x2_max_64f_a_avx(double* cVector, const double* aVector,
+                           const double* bVector, unsigned int num_points)
+{
+  unsigned int number = 0;
+  const unsigned int quarterPoints = num_points / 4;
+
+  double* cPtr = cVector;
+  const double* aPtr = aVector;
+  const double* bPtr=  bVector;
+
+  __m256d aVal, bVal, cVal;
+  for(;number < quarterPoints; number++){
+
+    aVal = _mm256_load_pd(aPtr);
+    bVal = _mm256_load_pd(bPtr);
+
+    cVal = _mm256_max_pd(aVal, bVal);
+
+    _mm256_store_pd(cPtr,cVal); // Store the results back into the C container
+
+    aPtr += 4;
+    bPtr += 4;
+    cPtr += 4;
+  }
+
+  number = quarterPoints * 4;
+  for(;number < num_points; number++){
+    const double a = *aPtr++;
+    const double b = *bPtr++;
+    *cPtr++ = ( a > b ? a : b);
+  }
+}
+#endif /* LV_HAVE_AVX */
+
+
 #ifdef LV_HAVE_SSE2
 #include <emmintrin.h>
 
@@ -134,3 +173,51 @@ volk_64f_x2_max_64f_generic(double* cVector, const double* aVector,
 
 
 #endif /* INCLUDED_volk_64f_x2_max_64f_a_H */
+
+
+#ifndef INCLUDED_volk_64f_x2_max_64f_u_H
+#define INCLUDED_volk_64f_x2_max_64f_u_H
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void
+volk_64f_x2_max_64f_u_avx(double* cVector, const double* aVector,
+                           const double* bVector, unsigned int num_points)
+{
+  unsigned int number = 0;
+  const unsigned int quarterPoints = num_points / 4;
+
+  double* cPtr = cVector;
+  const double* aPtr = aVector;
+  const double* bPtr=  bVector;
+
+  __m256d aVal, bVal, cVal;
+  for(;number < quarterPoints; number++){
+
+    aVal = _mm256_loadu_pd(aPtr);
+    bVal = _mm256_loadu_pd(bPtr);
+
+    cVal = _mm256_max_pd(aVal, bVal);
+
+    _mm256_storeu_pd(cPtr,cVal); // Store the results back into the C container
+
+    aPtr += 4;
+    bPtr += 4;
+    cPtr += 4;
+  }
+
+  number = quarterPoints * 4;
+  for(;number < num_points; number++){
+    const double a = *aPtr++;
+    const double b = *bPtr++;
+    *cPtr++ = ( a > b ? a : b);
+  }
+}
+#endif /* LV_HAVE_AVX */
+
+
+#endif /* INCLUDED_volk_64f_x2_max_64f_u_H */

--- a/kernels/volk/volk_64f_x2_min_64f.h
+++ b/kernels/volk/volk_64f_x2_min_64f.h
@@ -74,6 +74,45 @@
 #include <inttypes.h>
 #include <stdio.h>
 
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void
+volk_64f_x2_min_64f_a_avx(double* cVector, const double* aVector,
+                           const double* bVector, unsigned int num_points)
+{
+  unsigned int number = 0;
+  const unsigned int quarterPoints = num_points / 4;
+
+  double* cPtr = cVector;
+  const double* aPtr = aVector;
+  const double* bPtr=  bVector;
+
+  __m256d aVal, bVal, cVal;
+  for(;number < quarterPoints; number++){
+
+    aVal = _mm256_load_pd(aPtr);
+    bVal = _mm256_load_pd(bPtr);
+
+    cVal = _mm256_min_pd(aVal, bVal);
+
+    _mm256_store_pd(cPtr,cVal); // Store the results back into the C container
+
+    aPtr += 4;
+    bPtr += 4;
+    cPtr += 4;
+  }
+
+  number = quarterPoints * 4;
+  for(;number < num_points; number++){
+    const double a = *aPtr++;
+    const double b = *bPtr++;
+    *cPtr++ = ( a < b ? a : b);
+  }
+}
+#endif /* LV_HAVE_AVX */
+
+
 #ifdef LV_HAVE_SSE2
 #include <emmintrin.h>
 
@@ -134,3 +173,50 @@ volk_64f_x2_min_64f_generic(double* cVector, const double* aVector,
 
 
 #endif /* INCLUDED_volk_64f_x2_min_64f_a_H */
+
+#ifndef INCLUDED_volk_64f_x2_min_64f_u_H
+#define INCLUDED_volk_64f_x2_min_64f_u_H
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void
+volk_64f_x2_min_64f_u_avx(double* cVector, const double* aVector,
+                           const double* bVector, unsigned int num_points)
+{
+  unsigned int number = 0;
+  const unsigned int quarterPoints = num_points / 4;
+
+  double* cPtr = cVector;
+  const double* aPtr = aVector;
+  const double* bPtr=  bVector;
+
+  __m256d aVal, bVal, cVal;
+  for(;number < quarterPoints; number++){
+
+    aVal = _mm256_loadu_pd(aPtr);
+    bVal = _mm256_loadu_pd(bPtr);
+
+    cVal = _mm256_min_pd(aVal, bVal);
+
+    _mm256_storeu_pd(cPtr,cVal); // Store the results back into the C container
+
+    aPtr += 4;
+    bPtr += 4;
+    cPtr += 4;
+  }
+
+  number = quarterPoints * 4;
+  for(;number < num_points; number++){
+    const double a = *aPtr++;
+    const double b = *bPtr++;
+    *cPtr++ = ( a < b ? a : b);
+  }
+}
+#endif /* LV_HAVE_AVX */
+
+
+#endif /* INCLUDED_volk_64f_x2_min_64f_u_H */


### PR DESCRIPTION
Adds AVX intrinsics for volk_64f_convert_32f, volk_64f_x2_max_64f and
volk_64f_x2_min_64f kernels. 

See the results of the 'volk_profile' executable for the targeted kernels
RUN_VOLK_TESTS: volk_64f_convert_32f(131071,1987)
u_avx completed in 61.031ms
u_sse2 completed in 73.347ms
generic completed in 62.003ms
a_avx completed in 61.593ms
a_sse2 completed in 72.262ms
a_generic completed in 60.433ms
Best aligned arch: a_generic
Best unaligned arch: u_avx
RUN_VOLK_TESTS: volk_64f_x2_max_64f(131071,1987)
a_avx completed in 117.94ms
a_sse2 completed in 121.797ms
generic completed in 120.427ms
u_avx completed in 117.614ms
Best aligned arch: u_avx
Best unaligned arch: u_avx
RUN_VOLK_TESTS: volk_64f_x2_min_64f(131071,1987)
a_avx completed in 117.079ms
a_sse2 completed in 121.183ms
generic completed in 118.279ms
u_avx completed in 117.944ms
Best aligned arch: a_avx
Best unaligned arch: u_avx
