### PR TITLE
Redundant argument fix

### DIFF
--- a/include/volk/volk_avx_intrinsics.h
+++ b/include/volk/volk_avx_intrinsics.h
@@ -68,4 +68,39 @@ _mm256_magnitude_ps(__m256 cplxValue1, __m256 cplxValue2){
   return _mm256_sqrt_ps(_mm256_magnitudesquared_ps(cplxValue1, cplxValue2));
 }
 
+static inline __m256
+_mm256_polar_sign_mask(__m128i fbits){
+  __m256 sign_mask_dummy = _mm256_setzero_ps();
+  const __m128i zeros = _mm_set1_epi8(0x00);
+  const __m128i sign_extract = _mm_set1_epi8(0x80);
+  const __m128i shuffle_mask0 = _mm_setr_epi8(0xff, 0xff, 0xff, 0x00, 0xff, 0xff, 0xff, 0x01, 0xff, 0xff, 0xff, 0x02, 0xff, 0xff, 0xff, 0x03);
+  const __m128i shuffle_mask1 = _mm_setr_epi8(0xff, 0xff, 0xff, 0x04, 0xff, 0xff, 0xff, 0x05, 0xff, 0xff, 0xff, 0x06, 0xff, 0xff, 0xff, 0x07);
+
+  fbits = _mm_cmpgt_epi8(fbits, zeros);
+  fbits = _mm_and_si128(fbits, sign_extract);
+  __m128i sign_bits0 = _mm_shuffle_epi8(fbits, shuffle_mask0);
+  __m128i sign_bits1 = _mm_shuffle_epi8(fbits, shuffle_mask1);
+
+  __m256 sign_mask = _mm256_insertf128_ps(sign_mask_dummy, _mm_castsi128_ps(sign_bits0), 0x0);
+  return _mm256_insertf128_ps(sign_mask, _mm_castsi128_ps(sign_bits1), 0x1);
+}
+
+static inline __m256
+_mm256_polar_stage_llrs(__m256 src0, __m256 src1){
+    const __m256 sign_mask = _mm256_set1_ps(-0.0);
+    const __m256 abs_mask = _mm256_andnot_ps(sign_mask, _mm256_castsi256_ps(_mm256_set1_epi8(0xff)));
+    // deinterleave values
+    __m256 part0 = _mm256_permute2f128_ps(src0, src1, 0x20);
+    __m256 part1 = _mm256_permute2f128_ps(src0, src1, 0x31);
+    __m256 llr0 = _mm256_shuffle_ps(part0, part1, 0x88);
+    __m256 llr1 = _mm256_shuffle_ps(part0, part1, 0xdd);
+
+    // calculate result
+    __m256 sign = _mm256_xor_ps(_mm256_and_ps(llr0, sign_mask), _mm256_and_ps(llr1, sign_mask));
+    __m256 dst = _mm256_min_ps(_mm256_and_ps(llr0, abs_mask), _mm256_and_ps(llr1, abs_mask));
+    return _mm256_or_ps(dst, sign);
+}
+
+
+
 #endif /* INCLUDE_VOLK_VOLK_AVX_INTRINSICS_H_ */

--- a/include/volk/volk_avx_intrinsics.h
+++ b/include/volk/volk_avx_intrinsics.h
@@ -83,6 +83,9 @@ _mm256_polar_sign_mask(__m128i fbits){
 
   __m256 sign_mask = _mm256_insertf128_ps(sign_mask_dummy, _mm_castsi128_ps(sign_bits0), 0x0);
   return _mm256_insertf128_ps(sign_mask, _mm_castsi128_ps(sign_bits1), 0x1);
+//  // This is the desired function call. Though it seems to be missing in GCC.
+//  // Compare: https://software.intel.com/sites/landingpage/IntrinsicsGuide/#
+//  return _mm256_set_m128(_mm_castsi128_ps(sign_bits1), _mm_castsi128_ps(sign_bits0));
 }
 
 static inline void

--- a/kernels/volk/volk_32f_8u_polarbutterfly_32f.h
+++ b/kernels/volk/volk_32f_8u_polarbutterfly_32f.h
@@ -68,9 +68,6 @@
  * \endcode
  */
 
-//#ifndef LV_HAVE_AVX
-//#define LV_HAVE_AVX
-//#endif
 
 #ifndef VOLK_KERNELS_VOLK_VOLK_32F_8U_POLARBUTTERFLY_32F_H_
 #define VOLK_KERNELS_VOLK_VOLK_32F_8U_POLARBUTTERFLY_32F_H_
@@ -80,8 +77,8 @@
 static inline float
 llr_odd(const float la, const float lb)
 {
-  const float ala = fabs(la);
-  const float alb = fabs(lb);
+  const float ala = fabsf(la);
+  const float alb = fabsf(lb);
   return copysignf(1.0f, la) * copysignf(1.0f, lb) * (ala > alb ? alb : ala);
 }
 
