### PR TITLE
protokernels: Adds AVX2 for and, or kernels

### DIFF
--- a/kernels/volk/volk_32i_x2_and_32i.h
+++ b/kernels/volk/volk_32i_x2_and_32i.h
@@ -84,6 +84,43 @@
 #include <inttypes.h>
 #include <stdio.h>
 
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void
+volk_32i_x2_and_32i_a_avx2(int32_t* cVector, const int32_t* aVector,
+                          const int32_t* bVector, unsigned int num_points)
+{
+  unsigned int number = 0;
+  const unsigned int oneEightPoints = num_points / 8;
+
+  int32_t* cPtr = cVector;
+  const int32_t* aPtr = aVector;
+  const int32_t* bPtr = bVector;
+
+  __m256i aVal, bVal, cVal;
+  for(;number < oneEightPoints; number++){
+
+    aVal = _mm256_load_si256((__m256i*)aPtr);
+    bVal = _mm256_load_si256((__m256i*)bPtr);
+
+    cVal = _mm256_and_si256(aVal, bVal);
+
+    _mm256_store_si256((__m256i*)cPtr,cVal); // Store the results back into the C container
+
+    aPtr += 8;
+    bPtr += 8;
+    cPtr += 8;
+  }
+
+  number = oneEightPoints * 8;
+  for(;number < num_points; number++){
+    cVector[number] = aVector[number] & bVector[number];
+  }
+}
+#endif /* LV_HAVE_AVX2 */
+
+
 #ifdef LV_HAVE_SSE
 #include <xmmintrin.h>
 
@@ -185,3 +222,49 @@ volk_32i_x2_and_32i_u_orc(int32_t* cVector, const int32_t* aVector,
 
 
 #endif /* INCLUDED_volk_32i_x2_and_32i_a_H */
+
+
+#ifndef INCLUDED_volk_32i_x2_and_32i_u_H
+#define INCLUDED_volk_32i_x2_and_32i_u_H
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void
+volk_32i_x2_and_32i_u_avx2(int32_t* cVector, const int32_t* aVector,
+                          const int32_t* bVector, unsigned int num_points)
+{
+  unsigned int number = 0;
+  const unsigned int oneEightPoints = num_points / 8;
+
+  int32_t* cPtr = cVector;
+  const int32_t* aPtr = aVector;
+  const int32_t* bPtr = bVector;
+
+  __m256i aVal, bVal, cVal;
+  for(;number < oneEightPoints; number++){
+
+    aVal = _mm256_loadu_si256((__m256i*)aPtr);
+    bVal = _mm256_loadu_si256((__m256i*)bPtr);
+
+    cVal = _mm256_and_si256(aVal, bVal);
+
+    _mm256_storeu_si256((__m256i*)cPtr,cVal); // Store the results back into the C container
+
+    aPtr += 8;
+    bPtr += 8;
+    cPtr += 8;
+  }
+
+  number = oneEightPoints * 8;
+  for(;number < num_points; number++){
+    cVector[number] = aVector[number] & bVector[number];
+  }
+}
+#endif /* LV_HAVE_AVX2 */
+
+
+#endif /* INCLUDED_volk_32i_x2_and_32i_u_H */

--- a/kernels/volk/volk_32i_x2_or_32i.h
+++ b/kernels/volk/volk_32i_x2_or_32i.h
@@ -84,6 +84,43 @@
 #include <inttypes.h>
 #include <stdio.h>
 
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void
+volk_32i_x2_or_32i_a_avx2(int32_t* cVector, const int32_t* aVector,
+                          const int32_t* bVector, unsigned int num_points)
+{
+  unsigned int number = 0;
+  const unsigned int oneEightPoints = num_points / 8;
+
+  int32_t* cPtr = cVector;
+  const int32_t* aPtr = aVector;
+  const int32_t* bPtr = bVector;
+
+  __m256i aVal, bVal, cVal;
+  for(;number < oneEightPoints; number++){
+
+    aVal = _mm256_load_si256((__m256i*)aPtr);
+    bVal = _mm256_load_si256((__m256i*)bPtr);
+
+    cVal = _mm256_or_si256(aVal, bVal);
+
+    _mm256_store_si256((__m256i*)cPtr,cVal); // Store the results back into the C container
+
+    aPtr += 8;
+    bPtr += 8;
+    cPtr += 8;
+  }
+
+  number = oneEightPoints * 8;
+  for(;number < num_points; number++){
+    cVector[number] = aVector[number] | bVector[number];
+  }
+}
+#endif /* LV_HAVE_AVX2 */
+
+
 #ifdef LV_HAVE_SSE
 #include <xmmintrin.h>
 
@@ -185,3 +222,49 @@ volk_32i_x2_or_32i_u_orc(int32_t* cVector, const int32_t* aVector,
 
 
 #endif /* INCLUDED_volk_32i_x2_or_32i_a_H */
+
+
+#ifndef INCLUDED_volk_32i_x2_or_32i_u_H
+#define INCLUDED_volk_32i_x2_or_32i_u_H
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void
+volk_32i_x2_or_32i_u_avx2(int32_t* cVector, const int32_t* aVector,
+                          const int32_t* bVector, unsigned int num_points)
+{
+  unsigned int number = 0;
+  const unsigned int oneEightPoints = num_points / 8;
+
+  int32_t* cPtr = cVector;
+  const int32_t* aPtr = aVector;
+  const int32_t* bPtr = bVector;
+
+  __m256i aVal, bVal, cVal;
+  for(;number < oneEightPoints; number++){
+
+    aVal = _mm256_loadu_si256((__m256i*)aPtr);
+    bVal = _mm256_loadu_si256((__m256i*)bPtr);
+
+    cVal = _mm256_or_si256(aVal, bVal);
+
+    _mm256_storeu_si256((__m256i*)cPtr,cVal); // Store the results back into the C container
+
+    aPtr += 8;
+    bPtr += 8;
+    cPtr += 8;
+  }
+
+  number = oneEightPoints * 8;
+  for(;number < num_points; number++){
+    cVector[number] = aVector[number] | bVector[number];
+  }
+}
+#endif /* LV_HAVE_AVX2 */
+
+
+#endif /* INCLUDED_volk_32i_x2_or_32i_u_H */


### PR DESCRIPTION
Adds AVX2 support for volk_32i_x2_and_32i and volk_32i_x2_or_32i. Profiling results improve a bit compared to previous protokernels
```
RUN_VOLK_TESTS: volk_32i_x2_and_32i(131071,1987)
a_avx2 completed in 58.383ms
a_sse completed in 61.846ms
generic completed in 59.461ms
u_avx2 completed in 58.469ms
Best aligned arch: a_avx2
Best unaligned arch: u_avx2
RUN_VOLK_TESTS: volk_32i_x2_or_32i(131071,1987)
a_avx2 completed in 61.611ms
a_sse completed in 63.586ms
generic completed in 60.837ms
u_avx2 completed in 59.999ms
Best aligned arch: u_avx2
Best unaligned arch: u_avx2
```