### PR TITLE
ARMV8 kernels added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
     # Job 5 ... gcc-7
     - env: MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
       addons: {apt: {sources: "ubuntu-toolchain-r-test", packages: [*common_packages, g++-7]}}
-    # Job 6 ... ARM cross compile (gcc-4.8)
+    # Job 6 ... ARMv7 cross compile (gcc-4.8)
     - env: MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8 && BOOST_ROOT=$TRAVIS_BUILD_DIR/boost_1_66_0 && CMAKE_ARG=-DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/arm-linux-gnueabihf.cmake"
       addons: {apt: {sources: "ubuntu-toolchain-r-test", packages: [*common_packages, g++-arm-linux-gnueabihf, qemu-user]}}
       before_script:
@@ -36,6 +36,17 @@ matrix:
         - ./bootstrap.sh
         - echo "using gcc" ":" "arm" ":" "arm-linux-gnueabihf-g++ ;" > user-config.jam
         - BOOST_BUILD_PATH=./ ./b2 toolset=gcc-arm --with-system --with-filesystem
+        - cd ..
+    # Job 6 ... ARMv8 (aarch64) cross compile (gcc-4.8)
+    - env: MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8 && BOOST_ROOT=$TRAVIS_BUILD_DIR/boost_1_66_0 && CMAKE_ARG=-DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/aarch64-linux-gnu.cmake"
+      addons: {apt: {sources: "ubuntu-toolchain-r-test", packages: [*common_packages, g++-aarch64-linux-gnu, qemu-user]}}
+      before_script:
+        - wget --no-check-certificate https://sourceforge.net/projects/boost/files/boost/1.66.0/boost_1_66_0.tar.bz2
+        - tar xvf boost_1_66_0.tar.bz2 2>&1 | tail -10
+        - cd boost_1_66_0
+        - ./bootstrap.sh
+        - echo "using gcc" ":" "aarch64" ":" "aarch64-linux-gnu-g++ ;" > user-config.jam
+        - BOOST_BUILD_PATH=./ ./b2 toolset=gcc-aarch64 --with-system --with-filesystem
         - cd ..
     # Job 7 .. clang
     - env: MATRIX_EVAL="CC=\"clang -fprofile-instr-generate -fcoverage-mapping\" && CXX=\"clang++ -fprofile-instr-generate -fcoverage-mapping\""

--- a/cmake/Toolchains/aarch64-linux-gnu.cmake
+++ b/cmake/Toolchains/aarch64-linux-gnu.cmake
@@ -1,0 +1,33 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR ARM)
+
+if(MINGW OR CYGWIN OR WIN32)
+  set(UTIL_SEARCH_CMD where)
+elseif(UNIX OR APPLE)
+  set(UTIL_SEARCH_CMD which)
+endif()
+
+set(TOOLCHAIN_PREFIX aarch64-linux-gnu-)
+
+execute_process(
+  COMMAND ${UTIL_SEARCH_CMD} ${TOOLCHAIN_PREFIX}gcc
+  OUTPUT_VARIABLE BINUTILS_PATH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+get_filename_component(ARM_TOOLCHAIN_DIR ${BINUTILS_PATH} DIRECTORY)
+
+# The following is not needed on debian
+# Without that flag CMake is not able to pass test compilation check
+#set(CMAKE_EXE_LINKER_FLAGS_INIT "--specs=nosys.specs")
+
+set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}gcc)
+set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}g++)
+
+set(CMAKE_OBJCOPY ${ARM_TOOLCHAIN_DIR}/${TOOLCHAIN_PREFIX}objcopy CACHE INTERNAL "objcopy tool")
+set(CMAKE_SIZE_UTIL ${ARM_TOOLCHAIN_DIR}/${TOOLCHAIN_PREFIX}size CACHE INTERNAL "size tool")
+
+set(CMAKE_FIND_ROOT_PATH ${BINUTILS_PATH})
+
+set(CMAKE_CROSSCOMPILING_EMULATOR "qemu-aarch64 -L /usr/aarch64-linux-gnu/")

--- a/cmake/Toolchains/arm-linux-gnueabihf.cmake
+++ b/cmake/Toolchains/arm-linux-gnueabihf.cmake
@@ -24,6 +24,8 @@ get_filename_component(ARM_TOOLCHAIN_DIR ${BINUTILS_PATH} DIRECTORY)
 set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}gcc)
 set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
 set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}g++)
+## the following is needed for CheckCSourceCompiles used in lib/CMakeLists.txt
+set(CMAKE_C_FLAGS "-mfpu=neon" CACHE STRING "" FORCE)
 
 set(CMAKE_OBJCOPY ${ARM_TOOLCHAIN_DIR}/${TOOLCHAIN_PREFIX}objcopy CACHE INTERNAL "objcopy tool")
 set(CMAKE_SIZE_UTIL ${ARM_TOOLCHAIN_DIR}/${TOOLCHAIN_PREFIX}size CACHE INTERNAL "size tool")

