### PR TITLE
Adds neonv7 for volk_32fc_s32f_power_spectrum_32f

### DIFF
--- a/include/volk/volk_neon_intrinsics.h
+++ b/include/volk/volk_neon_intrinsics.h
@@ -21,6 +21,34 @@
  */
 
 /*
+ * Copyright (c) 2016-2019 ARM Limited.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * _vtaylor_polyq_f32
+ * _vlogq_f32
+ *
+ */
+
+/*
  * This file is intended to hold NEON intrinsics of intrinsics.
  * They should be used in VOLK kernels to avoid copy-pasta.
  */
@@ -73,6 +101,50 @@ _vmultiply_complexq_f32(float32x4x2_t a_val, float32x4x2_t b_val)
     c_val.val[0] = vsubq_f32(tmp_real.val[0], tmp_real.val[1]);
     c_val.val[1] = vaddq_f32(tmp_imag.val[0], tmp_imag.val[1]);
     return c_val;
+}
+
+/* From ARM Compute Library, MIT license */
+static inline float32x4_t _vtaylor_polyq_f32(float32x4_t x, const float32x4_t coeffs[8])
+{
+    float32x4_t cA   = vmlaq_f32(coeffs[0], coeffs[4], x);
+    float32x4_t cB   = vmlaq_f32(coeffs[2], coeffs[6], x);
+    float32x4_t cC   = vmlaq_f32(coeffs[1], coeffs[5], x);
+    float32x4_t cD   = vmlaq_f32(coeffs[3], coeffs[7], x);
+    float32x4_t x2  = vmulq_f32(x, x);
+    float32x4_t x4  = vmulq_f32(x2, x2);
+    float32x4_t res = vmlaq_f32(vmlaq_f32(cA, cB, x2), vmlaq_f32(cC, cD, x2), x4);
+    return res;
+}
+
+/* Natural logarithm.
+ * From ARM Compute Library, MIT license */
+static inline float32x4_t _vlogq_f32(float32x4_t x)
+{
+    const float32x4_t log_tab[8] = {
+        vdupq_n_f32(-2.29561495781f),
+        vdupq_n_f32(-2.47071170807f),
+        vdupq_n_f32(-5.68692588806f),
+        vdupq_n_f32(-0.165253549814f),
+        vdupq_n_f32(5.17591238022f),
+        vdupq_n_f32(0.844007015228f),
+        vdupq_n_f32(4.58445882797f),
+        vdupq_n_f32(0.0141278216615f),
+    };
+    
+    const int32x4_t   CONST_127 = vdupq_n_s32(127);           // 127
+    const float32x4_t CONST_LN2 = vdupq_n_f32(0.6931471805f); // ln(2)
+    
+    // Extract exponent
+    int32x4_t m = vsubq_s32(vreinterpretq_s32_u32(vshrq_n_u32(vreinterpretq_u32_f32(x), 23)), CONST_127);
+    float32x4_t val = vreinterpretq_f32_s32(vsubq_s32(vreinterpretq_s32_f32(x), vshlq_n_s32(m, 23)));
+    
+    // Polynomial Approximation
+    float32x4_t poly = _vtaylor_polyq_f32(val, log_tab);
+    
+    // Reconstruct
+    poly = vmlaq_f32(poly, vcvtq_f32_s32(m), CONST_LN2);
+    
+    return poly;
 }
 
 #endif /* INCLUDE_VOLK_VOLK_NEON_INTRINSICS_H_ */

--- a/kernels/volk/volk_32fc_s32f_power_spectrum_32f.h
+++ b/kernels/volk/volk_32fc_s32f_power_spectrum_32f.h
@@ -136,6 +136,52 @@ volk_32fc_s32f_power_spectrum_32f_a_sse3(float* logPowerOutput, const lv_32fc_t*
 }
 #endif /* LV_HAVE_SSE3 */
 
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+#include <volk/volk_neon_intrinsics.h>
+
+static inline void
+volk_32fc_s32f_power_spectrum_32f_neon(float* logPowerOutput, const lv_32fc_t* complexFFTInput, const float normalizationFactor, unsigned int num_points)
+{
+    float* logPowerOutputPtr = logPowerOutput;
+    const lv_32fc_t* complexFFTInputPtr = complexFFTInput;
+    const float iNormalizationFactor = 1.0 / normalizationFactor;
+    unsigned int number;
+    unsigned int quarter_points = num_points / 4;
+    float32x4x2_t fft_vec;
+    float32x4_t log_pwr_vec;
+    float32x4_t mag_squared_vec;
+    
+    const float inv_ln10_10 = 4.34294481903f; // 10.0/ln(10.)
+    
+    for(number = 0; number < quarter_points; number++) {
+        // Load
+        fft_vec = vld2q_f32((float*)complexFFTInputPtr);
+        // Prefetch next 4
+        __VOLK_PREFETCH(complexFFTInputPtr+4);
+        // Normalize
+        fft_vec.val[0] = vmulq_n_f32(fft_vec.val[0], iNormalizationFactor);
+        fft_vec.val[1] = vmulq_n_f32(fft_vec.val[1], iNormalizationFactor);
+        mag_squared_vec = _vmagnitudesquaredq_f32(fft_vec);
+        log_pwr_vec = vmulq_n_f32(_vlogq_f32(mag_squared_vec), inv_ln10_10);
+        // Store
+        vst1q_f32(logPowerOutputPtr, log_pwr_vec);
+        // Move pointers ahead
+        complexFFTInputPtr+=4;
+        logPowerOutputPtr+=4;
+    }
+    
+    // deal with the rest
+    for(number = quarter_points * 4; number < num_points; number++) {
+        const float real = lv_creal(*complexFFTInputPtr) * iNormalizationFactor;
+        const float imag = lv_cimag(*complexFFTInputPtr) * iNormalizationFactor;
+        *logPowerOutputPtr = 10.0 * log10f(((real * real) + (imag * imag)) + 1e-20);
+        complexFFTInputPtr++;
+        logPowerOutputPtr++;
+    }
+}
+
+#endif /* LV_HAVE_NEON */
 
 #ifdef LV_HAVE_GENERIC
 


### PR DESCRIPTION
```
RUN_VOLK_TESTS: volk_32fc_s32f_power_spectrum_32f(131071,1)
neon completed in 3.43933 ms
generic completed in 15.4339 ms
Best aligned arch: neon
Best unaligned arch: neon
```

4.5x faster is pretty good!