### PR TITLE
volk_config: add additional argument to volk_get_config_path

### DIFF
--- a/apps/volk_profile.cc
+++ b/apps/volk_profile.cc
@@ -70,7 +70,7 @@ int main(int argc, char *argv[]) {
     profile_options.add((option_t("json", "j", "Write results to JSON file named as argument value", set_json)));
     profile_options.add((option_t("path", "p", "Specify the volk_config path", set_volk_config)));
     profile_options.parse(argc, argv);
-    
+
     if (profile_options.present("help")) {
         return 0;
     }
@@ -156,7 +156,7 @@ int main(int argc, char *argv[]) {
 void read_results(std::vector<volk_test_results_t> *results)
 {
     char path[1024];
-    volk_get_config_path(path);
+    volk_get_config_path(path, true);
 
     read_results(results, std::string(path));
 }
@@ -213,7 +213,7 @@ void read_results(std::vector<volk_test_results_t> *results, std::string path)
 void write_results(const std::vector<volk_test_results_t> *results, bool update_result)
 {
     char path[1024];
-    volk_get_config_path(path);
+    volk_get_config_path(path, false);
 
     write_results( results, update_result, std::string(path));
 }
@@ -308,5 +308,3 @@ void write_json(std::ofstream &json_file, std::vector<volk_test_results_t> resul
     json_file << " ]" << std::endl;
     json_file << "}" << std::endl;
 }
-
-

--- a/include/volk/volk_prefs.h
+++ b/include/volk/volk_prefs.h
@@ -2,6 +2,7 @@
 #define INCLUDED_VOLK_PREFS_H
 
 #include <volk/volk_common.h>
+#include <stdbool.h>
 #include <stdlib.h>
 
 __VOLK_DECL_BEGIN
@@ -14,10 +15,11 @@ typedef struct volk_arch_pref
 } volk_arch_pref_t;
 
 ////////////////////////////////////////////////////////////////////////
-// get path to volk_config profiling info;
+// get path to volk_config profiling info; second arguments specifies
+// if config file should be tested on existence for reading.
 // returns \0 in the argument on failure.
 ////////////////////////////////////////////////////////////////////////
-VOLK_API void volk_get_config_path(char *);
+VOLK_API void volk_get_config_path(char *, bool);
 
 ////////////////////////////////////////////////////////////////////////
 // load prefs into global prefs struct

--- a/lib/volk_prefs.c
+++ b/lib/volk_prefs.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <string.h>
 #if defined(_MSC_VER)
 #include <io.h>
@@ -10,7 +11,7 @@
 #endif
 #include <volk/volk_prefs.h>
 
-void volk_get_config_path(char *path)
+void volk_get_config_path(char *path, bool read)
 {
     if (!path) return;
     const char *suffix = "/.volk/volk_config";
@@ -22,7 +23,9 @@ void volk_get_config_path(char *path)
     if(home!=NULL){
         strncpy(path,home,512);
         strcat(path,suffix2);
-        return;
+        if (!read || access(path, F_OK) != -1){
+            return;
+        }
     }
 
     //check for user-local config file
@@ -30,7 +33,7 @@ void volk_get_config_path(char *path)
     if (home != NULL){
         strncpy(path, home, 512);
         strcat(path, suffix);
-        if (access(path, F_OK) != -1){
+        if (!read || (access(path, F_OK) != -1)){
             return;
         }
     }
@@ -40,7 +43,7 @@ void volk_get_config_path(char *path)
     if (home != NULL){
         strncpy(path, home, 512);
         strcat(path, suffix);
-        if (access(path, F_OK) != -1){
+        if (!read || (access(path, F_OK) != -1)){
             return;
         }
     }
@@ -49,7 +52,9 @@ void volk_get_config_path(char *path)
     if (access("/etc/volk/volk_config", F_OK) != -1){
         strncpy(path, "/etc", 512);
         strcat(path, suffix2);
-        return;
+        if (!read || (access(path, F_OK) != -1)){
+            return;
+        }
     }
 
     //If still no path was found set path[0] to '0' and fall through
@@ -65,7 +70,7 @@ size_t volk_load_preferences(volk_arch_pref_t **prefs_res)
     volk_arch_pref_t *prefs = NULL;
 
     //get the config path
-    volk_get_config_path(path);
+    volk_get_config_path(path, true);
     if (!path[0]) return n_arch_prefs; //no prefs found
     config_file = fopen(path, "r");
     if(!config_file) return n_arch_prefs; //no prefs found


### PR DESCRIPTION
This allows to specify if the config path should be used for reading
configuration or just for writing. In the case of configuration reading
the path is checked for existence. For writing configuration files this
is obviously wrong.