### PR TITLE
cmake: add back pre-"modern CMake targets" find variables

### DIFF
--- a/cmake/Modules/VolkConfig.cmake.in
+++ b/cmake/Modules/VolkConfig.cmake.in
@@ -3,3 +3,32 @@ get_filename_component(VOLK_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 if(NOT TARGET Volk::volk)
   include("${VOLK_CMAKE_DIR}/VolkTargets.cmake")
 endif()
+
+# set VOLK_FOUND to be set globally, for whether a compatible Volk was
+# found -- could be a correct enough version or any version depending
+# on how find_package was called.
+if(NOT TARGET Volk::volk)
+  set(VOLK_FOUND FALSE)
+else()
+  set(VOLK_FOUND TRUE)
+endif()
+
+# cache whether a compatible Volk was found for
+# use anywhere in the calling project
+set(VOLK_FOUND ${VOLK_FOUND} CACHE BOOL "Whether a compatible Volk was found" FORCE)
+
+if(VOLK_FOUND)
+  # use the new target library, regardless of whether new or old style
+  # we still need to set a variable with the library name so that there
+  # is a variable to reference in the using-project's cmake scripts!
+  set(VOLK_LIBRARIES Volk::volk CACHE STRING "Volk Library" FORCE)
+
+  # INTERFACE_INCLUDE_DIRECTORIES should always be set
+  get_target_property(VOLK_INCLUDE_DIRS Volk::volk INTERFACE_INCLUDE_DIRECTORIES)
+  set(VOLK_INCLUDE_DIRS ${VOLK_INCLUDE_DIRS} CACHE STRING "Volk Include Directories" FORCE)
+
+  # for backward compatibility with old-CMake non-target project finding
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(VOLK DEFAULT_MSG VOLK_LIBRARIES VOLK_INCLUDE_DIRS)
+  mark_as_advanced(VOLK_LIBRARIES VOLK_INCLUDE_DIRS)
+endif(VOLK_FOUND)


### PR DESCRIPTION
These variables were removed in beeb942ec7bd838ecf3e0e7f47688298d6057e8a:
+ VOLK_FOUND
+ VOLK_LIBRARIES
+ VOLK_INCLUDE_DIRS
and are used by the CMake script trying to find Volk. Without them, the finding script has to manually determine these variables, including whether Volk was even found .. and this should not be the case! Although GNU Radio was fixed to work without these variables, there are a variety of other projects that still rely on these variables to find and use Volk. This change adds these variables back into the CMake Volk find script. NOTE that the CMake targets are left untouched, and VOLK_LIBRARIES is set to the target library.