### PR TITLE
Disable SSE when compile vs2013 or higher

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,21 +2,15 @@ clone_depth: 1
 
 os: Visual Studio 2013
 
-install:
-    - echo "Installing Boost libraries..."
-    - nuget install boost_system-vc120
-    - nuget install boost_filesystem-vc120
-    - nuget install boost_chrono-vc120
-    - nuget install boost_program_options-vc120
-    - nuget install boost_unit_test_framework-vc120
+environment:
+    BOOST_ROOT: C:\Libraries\boost_1_59_0
+    BOOST_LIBRARYDIR_WIN64: C:\Libraries\boost_1_59_0\lib64-msvc-12.0
 
+install:
     - echo "Installing Cheetah templates..."
-    - appveyor DownloadFile https://pypi.python.org/packages/source/C/Cheetah/Cheetah-2.4.4.tar.gz
-    - 7z x Cheetah-2.4.4.tar.gz
-    - 7z x -y Cheetah-2.4.4.tar
-    - cd Cheetah-2.4.4
-    - c:\Python27\python.exe setup.py build
-    - c:\Python27\python.exe setup.py install
+    - pip install Cheetah
+    - pip install mako
+    - pip install six
 
 build_script:
     - cd c:\projects\volk
@@ -25,14 +19,16 @@ build_script:
     - set PATH=%PATH%;C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin
 
     - cmake -G "Visual Studio 12 Win64" \
-        -DBoost_CHRONO_LIBRARY_RELEASE:FILEPATH=c:/projects/volk/boost_chrono-vc120.1.59.0.0/lib/native/address-model-64/lib/boost_chrono-vc120-mt-1_59.lib \
-        -DBoost_FILESYSTEM_LIBRARY_RELEASE:FILEPATH=c:/projects/volk/boost_filesystem-vc120.1.59.0.0/lib/native/address-model-64/lib/boost_filesystem-vc120-mt-1_59.lib \
-        -DBoost_PROGRAM_OPTIONS_LIBRARY_RELEASE:FILEPATH=c:/projects/volk/boost_program_options-vc120.1.59.0.0/lib/native/address-model-64/lib/boost_program_options-vc120-mt-1_59.lib \
-        -DBoost_SYSTEM_LIBRARY_RELEASE:FILEPATH=c:/projects/volk/boost_system-vc120.1.59.0.0/lib/native/address-model-64/lib/boost_system-vc120-mt-1_59.lib \
-        -DBoost_UNIT_TEST_FRAMEWORK_LIBRARY_RELEASE:FILEPATH=c:/projects/volk/boost_unit_test_framework-vc120.1.59.0.0/lib/native/address-model-64/lib/boost_unit_test_framework-vc120-mt-1_59.lib \
-        -DBoost_INCLUDE_DIR:PATH=c:/projects/volk/boost.1.59.0.0/lib/native/include \
+         -DBoost_CHRONO_LIBRARY_RELEASE:FILEPATH=c:/Libraries/boost_1_59_0/lib64-msvc-12.0/boost_chrono-vc120-mt-1_59.lib \
+        -DBoost_FILESYSTEM_LIBRARY_RELEASE:FILEPATH=c:/Libraries/boost_1_59_0/lib64-msvc-12.0/boost_filesystem-vc120-mt-1_59.lib \
+        -DBoost_PROGRAM_OPTIONS_LIBRARY_RELEASE:FILEPATH=c:/Libraries/boost_1_59_0/lib64-msvc-12.0/boost_program_options-vc120-mt-1_59.lib \
+        -DBoost_SYSTEM_LIBRARY_RELEASE:FILEPATH=c:/Libraries/boost_1_59_0/lib64-msvc-12.0/boost_system-vc120-mt-1_59.lib \
+        -DBoost_UNIT_TEST_FRAMEWORK_LIBRARY_RELEASE:FILEPATH=c:/Libraries/boost_1_59_0/lib64-msvc-12.0/boost_unit_test_framework-vc120-mt-1_59.lib \
+        -DBoost_INCLUDE_DIR:PATH=c:/Libraries/boost_1_59_0/ \
         -DCMAKE_BUILD_TYPE:STRING=Release -DENABLE_ORC:BOOL=OFF -DENABLE_TESTING:BOOL=OFF \
         .
