### PR TITLE
Fix memory error and add ASAN build target 

### DIFF
--- a/cmake/Modules/VolkBuildTypes.cmake
+++ b/cmake/Modules/VolkBuildTypes.cmake
@@ -40,6 +40,7 @@ set(__INCLUDED_VOLK_BUILD_TYPES_CMAKE TRUE)
 list(APPEND AVAIL_BUILDTYPES
   None Debug Release RelWithDebInfo MinSizeRel
   DebugParanoid NoOptWithASM O2WithASM O3WithASM
+  ASAN
 )
 
 ########################################################################
@@ -186,4 +187,25 @@ if(NOT WIN32)
     CMAKE_C_FLAGS_O3WITHASM
     CMAKE_EXE_LINKER_FLAGS_O3WITHASM
     CMAKE_SHARED_LINKER_FLAGS_O3WITHASM)
+endif(NOT WIN32)
+
+########################################################################
+# For GCC and Clang, we can set a build type:
+#
+# -DCMAKE_BUILD_TYPE=ASAN
+#
+# This type creates an address sanitized build (-fsanitize=address)
+# and defaults to the DebugParanoid linker flags.
+# NOTE: This is not defined on Windows systems.
+########################################################################
+if(NOT WIN32)
+  SET(CMAKE_CXX_FLAGS_ASAN "-Wall -Wextra -g -O2 -fsanitize=address -fno-omit-frame-pointer" CACHE STRING
+    "Flags used by the C++ compiler during Address Sanitized builds." FORCE)
+  SET(CMAKE_C_FLAGS_ASAN "-Wall -Wextra -g -O2 -fsanitize=address -fno-omit-frame-pointer" CACHE STRING
+    "Flags used by the C compiler during Address Sanitized builds." FORCE)
+  MARK_AS_ADVANCED(
+    CMAKE_CXX_FLAGS_ASAN
+    CMAKE_C_FLAGS_ASAN
+    CMAKE_EXE_LINKER_FLAGS_DEBUGPARANOID
+    CMAKE_SHARED_LINKER_DEBUGPARANOID)
 endif(NOT WIN32)

