### PR TITLE
Replace `asm` keyword with platform specific `__VOLK_ASM`

### DIFF
--- a/include/volk/volk_common.h
+++ b/include/volk/volk_common.h
@@ -9,6 +9,8 @@
 #  define __VOLK_ATTR_UNUSED     __attribute__((unused))
 #  define __VOLK_ATTR_INLINE     __attribute__((always_inline))
 #  define __VOLK_ATTR_DEPRECATED __attribute__((deprecated))
+#  define __VOLK_ASM __asm__
+#  define __VOLK_VOLATILE __volatile__
 #  if __GNUC__ >= 4
 #    define __VOLK_ATTR_EXPORT   __attribute__((visibility("default")))
 #    define __VOLK_ATTR_IMPORT   __attribute__((visibility("default")))
@@ -25,6 +27,8 @@
 #  define __VOLK_ATTR_EXPORT     __declspec(dllexport)
 #  define __VOLK_ATTR_IMPORT     __declspec(dllimport)
 #  define __VOLK_PREFETCH(addr)
+#  define __VOLK_ASM __asm
+#  define __VOLK_VOLATILE
 #else
 #  define __VOLK_ATTR_ALIGNED(x)
 #  define __VOLK_ATTR_UNUSED
@@ -33,6 +37,8 @@
 #  define __VOLK_ATTR_EXPORT
 #  define __VOLK_ATTR_IMPORT
 #  define __VOLK_PREFETCH(addr)
+#  define __VOLK_ASM __asm__
+#  define __VOLK_VOLATILE __volatile__
 #endif
 
 ////////////////////////////////////////////////////////////////////////

--- a/kernels/volk/volk_16i_x4_quad_max_star_16i.h
+++ b/kernels/volk/volk_16i_x4_quad_max_star_16i.h
@@ -132,7 +132,7 @@ volk_16i_x4_quad_max_star_16i_a_sse2(short* target, short* src0, short* src1,
   }
 
 
-  /*asm volatile
+  /*__VOLK_ASM __VOLK_VOLATILE
     (
     "volk_16i_x4_quad_max_star_16i_a_sse2_L1:\n\t"
     "cmp $0, %[bound]\n\t"

--- a/kernels/volk/volk_16i_x5_add_quad_16i_x4.h
+++ b/kernels/volk/volk_16i_x5_add_quad_16i_x4.h
@@ -121,7 +121,7 @@ volk_16i_x5_add_quad_16i_x4_a_sse2(short* target0, short* target1, short* target
     p_target2 += 1;
     p_target3 += 1;
   }
-  /*asm volatile
+  /*__VOLK_ASM __VOLK_VOLATILE
     (
     ".%=volk_16i_x5_add_quad_16i_x4_a_sse2_L1:\n\t"
     "cmp $0, %[bound]\n\t"

--- a/kernels/volk/volk_32fc_x2_conjugate_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_x2_conjugate_dot_prod_32fc.h
@@ -361,7 +361,7 @@ static inline void volk_32fc_x2_conjugate_dot_prod_32fc_a_sse(lv_32fc_t* result,
 
   __VOLK_ATTR_ALIGNED(16) static const uint32_t conjugator[4]= {0x00000000, 0x80000000, 0x00000000, 0x80000000};
 
-  asm volatile
+  __VOLK_ASM __VOLK_VOLATILE
     (
      "#  ccomplex_conjugate_dotprod_generic (float* result, const float *input,\n\t"
      "#                         const float *taps, unsigned num_bytes)\n\t"
@@ -497,7 +497,7 @@ static inline void volk_32fc_x2_conjugate_dot_prod_32fc_a_sse_32(lv_32fc_t* resu
   int bound = num_bytes >> 4;
   int leftovers = num_bytes % 16;
 
-  asm volatile
+  __VOLK_ASM __VOLK_VOLATILE
     (
      "	#pushl	%%ebp\n\t"
      "	#movl	%%esp, %%ebp\n\t"

--- a/kernels/volk/volk_32fc_x2_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_x2_dot_prod_32fc.h
@@ -109,7 +109,7 @@ static inline void volk_32fc_x2_dot_prod_32fc_u_sse_64(lv_32fc_t* result, const 
   const unsigned int num_bytes = num_points*8;
   unsigned int isodd = num_points & 1;
 
-  asm
+  __VOLK_ASM
     (
      "#  ccomplex_dotprod_generic (float* result, const float *input,\n\t"
      "#                         const float *taps, unsigned num_bytes)\n\t"
@@ -488,7 +488,7 @@ static inline void volk_32fc_x2_dot_prod_32fc_a_sse_64(lv_32fc_t* result, const 
   const unsigned int num_bytes = num_points*8;
   unsigned int isodd = num_points & 1;
 
-  asm
+  __VOLK_ASM
     (
      "#  ccomplex_dotprod_generic (float* result, const float *input,\n\t"
      "#                         const float *taps, unsigned num_bytes)\n\t"
@@ -622,7 +622,7 @@ static inline void volk_32fc_x2_dot_prod_32fc_a_sse_32(lv_32fc_t* result, const 
   const unsigned int num_bytes = num_points*8;
   unsigned int isodd = num_points & 1;
 
-  asm volatile
+  __VOLK_ASM __VOLK_VOLATILE
     (
      "	#pushl	%%ebp\n\t"
      "	#movl	%%esp, %%ebp\n\t"

--- a/tmpl/volk_cpu.tmpl.c
+++ b/tmpl/volk_cpu.tmpl.c
@@ -45,7 +45,7 @@ struct VOLK_CPU volk_cpu;
     #if ((__GNUC__ > 4 || __GNUC__ == 4 && __GNUC_MINOR__ >= 2) || (__clang_major__ >= 3)) && defined(HAVE_XGETBV)
     static inline unsigned long long _xgetbv(unsigned int index){
         unsigned int eax, edx;
-        __asm__ __volatile__("xgetbv" : "=a"(eax), "=d"(edx) : "c"(index));
+        __VOLK_ASM __VOLK_VOLATILE ("xgetbv" : "=a"(eax), "=d"(edx) : "c"(index));
         return ((unsigned long long)edx << 32) | eax;
     }
     #define __xgetbv() _xgetbv(0)


### PR DESCRIPTION
For GCC/Clang in `-std=c99` or `-ansi` mode the keyword `asm` is not valid and `__asm__` should be used. For MSVC `__asm` is the inline assembly keyword to use. 

Similar for `volatile` the new keyword for GCC/Clang is `__volatile__` and MSVC isn't optimizing/touching assembly code anyway so no volatile keyword nesscary there.

This PR replaces all occurences of `asm` and `volatile` with the `__VOLK` defines and defines them in `volk_common.h`. 