+        
+
 
     - cmake --build . --config Release --target INSTALL
 
@@ -42,11 +38,11 @@ build_script:
 
     # Create the deps archive
     - mkdir dlls
-    - copy c:\projects\volk\boost_chrono-vc120.1.59.0.0\lib\native\address-model-64\lib\boost_chrono-vc120-mt-1_59.dll dlls\boost_chrono-vc120-mt-1_59.dll
-    - copy c:\projects\volk\boost_filesystem-vc120.1.59.0.0\lib\native\address-model-64\lib\boost_filesystem-vc120-mt-1_59.dll dlls\boost_filesystem-vc120-mt-1_59.dll
-    - copy c:\projects\volk\boost_program_options-vc120.1.59.0.0\lib\native\address-model-64\lib\boost_program_options-vc120-mt-1_59.dll dlls\boost_program_options-vc120-mt-1_59.dll
-    - copy c:\projects\volk\boost_system-vc120.1.59.0.0\lib\native\address-model-64\lib\boost_system-vc120-mt-1_59.dll dlls\boost_system-vc120-mt-1_59.dll
-    - copy c:\projects\volk\boost_unit_test_framework-vc120.1.59.0.0\lib\native\address-model-64\lib\boost_unit_test_framework-vc120-mt-1_59.dll dlls\boost_unit_test_framework-vc120-mt-1_59.dll
+    - copy c:\Libraries\boost_1_59_0\lib64-msvc-12.0\boost_chrono-vc120-mt-1_59.dll dlls\boost_chrono-vc120-mt-1_59.dll
+    - copy c:\Libraries\boost_1_59_0\lib64-msvc-12.0\boost_filesystem-vc120-mt-1_59.dll dlls\boost_filesystem-vc120-mt-1_59.dll
+    - copy c:\Libraries\boost_1_59_0\lib64-msvc-12.0\boost_program_options-vc120-mt-1_59.dll dlls\boost_program_options-vc120-mt-1_59.dll
+    - copy c:\Libraries\boost_1_59_0\lib64-msvc-12.0\boost_system-vc120-mt-1_59.dll dlls\boost_system-vc120-mt-1_59.dll
+    - copy c:\Libraries\boost_1_59_0\lib64-msvc-12.0\boost_unit_test_framework-vc120-mt-1_59.dll dlls\boost_unit_test_framework-vc120-mt-1_59.dll
     - cd dlls
     - 7z a "c:\libvolk-x64-deps.zip" *
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,14 @@ clone_depth: 1
 
 os: Visual Studio 2013
 
-environment:
-    BOOST_ROOT: C:\Libraries\boost_1_59_0
-    BOOST_LIBRARYDIR_WIN64: C:\Libraries\boost_1_59_0\lib64-msvc-12.0
-
 install:
+    - echo "Installing Boost libraries..."
+    - nuget install boost_system-vc120 -Version 1.59.0
+    - nuget install boost_filesystem-vc120 -Version 1.59.0
+    - nuget install boost_chrono-vc120 -Version 1.59.0
+    - nuget install boost_program_options-vc120 -Version 1.59.0
+    - nuget install boost_unit_test_framework-vc120 -Version 1.59.0
+
     - echo "Installing Cheetah templates..."
     - pip install Cheetah
     - pip install mako
@@ -19,16 +22,14 @@ build_script:
     - set PATH=%PATH%;C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin
 
     - cmake -G "Visual Studio 12 Win64" \
