### PR TITLE
Includes for GCC 7.2 compatibility

### DIFF
--- a/apps/volk_option_helpers.h
+++ b/apps/volk_option_helpers.h
@@ -6,6 +6,8 @@
 #define VOLK_VOLK_OPTION_HELPERS_H
 
 #include <string>
+#include <cstring>
+#include <limits.h>
 #include <vector>
 #include <map>
 


### PR DESCRIPTION
Just tried VOLK on a fresh Ubuntu 18.04 install and wouldn't compile with GCC 7.2. These includes fixed it.