### PR TITLE
tests: split testcases in ctest for granualar failure reports

### DIFF
--- a/cmake/Modules/VolkAddTest.cmake
+++ b/cmake/Modules/VolkAddTest.cmake
@@ -23,23 +23,39 @@ endif()
 set(__INCLUDED_VOLK_ADD_TEST TRUE)
 
 ########################################################################
+# Generate a test executable which can be used in ADD_TEST to call
+# various subtests.
+#
+# SOURCES        - sources for the test
+# TARGET_DEPS    - build target dependencies (e.g., libraries)
+########################################################################
+
+function(VOLK_GEN_TEST executable_name)
+    include(CMakeParseArgumentsCopy)
+    CMAKE_PARSE_ARGUMENTS(VOLK_TEST "" "" "SOURCES;TARGET_DEPS;EXTRA_LIB_DIRS;ENVIRONS;ARGS" ${ARGN})
+    add_executable(${executable_name} ${VOLK_TEST_SOURCES})
+    target_link_libraries(${executable_name} ${VOLK_TEST_TARGET_DEPS})
+endfunction()
+
+########################################################################
 # Add a unit test and setup the environment for it.
 # Encloses ADD_TEST, with additional functionality to create a shell
 # script that sets the environment to gain access to in-build binaries
 # properly. The following variables are used to pass in settings:
+# A test executable has to be generated with VOLK_GEN_TEST beforehand.
+# The executable name has to be passed as argument.
 #
 # NAME           - the test name
-# SOURCES        - sources for the test
 # TARGET_DEPS    - build target dependencies (e.g., libraries)
 # EXTRA_LIB_DIRS - other directories for the library path
 # ENVIRONS       - other environment key/value pairs
 # ARGS           - arguments for the test
 ########################################################################
-function(VOLK_ADD_TEST test_name)
+function(VOLK_ADD_TEST test_name executable_name)
 
   #parse the arguments for component names
   include(CMakeParseArgumentsCopy)
-  CMAKE_PARSE_ARGUMENTS(VOLK_TEST "" "" "SOURCES;TARGET_DEPS;EXTRA_LIB_DIRS;ENVIRONS;ARGS" ${ARGN})
+  CMAKE_PARSE_ARGUMENTS(VOLK_TEST "" "" "TARGET_DEPS;EXTRA_LIB_DIRS;ENVIRONS;ARGS" ${ARGN})
 
   #set the initial environs to use
   set(environs ${VOLK_TEST_ENVIRONS})
@@ -65,7 +81,7 @@ function(VOLK_ADD_TEST test_name)
     #"add_test" command, via the $<FOO:BAR> operator; make sure the
     #test's directory is first, since it ($1) is prepended to PATH.
     unset(TARGET_DIR_LIST)
-    foreach(target ${test_name} ${VOLK_TEST_TARGET_DEPS})
+    foreach(target ${executable_name} ${VOLK_TEST_TARGET_DEPS})
       list(APPEND TARGET_DIR_LIST "\$<TARGET_FILE_DIR:${target}>")
     endforeach()
 
@@ -134,17 +150,16 @@ function(VOLK_ADD_TEST test_name)
       file(APPEND ${sh_file} "export ${environ}\n")
     endforeach(environ)
 
+    set(VOLK_TEST_ARGS "${test_name}")
+
     #redo the test args to have a space between each
     string(REPLACE ";" " " VOLK_TEST_ARGS "${VOLK_TEST_ARGS}")
 
     #finally: append the test name to execute
-    file(APPEND ${sh_file} "${CMAKE_CROSSCOMPILING_EMULATOR} ${test_name} ${VOLK_TEST_ARGS}\n")
+    file(APPEND ${sh_file} "${CMAKE_CROSSCOMPILING_EMULATOR} ${executable_name} ${VOLK_TEST_ARGS}\n")
 
     #make the shell file executable
     execute_process(COMMAND chmod +x ${sh_file})
-
-    add_executable(${test_name} ${VOLK_TEST_SOURCES})
-    target_link_libraries(${test_name} ${VOLK_TEST_TARGET_DEPS})
 
     #add the shell file as the test to execute;
     #use the form that allows for $<FOO:BAR> substitutions,
@@ -195,9 +210,6 @@ function(VOLK_ADD_TEST test_name)
     #finally: append the test name to execute
     file(APPEND ${bat_file} ${test_name} " " ${VOLK_TEST_ARGS} "\n")
     file(APPEND ${bat_file} "\n")
-
-    add_executable(${test_name} ${VOLK_TEST_SOURCES})
-    target_link_libraries(${test_name} ${VOLK_TEST_TARGET_DEPS})
 
     add_test(${test_name} ${bat_file})
   endif(WIN32)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -201,7 +201,7 @@ if(CPU_IS_x86)
         file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/test_cvtpi32_ps
           ${CMAKE_CURRENT_BINARY_DIR}/test_cvtpi32_ps.c)
     else(CMAKE_SIZEOF_VOID_P EQUAL 4)
-	    # 64-bit compilations won't need this command so don't overrule AVX 
+	    # 64-bit compilations won't need this command so don't overrule AVX
 	    set(HAVE_AVX_CVTPI32_PS 0)
     endif(CMAKE_SIZEOF_VOID_P EQUAL 4)
 
