### PR TITLE
Fix 32u_reverse_32u for ARM.

### DIFF
--- a/kernels/volk/volk_32u_reverse_32u.h
+++ b/kernels/volk/volk_32u_reverse_32u.h
@@ -337,7 +337,7 @@ static inline void volk_32u_reverse_32u_bintree_permute_bottom_up(uint32_t* out,
 #include <arm_neon.h>
 
 #define DO_RBIT                                          \
-    asm("rbit %1,%0" : "=r" (*out_ptr) : "r" (*in_ptr)); \
+    asm("rbit %0,%1" : "=r" (*out_ptr) : "r" (*in_ptr)); \
     in_ptr++;                                            \
     out_ptr++;
 


### PR DESCRIPTION
 * Order of operands in inline asm reversed.
 * Worked for some tune setting since gcc generated rbit lr, lr so
   order didn't matter. For other tune settings it generated rbit r3, r2
   which would fail QA test.

Signed-off-by: Philip Balister <philip@balister.org>