### PR TITLE
Python 3 compatibility fixes to allow volk_modtool to import

### DIFF
--- a/cmake/Modules/VolkPython.cmake
+++ b/cmake/Modules/VolkPython.cmake
@@ -202,7 +202,7 @@ function(VOLK_PYTHON_INSTALL)
             add_custom_command(
                 OUTPUT ${pyexefile} DEPENDS ${pyfile}
                 COMMAND ${PYTHON_EXECUTABLE} -c
-                "open('${pyexefile}','w').write('\#!${pyexe_native}\\n'+open('${pyfile}').read())"
+                "open('${pyexefile}','w').write(r'\#!${pyexe_native}'+'\\n'+open('${pyfile}').read())"
                 COMMENT "Shebangin ${pyfile_name}"
                 VERBATIM
             )

--- a/gen/volk_arch_defs.py
+++ b/gen/volk_arch_defs.py
@@ -22,7 +22,7 @@ import six
 archs = list()
 arch_dict = dict()
 
-class arch_class:
+class arch_class(object):
     def __init__(self, flags, checks, **kwargs):
         for key, cast, failval in (
             ('name', str, None),

--- a/gen/volk_kernel_defs.py
+++ b/gen/volk_kernel_defs.py
@@ -118,7 +118,7 @@ def flatten_section_text(sections):
 ########################################################################
 # Extract kernel info from section, represent as an implementation
 ########################################################################
-class impl_class:
+class impl_class(object):
     def __init__(self, kern_name, header, body):
         #extract LV_HAVE_*
         self.deps = set(res.lower() for res in re.findall(r'LV_HAVE_(\w+)', header))
@@ -160,7 +160,7 @@ def extract_lv_haves(code):
 ########################################################################
 # Represent a processing kernel, parse from file
 ########################################################################
-class kernel_class:
+class kernel_class(object):
     def __init__(self, kernel_file):
         self.name = os.path.splitext(os.path.basename(kernel_file))[0]
         self.pname = self.name.replace('volk_', 'p_')

--- a/gen/volk_machine_defs.py
+++ b/gen/volk_machine_defs.py
@@ -24,7 +24,7 @@ from volk_arch_defs import arch_dict
 machines = list()
 machine_dict = dict()
 
-class machine_class:
+class machine_class(object):
     def __init__(self, name, archs):
         self.name = name
         self.archs = list()
@@ -34,7 +34,7 @@ class machine_class:
             arch = arch_dict[arch_name]
             self.archs.append(arch)
             self.arch_names.append(arch_name)
-        self.alignment = max(map(lambda a: a.alignment, self.archs))
+        self.alignment = max([a.alignment for a in self.archs])
 
     def __repr__(self): return self.name
 

--- a/python/volk_modtool/__init__.py
+++ b/python/volk_modtool/__init__.py
@@ -20,5 +20,5 @@
 # Boston, MA 02110-1301, USA.
 #
 
-from cfg import volk_modtool_config
-from volk_modtool_generate import volk_modtool
+from .cfg import volk_modtool_config
+from .volk_modtool_generate import volk_modtool

--- a/python/volk_modtool/cfg.py
+++ b/python/volk_modtool/cfg.py
@@ -22,14 +22,15 @@
 
 from __future__ import print_function
 
-import ConfigParser
 import sys
 import os
 import exceptions
 import re
 
+from six.moves import configparser, input
 
-class volk_modtool_config:
+
+class volk_modtool_config(object):
     def key_val_sub(self, num, stuff, section):
         return re.sub(r'\$' + 'k' + str(num), stuff[num][0], (re.sub(r'\$' + str(num), stuff[num][1], section[1][num])));
 
@@ -67,7 +68,7 @@ class volk_modtool_config:
         self.remapification = [(self.config_name, self.config_defaults_remap)]
         self.verification = [(self.config_name, self.config_defaults_verify)]
         default = os.path.join(os.getcwd(), 'volk_modtool.cfg')
-        icfg = ConfigParser.RawConfigParser()
+        icfg = configparser.RawConfigParser()
         if cfg:
             icfg.read(cfg)
         elif os.path.exists(default):
@@ -76,7 +77,7 @@ class volk_modtool_config:
             print("Initializing config file...")
             icfg.add_section(self.config_name)
             for kn in self.config_defaults:
-                rv = raw_input("%s: "%(kn))
+                rv = input("%s: "%(kn))
                 icfg.set(self.config_name, kn, rv)
         self.cfg = icfg
         self.remap()

--- a/python/volk_modtool/cfg.py
+++ b/python/volk_modtool/cfg.py
@@ -24,7 +24,6 @@ from __future__ import print_function
 
 import sys
 import os
-import exceptions
 import re
 
 from six.moves import configparser, input
@@ -48,11 +47,11 @@ class volk_modtool_config(object):
             try:
                val = eval(self.key_val_sub(i, stuff, section))
                if val == False:
-                   raise exceptions.ValueError
+                   raise ValueError
             except ValueError:
-                raise exceptions.ValueError('Verification function returns False... key:%s, val:%s'%(stuff[i][0], stuff[i][1]))
+                raise ValueError('Verification function returns False... key:%s, val:%s'%(stuff[i][0], stuff[i][1]))
             except:
-                raise exceptions.IOError('bad configuration... key:%s, val:%s'%(stuff[i][0], stuff[i][1]))
+                raise IOError('bad configuration... key:%s, val:%s'%(stuff[i][0], stuff[i][1]))
 
 
     def __init__(self, cfg=None):

--- a/python/volk_modtool/volk_modtool
+++ b/python/volk_modtool/volk_modtool
@@ -24,7 +24,6 @@ from __future__ import print_function
 from volk_modtool import volk_modtool, volk_modtool_config
 from optparse import OptionParser, OptionGroup
 
-import exceptions
 import os
 import sys
 
@@ -80,7 +79,7 @@ if __name__ == '__main__':
 
         if options.add_kernel:
             if not options.kernel_name:
-                raise exceptions.IOError("This action requires the -n option.");
+                raise IOError("This action requires the -n option.");
             else:
                 name = options.kernel_name;
             if options.base_path:
@@ -91,7 +90,7 @@ if __name__ == '__main__':
 
         if options.remove_kernel:
             if not options.kernel_name:
-                raise exceptions.IOError("This action requires the -n option.");
+                raise IOError("This action requires the -n option.");
             else:
                 name = options.kernel_name;
             my_modtool.remove_kernel(name);
@@ -108,7 +107,7 @@ if __name__ == '__main__':
 
         if options.remote_list:
             if not options.base_path:
-                raise exceptions.IOError("This action requires the -b option.  Try -l or -k for listing kernels in the base or the module.")
+                raise IOError("This action requires the -b option.  Try -l or -k for listing kernels in the base or the module.")
             else:
                 base = options.base_path;
             kernelset = my_modtool.get_current_kernels(base);

--- a/python/volk_modtool/volk_modtool
+++ b/python/volk_modtool/volk_modtool
@@ -20,6 +20,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
+from __future__ import print_function
 from volk_modtool import volk_modtool, volk_modtool_config
 from optparse import OptionParser, OptionGroup
 
@@ -59,12 +60,12 @@ if __name__ == '__main__':
         parser.print_help()
 
     elif options.moo:
-        print "         (__)    "
-        print "         (oo)    "
-        print "   /------\/     "
-        print "  / |    ||      "
-        print " *  /\---/\      "
-        print "    ~~   ~~      "
+        print("         (__)    ")
+        print("         (oo)    ")
+        print("   /------\/     ")
+        print("  / |    ||      ")
+        print(" *  /\---/\      ")
+        print("    ~~   ~~      ")
 
     else:
         my_cfg = volk_modtool_config(options.config_file);
@@ -112,12 +113,12 @@ if __name__ == '__main__':
                 base = options.base_path;
             kernelset = my_modtool.get_current_kernels(base);
             for i in kernelset:
-                print i;
+                print(i);
 
         if options.list:
             kernelset = my_modtool.get_current_kernels();
             for i in kernelset:
-                print i;
+                print(i);
 
         if options.kernels:
             dest = my_cfg.cfg.get(my_cfg.config_name, 'destination');
@@ -125,4 +126,4 @@ if __name__ == '__main__':
             base = os.path.join(dest, 'volk_' + name);
             kernelset = my_modtool.get_current_kernels(base);
             for i in kernelset:
-                print i;
+                print(i);

--- a/python/volk_modtool/volk_modtool_generate.py
+++ b/python/volk_modtool/volk_modtool_generate.py
@@ -24,7 +24,6 @@ from __future__ import print_function
 import os
 import re
 import glob
-from sets import Set
 
 
 class volk_modtool(object):
@@ -182,7 +181,7 @@ class volk_modtool(object):
 
         inpath = os.path.abspath(base)
         kernel = re.compile(name)
-        search_kernels = Set([kernel])
+        search_kernels = set([kernel])
         profile = re.compile(r'^\s*VOLK_PROFILE')
         puppet = re.compile(r'^\s*VOLK_PUPPET')
         src_dest = os.path.join(inpath, 'apps/', top[:-1] + '_profile.cc')
@@ -249,7 +248,7 @@ class volk_modtool(object):
         self.convert_kernel(oldvolk, name, base, inpath, top)
 
         kernel = re.compile(name)
-        search_kernels = Set([kernel])
+        search_kernels = set([kernel])
 
         profile = re.compile(r'^\s*VOLK_PROFILE')
         puppet = re.compile(r'^\s*VOLK_PUPPET')

--- a/python/volk_modtool/volk_modtool_generate.py
+++ b/python/volk_modtool/volk_modtool_generate.py
@@ -28,7 +28,7 @@ import exceptions
 from sets import Set
 
 
-class volk_modtool:
+class volk_modtool(object):
     def __init__(self, cfg):
         self.volk = re.compile('volk')
         self.remove_after_underscore = re.compile("_.*")
@@ -105,7 +105,7 @@ class volk_modtool:
                               "volk_typedefs.h", "volk.tmpl.h"]
         for root, dirnames, filenames in os.walk(self.my_dict['base']):
             for name in filenames:
-                t_table = map(lambda a: re.search(a, name), current_kernel_names)
+                t_table = [re.search(a, name) for a in current_kernel_names]
                 t_table = set(t_table)
                 if (t_table == set([None])) or (name == "volk_32f_null_32f.h"):
                     infile = os.path.join(root, name)

--- a/python/volk_modtool/volk_modtool_generate.py
+++ b/python/volk_modtool/volk_modtool_generate.py
@@ -24,7 +24,6 @@ from __future__ import print_function
 import os
 import re
 import glob
-import exceptions
 from sets import Set
 
 
@@ -94,7 +93,7 @@ class volk_modtool(object):
     def make_module_skeleton(self):
         dest = os.path.join(self.my_dict['destination'], 'volk_' + self.my_dict['name'])
         if os.path.exists(dest):
-            raise exceptions.IOError("Destination %s already exits!" % dest)
+            raise IOError("Destination %s already exits!" % dest)
 
         if not os.path.exists(os.path.join(self.my_dict['destination'], 'volk_' + self.my_dict['name'], 'kernels/volk_' + self.my_dict['name'])):
             os.makedirs(os.path.join(self.my_dict['destination'], 'volk_' + self.my_dict['name'], 'kernels/volk_' + self.my_dict['name']))
@@ -179,7 +178,7 @@ class volk_modtool(object):
         base = os.path.join(self.my_dict['destination'], top[:-1])
 
         if not name in self.get_current_kernels():
-            raise exceptions.IOError("Requested kernel %s is not in module %s" % (name, base))
+            raise IOError("Requested kernel %s is not in module %s" % (name, base))
 
         inpath = os.path.abspath(base)
         kernel = re.compile(name)
@@ -238,7 +237,7 @@ class volk_modtool(object):
         else:
             basename = self.get_basename(base)
         if not name in self.get_current_kernels(base):
-            raise exceptions.IOError("Requested kernel %s is not in module %s" % (name, base))
+            raise IOError("Requested kernel %s is not in module %s" % (name, base))
 
         inpath = os.path.abspath(base)
         if len(basename) > 0:


### PR DESCRIPTION
This is a collection of Python 3 compatibility fixes that allow volk_modtool to be imported. I haven't tested functionality.

This also includes a fix for a build problem that I encountered when using Python 3 and '\u' appears in the string for the Python path.