### PR TITLE
Update gnuradio.org links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Welcome to VOLK!
 
 VOLK is a sub-project of GNU Radio. Please see http://libvolk.org for bug
 tracking, documentation, source code, and contact information about VOLK.
-See http://gnuradio.org/ for information about GNU Radio.
+See https://www.gnuradio.org/ for information about GNU Radio.
 
 Bleeding edge code can be found in our git repository at
-http://gnuradio.org/git/volk.git/.
+https://www.gnuradio.org/git/volk.git/.
 
 How to use VOLK:
 

--- a/python/volk_modtool/README
+++ b/python/volk_modtool/README
@@ -76,8 +76,8 @@ This will put the code for the new kernel into
 
 Other kernels must be added by hand. See the following webpages for
 more information about creating VOLK kernels:
-  http://gnuradio.org/doc/doxygen/volk_guide.html
-  http://gnuradio.org/redmine/projects/gnuradio/wiki/Volk
+  https://www.gnuradio.org/doc/doxygen/volk_guide.html
+  https://wiki.gnuradio.org/index.php/Volk
 
 
 ======================================================================
@@ -111,4 +111,3 @@ Options for Listing Kernels:
   -r, --remote-list
        Lists all kernels in another VOLK module that is specified
        using the -b option.
-


### PR DESCRIPTION
I've updated the gnuradio.org links to use the canonical address (https://www.gnuradio.org) and fixed a wiki link to point to the new wiki location.