### PR TITLE
Make sure that regexp are raw strings if they have \

### DIFF
--- a/gen/volk_kernel_defs.py
+++ b/gen/volk_kernel_defs.py
@@ -53,7 +53,7 @@ def split_into_nested_ifdef_sections(code):
     header = 'text'
     in_section_depth = 0
     for i, line in enumerate(code.splitlines()):
-        m = re.match('^(\s*)#(\s*)(\w+)(.*)$', line)
+        m = re.match(r'^(\s*)#(\s*)(\w+)(.*)$', line)
         line_is = 'normal'
         if m:
             p0, p1, fcn, stuff = m.groups()
@@ -121,11 +121,11 @@ def flatten_section_text(sections):
 class impl_class:
     def __init__(self, kern_name, header, body):
         #extract LV_HAVE_*
-        self.deps = set(res.lower() for res in re.findall('LV_HAVE_(\w+)', header))
+        self.deps = set(res.lower() for res in re.findall(r'LV_HAVE_(\w+)', header))
         #extract function suffix and args
         body = flatten_section_text(body)
         try:
-            fcn_matcher = re.compile('^.*(%s\\w*)\\s*\\((.*)$'%kern_name, re.DOTALL | re.MULTILINE)
+            fcn_matcher = re.compile(r'^.*(%s\w*)\s*\((.*)$'%kern_name, re.DOTALL | re.MULTILINE)
             body = body.split('{')[0].rsplit(')', 1)[0] #get the part before the open ){ bracket
             m = fcn_matcher.match(body)
             impl_name, the_rest = m.groups()
@@ -133,7 +133,7 @@ class impl_class:
             self.args = list()
             fcn_args = the_rest.split(',')
             for fcn_arg in fcn_args:
-                arg_matcher = re.compile('^\s*(.*\\W)\s*(\w+)\s*$', re.DOTALL | re.MULTILINE)
+                arg_matcher = re.compile(r'^\s*(.*\W)\s*(\w+)\s*$', re.DOTALL | re.MULTILINE)
                 m = arg_matcher.match(fcn_arg)
                 arg_type, arg_name = m.groups()
                 self.args.append((arg_type, arg_name))
@@ -153,7 +153,7 @@ def extract_lv_haves(code):
     haves = list()
     for line in code.splitlines():
         if not line.strip().startswith('#'): continue
-        have_set = set(res.lower() for res in  re.findall('LV_HAVE_(\w+)', line))
+        have_set = set(res.lower() for res in  re.findall(r'LV_HAVE_(\w+)', line))
         if have_set: haves.append(have_set)
     return haves
 

--- a/python/volk_modtool/cfg.py
+++ b/python/volk_modtool/cfg.py
@@ -31,7 +31,7 @@ import re
 
 class volk_modtool_config:
     def key_val_sub(self, num, stuff, section):
-        return re.sub('\$' + 'k' + str(num), stuff[num][0], (re.sub('\$' + str(num), stuff[num][1], section[1][num])));
+        return re.sub(r'\$' + 'k' + str(num), stuff[num][0], (re.sub(r'\$' + str(num), stuff[num][1], section[1][num])));
 
     def verify(self):
         for i in self.verification:

--- a/python/volk_modtool/volk_modtool_generate.py
+++ b/python/volk_modtool/volk_modtool_generate.py
@@ -33,15 +33,15 @@ class volk_modtool:
         self.volk = re.compile('volk')
         self.remove_after_underscore = re.compile("_.*")
         self.volk_included = re.compile('INCLUDED_VOLK')
-        self.volk_run_tests = re.compile('^\s*VOLK_RUN_TESTS.*\n', re.MULTILINE)
-        self.volk_profile = re.compile('^\s*(VOLK_PROFILE|VOLK_PUPPET_PROFILE).*\n', re.MULTILINE)
-        self.volk_kernel_tests = re.compile('^\s*\((VOLK_INIT_TEST|VOLK_INIT_PUPP).*\n', re.MULTILINE)
-        self.volk_null_kernel = re.compile('^\s*;\n', re.MULTILINE)
+        self.volk_run_tests = re.compile(r'^\s*VOLK_RUN_TESTS.*\n', re.MULTILINE)
+        self.volk_profile = re.compile(r'^\s*(VOLK_PROFILE|VOLK_PUPPET_PROFILE).*\n', re.MULTILINE)
+        self.volk_kernel_tests = re.compile(r'^\s*\((VOLK_INIT_TEST|VOLK_INIT_PUPP).*\n', re.MULTILINE)
+        self.volk_null_kernel = re.compile(r'^\s*;\n', re.MULTILINE)
         self.my_dict = cfg
