### PR TITLE
cmake: bump minimum version to 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.8)
 set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "Choose build type: None Debug Release RelWithDebInfo MinSizeRel")
 project(volk)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -208,14 +208,6 @@ if(CPU_IS_x86)
     # Disable SSE4a if Clang is less than version 3.2
     if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
       # Figure out the version of Clang
-      if(CMAKE_VERSION VERSION_LESS "2.8.10")
-        # Extract the Clang version from the --version string.
-        # In cmake 2.8.10, we can just use CMAKE_C_COMPILER_VERSION
-        # without having to go through these string manipulations
-        execute_process(COMMAND ${CMAKE_C_COMPILER} --version
-          OUTPUT_VARIABLE clang_version)
-        string(REGEX MATCH "[0-9].[0-9]" CMAKE_C_COMPILER_VERSION ${clang_version})
-      endif(CMAKE_VERSION VERSION_LESS "2.8.10")
 
       if(CMAKE_C_COMPILER_VERSION VERSION_LESS "3.2")
         OVERRULE_ARCH(sse4_a "Clang >= 3.2 required for SSE4a")
@@ -440,42 +432,32 @@ string(REPLACE "\n" " \\n" COMPILER_INFO ${COMPILER_INFO})
 # Handle ASM support
 #  on by default, but let users turn it off
 ########################################################################
-if(${CMAKE_VERSION} VERSION_GREATER "2.8.9")
-  set(ASM_ARCHS_AVAILABLE "neonv7" "neonv8")
+set(ASM_ARCHS_AVAILABLE "neonv7" "neonv8")
 
-  set(FULL_C_FLAGS "${CMAKE_C_FLAGS}" "${CMAKE_CXX_COMPILER_ARG1}")
+set(FULL_C_FLAGS "${CMAKE_C_FLAGS}" "${CMAKE_CXX_COMPILER_ARG1}")
 
-  # sort through a list of all architectures we have ASM for
-  # if we find one that matches our current system architecture
-  # set up the assembler flags and include the source files
-  foreach(ARCH ${ASM_ARCHS_AVAILABLE})
-      string(REGEX MATCH "${ARCH}" ASM_ARCH "${available_archs}")
-    if( ASM_ARCH STREQUAL "neonv7" )
-      message(STATUS "---- Adding ASM files") # we always use ATT syntax
-      message(STATUS "-- Detected neon architecture; enabling ASM")
-      # architecture specific assembler flags are now set in the cmake toolchain file
-      # then add the files
-      include_directories(${PROJECT_SOURCE_DIR}/kernels/volk/asm/neon)
-      file(GLOB asm_files ${PROJECT_SOURCE_DIR}/kernels/volk/asm/neon/*.s)
-      foreach(asm_file ${asm_files})
-        list(APPEND volk_sources ${asm_file})
-        message(STATUS "Adding source file: ${asm_file}")
-      endforeach(asm_file)
-    endif()
-    enable_language(ASM)
-    message(STATUS "c flags: ${FULL_C_FLAGS}")
-    message(STATUS "asm flags: ${CMAKE_ASM_FLAGS}")
-  endforeach(ARCH)
+# sort through a list of all architectures we have ASM for
+# if we find one that matches our current system architecture
+# set up the assembler flags and include the source files
+foreach(ARCH ${ASM_ARCHS_AVAILABLE})
+  string(REGEX MATCH "${ARCH}" ASM_ARCH "${available_archs}")
+if( ASM_ARCH STREQUAL "neonv7" )
+  message(STATUS "---- Adding ASM files") # we always use ATT syntax
+  message(STATUS "-- Detected neon architecture; enabling ASM")
+  # architecture specific assembler flags are now set in the cmake toolchain file
+  # then add the files
+  include_directories(${PROJECT_SOURCE_DIR}/kernels/volk/asm/neon)
+  file(GLOB asm_files ${PROJECT_SOURCE_DIR}/kernels/volk/asm/neon/*.s)
+  foreach(asm_file ${asm_files})
+    list(APPEND volk_sources ${asm_file})
+    message(STATUS "Adding source file: ${asm_file}")
+  endforeach(asm_file)
+endif()
+enable_language(ASM)
+message(STATUS "c flags: ${FULL_C_FLAGS}")
+message(STATUS "asm flags: ${CMAKE_ASM_FLAGS}")
+endforeach(ARCH)
 
-else(${CMAKE_VERSION} VERSION_GREATER "2.8.9")
-  message(STATUS "Not enabling ASM support. CMake >= 2.8.10 required.")
-  foreach(machine_name ${available_machines})
-    string(REGEX MATCH "neon" NEON_MACHINE ${machine_name})
-    if( NEON_MACHINE STREQUAL "neon")
-      message(FATAL_ERROR "CMake >= 2.8.10 is required for ARM NEON support")
-    endif()
-  endforeach()
-endif(${CMAKE_VERSION} VERSION_GREATER "2.8.9")
 
 ########################################################################
 # Handle orc support


### PR DESCRIPTION
This commit bumps the minimum required CMake version to 3.8. This is in
line with GNU Radio 3.8 requirements. Ubuntu 18.04 provides CMake 3.10.
Other distros are probably ahead of Ubuntu LTS.
Alternatively, we could bump the minimum version to 3.5.1 because this
is the version Ubuntu 16.04 ships. Though, I'd argue that `master`
should require newer versions. This would also be in line with hopefully
moving to C++17 in the near future.