### PR TITLE
Search for system-wide volk_config file

### DIFF
--- a/lib/volk_prefs.c
+++ b/lib/volk_prefs.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include <volk/volk_prefs.h>
 
 void volk_get_config_path(char *path)
@@ -16,6 +17,13 @@ void volk_get_config_path(char *path)
     if(home!=NULL){
         strncpy(path,home,512);
         strcat(path,suffix2);
+        return;
+    }
+
+    //check for system-wide config file
+    if (access("/etc/volk/volk_config", F_OK) != -1){
+        strncpy(path, "/etc", 512);
+        strcat(path, suffix2);
         return;
     }
 


### PR DESCRIPTION
Hi!
The volk_config file generated by volk_profile has no reason to be different from one user to another on the same computer. So I think it would be interesting that volk also searches for the volk_config file in a system-wide location, i.e. /etc/volk/volk_config.
Regards,
Thomas