-         -DBoost_CHRONO_LIBRARY_RELEASE:FILEPATH=c:/Libraries/boost_1_59_0/lib64-msvc-12.0/boost_chrono-vc120-mt-1_59.lib \
-        -DBoost_FILESYSTEM_LIBRARY_RELEASE:FILEPATH=c:/Libraries/boost_1_59_0/lib64-msvc-12.0/boost_filesystem-vc120-mt-1_59.lib \
-        -DBoost_PROGRAM_OPTIONS_LIBRARY_RELEASE:FILEPATH=c:/Libraries/boost_1_59_0/lib64-msvc-12.0/boost_program_options-vc120-mt-1_59.lib \
-        -DBoost_SYSTEM_LIBRARY_RELEASE:FILEPATH=c:/Libraries/boost_1_59_0/lib64-msvc-12.0/boost_system-vc120-mt-1_59.lib \
-        -DBoost_UNIT_TEST_FRAMEWORK_LIBRARY_RELEASE:FILEPATH=c:/Libraries/boost_1_59_0/lib64-msvc-12.0/boost_unit_test_framework-vc120-mt-1_59.lib \
-        -DBoost_INCLUDE_DIR:PATH=c:/Libraries/boost_1_59_0/ \
+        -DBoost_CHRONO_LIBRARY_RELEASE:FILEPATH=c:/projects/volk/boost_chrono-vc120.1.59.0.0/lib/native/address-model-64/lib/boost_chrono-vc120-mt-1_59.lib \
+        -DBoost_FILESYSTEM_LIBRARY_RELEASE:FILEPATH=c:/projects/volk/boost_filesystem-vc120.1.59.0.0/lib/native/address-model-64/lib/boost_filesystem-vc120-mt-1_59.lib \
+        -DBoost_PROGRAM_OPTIONS_LIBRARY_RELEASE:FILEPATH=c:/projects/volk/boost_program_options-vc120.1.59.0.0/lib/native/address-model-64/lib/boost_program_options-vc120-mt-1_59.lib \
+        -DBoost_SYSTEM_LIBRARY_RELEASE:FILEPATH=c:/projects/volk/boost_system-vc120.1.59.0.0/lib/native/address-model-64/lib/boost_system-vc120-mt-1_59.lib \
+        -DBoost_UNIT_TEST_FRAMEWORK_LIBRARY_RELEASE:FILEPATH=c:/projects/volk/boost_unit_test_framework-vc120.1.59.0.0/lib/native/address-model-64/lib/boost_unit_test_framework-vc120-mt-1_59.lib \
+        -DBoost_INCLUDE_DIR:PATH=c:/projects/volk/boost.1.59.0.0/lib/native/include \
         -DCMAKE_BUILD_TYPE:STRING=Release -DENABLE_ORC:BOOL=OFF -DENABLE_TESTING:BOOL=OFF \
         .
-        
-
 
     - cmake --build . --config Release --target INSTALL
 
@@ -38,11 +39,11 @@ build_script:
 
     # Create the deps archive
     - mkdir dlls