-        self.lastline = re.compile('\s*char path\[1024\];.*')
-        self.badassert = re.compile('^\s*assert\(toked\[0\] == "volk_.*\n', re.MULTILINE)
+        self.lastline = re.compile(r'\s*char path\[1024\];.*')
+        self.badassert = re.compile(r'^\s*assert\(toked\[0\] == "volk_.*\n', re.MULTILINE)
         self.goodassert = '    assert(toked[0] == "volk");\n'
-        self.baderase = re.compile('^\s*toked.erase\(toked.begin\(\)\);.*\n', re.MULTILINE)
+        self.baderase = re.compile(r'^\s*toked.erase\(toked.begin\(\)\);.*\n', re.MULTILINE)
         self.gooderase = '    toked.erase(toked.begin());\n    toked.erase(toked.begin());\n'
 
     def get_basename(self, base=None):
@@ -71,7 +71,7 @@ class volk_modtool:
 
         for line in hdr_files:
 
-            subline = re.search(".*\.h.*", os.path.basename(line))
+            subline = re.search(r".*\.h.*", os.path.basename(line))
             if subline:
                 subsubline = begins.search(subline.group(0))
                 if subsubline:
@@ -85,7 +85,7 @@ class volk_modtool:
         for line in hdr_files:
             for dt in datatypes:
                 if dt in line:
-                    subline = re.search(begins.pattern[:-2] + dt + ".*(?=\.h)", line)
+                    subline = re.search(begins.pattern[:-2] + dt + r".*(?=\.h)", line)
                     if subline:
                         functions.append(subline.group(0))
 
@@ -184,8 +184,8 @@ class volk_modtool:
         inpath = os.path.abspath(base)
         kernel = re.compile(name)
         search_kernels = Set([kernel])
-        profile = re.compile('^\s*VOLK_PROFILE')
-        puppet = re.compile('^\s*VOLK_PUPPET')
+        profile = re.compile(r'^\s*VOLK_PROFILE')
+        puppet = re.compile(r'^\s*VOLK_PUPPET')
         src_dest = os.path.join(inpath, 'apps/', top[:-1] + '_profile.cc')
         infile = open(src_dest)
         otherlines = infile.readlines()
@@ -252,8 +252,8 @@ class volk_modtool:
         kernel = re.compile(name)
         search_kernels = Set([kernel])
 
-        profile = re.compile('^\s*VOLK_PROFILE')
-        puppet = re.compile('^\s*VOLK_PUPPET')
+        profile = re.compile(r'^\s*VOLK_PROFILE')
+        puppet = re.compile(r'^\s*VOLK_PUPPET')
         infile = open(os.path.join(inpath, 'apps/', oldvolk.pattern + '_profile.cc'))
         otherinfile = open(os.path.join(self.my_dict['destination'], 'volk_' + self.my_dict['name'], 'apps/volk_' + self.my_dict['name'] + '_profile.cc'))
         dest = os.path.join(self.my_dict['destination'], 'volk_' + self.my_dict['name'], 'apps/volk_' + self.my_dict['name'] + '_profile.cc')
@@ -300,7 +300,7 @@ class volk_modtool:
         inserted = False
         insert = False
         for otherline in otherlines:
-            if re.match('\s*', otherline) is None or re.match('\s*#.*', otherline) is None:
+            if re.match(r'\s*', otherline) is None or re.match(r'\s*#.*', otherline) is None:
                 insert = True
             if insert and not inserted:
                 inserted = True


### PR DESCRIPTION
There are a lot of regular expressions that need to be raw strings,
right now this causes a lot of errors like:

DeprecationWarning: invalid escape sequence '\/'