@@ -160,7 +157,7 @@ calculate_max_stage_depth_for_row(const int frame_exp, const int row)
 
 static inline void
 volk_32f_8u_polarbutterfly_32f_generic(float* llrs, unsigned char* u,
-    const int frame_size_dummy, const int frame_exp,
+    const int frame_exp,
     const int stage, const int u_num, const int row)
 {
   const int frame_size = 0x01 << frame_exp;
@@ -194,16 +191,17 @@ volk_32f_8u_polarbutterfly_32f_generic(float* llrs, unsigned char* u,
   if(frame_exp > next_stage){
     unsigned char* u_half = u + frame_size;
     odd_xor_even_values(u_half, u, u_num);
-    volk_32f_8u_polarbutterfly_32f_generic(next_llrs, u_half, frame_size, frame_exp, next_stage, u_num, next_upper_row);
+    volk_32f_8u_polarbutterfly_32f_generic(next_llrs, u_half, frame_exp, next_stage, u_num, next_upper_row);
 
     even_u_values(u_half, u, u_num);
-    volk_32f_8u_polarbutterfly_32f_generic(next_llrs, u_half, frame_size, frame_exp, next_stage, u_num, next_lower_row);
+    volk_32f_8u_polarbutterfly_32f_generic(next_llrs, u_half, frame_exp, next_stage, u_num, next_lower_row);
   }
 
   *call_row_llr = llr_odd(*upper_right_llr_ptr, *lower_right_llr_ptr);
 }
 
 #endif /* LV_HAVE_GENERIC */
+
 
 #ifdef LV_HAVE_AVX
 #include <immintrin.h>
@@ -219,7 +217,7 @@ volk_32f_8u_polarbutterfly_32f_generic(float* llrs, unsigned char* u,
 
 static inline void
 volk_32f_8u_polarbutterfly_32f_u_avx(float* llrs, unsigned char* u,
-    const int frame_size_dummy, const int frame_exp,
+    const int frame_exp,
     const int stage, const int u_num, const int row)
 {
   const int frame_size = 0x01 << frame_exp;
@@ -231,7 +229,7 @@ volk_32f_8u_polarbutterfly_32f_u_avx(float* llrs, unsigned char* u,
 
   const int max_stage_depth = calculate_max_stage_depth_for_row(frame_exp, row);
   if(max_stage_depth < 3){ // vectorized version needs larger vectors.
-    volk_32f_8u_polarbutterfly_32f_generic(llrs, u, frame_size, frame_exp, stage, u_num, row);
+    volk_32f_8u_polarbutterfly_32f_generic(llrs, u, frame_exp, stage, u_num, row);
     return;
   }
 

--- a/kernels/volk/volk_32f_8u_polarbutterflypuppet_32f.h
+++ b/kernels/volk/volk_32f_8u_polarbutterflypuppet_32f.h
@@ -100,7 +100,7 @@ volk_32f_8u_polarbutterflypuppet_32f_generic(float* llrs, const float* input, un
 
   unsigned int u_num = 0;
   for(; u_num < frame_size; u_num++){
-    volk_32f_8u_polarbutterfly_32f_generic(llrs, u, frame_size, frame_exp, 0, u_num, u_num);
+    volk_32f_8u_polarbutterfly_32f_generic(llrs, u, elements, frame_exp, 0, u_num, u_num);
     u[u_num] = llrs[u_num] > 0 ? 0 : 1;
   }
 
@@ -120,7 +120,7 @@ volk_32f_8u_polarbutterflypuppet_32f_u_avx(float* llrs, const float* input, unsi
 
   unsigned int u_num = 0;
   for(; u_num < frame_size; u_num++){
-    volk_32f_8u_polarbutterfly_32f_u_avx(llrs, u, frame_size, frame_exp, 0, u_num, u_num);
+    volk_32f_8u_polarbutterfly_32f_u_avx(llrs, u, elements, frame_exp, 0, u_num, u_num);
     u[u_num] = llrs[u_num] > 0 ? 0 : 1;
   }
 

--- a/kernels/volk/volk_32f_8u_polarbutterflypuppet_32f.h
+++ b/kernels/volk/volk_32f_8u_polarbutterflypuppet_32f.h
@@ -100,7 +100,7 @@ volk_32f_8u_polarbutterflypuppet_32f_generic(float* llrs, const float* input, un
 
   unsigned int u_num = 0;
   for(; u_num < frame_size; u_num++){
-    volk_32f_8u_polarbutterfly_32f_generic(llrs, u, elements, frame_exp, 0, u_num, u_num);
+    volk_32f_8u_polarbutterfly_32f_generic(llrs, u, frame_exp, 0, u_num, u_num);
     u[u_num] = llrs[u_num] > 0 ? 0 : 1;
   }
 
@@ -120,7 +120,7 @@ volk_32f_8u_polarbutterflypuppet_32f_u_avx(float* llrs, const float* input, unsi
 
   unsigned int u_num = 0;
   for(; u_num < frame_size; u_num++){
-    volk_32f_8u_polarbutterfly_32f_u_avx(llrs, u, elements, frame_exp, 0, u_num, u_num);
+    volk_32f_8u_polarbutterfly_32f_u_avx(llrs, u, frame_exp, 0, u_num, u_num);
     u[u_num] = llrs[u_num] > 0 ? 0 : 1;
   }
 


### PR DESCRIPTION
These patches aim to fix issue #141 
Fixed issues:
- Redundant argument `frame_size` was removed. Changes API -> how to proceed?
- replaced `fabs` by `fabsf`
- refactored code for better readability.

This PR should serve as a baseline for further discussion.

For now, these bulletpoints are considered nonissues:
- `calculate_max_stage_depth_for_row` without loop. Any ideas how to express this more elegantly?
- `copysignf(1.0f, la) * copysignf(1.0f, lb) * (ala > alb ? alb : ala)` is actually the exact MinSum approximation formula. It says: `sign(a) * sign(b) * min(abs(a), abs(b))`.

Since the original issue was to fix test failures with GCC7.x this PR might need more commits and discussion. Though, flushing the SIMD units between the two major loops might fix this issue as well.