### PR TITLE
kernels: fix more rounding issues

### DIFF
--- a/kernels/volk/volk_16ic_magnitude_16i.h
+++ b/kernels/volk/volk_16ic_magnitude_16i.h
@@ -102,7 +102,7 @@ volk_16ic_magnitude_16i_a_avx2(int16_t* magnitudeVector, const lv_16sc_t* comple
 
     result = _mm256_mul_ps(result, vScalar); // Scale the results
 
-    int1 = _mm256_cvttps_epi32(result);
+    int1 = _mm256_cvtps_epi32(result);
     int1 = _mm256_packs_epi32(int1, int1);
     int1 = _mm256_permutevar8x32_epi32(int1, idx); //permute to compensate for shuffling in hadd and packs
     short1 = _mm256_extracti128_si256(int1, 0);
@@ -117,7 +117,7 @@ volk_16ic_magnitude_16i_a_avx2(int16_t* magnitudeVector, const lv_16sc_t* comple
     const float val1Real = (float)(*complexVectorPtr++) / 32768.0;
     const float val1Imag = (float)(*complexVectorPtr++) / 32768.0;
     const float val1Result = sqrtf((val1Real * val1Real) + (val1Imag * val1Imag)) * 32768.0;
-    *magnitudeVectorPtr++ = (int16_t)(val1Result);
+    *magnitudeVectorPtr++ = (int16_t)rintf(val1Result);
   }
 }
 #endif /* LV_HAVE_AVX2 */
@@ -347,7 +347,7 @@ volk_16ic_magnitude_16i_u_avx2(int16_t* magnitudeVector, const lv_16sc_t* comple
 
     result = _mm256_mul_ps(result, vScalar); // Scale the results
 
-    int1 = _mm256_cvttps_epi32(result);
+    int1 = _mm256_cvtps_epi32(result);
     int1 = _mm256_packs_epi32(int1, int1);
     int1 = _mm256_permutevar8x32_epi32(int1, idx); //permute to compensate for shuffling in hadd and packs
     short1 = _mm256_extracti128_si256(int1, 0);
@@ -362,7 +362,7 @@ volk_16ic_magnitude_16i_u_avx2(int16_t* magnitudeVector, const lv_16sc_t* comple
     const float val1Real = (float)(*complexVectorPtr++) / 32768.0;
     const float val1Imag = (float)(*complexVectorPtr++) / 32768.0;
     const float val1Result = sqrtf((val1Real * val1Real) + (val1Imag * val1Imag)) * 32768.0;
-    *magnitudeVectorPtr++ = (int16_t)(val1Result);
+    *magnitudeVectorPtr++ = (int16_t)rintf(val1Result);
   }
 }
 #endif /* LV_HAVE_AVX2 */