@@ -619,10 +619,15 @@ if(ENABLE_TESTING)
     )
 
     include(VolkAddTest)
-    VOLK_ADD_TEST(volk_test_all
+    VOLK_GEN_TEST("volk_test_all"
         SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/testqa.cc
-                       ${CMAKE_CURRENT_SOURCE_DIR}/qa_utils.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/qa_utils.cc
         TARGET_DEPS volk
-    )
+      )
+    foreach(kernel ${h_files})
+      get_filename_component(kernel ${kernel} NAME)
+      string(REPLACE ".h" "" kernel ${kernel})
+      VOLK_ADD_TEST(${kernel} "volk_test_all")
+    endforeach()
 
 endif(ENABLE_TESTING)

--- a/lib/testqa.cc
+++ b/lib/testqa.cc
@@ -34,7 +34,7 @@
 
 void print_qa_xml(std::vector<volk_test_results_t> results, unsigned int nfails);
 
-int main()
+int main(int argc, char* argv[])
 {
     bool qa_ret_val = 0;
 
@@ -48,41 +48,58 @@ int main()
     volk_test_params_t test_params(def_tol, def_scalar, def_vlen, def_iter,
         def_benchmark_mode, def_kernel_regex);
     std::vector<volk_test_case_t> test_cases = init_test_list(test_params);
-
-    std::vector<std::string> qa_failures;
     std::vector<volk_test_results_t> results;
-    // Test every kernel reporting failures when they occur
-    for(unsigned int ii = 0; ii < test_cases.size(); ++ii) {
-        bool qa_result = false;
-        volk_test_case_t test_case = test_cases[ii];
-        try {
-            qa_result = run_volk_tests(test_case.desc(), test_case.kernel_ptr(), test_case.name(),
-                test_case.test_parameters(), &results, test_case.puppet_master_name());
-        }
-        catch(...) {
-            // TODO: what exceptions might we need to catch and how do we handle them?
-            std::cerr << "Exception found on kernel: " << test_case.name() << std::endl;
-            qa_result = false;
+
+    if (argc > 1){
+        for(unsigned int ii = 0; ii < test_cases.size(); ++ii){
+            if (std::string(argv[1]) == test_cases[ii].name()){
+                volk_test_case_t test_case = test_cases[ii];
+                if (run_volk_tests(test_case.desc(), test_case.kernel_ptr(),
+                                   test_case.name(),
+                                   test_case.test_parameters(), &results,
+                                   test_case.puppet_master_name())) {
+                  return 1;
+                } else {
+                  return 0;
+                }
+            }
         }
 
-        if(qa_result) {
-            std::cerr << "Failure on " << test_case.name() << std::endl;
-            qa_failures.push_back(test_case.name());
-        }
-    }
+    }else{
+        std::vector<std::string> qa_failures;
+        // Test every kernel reporting failures when they occur
+        for(unsigned int ii = 0; ii < test_cases.size(); ++ii) {
+            bool qa_result = false;
+            volk_test_case_t test_case = test_cases[ii];
+            try {
+                qa_result = run_volk_tests(test_case.desc(), test_case.kernel_ptr(), test_case.name(),
+                                           test_case.test_parameters(), &results, test_case.puppet_master_name());
+            }
+            catch(...) {
+                // TODO: what exceptions might we need to catch and how do we handle them?
+                std::cerr << "Exception found on kernel: " << test_case.name() << std::endl;
+                qa_result = false;
+            }
 
-    // Generate XML results
-    print_qa_xml(results, qa_failures.size());
-
-    // Summarize QA results
-    std::cerr << "Kernel QA finished: " << qa_failures.size() << " failures out of "
-        << test_cases.size() << " tests." << std::endl;
-    if(qa_failures.size() > 0) {
-        std::cerr << "The following kernels failed QA:" << std::endl;
-        for(unsigned int ii = 0; ii < qa_failures.size(); ++ii) {
-            std::cerr << "    " << qa_failures[ii] << std::endl;
+            if(qa_result) {
+                std::cerr << "Failure on " << test_case.name() << std::endl;
+                qa_failures.push_back(test_case.name());
+            }
         }
-        qa_ret_val = 1;
+
+        // Generate XML results
+        print_qa_xml(results, qa_failures.size());
+
+        // Summarize QA results
+        std::cerr << "Kernel QA finished: " << qa_failures.size() << " failures out of "
+                  << test_cases.size() << " tests." << std::endl;
+        if(qa_failures.size() > 0) {
+            std::cerr << "The following kernels failed QA:" << std::endl;
+            for(unsigned int ii = 0; ii < qa_failures.size(); ++ii) {
+                std::cerr << "    " << qa_failures[ii] << std::endl;
+            }
+            qa_ret_val = 1;
+        }
     }
 
     return qa_ret_val;

--- a/lib/testqa.cc
+++ b/lib/testqa.cc
@@ -64,6 +64,8 @@ int main(int argc, char* argv[])
                 }
             }
         }
+        std::cerr << "Did not run a test for kernel: " << std::string(argv[1]) << " !" << std::endl;
+        return 0;
 
     }else{
         std::vector<std::string> qa_failures;


### PR DESCRIPTION
Previously one would have to parse the output of ctest -V or ctest
--output-on-failure to understand which tests failed.

Leveraging integration into ctest we can use one executable and use
commandline arguments to call various subtestcases to integrate better
with ctest