--- a/kernels/volk/volk_16i_max_star_16i.h
+++ b/kernels/volk/volk_16i_max_star_16i.h
@@ -129,7 +129,7 @@ volk_16i_max_star_16i_neon(short* target, short* src0, unsigned int num_points)
   int16x8_t input_vec;
   int16x8_t diff, zeros;
   uint16x8_t comp1, comp2;
-  zeros = veorq_s16(zeros, zeros);
+  zeros = vdupq_n_s16(0);
 
   int16x8x2_t tmpvec;
 

--- a/kernels/volk/volk_16i_max_star_horizontal_16i.h
+++ b/kernels/volk/volk_16i_max_star_horizontal_16i.h
@@ -166,7 +166,7 @@ volk_16i_max_star_horizontal_16i_neon(int16_t* target, int16_t* src0, unsigned i
   int16x8x2_t input_vec;
   int16x8_t diff, max_vec, zeros;
   uint16x8_t comp1, comp2;
-  zeros = veorq_s16(zeros, zeros);
+  zeros = vdupq_n_s16(0);
   for(number=0; number < eighth_points; ++number) {
     input_vec = vld2q_s16(src0);
     //__VOLK_PREFETCH(src0+16);

--- a/kernels/volk/volk_16i_x4_quad_max_star_16i.h
+++ b/kernels/volk/volk_16i_x4_quad_max_star_16i.h
@@ -218,7 +218,7 @@ volk_16i_x4_quad_max_star_16i_neon(short* target, short* src0, short* src1,
   int16x8_t comp0, comp1, comp2, comp3;
   int16x8_t result1_vec, result2_vec;
   int16x8_t zeros;
-  zeros = veorq_s16(zeros, zeros);
+  zeros = vdupq_n_s16(0);
   for(i=0; i < eighth_points; ++i) {
     src0_vec = vld1q_s16(src0);
     src1_vec = vld1q_s16(src1);

--- a/kernels/volk/volk_32fc_s32fc_multiply_32fc.h
+++ b/kernels/volk/volk_32fc_s32fc_multiply_32fc.h
@@ -297,13 +297,13 @@ static inline void volk_32fc_s32fc_multiply_32fc_neon(lv_32fc_t* cVector, const 
         tmp_imag.val[1] = vmlaq_f32(tmp_imag.val[1], a_val.val[0], scalar_val.val[1]);
         tmp_imag.val[0] = vmlsq_f32(tmp_imag.val[0], a_val.val[1], scalar_val.val[1]);
 
-        vst2q_f32((float*)cVector, tmp_imag);
+        vst2q_f32((float*)cPtr, tmp_imag);
         aPtr += 4;
-        cVector += 4;
+        cPtr += 4;
     }
 
     for(number = quarter_points*4; number < num_points; number++){
-      *cVector++ = *aPtr++ * scalar;
+      *cPtr++ = *aPtr++ * scalar;
     }
 }
 #endif /* LV_HAVE_NEON */

--- a/kernels/volk/volk_32u_byteswap.h
+++ b/kernels/volk/volk_32u_byteswap.h
@@ -199,6 +199,40 @@ static inline void volk_32u_byteswap_neon(uint32_t* intsToSwap, unsigned int num
 }
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32u_byteswap_neonv8(uint32_t* intsToSwap, unsigned int num_points){
+  uint32_t* inputPtr = (uint32_t*)intsToSwap;
+  const unsigned int n8points = num_points / 8;
+  uint8x16_t input;
+  uint8x16_t idx = { 3,2,1,0, 7,6,5,4, 11,10,9,8, 15,14,13,12 };
+
+  unsigned int number = 0;
+  for(number = 0; number < n8points; ++number){
+    __VOLK_PREFETCH(inputPtr+8);
+    input = vld1q_u8((uint8_t*) inputPtr);
+    input = vqtbl1q_u8(input, idx);
+    vst1q_u8((uint8_t*) inputPtr, input);
+    inputPtr += 4;
+
+    input = vld1q_u8((uint8_t*) inputPtr);
+    input = vqtbl1q_u8(input, idx);
+    vst1q_u8((uint8_t*) inputPtr, input);
+    inputPtr += 4;
+  }
+
+  for(number = n8points * 8; number < num_points; ++number){
+    uint32_t output = *inputPtr;
+
+    output = (((output >> 24) & 0xff) | ((output >> 8) & 0x0000ff00) | ((output << 8) & 0x00ff0000) | ((output << 24) & 0xff000000));
+
+    *inputPtr++ = output;
+  }
+
+}
+#endif /* LV_HAVE_NEONV8 */
+
 
 #ifdef LV_HAVE_GENERIC
 

--- a/kernels/volk/volk_32u_byteswappuppet_32u.h
+++ b/kernels/volk/volk_32u_byteswappuppet_32u.h
@@ -23,6 +23,15 @@ static inline void volk_32u_byteswappuppet_32u_neon(uint32_t*output, uint32_t* i
 }
 #endif
 
+#ifdef LV_HAVE_NEONV8
+static inline void volk_32u_byteswappuppet_32u_neonv8(uint32_t*output, uint32_t* intsToSwap, unsigned int num_points){
+
+    volk_32u_byteswap_neonv8((uint32_t*)intsToSwap, num_points);
+    memcpy((void*)output, (void*)intsToSwap, num_points * sizeof(uint32_t));
+
+}
+#endif
+
 #ifdef LV_HAVE_SSE2
 static inline void volk_32u_byteswappuppet_32u_u_sse2(uint32_t *output, uint32_t* intsToSwap, unsigned int num_points){
 

--- a/kernels/volk/volk_64u_byteswappuppet_64u.h
+++ b/kernels/volk/volk_64u_byteswappuppet_64u.h
@@ -15,6 +15,14 @@ static inline void volk_64u_byteswappuppet_64u_generic(uint64_t*output, uint64_t
 }
 #endif
 
+#ifdef LV_HAVE_NEONV8
+static inline void volk_64u_byteswappuppet_64u_neonv8(uint64_t*output, uint64_t* intsToSwap, unsigned int num_points){
+
+    volk_64u_byteswap_neonv8((uint64_t*)intsToSwap, num_points);
+    memcpy((void*)output, (void*)intsToSwap, num_points * sizeof(uint64_t));
+
+}
+#else
 #ifdef LV_HAVE_NEON
 static inline void volk_64u_byteswappuppet_64u_neon(uint64_t*output, uint64_t* intsToSwap, unsigned int num_points){
 
@@ -22,6 +30,7 @@ static inline void volk_64u_byteswappuppet_64u_neon(uint64_t*output, uint64_t* i
     memcpy((void*)output, (void*)intsToSwap, num_points * sizeof(uint64_t));
 
 }
+#endif
 #endif
 
 #ifdef LV_HAVE_SSE2


### PR DESCRIPTION
Recently I got a raspberry pi3b+ and installed a 64bit operation system. Thanks to @balister's work (https://github.com/gnuradio/volk/commit/e98e9277409cd658f1a5b65ffaa0caab842bebce) support for ARMV8 kernels is available:
- `volk_32u_reverse_32u` and `volk_64u_byteswappuppet_64u` failed on this system and the commits in this pull request fix this problem, along with 
- fixes for some compiler warnings for other NEON kernels

```
pi@raspberrypi:~/volk/build$ uname -a
Linux raspberrypi 4.14.34-v8+ #1 SMP PREEMPT Tue Apr 17 02:45:42 PDT 2018 aarch64 GNU/Linux
```

```
pi@raspberrypi:~/volk/build$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/aarch64-linux-gnu/6/lto-wrapper
Target: aarch64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Debian 6.3.0-18+deb9u1' --with-bugurl=file:///usr/share/doc/gcc-6/README.Bugs --enable-languages=c,ada,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-6 --program-prefix=aarch64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-libquadmath --enable-plugin --enable-default-pie --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-6-arm64/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-6-arm64 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-6-arm64 --with-arch-directory=aarch64 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-multiarch --enable-fix-cortex-a53-843419 --enable-checking=release --build=aarch64-linux-gnu --host=aarch64-linux-gnu --target=aarch64-linux-gnu
Thread model: posix
gcc version 6.3.0 20170516 (Debian 6.3.0-18+deb9u1) 

```
```
RUN_VOLK_TESTS: volk_32u_byteswappuppet_32u(131071,1987)
generic completed in 2053.52ms
neon completed in 3385.98ms
neonv8 completed in 2022.6ms
Best aligned arch: neonv8
Best unaligned arch: neonv8
RUN_VOLK_TESTS: volk_64u_byteswappuppet_64u(131071,1987)
generic completed in 5102.81ms
neonv8 completed in 5128.74ms
Best aligned arch: generic
Best unaligned arch: generic

RUN_VOLK_TESTS: volk_32u_reverse_32u(131071,100)
dword_shuffle completed in 4487.62ms
byte_shuffle completed in 4299.86ms
lut completed in 384.891ms
2001magic completed in 1491.04ms
1972magic completed in 2321.11ms
bintree_permute_top_down completed in 151.438ms
bintree_permute_bottom_up completed in 150.966ms
neonv8 completed in 54.658ms
Best aligned arch: neonv8
Best unaligned arch: neonv8

```

