### PR TITLE
Update Boost filesystem usage

### DIFF
--- a/apps/volk_profile.cc
+++ b/apps/volk_profile.cc
@@ -227,10 +227,10 @@ void write_results(const std::vector<volk_test_results_t> *results, bool update_
      * These
      */
     const fs::path config_path(path);
-    if (! fs::exists(config_path.branch_path()))
+    if (! fs::exists(config_path.parent_path()))
     {
-        std::cout << "Creating " << config_path.branch_path() << "..." << std::endl;
-        fs::create_directories(config_path.branch_path());
+        std::cout << "Creating " << config_path.parent_path() << "..." << std::endl;
+        fs::create_directories(config_path.parent_path());
     }
 
     std::ofstream config;


### PR DESCRIPTION
This patch replaces all calls to `boost::filesystem::branch_path` with
`boost::filesystem::parent_path` because `branch_path` is deprecated and
it just calls `parent_path` anyways.

Also, this makes it easier to switch to `std::filesystem` because the
STL only provides `parent_path`. Eventually, this patch makes it easier
to purge Boost.
`apps/volk_profile.cc` is the last file to use Boost. The only Boost
usage is related to `filesystem`. With this patch you can just replace
the Boost includes with `#include <filesystem>` and replace:
`namespace fs = boost::filesystem;` with
`namespace fs = std::filesystem;`.

Only the most recent compilers offer `std::filesystem`. Older compilers
(even GCC7.3) might require `std::experimental::filesystem`.

This patch is related to #174.