-    - copy c:\Libraries\boost_1_59_0\lib64-msvc-12.0\boost_chrono-vc120-mt-1_59.dll dlls\boost_chrono-vc120-mt-1_59.dll
-    - copy c:\Libraries\boost_1_59_0\lib64-msvc-12.0\boost_filesystem-vc120-mt-1_59.dll dlls\boost_filesystem-vc120-mt-1_59.dll
-    - copy c:\Libraries\boost_1_59_0\lib64-msvc-12.0\boost_program_options-vc120-mt-1_59.dll dlls\boost_program_options-vc120-mt-1_59.dll
-    - copy c:\Libraries\boost_1_59_0\lib64-msvc-12.0\boost_system-vc120-mt-1_59.dll dlls\boost_system-vc120-mt-1_59.dll
-    - copy c:\Libraries\boost_1_59_0\lib64-msvc-12.0\boost_unit_test_framework-vc120-mt-1_59.dll dlls\boost_unit_test_framework-vc120-mt-1_59.dll
+    - copy c:\projects\volk\boost_chrono-vc120.1.59.0.0\lib\native\address-model-64\lib\boost_chrono-vc120-mt-1_59.dll dlls\boost_chrono-vc120-mt-1_59.dll
+    - copy c:\projects\volk\boost_filesystem-vc120.1.59.0.0\lib\native\address-model-64\lib\boost_filesystem-vc120-mt-1_59.dll dlls\boost_filesystem-vc120-mt-1_59.dll
+    - copy c:\projects\volk\boost_program_options-vc120.1.59.0.0\lib\native\address-model-64\lib\boost_program_options-vc120-mt-1_59.dll dlls\boost_program_options-vc120-mt-1_59.dll
+    - copy c:\projects\volk\boost_system-vc120.1.59.0.0\lib\native\address-model-64\lib\boost_system-vc120-mt-1_59.dll dlls\boost_system-vc120-mt-1_59.dll
+    - copy c:\projects\volk\boost_unit_test_framework-vc120.1.59.0.0\lib\native\address-model-64\lib\boost_unit_test_framework-vc120-mt-1_59.dll dlls\boost_unit_test_framework-vc120-mt-1_59.dll
     - cd dlls
     - 7z a "c:\libvolk-x64-deps.zip" *
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,52 +1,54 @@
 clone_depth: 1
-
-os: Visual Studio 2013
-
+image: Visual Studio 2017
+cache:
+  - C:\projects\volk\packages -> appveyor.yml
+environment:
+  BOOST_FILENAME_VERSION: 1_59
+  BOOST_VERSION: 1.59.0
+  environment:
+  matrix:
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      CMAKE_GENERATOR: Visual Studio 12 2013
+      VC_VERSION: vc120
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      CMAKE_GENERATOR: Visual Studio 14 2015
+      VC_VERSION: vc140
+ 
 install:
-    - echo "Installing Boost libraries..."
-    - nuget install boost_system-vc120 -Version 1.59.0
-    - nuget install boost_filesystem-vc120 -Version 1.59.0
-    - nuget install boost_chrono-vc120 -Version 1.59.0
-    - nuget install boost_program_options-vc120 -Version 1.59.0
-    - nuget install boost_unit_test_framework-vc120 -Version 1.59.0
-
-    - echo "Installing Cheetah templates..."
+    - cd c:\projects\volk
+    - mkdir packages
+    - cd packages
+    - nuget install boost_system-%VC_VERSION% -Version %BOOST_VERSION%
+    - nuget install boost_filesystem-%VC_VERSION% -Version %BOOST_VERSION%
+    - nuget install boost_chrono-%VC_VERSION% -Version %BOOST_VERSION%
+    - nuget install boost_program_options-%VC_VERSION% -Version %BOOST_VERSION%
+    - nuget install boost_unit_test_framework-%VC_VERSION% -Version %BOOST_VERSION%
+    - cd ..
     - pip install Cheetah
     - pip install mako
     - pip install six