--- a/kernels/volk/volk_32f_s32f_convert_32i.h
+++ b/kernels/volk/volk_32f_s32f_convert_32i.h
@@ -101,7 +101,7 @@ volk_32f_s32f_convert_32i_u_avx(int32_t* outputVector, const float* inputVector,
     inputVal1 = _mm256_loadu_ps(inputVectorPtr); inputVectorPtr += 8;
 
     inputVal1 = _mm256_max_ps(_mm256_min_ps(_mm256_mul_ps(inputVal1, vScalar), vmax_val), vmin_val);
-    intInputVal1 = _mm256_cvttps_epi32(inputVal1);
+    intInputVal1 = _mm256_cvtps_epi32(inputVal1);
 
     _mm256_storeu_si256((__m256i*)outputVectorPtr, intInputVal1);
     outputVectorPtr += 8;

--- a/kernels/volk/volk_32f_x2_s32f_interleave_16ic.h
+++ b/kernels/volk/volk_32f_x2_s32f_interleave_16ic.h
@@ -165,8 +165,8 @@ volk_32f_x2_s32f_interleave_16ic_a_sse2(lv_16sc_t* complexVector, const float* i
     cplxValue2 = _mm_unpackhi_ps(iValue, qValue);
     cplxValue2 = _mm_mul_ps(cplxValue2, vScalar);
 
-    intValue1 = _mm_cvttps_epi32(cplxValue1);
-    intValue2 = _mm_cvttps_epi32(cplxValue2);
+    intValue1 = _mm_cvtps_epi32(cplxValue1);
+    intValue2 = _mm_cvtps_epi32(cplxValue2);
 
     intValue1 = _mm_packs_epi32(intValue1, intValue2);
 

--- a/kernels/volk/volk_32f_x2_s32f_interleave_16ic.h
+++ b/kernels/volk/volk_32f_x2_s32f_interleave_16ic.h
@@ -111,8 +111,8 @@ volk_32f_x2_s32f_interleave_16ic_a_avx2(lv_16sc_t* complexVector, const float* i
     cplxValue2 = _mm256_unpackhi_ps(iValue, qValue);
     cplxValue2 = _mm256_mul_ps(cplxValue2, vScalar);
 
-    intValue1 = _mm256_cvttps_epi32(cplxValue1);
-    intValue2 = _mm256_cvttps_epi32(cplxValue2);
+    intValue1 = _mm256_cvtps_epi32(cplxValue1);
+    intValue2 = _mm256_cvtps_epi32(cplxValue2);
 
     intValue1 = _mm256_packs_epi32(intValue1, intValue2);
 
@@ -308,8 +308,8 @@ volk_32f_x2_s32f_interleave_16ic_u_avx2(lv_16sc_t* complexVector, const float* i
     cplxValue2 = _mm256_unpackhi_ps(iValue, qValue);
     cplxValue2 = _mm256_mul_ps(cplxValue2, vScalar);
 
-    intValue1 = _mm256_cvttps_epi32(cplxValue1);
-    intValue2 = _mm256_cvttps_epi32(cplxValue2);
+    intValue1 = _mm256_cvtps_epi32(cplxValue1);
+    intValue2 = _mm256_cvtps_epi32(cplxValue2);
 
     intValue1 = _mm256_packs_epi32(intValue1, intValue2);
 

--- a/kernels/volk/volk_32fc_s32f_magnitude_16i.h
+++ b/kernels/volk/volk_32fc_s32f_magnitude_16i.h
@@ -113,7 +113,7 @@ volk_32fc_s32f_magnitude_16i_a_avx2(int16_t* magnitudeVector, const lv_32fc_t* c
 
     result = _mm256_mul_ps(result, vScalar);
 
-    resultInt = _mm256_cvttps_epi32(result);
+    resultInt = _mm256_cvtps_epi32(result);
     resultInt = _mm256_packs_epi32(resultInt, resultInt);
     resultInt = _mm256_permutevar8x32_epi32(resultInt, idx); //permute to compensate for shuffling in hadd and packs
     resultShort = _mm256_extracti128_si256(resultInt,0);
@@ -126,7 +126,7 @@ volk_32fc_s32f_magnitude_16i_a_avx2(int16_t* magnitudeVector, const lv_32fc_t* c
   for(; number < num_points; number++){
     float val1Real = *complexVectorPtr++;
     float val1Imag = *complexVectorPtr++;
-    *magnitudeVectorPtr++ = (int16_t)(sqrtf((val1Real * val1Real) + (val1Imag * val1Imag)) * scalar);
+    *magnitudeVectorPtr++ = (int16_t)rintf(sqrtf((val1Real * val1Real) + (val1Imag * val1Imag)) * scalar);
   }
 }
 #endif /* LV_HAVE_AVX2 */
@@ -320,7 +320,7 @@ volk_32fc_s32f_magnitude_16i_u_avx2(int16_t* magnitudeVector, const lv_32fc_t* c
 
     result = _mm256_mul_ps(result, vScalar);
 
-    resultInt = _mm256_cvttps_epi32(result);
+    resultInt = _mm256_cvtps_epi32(result);
     resultInt = _mm256_packs_epi32(resultInt, resultInt);
     resultInt = _mm256_permutevar8x32_epi32(resultInt, idx); //permute to compensate for shuffling in hadd and packs
     resultShort = _mm256_extracti128_si256(resultInt,0);


### PR DESCRIPTION
in 32f_s32f_convert_32i the AVX kernel needs to use the non-truncating
intrinsic and in the 32f_x2_s32f_interleave_16ic kernel the SSE2 kernel
needs to use the non-truncating intrinsic.