### PR TITLE
AVX support to `volk_32f_*` kernels

### DIFF
--- a/kernels/volk/volk_32f_s32f_normalize.h
+++ b/kernels/volk/volk_32f_s32f_normalize.h
@@ -105,6 +105,39 @@ static inline void volk_32f_s32f_normalize_a_sse(float* vecBuffer, const float s
 }
 #endif /* LV_HAVE_SSE */
 
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void volk_32f_s32f_normalize_a_avx(float* vecBuffer, const float scalar, unsigned int num_points){
+  unsigned int number = 0;
+  float* inputPtr = vecBuffer;
+
+  const float invScalar = 1.0 / scalar;
+  __m256 vecScalar = _mm256_set1_ps(invScalar);
+  __m256 input1;
+
+  const uint64_t eigthPoints = num_points / 8;
+  for(;number < eigthPoints; number++){
+
+    input1 = _mm256_load_ps(inputPtr);
+
+    input1 = _mm256_mul_ps(input1, vecScalar);
+
+    _mm256_store_ps(inputPtr, input1);
+
+    inputPtr += 8;
+  }
+
+  number = eigthPoints*8;
+  for(; number < num_points; number++){
+    *inputPtr *= invScalar;
+    inputPtr++;
+  }
+}
+#endif /* LV_HAVE_AVX */
+
+
 #ifdef LV_HAVE_GENERIC
 
 static inline void volk_32f_s32f_normalize_generic(float* vecBuffer, const float scalar, unsigned int num_points){
@@ -128,6 +161,45 @@ static inline void volk_32f_s32f_normalize_u_orc(float* vecBuffer, const float s
 #endif /* LV_HAVE_GENERIC */
 
 
-
-
 #endif /* INCLUDED_volk_32f_s32f_normalize_a_H */
+
+
+#ifndef INCLUDED_volk_32f_s32f_normalize_u_H
+#define INCLUDED_volk_32f_s32f_normalize_u_H
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void volk_32f_s32f_normalize_u_avx(float* vecBuffer, const float scalar, unsigned int num_points){
+  unsigned int number = 0;
+  float* inputPtr = vecBuffer;
+
+  const float invScalar = 1.0 / scalar;
+  __m256 vecScalar = _mm256_set1_ps(invScalar);
+  __m256 input1;
+
+  const uint64_t eigthPoints = num_points / 8;
+  for(;number < eigthPoints; number++){
+
+    input1 = _mm256_loadu_ps(inputPtr);
+
+    input1 = _mm256_mul_ps(input1, vecScalar);
+
+    _mm256_storeu_ps(inputPtr, input1);
+
+    inputPtr += 8;
+  }
+
+  number = eigthPoints*8;
+  for(; number < num_points; number++){
+    *inputPtr *= invScalar;
+    inputPtr++;
+  }
+}
+#endif /* LV_HAVE_AVX */
+
+
+#endif /* INCLUDED_volk_32f_s32f_normalize_u_H */

--- a/kernels/volk/volk_32f_s32f_stddev_32f.h
+++ b/kernels/volk/volk_32f_s32f_stddev_32f.h
@@ -132,6 +132,65 @@ volk_32f_s32f_stddev_32f_a_sse4_1(float* stddev, const float* inputBuffer,
 #endif /* LV_HAVE_SSE4_1 */
 
 
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void
+volk_32f_s32f_stddev_32f_a_avx(float* stddev, const float* inputBuffer,
+                                  const float mean, unsigned int num_points)
+{
+  float returnValue = 0;
+  if(num_points > 0){
+    unsigned int number = 0;
+    const unsigned int thirtySecondPoints = num_points / 32;
+
+    const float* aPtr = inputBuffer;
+
+    __VOLK_ATTR_ALIGNED(32) float squareBuffer[8];
+
+    __m256 squareAccumulator = _mm256_setzero_ps();
+    __m256 aVal1, aVal2, aVal3, aVal4;
+    __m256 cVal1, cVal2, cVal3, cVal4;
+    for(;number < thirtySecondPoints; number++) {
+      aVal1 = _mm256_load_ps(aPtr); aPtr += 8;
+      cVal1 = _mm256_dp_ps(aVal1, aVal1, 0xF1);
+
+      aVal2 = _mm256_load_ps(aPtr); aPtr += 8;
+      cVal2 = _mm256_dp_ps(aVal2, aVal2, 0xF2);
+
+      aVal3 = _mm256_load_ps(aPtr); aPtr += 8;
+      cVal3 = _mm256_dp_ps(aVal3, aVal3, 0xF4);
+
+      aVal4 = _mm256_load_ps(aPtr); aPtr += 8;
+      cVal4 = _mm256_dp_ps(aVal4, aVal4, 0xF8);
+
+      cVal1 = _mm256_or_ps(cVal1, cVal2);
+      cVal3 = _mm256_or_ps(cVal3, cVal4);
+      cVal1 = _mm256_or_ps(cVal1, cVal3);
+
+      squareAccumulator = _mm256_add_ps(squareAccumulator, cVal1); // squareAccumulator += x^2
+    }
+    _mm256_store_ps(squareBuffer,squareAccumulator); // Store the results back into the C container
+    returnValue = squareBuffer[0];  returnValue += squareBuffer[1];
+    returnValue += squareBuffer[2]; returnValue += squareBuffer[3];
+    returnValue += squareBuffer[4]; returnValue += squareBuffer[5];
+    returnValue += squareBuffer[6]; returnValue += squareBuffer[7];
+
+    number = thirtySecondPoints * 32;
+    for(;number < num_points; number++){
+      returnValue += (*aPtr) * (*aPtr);
+      aPtr++;
+    }
+    returnValue /= num_points;
+    returnValue -= (mean * mean);
+    returnValue = sqrtf(returnValue);
+  }
+  *stddev = returnValue;
+}
+
+#endif /* LV_HAVE_AVX */
+
+
 #ifdef LV_HAVE_SSE
 #include <xmmintrin.h>
 

--- a/kernels/volk/volk_32f_sqrt_32f.h
+++ b/kernels/volk/volk_32f_sqrt_32f.h
@@ -102,6 +102,39 @@ volk_32f_sqrt_32f_a_sse(float* cVector, const float* aVector, unsigned int num_p
 #endif /* LV_HAVE_SSE */
 
 
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void
+volk_32f_sqrt_32f_a_avx(float* cVector, const float* aVector, unsigned int num_points)
+{
+  unsigned int number = 0;
+  const unsigned int eigthPoints = num_points / 8;
+
+  float* cPtr = cVector;
+  const float* aPtr = aVector;
+
+  __m256 aVal, cVal;
+  for(;number < eigthPoints; number++) {
+    aVal = _mm256_load_ps(aPtr);
+
+    cVal = _mm256_sqrt_ps(aVal);
+
+    _mm256_store_ps(cPtr,cVal); // Store the results back into the C container
+
+    aPtr += 8;
+    cPtr += 8;
+  }
+
+  number = eigthPoints * 8;
+  for(;number < num_points; number++) {
+    *cPtr++ = sqrtf(*aPtr++);
+  }
+}
+
+#endif /* LV_HAVE_AVX */
+
+
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
 

--- a/kernels/volk/volk_32f_x2_divide_32f.h
+++ b/kernels/volk/volk_32f_x2_divide_32f.h
@@ -110,6 +110,42 @@ volk_32f_x2_divide_32f_a_sse(float* cVector, const float* aVector,
 #endif /* LV_HAVE_SSE */
 
 
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void
+volk_32f_x2_divide_32f_a_avx(float* cVector, const float* aVector,
+                             const float* bVector, unsigned int num_points)
+{
+  unsigned int number = 0;
+  const unsigned int eigthPoints = num_points / 8;
+
+  float* cPtr = cVector;
+  const float* aPtr = aVector;
+  const float* bPtr=  bVector;
+
+  __m256 aVal, bVal, cVal;
+  for(;number < eigthPoints; number++){
+    aVal = _mm256_load_ps(aPtr);
+    bVal = _mm256_load_ps(bPtr);
+
+    cVal = _mm256_div_ps(aVal, bVal);
+
+    _mm256_store_ps(cPtr,cVal); // Store the results back into the C container
+
+    aPtr += 8;
+    bPtr += 8;
+    cPtr += 8;
+  }
+
+  number = eigthPoints * 8;
+  for(;number < num_points; number++){
+    *cPtr++ = (*aPtr++) / (*bPtr++);
+  }
+}
+#endif /* LV_HAVE_AVX */
+
+
 #ifdef LV_HAVE_GENERIC
 
 static inline void
@@ -145,3 +181,47 @@ volk_32f_x2_divide_32f_u_orc(float* cVector, const float* aVector,
 
 
 #endif /* INCLUDED_volk_32f_x2_divide_32f_a_H */
+
+
+#ifndef INCLUDED_volk_32f_x2_divide_32f_u_H
+#define INCLUDED_volk_32f_x2_divide_32f_u_H
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void
+volk_32f_x2_divide_32f_u_avx(float* cVector, const float* aVector,
+                             const float* bVector, unsigned int num_points)
+{
+  unsigned int number = 0;
+  const unsigned int eigthPoints = num_points / 8;
+
+  float* cPtr = cVector;
+  const float* aPtr = aVector;
+  const float* bPtr=  bVector;
+
+  __m256 aVal, bVal, cVal;
+  for(;number < eigthPoints; number++){
+    aVal = _mm256_loadu_ps(aPtr);
+    bVal = _mm256_loadu_ps(bPtr);
+
+    cVal = _mm256_div_ps(aVal, bVal);
+
+    _mm256_storeu_ps(cPtr,cVal); // Store the results back into the C container
+
+    aPtr += 8;
+    bPtr += 8;
+    cPtr += 8;
+  }
+
+  number = eigthPoints * 8;
+  for(;number < num_points; number++){
+    *cPtr++ = (*aPtr++) / (*bPtr++);
+  }
+}
+#endif /* LV_HAVE_AVX */
+
+#endif /* INCLUDED_volk_32f_x2_divide_32f_u_H */

--- a/kernels/volk/volk_32f_x2_dot_prod_16i.h
+++ b/kernels/volk/volk_32f_x2_dot_prod_16i.h
@@ -82,6 +82,154 @@ static inline void volk_32f_x2_dot_prod_16i_generic(int16_t* result, const float
 #endif /*LV_HAVE_GENERIC*/
 
 
+#ifdef LV_HAVE_AVX
+
+static inline void volk_32f_x2_dot_prod_16i_a_avx(int16_t* result, const  float* input, const  float* taps, unsigned int num_points) {
+
+  unsigned int number = 0;
+  const unsigned int thirtySecondPoints = num_points / 32;
+
+  float dotProduct = 0;
+  const float* aPtr = input;
+  const float* bPtr = taps;
+
+  __m256 a0Val, a1Val, a2Val, a3Val;
+  __m256 b0Val, b1Val, b2Val, b3Val;
+  __m256 c0Val, c1Val, c2Val, c3Val;
+
+  __m256 dotProdVal0 = _mm256_setzero_ps();
+  __m256 dotProdVal1 = _mm256_setzero_ps();
+  __m256 dotProdVal2 = _mm256_setzero_ps();
+  __m256 dotProdVal3 = _mm256_setzero_ps();
+
+  for(;number < thirtySecondPoints; number++){
+
+    a0Val = _mm256_load_ps(aPtr);
+    a1Val = _mm256_load_ps(aPtr+8);
+    a2Val = _mm256_load_ps(aPtr+16);
+    a3Val = _mm256_load_ps(aPtr+24);
+
+    b0Val = _mm256_load_ps(bPtr);
+    b1Val = _mm256_load_ps(bPtr+8);
+    b2Val = _mm256_load_ps(bPtr+16);
+    b3Val = _mm256_load_ps(bPtr+24);
+
+    c0Val = _mm256_mul_ps(a0Val, b0Val);
+    c1Val = _mm256_mul_ps(a1Val, b1Val);
+    c2Val = _mm256_mul_ps(a2Val, b2Val);
+    c3Val = _mm256_mul_ps(a3Val, b3Val);
+
+    dotProdVal0 = _mm256_add_ps(c0Val, dotProdVal0);
+    dotProdVal1 = _mm256_add_ps(c1Val, dotProdVal1);
+    dotProdVal2 = _mm256_add_ps(c2Val, dotProdVal2);
+    dotProdVal3 = _mm256_add_ps(c3Val, dotProdVal3);
+
+    aPtr += 32;
+    bPtr += 32;
+  }
+
+  dotProdVal0 = _mm256_add_ps(dotProdVal0, dotProdVal1);
+  dotProdVal0 = _mm256_add_ps(dotProdVal0, dotProdVal2);
+  dotProdVal0 = _mm256_add_ps(dotProdVal0, dotProdVal3);
+
+  __VOLK_ATTR_ALIGNED(32) float dotProductVector[8];
+
+  _mm256_store_ps(dotProductVector,dotProdVal0); // Store the results back into the dot product vector
+
+  dotProduct = dotProductVector[0];
+  dotProduct += dotProductVector[1];
+  dotProduct += dotProductVector[2];
+  dotProduct += dotProductVector[3];
+  dotProduct += dotProductVector[4];
+  dotProduct += dotProductVector[5];
+  dotProduct += dotProductVector[6];
+  dotProduct += dotProductVector[7];
+
+  number = thirtySecondPoints*32;
+  for(;number < num_points; number++){
+    dotProduct += ((*aPtr++) * (*bPtr++));
+  }
+
+  *result = (short)dotProduct;
+}
+
+#endif /*LV_HAVE_AVX*/
+
+
+#ifdef LV_HAVE_AVX
+
+static inline void volk_32f_x2_dot_prod_16i_u_avx(int16_t* result, const  float* input, const  float* taps, unsigned int num_points) {
+
+  unsigned int number = 0;
+  const unsigned int thirtySecondPoints = num_points / 32;
+
+  float dotProduct = 0;
+  const float* aPtr = input;
+  const float* bPtr = taps;
+
+  __m256 a0Val, a1Val, a2Val, a3Val;
+  __m256 b0Val, b1Val, b2Val, b3Val;
+  __m256 c0Val, c1Val, c2Val, c3Val;
+
+  __m256 dotProdVal0 = _mm256_setzero_ps();
+  __m256 dotProdVal1 = _mm256_setzero_ps();
+  __m256 dotProdVal2 = _mm256_setzero_ps();
+  __m256 dotProdVal3 = _mm256_setzero_ps();
+
+  for(;number < thirtySecondPoints; number++){
+
+    a0Val = _mm256_loadu_ps(aPtr);
+    a1Val = _mm256_loadu_ps(aPtr+8);
+    a2Val = _mm256_loadu_ps(aPtr+16);
+    a3Val = _mm256_loadu_ps(aPtr+24);
+
+    b0Val = _mm256_loadu_ps(bPtr);
+    b1Val = _mm256_loadu_ps(bPtr+8);
+    b2Val = _mm256_loadu_ps(bPtr+16);
+    b3Val = _mm256_loadu_ps(bPtr+24);
+
+    c0Val = _mm256_mul_ps(a0Val, b0Val);
+    c1Val = _mm256_mul_ps(a1Val, b1Val);
+    c2Val = _mm256_mul_ps(a2Val, b2Val);
+    c3Val = _mm256_mul_ps(a3Val, b3Val);
+
+    dotProdVal0 = _mm256_add_ps(c0Val, dotProdVal0);
+    dotProdVal1 = _mm256_add_ps(c1Val, dotProdVal1);
+    dotProdVal2 = _mm256_add_ps(c2Val, dotProdVal2);
+    dotProdVal3 = _mm256_add_ps(c3Val, dotProdVal3);
+
+    aPtr += 32;
+    bPtr += 32;
+  }
+
+  dotProdVal0 = _mm256_add_ps(dotProdVal0, dotProdVal1);
+  dotProdVal0 = _mm256_add_ps(dotProdVal0, dotProdVal2);
+  dotProdVal0 = _mm256_add_ps(dotProdVal0, dotProdVal3);
+
+  __VOLK_ATTR_ALIGNED(32) float dotProductVector[8];
+
+  _mm256_storeu_ps(dotProductVector,dotProdVal0); // Store the results back into the dot product vector
+
+  dotProduct = dotProductVector[0];
+  dotProduct += dotProductVector[1];
+  dotProduct += dotProductVector[2];
+  dotProduct += dotProductVector[3];
+  dotProduct += dotProductVector[4];
+  dotProduct += dotProductVector[5];
+  dotProduct += dotProductVector[6];
+  dotProduct += dotProductVector[7];
+
+  number = thirtySecondPoints*32;
+  for(;number < num_points; number++){
+    dotProduct += ((*aPtr++) * (*bPtr++));
+  }
+
+  *result = (short)dotProduct;
+}
+
+#endif /*LV_HAVE_AVX*/
+
+
 #ifdef LV_HAVE_SSE
 
 static inline void volk_32f_x2_dot_prod_16i_a_sse(int16_t* result, const  float* input, const  float* taps, unsigned int num_points) {

--- a/kernels/volk/volk_32f_x2_max_32f.h
+++ b/kernels/volk/volk_32f_x2_max_32f.h
@@ -112,6 +112,44 @@ volk_32f_x2_max_32f_a_sse(float* cVector, const float* aVector,
 #endif /* LV_HAVE_SSE */
 
 
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void
+volk_32f_x2_max_32f_a_avx(float* cVector, const float* aVector,
+                          const float* bVector, unsigned int num_points)
+{
+  unsigned int number = 0;
+  const unsigned int eigthPoints = num_points / 8;
+
+  float* cPtr = cVector;
+  const float* aPtr = aVector;
+  const float* bPtr=  bVector;
+
+  __m256 aVal, bVal, cVal;
+  for(;number < eigthPoints; number++){
+    aVal = _mm256_load_ps(aPtr);
+    bVal = _mm256_load_ps(bPtr);
+
+    cVal = _mm256_max_ps(aVal, bVal);
+
+    _mm256_store_ps(cPtr,cVal); // Store the results back into the C container
+
+    aPtr += 8;
+    bPtr += 8;
+    cPtr += 8;
+  }
+
+  number = eigthPoints * 8;
+  for(;number < num_points; number++){
+    const float a = *aPtr++;
+    const float b = *bPtr++;
+    *cPtr++ = ( a > b ? a : b);
+  }
+}
+#endif /* LV_HAVE_AVX */
+
+
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
 
@@ -180,3 +218,49 @@ volk_32f_x2_max_32f_u_orc(float* cVector, const float* aVector,
 
 
 #endif /* INCLUDED_volk_32f_x2_max_32f_a_H */
+
+
+#ifndef INCLUDED_volk_32f_x2_max_32f_u_H
+#define INCLUDED_volk_32f_x2_max_32f_u_H
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void
+volk_32f_x2_max_32f_u_avx(float* cVector, const float* aVector,
+                          const float* bVector, unsigned int num_points)
+{
+  unsigned int number = 0;
+  const unsigned int eigthPoints = num_points / 8;
+
+  float* cPtr = cVector;
+  const float* aPtr = aVector;
+  const float* bPtr=  bVector;
+
+  __m256 aVal, bVal, cVal;
+  for(;number < eigthPoints; number++){
+    aVal = _mm256_loadu_ps(aPtr);
+    bVal = _mm256_loadu_ps(bPtr);
+
+    cVal = _mm256_max_ps(aVal, bVal);
+
+    _mm256_storeu_ps(cPtr,cVal); // Store the results back into the C container
+
+    aPtr += 8;
+    bPtr += 8;
+    cPtr += 8;
+  }
+
+  number = eigthPoints * 8;
+  for(;number < num_points; number++){
+    const float a = *aPtr++;
+    const float b = *bPtr++;
+    *cPtr++ = ( a > b ? a : b);
+  }
+}
+#endif /* LV_HAVE_AVX */
+
+#endif /* INCLUDED_volk_32f_x2_max_32f_u_H */

--- a/kernels/volk/volk_32f_x2_min_32f.h
+++ b/kernels/volk/volk_32f_x2_min_32f.h
@@ -112,6 +112,44 @@ volk_32f_x2_min_32f_a_sse(float* cVector, const float* aVector,
 #endif /* LV_HAVE_SSE */
 
 
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void
+volk_32f_x2_min_32f_a_avx(float* cVector, const float* aVector,
+                          const float* bVector, unsigned int num_points)
+{
+  unsigned int number = 0;
+  const unsigned int eigthPoints = num_points / 8;
+
+  float* cPtr = cVector;
+  const float* aPtr = aVector;
+  const float* bPtr=  bVector;
+
+  __m256 aVal, bVal, cVal;
+  for(;number < eigthPoints; number++){
+    aVal = _mm256_load_ps(aPtr);
+    bVal = _mm256_load_ps(bPtr);
+
+    cVal = _mm256_min_ps(aVal, bVal);
+
+    _mm256_store_ps(cPtr,cVal); // Store the results back into the C container
+
+    aPtr += 8;
+    bPtr += 8;
+    cPtr += 8;
+  }
+
+  number = eigthPoints * 8;
+  for(;number < num_points; number++){
+    const float a = *aPtr++;
+    const float b = *bPtr++;
+    *cPtr++ = ( a < b ? a : b);
+  }
+}
+#endif /* LV_HAVE_AVX */
+
+
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
 
@@ -183,3 +221,49 @@ volk_32f_x2_min_32f_u_orc(float* cVector, const float* aVector,
 
 
 #endif /* INCLUDED_volk_32f_x2_min_32f_a_H */
+
+
+#ifndef INCLUDED_volk_32f_x2_min_32f_u_H
+#define INCLUDED_volk_32f_x2_min_32f_u_H
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void
+volk_32f_x2_min_32f_u_avx(float* cVector, const float* aVector,
+                          const float* bVector, unsigned int num_points)
+{
+  unsigned int number = 0;
+  const unsigned int eigthPoints = num_points / 8;
+
+  float* cPtr = cVector;
+  const float* aPtr = aVector;
+  const float* bPtr=  bVector;
+
+  __m256 aVal, bVal, cVal;
+  for(;number < eigthPoints; number++){
+    aVal = _mm256_loadu_ps(aPtr);
+    bVal = _mm256_loadu_ps(bPtr);
+
+    cVal = _mm256_min_ps(aVal, bVal);
+
+    _mm256_storeu_ps(cPtr,cVal); // Store the results back into the C container
+
+    aPtr += 8;
+    bPtr += 8;
+    cPtr += 8;
+  }
+
+  number = eigthPoints * 8;
+  for(;number < num_points; number++){
+    const float a = *aPtr++;
+    const float b = *bPtr++;
+    *cPtr++ = ( a < b ? a : b);
+  }
+}
+#endif /* LV_HAVE_AVX */
+
+#endif /* INCLUDED_volk_32f_x2_min_32f_u_H */


### PR DESCRIPTION
Adds AVX support to kernels:

1. `volk_32f_s32f_normalize`
2. `volk_32f_s32f_stddev_32f`
3. `volk_32f_sqrt_32f`
4. `volk_32f_x2_max_32f`
5. `volk_32f_x2_min_32f`
6. `32f_x2_divide_32f`
7. `32f_x2_dot_prod_16i`

Some relative speed improvements were shown
```
RUN_VOLK_TESTS: volk_32f_x2_divide_32f(131071,1987)
a_sse completed in 159.85ms
a_avx completed in 159.853ms
generic completed in 161.684ms
u_avx completed in 159.979ms
Best aligned arch: a_sse
Best unaligned arch: u_avx
RUN_VOLK_TESTS: volk_32f_x2_max_32f(131071,1987)
a_sse completed in 111.231ms
a_avx completed in 113.816ms
generic completed in 111.314ms
u_avx completed in 113.033ms
Best aligned arch: a_sse
Best unaligned arch: generic
RUN_VOLK_TESTS: volk_32f_x2_min_32f(131071,1987)
a_sse completed in 109.275ms
a_avx completed in 112.555ms
generic completed in 110.697ms
u_avx completed in 113.248ms
Best aligned arch: a_sse
Best unaligned arch: generic
RUN_VOLK_TESTS: volk_32f_s32f_normalize(131071,1987)
a_sse completed in 71.353ms
a_avx completed in 60.461ms
generic completed in 59.92ms
u_avx completed in 68.679ms
Best aligned arch: generic
Best unaligned arch: generic
RUN_VOLK_TESTS: volk_32f_sqrt_32f(131071,1987)
a_sse completed in 161.223ms
a_avx completed in 159.87ms
generic completed in 3569.91ms
Best aligned arch: a_avx
Best unaligned arch: generic
RUN_VOLK_TESTS: volk_32f_s32f_stddev_32f(131071,1987)
a_sse4_1 completed in 70.112ms
a_avx completed in 44.808ms
a_sse completed in 204.089ms
generic completed in 272.861ms
Best aligned arch: a_avx
Best unaligned arch: generic
RUN_VOLK_TESTS: volk_32f_x2_dot_prod_16i(131071,1987)
generic completed in 277.492ms
a_avx completed in 75.853ms
u_avx completed in 73.843ms
a_sse completed in 75.399ms
u_sse completed in 74.373ms
Best aligned arch: u_avx
Best unaligned arch: u_avx
```