### PR TITLE
added a NEON version of volk_8i_s32f_convert_32f

### DIFF
--- a/kernels/volk/volk_32fc_x2_add_32fc.h
+++ b/kernels/volk/volk_32fc_x2_add_32fc.h
@@ -250,18 +250,18 @@ volk_32fc_x2_add_32fc_u_neon(lv_32fc_t* cVector, const lv_32fc_t* aVector,
   lv_32fc_t* cPtr = cVector;
   const lv_32fc_t* aPtr = aVector;
   const lv_32fc_t* bPtr=  bVector;
-  lv_32fc_t32x4_t aVal, bVal, cVal;
-  for(number=0; number < quarterPoints; number++){
+  float32x4_t aVal, bVal, cVal;
+  for(number=0; number < halfPoints; number++){
     // Load in to NEON registers
-    aVal = vld1q_f32(aPtr);
-    bVal = vld1q_f32(bPtr);
+    aVal = vld1q_f32((const float32_t*)(aPtr));
+    bVal = vld1q_f32((const float32_t*)(bPtr));
     __VOLK_PREFETCH(aPtr+2);
     __VOLK_PREFETCH(bPtr+2);
 
     // vector add
     cVal = vaddq_f32(aVal, bVal);
     // Store the results back into the C container
-    vst1q_f32(cPtr,cVal);
+    vst1q_f32((float*)(cPtr),cVal);
 
     aPtr += 2; // q uses quadwords, 4 lv_32fc_ts per vadd
     bPtr += 2;


### PR DESCRIPTION
Tested on a beaglebone (debian 8, using gcc4.9.2, `Linux kiwisdr 4.4.9-ti-r25 #1 SMP Thu May 5 23:08:13 UTC 2016 armv7l GNU/Linux`)

```
RUN_VOLK_TESTS: volk_8i_s32f_convert_32f(131071,1987)
generic completed in 930.256ms
neon completed in 694.118ms
a_generic completed in 930.796ms
Best aligned arch: neon
Best unaligned arch: neon

RUN_VOLK_TESTS: volk_32fc_s32fc_multiply_32fc(131071,1987)
generic completed in 39817.5ms
neon completed in 5118.81ms
a_generic completed in 39721ms
Best aligned arch: neon
Best unaligned arch: neon

RUN_VOLK_TESTS: volk_32fc_x2_add_32fc(131071,1987)
generic completed in 6821.64ms
u_neon completed in 5830.23ms
Best aligned arch: u_neon
Best unaligned arch: u_neon
```

