### PR TITLE
apps: fix #include's for volk_option_helpers

### DIFF
--- a/apps/volk_option_helpers.cc
+++ b/apps/volk_option_helpers.cc
@@ -4,6 +4,9 @@
 
 #include "volk_option_helpers.h"
 
+#include <limits.h>
+#include <string.h>
+
 #include <iostream>
 
 /*


### PR DESCRIPTION
Needed mostly for older Mac OS X; shouldn't hurt others.

At least on Mac OS X / macOS:
"INT_MIN" comes from <limits.h>
"strncmp" comes from <string.h>