### PR TITLE
Fix AVX FMA rotator

### DIFF
--- a/kernels/volk/volk_32fc_s32fc_x2_rotator_32fc.h
+++ b/kernels/volk/volk_32fc_s32fc_x2_rotator_32fc.h
@@ -690,7 +690,7 @@ static inline void volk_32fc_s32fc_x2_rotator_32fc_a_avx_fma(lv_32fc_t* outVecto
         yhp = _mm256_movehdup_ps(inc_Val);
 
         tmp1 = aVal;
-        tmp1p = ylp;
+        tmp1p = phase_Val;
 
         aVal = _mm256_shuffle_ps(aVal, aVal, 0xB1);
         phase_Val = _mm256_shuffle_ps(phase_Val, phase_Val, 0xB1);
@@ -788,7 +788,7 @@ static inline void volk_32fc_s32fc_x2_rotator_32fc_u_avx_fma(lv_32fc_t* outVecto
         yhp = _mm256_movehdup_ps(inc_Val);
 
         tmp1 = aVal;
-        tmp1p = ylp;
+        tmp1p = phase_Val;
 
         aVal = _mm256_shuffle_ps(aVal, aVal, 0xB1);
         phase_Val = _mm256_shuffle_ps(phase_Val, phase_Val, 0xB1);

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -24,6 +24,13 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     volk_test_params_t test_params_inacc = test_params.make_tol(1e-2);
     volk_test_params_t test_params_inacc_tenth = test_params.make_tol(1e-1);
 
+    volk_test_params_t test_params_power(test_params);
+    test_params_power.set_scalar(2.5);
+
+    volk_test_params_t test_params_rotator(test_params);
+    test_params_rotator.set_scalar(std::polar(1.0f, 0.1f));
+    test_params_rotator.set_tol(1e-3);
+
     std::vector<volk_test_case_t> test_cases;
     QA(VOLK_INIT_PUPP(volk_64u_popcntpuppet_64u, volk_64u_popcnt,     test_params))
     QA(VOLK_INIT_PUPP(volk_64u_popcntpuppet_64u, volk_64u_popcnt,     test_params))
@@ -32,7 +39,7 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     QA(VOLK_INIT_PUPP(volk_32u_byteswappuppet_32u, volk_32u_byteswap, test_params))
     QA(VOLK_INIT_PUPP(volk_32u_popcntpuppet_32u, volk_32u_popcnt_32u,  test_params))
     QA(VOLK_INIT_PUPP(volk_64u_byteswappuppet_64u, volk_64u_byteswap, test_params))
-    QA(VOLK_INIT_PUPP(volk_32fc_s32fc_rotatorpuppet_32fc, volk_32fc_s32fc_x2_rotator_32fc, test_params))
+    QA(VOLK_INIT_PUPP(volk_32fc_s32fc_rotatorpuppet_32fc, volk_32fc_s32fc_x2_rotator_32fc, test_params_rotator))
     QA(VOLK_INIT_PUPP(volk_8u_conv_k7_r2puppet_8u, volk_8u_x4_conv_k7_r2_8u, test_params.make_tol(0)))
     QA(VOLK_INIT_PUPP(volk_32f_x2_fm_detectpuppet_32f, volk_32f_s32f_32f_fm_detect_32f, test_params))
     QA(VOLK_INIT_TEST(volk_16ic_s32f_deinterleave_real_32f,           test_params))
@@ -63,7 +70,7 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     QA(VOLK_INIT_TEST(volk_32f_atan_32f,                              test_params_inacc))
     QA(VOLK_INIT_TEST(volk_32f_asin_32f,                              test_params_inacc))
     QA(VOLK_INIT_TEST(volk_32f_acos_32f,                              test_params_inacc))
-    QA(VOLK_INIT_TEST(volk_32fc_s32f_power_32fc,                      test_params))
+    QA(VOLK_INIT_TEST(volk_32fc_s32f_power_32fc,                      test_params_power))
     QA(VOLK_INIT_TEST(volk_32f_s32f_calc_spectral_noise_floor_32f,    test_params_inacc))
     QA(VOLK_INIT_TEST(volk_32fc_s32f_atan2_32f,                       test_params))
     QA(VOLK_INIT_TEST(volk_32fc_x2_conjugate_dot_prod_32fc,           test_params_inacc_tenth))

--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -302,6 +302,14 @@ bool ccompare(t *in1, t *in2, unsigned int vlen, float tol, bool absolute_mode) 
     bool fail = false;
     int print_max_errs = 10;
     for(unsigned int i=0; i<2*vlen; i+=2) {
+        if (std::isnan(in1[i]) || std::isnan(in1[i+1]) || std::isnan(in2[i]) || std::isnan(in2[i+1])
+                || std::isinf(in1[i]) || std::isinf(in1[i+1]) || std::isinf(in2[i]) || std::isinf(in2[i+1])) {
+            fail=true;
+            if(print_max_errs-- > 0) {
+                std::cout << "offset " << i/2 << " in1: " << in1[i] << " + " << in1[i+1] << "j  in2: " << in2[i] << " + " << in2[i+1] << "j";
+                std::cout << " tolerance was: " << tol << std::endl;
+            }
+        }
         t diff[2] = { in1[i] - in2[i], in1[i+1] - in2[i+1] };
         t err  = std::sqrt(diff[0] * diff[0] + diff[1] * diff[1]);
         t norm = std::sqrt(in1[i] * in1[i] + in1[i+1] * in1[i+1]);


### PR DESCRIPTION
Fixes https://github.com/gnuradio/gnuradio/issues/2748.

This change makes the loops on lines 684-707 and 782-805 match the ones on lines 653-677 and 751-775, after which the rotator correctly rotates the final `(fourthPoints % ROTATOR_RELOAD) * 4`samples.