-
-build_script:
-    - cd c:\projects\volk
-
-    # Without this directory in the %PATH%, compiler tests fail because of missing DLLs
-    - set PATH=%PATH%;C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin
-
-    - cmake -G "Visual Studio 12 Win64" \
-        -DBoost_CHRONO_LIBRARY_RELEASE:FILEPATH=c:/projects/volk/boost_chrono-vc120.1.59.0.0/lib/native/address-model-64/lib/boost_chrono-vc120-mt-1_59.lib \
-        -DBoost_FILESYSTEM_LIBRARY_RELEASE:FILEPATH=c:/projects/volk/boost_filesystem-vc120.1.59.0.0/lib/native/address-model-64/lib/boost_filesystem-vc120-mt-1_59.lib \
-        -DBoost_PROGRAM_OPTIONS_LIBRARY_RELEASE:FILEPATH=c:/projects/volk/boost_program_options-vc120.1.59.0.0/lib/native/address-model-64/lib/boost_program_options-vc120-mt-1_59.lib \
-        -DBoost_SYSTEM_LIBRARY_RELEASE:FILEPATH=c:/projects/volk/boost_system-vc120.1.59.0.0/lib/native/address-model-64/lib/boost_system-vc120-mt-1_59.lib \
-        -DBoost_UNIT_TEST_FRAMEWORK_LIBRARY_RELEASE:FILEPATH=c:/projects/volk/boost_unit_test_framework-vc120.1.59.0.0/lib/native/address-model-64/lib/boost_unit_test_framework-vc120-mt-1_59.lib \
-        -DBoost_INCLUDE_DIR:PATH=c:/projects/volk/boost.1.59.0.0/lib/native/include \
+before_build:
+    - cmake -G "%CMAKE_GENERATOR% Win64" \
+        -DBoost_CHRONO_LIBRARY_RELEASE:FILEPATH=c:/projects/volk/packages/boost_chrono-%VC_VERSION%.%BOOST_VERSION%.0/lib/native/address-model-64/lib/boost_chrono-%VC_VERSION%-mt-%BOOST_FILENAME_VERSION%.lib \
+        -DBoost_FILESYSTEM_LIBRARY_RELEASE:FILEPATH=c:/projects/volk/packages/boost_filesystem-%VC_VERSION%.%BOOST_VERSION%.0/lib/native/address-model-64/lib/boost_filesystem-%VC_VERSION%-mt-%BOOST_FILENAME_VERSION%.lib \
+        -DBoost_PROGRAM_OPTIONS_LIBRARY_RELEASE:FILEPATH=c:/projects/volk/packages/boost_program_options-%VC_VERSION%.%BOOST_VERSION%.0/lib/native/address-model-64/lib/boost_program_options-%VC_VERSION%-mt-%BOOST_FILENAME_VERSION%.lib \
+        -DBoost_SYSTEM_LIBRARY_RELEASE:FILEPATH=c:/projects/volk/packages/boost_system-%VC_VERSION%.%BOOST_VERSION%.0/lib/native/address-model-64/lib/boost_system-%VC_VERSION%-mt-%BOOST_FILENAME_VERSION%.lib \
+        -DBoost_UNIT_TEST_FRAMEWORK_LIBRARY_RELEASE:FILEPATH=c:/projects/volk/packages/boost_unit_test_framework-%VC_VERSION%.%BOOST_VERSION%.0/lib/native/address-model-64/lib/boost_unit_test_framework-%VC_VERSION%-mt-%BOOST_FILENAME_VERSION%.lib \
+        -DBoost_INCLUDE_DIR:PATH=c:/projects/volk/packages/boost.%BOOST_VERSION%.0/lib/native/include \
         -DCMAKE_BUILD_TYPE:STRING=Release -DENABLE_ORC:BOOL=OFF -DENABLE_TESTING:BOOL=OFF \
         .
-
+build_script:
     - cmake --build . --config Release --target INSTALL
-
-    # Create an archive
+after_build:
     - cd "c:\Program Files"
-    - 7z a "c:\libvolk-x64.zip" volk
-
-    # Create the deps archive
+    - 7z a "c:\libvolk-x64-%VC_VERSION%.zip" volk
     - mkdir dlls
