### PR TITLE
added ARM version of volk_32u_reverse_32u (RBIT)

### DIFF
--- a/kernels/volk/volk_32u_reverse_32u.h
+++ b/kernels/volk/volk_32u_reverse_32u.h
@@ -332,5 +332,36 @@ static inline void volk_32u_reverse_32u_bintree_permute_bottom_up(uint32_t* out,
   }
 }
 #endif /* LV_HAVE_GENERIC */
+
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+
+#define DO_RBIT                                          \
+    asm("rbit %1,%0" : "=r" (*out_ptr) : "r" (*in_ptr)); \
+    in_ptr++;                                            \
+    out_ptr++;
+
+static inline void volk_32u_reverse_32u_arm(uint32_t* out, const uint32_t* in,
+                                            unsigned int num_points)
+{
+
+    const uint32_t *in_ptr = in;
+    uint32_t *out_ptr = out;
+    const unsigned int eighthPoints = num_points/8;
+    unsigned int number = 0;
+    for(; number < eighthPoints; ++number){
+        __VOLK_PREFETCH(in_ptr+8);
+        DO_RBIT; DO_RBIT; DO_RBIT; DO_RBIT;
+        DO_RBIT; DO_RBIT; DO_RBIT; DO_RBIT;
+    }
+    number = eighthPoints*8;
+    for(; number < num_points; ++number){
+        DO_RBIT;
+    }
+}
+#undef DO_RBIT
+#endif /* LV_HAVE_NEON */
+
+
 #endif /* INCLUDED_volk_32u_reverse_32u_u_H */
 


### PR DESCRIPTION
On ARM there is the RBIT instruction which according to https://hardwarebug.org/2014/05/15/cortex-a7-instruction-cycle-timings/ takes one cycle and has a latency of two cycles.

This is not SIMD but it nevertheless improves the performance. Please comment on the naming (_arm vs. _neon).

Test results on a beaglebone:
```
RUN_VOLK_TESTS: volk_32u_reverse_32u(131071,100)
dword_shuffle completed in 1973ms
byte_shuffle completed in 2440.86ms
lut completed in 327.8ms
2001magic completed in 2738.04ms
1972magic completed in 11533.7ms
bintree_permute_top_down completed in 352.374ms
bintree_permute_bottom_up completed in 279.127ms
arm completed in 211.525ms
Best aligned arch: arm
Best unaligned arch: arm
```
