### PR TITLE
Fixing a minimal bug in the log2 docstring

### DIFF
--- a/kernels/volk/volk_32f_log2_32f.h
+++ b/kernels/volk/volk_32f_log2_32f.h
@@ -62,7 +62,7 @@
  * \li num_points: The number of data points.
  *
  * \b Outputs
- * \li cVector: The output vector.
+ * \li bVector: The output vector.
  *
  * \b Example
  * \code


### PR DESCRIPTION
output vector's called bVector, not cVector