--- a/kernels/volk/volk_8u_x2_encodeframepolar_8u.h
+++ b/kernels/volk/volk_8u_x2_encodeframepolar_8u.h
@@ -166,7 +166,7 @@ volk_8u_x2_encodeframepolar_8u_u_ssse3(unsigned char* frame, unsigned char* temp
   const __m128i mask_stage3 = _mm_set_epi8(0x0, 0x0, 0x0, 0x0, 0xFF, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x0, 0xFF, 0xFF, 0xFF, 0xFF);
   const __m128i mask_stage2 = _mm_set_epi8(0x0, 0x0, 0xFF, 0xFF, 0x0, 0x0, 0xFF, 0xFF, 0x0, 0x0, 0xFF, 0xFF, 0x0, 0x0, 0xFF, 0xFF);
 
-  for(branch = 0; branch < num_branches; ++branch){
+  for(branch = 1; branch < num_branches; ++branch){
     // shuffle once for bit-reversal.
     r_temp0 = _mm_shuffle_epi8(r_temp0, shuffle_stage4);
 
@@ -194,6 +194,29 @@ volk_8u_x2_encodeframepolar_8u_u_ssse3(unsigned char* frame, unsigned char* temp
     _mm_storeu_si128((__m128i*)frame_ptr, r_frame0);
     frame_ptr += 16;
   }
+  r_temp0 = _mm_shuffle_epi8(r_temp0, shuffle_stage4);
+
+  shifted = _mm_srli_si128(r_temp0, 8);
+  shifted = _mm_and_si128(shifted, mask_stage4);
+  r_frame0 = _mm_xor_si128(shifted, r_temp0);
+
+  // start loading the next chunk, but do not
+  // reload r_temp0
+
+  shifted = _mm_srli_si128(r_frame0, 4);
+  shifted = _mm_and_si128(shifted, mask_stage3);
+  r_frame0 = _mm_xor_si128(shifted, r_frame0);
+
+  shifted = _mm_srli_si128(r_frame0, 2);
+  shifted = _mm_and_si128(shifted, mask_stage2);
+  r_frame0 = _mm_xor_si128(shifted, r_frame0);
+
+  shifted = _mm_srli_si128(r_frame0, 1);
+  shifted = _mm_and_si128(shifted, mask_stage1);
+  r_frame0 = _mm_xor_si128(shifted, r_frame0);
+
+  // store result of chunk.
+  _mm_storeu_si128((__m128i*)frame_ptr, r_frame0);
 }
 
 #endif /* LV_HAVE_SSSE3 */
@@ -288,7 +311,7 @@ volk_8u_x2_encodeframepolar_8u_a_ssse3(unsigned char* frame, unsigned char* temp
   const __m128i mask_stage3 = _mm_set_epi8(0x0, 0x0, 0x0, 0x0, 0xFF, 0xFF, 0xFF, 0xFF, 0x0, 0x0, 0x0, 0x0, 0xFF, 0xFF, 0xFF, 0xFF);
   const __m128i mask_stage2 = _mm_set_epi8(0x0, 0x0, 0xFF, 0xFF, 0x0, 0x0, 0xFF, 0xFF, 0x0, 0x0, 0xFF, 0xFF, 0x0, 0x0, 0xFF, 0xFF);
 
-  for(branch = 0; branch < num_branches; ++branch){
+  for(branch = 1; branch < num_branches; ++branch){
     // shuffle once for bit-reversal.
     r_temp0 = _mm_shuffle_epi8(r_temp0, shuffle_stage4);
 
@@ -316,6 +339,29 @@ volk_8u_x2_encodeframepolar_8u_a_ssse3(unsigned char* frame, unsigned char* temp
     _mm_store_si128((__m128i*)frame_ptr, r_frame0);
     frame_ptr += 16;
   }
+  // shuffle once for bit-reversal.
+  r_temp0 = _mm_shuffle_epi8(r_temp0, shuffle_stage4);
+
+  shifted = _mm_srli_si128(r_temp0, 8);
+  shifted = _mm_and_si128(shifted, mask_stage4);
+  r_frame0 = _mm_xor_si128(shifted, r_temp0);
+
+  // start loading the next chunk, but do not
+  // reload r_temp0
+  shifted = _mm_srli_si128(r_frame0, 4);
+  shifted = _mm_and_si128(shifted, mask_stage3);
+  r_frame0 = _mm_xor_si128(shifted, r_frame0);
+
+  shifted = _mm_srli_si128(r_frame0, 2);
+  shifted = _mm_and_si128(shifted, mask_stage2);
+  r_frame0 = _mm_xor_si128(shifted, r_frame0);
+
+  shifted = _mm_srli_si128(r_frame0, 1);
+  shifted = _mm_and_si128(shifted, mask_stage1);
+  r_frame0 = _mm_xor_si128(shifted, r_frame0);
+
+  // store result of chunk.
+  _mm_store_si128((__m128i*)frame_ptr, r_frame0);
 }
 #endif /* LV_HAVE_SSSE3 */
 


### PR DESCRIPTION
## Add ASAN Build Target

Allows building an address sanitized build with `-DCMAKE_BUILD_TYPE=ASAN`. See [The LLVM docs](https://clang.llvm.org/docs/AddressSanitizer.html) for details.

## Fix read out of bounds

After compiling an address sanitized build I ran the unit tests and hit a heap overflow, which looked like an off by one error. I'm sure there is a more elegant solution, and I'm more than happy to work on it. Any feedback is welcome :smile:

It looks like if `frame_size` is `66536`, `num_branches` is `4096`. On the last iteration of the loop storing chunks in the `frame_ptr`, `temp_ptr ==  temp_ptr + 16 + (4095 * 16) == temp + 66536` and the use of `_mm_loadu_si128` will read out of bounds.
