### PR TITLE
Fix kernel generation with python3

### DIFF
--- a/gen/volk_kernel_defs.py
+++ b/gen/volk_kernel_defs.py
@@ -25,6 +25,7 @@ import os
 import re
 import sys
 import glob
+import io
 
 ########################################################################
 # Strip comments from a c/cpp file.
@@ -164,7 +165,8 @@ class kernel_class:
     def __init__(self, kernel_file):
         self.name = os.path.splitext(os.path.basename(kernel_file))[0]
         self.pname = self.name.replace('volk_', 'p_')
-        code = open(kernel_file, 'r').read()
+        # io.open for python2 compat with `encoding=`
+        code = io.open(kernel_file, 'rt', encoding='utf-8').read()
         code = comment_remover(code)
         sections = split_into_nested_ifdef_sections(code)
         self._impls = list()


### PR DESCRIPTION
Python3 tries to guess the file encoding, and guesses incorrectly for some volk kernel files which causes errors. This PR sets the encoding to UTF-8 (and also explicitly opens the file in text-read mode). 

Using `io.open` as opposed to `open` allows this code to work in both py2 and py3 (py2 doesnt have `open(encoding=...)`, but is slower than plain `open` on both. When py2 support is dropped, this should be changed to `open(...`

(closing until i finish testing as it breaks py2 due to io.open returning a unicode string)
[Error in question.](https://gist.github.com/lukeadams/7548b260c5c31d35e25dd87b676b62b2)