### PR TITLE
Fixes for complex conj-dot-prod kernel for both aligned and unaligned

### DIFF
--- a/kernels/volk/volk_32fc_x2_conjugate_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_x2_conjugate_dot_prod_32fc.h
@@ -131,7 +131,7 @@ volk_32fc_x2_conjugate_dot_prod_32fc_u_avx(lv_32fc_t* result, const lv_32fc_t* i
   for (point=quarter_points*4; point < num_points; ++point) {
     float a_r = *a_p++;
     float a_i = *a_p++;
-    float b_r = *a_p++;
+    float b_r = *b_p++;
     float b_i = *b_p++;
     *result += lv_cmake(a_r*b_r + a_i*b_i, a_r*-b_i + a_i*b_r);
   }
@@ -170,7 +170,7 @@ volk_32fc_x2_conjugate_dot_prod_32fc_a_avx(lv_32fc_t* result, const lv_32fc_t* i
   for (point=quarter_points*4; point < num_points; ++point) {
     float a_r = *a_p++;
     float a_i = *a_p++;
-    float b_r = *a_p++;
+    float b_r = *b_p++;
     float b_i = *b_p++;
     *result += lv_cmake(a_r*b_r + a_i*b_i, a_r*-b_i + a_i*b_r);
   }


### PR DESCRIPTION
    Fixes for complex conj-dot-prod kernel for both aligned and unaligned
    avx2 architectures.  The incrementing of input and taps pointers
    performed by the for-loop to perform the conj-dot-prod operation on
    the residual number of quad points (i.e. when num_points is not a multiple
    of 4) was not correct.