-    - copy c:\projects\volk\boost_chrono-vc120.1.59.0.0\lib\native\address-model-64\lib\boost_chrono-vc120-mt-1_59.dll dlls\boost_chrono-vc120-mt-1_59.dll
-    - copy c:\projects\volk\boost_filesystem-vc120.1.59.0.0\lib\native\address-model-64\lib\boost_filesystem-vc120-mt-1_59.dll dlls\boost_filesystem-vc120-mt-1_59.dll
-    - copy c:\projects\volk\boost_program_options-vc120.1.59.0.0\lib\native\address-model-64\lib\boost_program_options-vc120-mt-1_59.dll dlls\boost_program_options-vc120-mt-1_59.dll
-    - copy c:\projects\volk\boost_system-vc120.1.59.0.0\lib\native\address-model-64\lib\boost_system-vc120-mt-1_59.dll dlls\boost_system-vc120-mt-1_59.dll
-    - copy c:\projects\volk\boost_unit_test_framework-vc120.1.59.0.0\lib\native\address-model-64\lib\boost_unit_test_framework-vc120-mt-1_59.dll dlls\boost_unit_test_framework-vc120-mt-1_59.dll
+    - copy c:\projects\volk\packages\boost_chrono-%VC_VERSION%.%BOOST_VERSION%.0\lib\native\address-model-64\lib\boost_chrono-%VC_VERSION%-mt-%BOOST_FILENAME_VERSION%.dll dlls\boost_chrono-%VC_VERSION%-mt-%BOOST_FILENAME_VERSION%.dll
+    - copy c:\projects\volk\packages\boost_filesystem-%VC_VERSION%.%BOOST_VERSION%.0\lib\native\address-model-64\lib\boost_filesystem-%VC_VERSION%-mt-%BOOST_FILENAME_VERSION%.dll dlls\boost_filesystem-%VC_VERSION%-mt-%BOOST_FILENAME_VERSION%.dll
+    - copy c:\projects\volk\packages\boost_program_options-%VC_VERSION%.%BOOST_VERSION%.0\lib\native\address-model-64\lib\boost_program_options-%VC_VERSION%-mt-%BOOST_FILENAME_VERSION%.dll dlls\boost_program_options-%VC_VERSION%-mt-%BOOST_FILENAME_VERSION%.dll
+    - copy c:\projects\volk\packages\boost_system-%VC_VERSION%.%BOOST_VERSION%.0\lib\native\address-model-64\lib\boost_system-%VC_VERSION%-mt-%BOOST_FILENAME_VERSION%.dll dlls\boost_system-%VC_VERSION%-mt-%BOOST_FILENAME_VERSION%.dll
+    - copy c:\projects\volk\packages\boost_unit_test_framework-%VC_VERSION%.%BOOST_VERSION%.0\lib\native\address-model-64\lib\boost_unit_test_framework-%VC_VERSION%-mt-%BOOST_FILENAME_VERSION%.dll dlls\boost_unit_test_framework-%VC_VERSION%-mt-%BOOST_FILENAME_VERSION%.dll
     - cd dlls
-    - 7z a "c:\libvolk-x64-deps.zip" *
-
-    # Push it!
-    - appveyor PushArtifact c:\libvolk-x64.zip
-    - appveyor PushArtifact c:\libvolk-x64-deps.zip
+    - 7z a "c:\libvolk-x64-deps-%VC_VERSION%.zip" *
+    - appveyor PushArtifact c:\libvolk-x64-%VC_VERSION%.zip
+    - appveyor PushArtifact c:\libvolk-x64-deps-%VC_VERSION%.zip

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -274,6 +274,9 @@ if(NOT CROSSCOMPILE_MULTILIB AND CPU_IS_x86)
     #MSVC 64 bit does not have MMX, overrule it
     if (${SIZEOF_CPU} EQUAL 64 AND MSVC)
         OVERRULE_ARCH(mmx "No MMX for Win64")
+	if (MSVC_VERSION GREATER 1700)
+            OVERRULE_ARCH(sse "No SSE for Win64 Visual Studio 2013")
+        endif()
     endif()
 
 endif()


### PR DESCRIPTION
So far it has been the way I found to be able to compile using Visual Studio, without disabling SSE to 64 bit, it apprehends a linkage error.

I still do not know the general structure of the project, so I did it in my view was palliative, just to allow me to use in my project.

I also adjusted the file used for the appveyor build to make it easier to see the behavior I mentioned above. https://ci.appveyor.com/project/0unit/volk