### PR TITLE
Boost: build without Boost and C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,6 @@ endif(MSVC)
 ########################################################################
 # Dependencies setup
 ########################################################################
-
 # Python
 include(VolkPython) #sets PYTHON_EXECUTABLE and PYTHON_DASH_B
 VOLK_PYTHON_CHECK_MODULE("python >= 2.7" sys "sys.version.split()[0] >= '2.7'" PYTHON_MIN_VER_FOUND)
@@ -111,10 +110,14 @@ if(MSVC)
     endif(BOOST_ALL_DYN_LINK)
 endif(MSVC)
 
-include(VolkBoost)
+if(CMAKE_CXX_STANDARD GREATER_EQUAL 17)
+    set(Boost_LIBRARIES "")
+else()
+    include(VolkBoost)
 
-if(NOT Boost_FOUND)
-    message(FATAL_ERROR "VOLK Requires boost to build")
+    if(NOT Boost_FOUND)
+        message(FATAL_ERROR "VOLK Requires boost to build")
+    endif()
 endif()
 
 # Orc

--- a/README.md
+++ b/README.md
@@ -45,3 +45,10 @@ Build with cmake:
     $ sudo make install
 
 That's it!
+
+## BoostSANS
+
+It is possible to build VOLK without Boost. Though, this depends on the latest C++ compilers. Be aware that this requires GCC9 or later. In `CMakeLists.txt` change the line `set(CMAKE_CXX_STANDARD 11)` to `set(CMAKE_CXX_STANDARD 17)`.
+Rerun the build instructions.
+
+Voila! That's it!

--- a/apps/volk_profile.cc
+++ b/apps/volk_profile.cc
@@ -20,9 +20,16 @@
  * Boston, MA 02110-1301, USA.
  */
 
+
+// For C++17 '__cplusplus == 201703L'
+#if __cplusplus > 201700L
+#include <filesystem>
+#else
 #include <boost/filesystem/operations.hpp>   // for create_directories, exists
 #include <boost/filesystem/path.hpp>         // for path, operator<<
 #include <boost/filesystem/path_traits.hpp>  // for filesystem
+#endif
+
 #include <stddef.h>                          // for size_t
 #include <sys/stat.h>                        // for stat
 #include <volk/volk_prefs.h>                 // for volk_get_config_path
@@ -38,8 +45,11 @@
 #include "volk_option_helpers.h"             // for option_list, option_t
 #include "volk_profile.h"
 
-
+#if __cplusplus > 201700L
+namespace fs = std::filesystem;
+#else
 namespace fs = boost::filesystem;
+#endif
 
 volk_test_params_t test_params(1e-6f, 327.f, 131071, 1987, false, "");
 


### PR DESCRIPTION
This commit enables us to build VOLK without Boost as a dependency. If
you set the `CMAKE_CXX_STANDARD` flag to 17, the build system will not
search for Boost anymore. In this case the STL `<filesystem>` will be
used. This include does only work with the latest compilers e.g. GCC9
and later. It does not work with GCC7 or Clang6.
This commit might help to avoid build problems that arise with Boost
1.70.