### PR TITLE
Misc. comment typos

### DIFF
--- a/docs/terms_and_techniques.dox
+++ b/docs/terms_and_techniques.dox
@@ -42,7 +42,7 @@ Add new kernels to the list in lib/kernel_tests.h. This adds the kernel to
 VOLK's QA tool as well as the volk profiler. Many kernels are able to
 share test parameters, but new kernels might need new ones.
 
-If the VOLK kernel does not 'fit' the the standard set of function parameters
+If the VOLK kernel does not 'fit' the standard set of function parameters
 expected by the volk_profile structure, you need to create a VOLK puppet
 function to help the profiler call the kernel. This is essentially due to the
 function run_volk_tests which has a limited number of function prototypes that

--- a/kernels/volk/volk_16u_byteswap.h
+++ b/kernels/volk/volk_16u_byteswap.h
@@ -256,7 +256,7 @@ static inline void volk_16u_byteswap_neon_table(uint16_t* intsToSwap, unsigned i
   uint8x8_t int_lookup01, int_lookup23, int_lookup45, int_lookup67;
   uint8x8_t swapped_int01, swapped_int23, swapped_int45, swapped_int67;
 
-  /* these magic numbers are used as byte-indeces in the LUT.
+  /* these magic numbers are used as byte-indices in the LUT.
      they are pre-computed to save time. A simple C program
      can calculate them; for example for lookup01:
     uint8_t chars[8] = {24, 16, 8, 0, 25, 17, 9, 1};

--- a/kernels/volk/volk_32u_byteswap.h
+++ b/kernels/volk/volk_32u_byteswap.h
@@ -162,7 +162,7 @@ static inline void volk_32u_byteswap_neon(uint32_t* intsToSwap, unsigned int num
   uint8x8_t int_lookup01, int_lookup23, int_lookup45, int_lookup67;
   uint8x8_t swapped_int01, swapped_int23, swapped_int45, swapped_int67;
 
-  /* these magic numbers are used as byte-indeces in the LUT.
+  /* these magic numbers are used as byte-indices in the LUT.
      they are pre-computed to save time. A simple C program
      can calculate them; for example for lookup01:
     uint8_t chars[8] = {24, 16, 8, 0, 25, 17, 9, 1};

--- a/kernels/volk/volk_64u_byteswap.h
+++ b/kernels/volk/volk_64u_byteswap.h
@@ -250,7 +250,7 @@ static inline void volk_64u_byteswap_neon(uint64_t* intsToSwap, unsigned int num
   uint8x8_t int_lookup01, int_lookup23, int_lookup45, int_lookup67;
   uint8x8_t swapped_int01, swapped_int23, swapped_int45, swapped_int67;
 
-  /* these magic numbers are used as byte-indeces in the LUT.
+  /* these magic numbers are used as byte-indices in the LUT.
      they are pre-computed to save time. A simple C program
      can calculate them; for example for lookup01:
     uint8_t chars[8] = {24, 16, 8, 0, 25, 17, 9, 1};


### PR DESCRIPTION
Found via `codespell` via downstream `gnuradio`