### PR TITLE
Adds Neonv8 protokernel to 'volk_32f_64f_add_64f'

### DIFF
--- a/cmake/Toolchains/arm_cortex_a72_hardfp_native.cmake
+++ b/cmake/Toolchains/arm_cortex_a72_hardfp_native.cmake
@@ -4,6 +4,6 @@
 ########################################################################
 set(CMAKE_CXX_COMPILER g++)
 set(CMAKE_C_COMPILER  gcc)
-set(CMAKE_CXX_FLAGS "-ffast-math -march=armv8-a -mtune=cortex-a72 -mfpu=neon-fp-armv8 -mfloat-abi=hard" CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS "-march=armv8-a -mtune=cortex-a72 -mfpu=neon-fp-armv8 -mfloat-abi=hard" CACHE STRING "" FORCE)
 set(CMAKE_C_FLAGS ${CMAKE_CXX_FLAGS} CACHE STRING "" FORCE) #same flags for C sources
 set(CMAKE_ASM_FLAGS "${CMAKE_CXX_FLAGS} -mthumb -g" CACHE STRING "" FORCE) #same flags for asm sources

--- a/cmake/Toolchains/arm_cortex_a72_hardfp_native.cmake
+++ b/cmake/Toolchains/arm_cortex_a72_hardfp_native.cmake
@@ -4,5 +4,6 @@
 ########################################################################
 set(CMAKE_CXX_COMPILER g++)
 set(CMAKE_C_COMPILER  gcc)
-set(CMAKE_CXX_FLAGS "-march=armv8-a -mtune=cortex-a72 -mfpu=neon-fp-armv8 -mfloat-abi=hard" CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS "-ffast-math -march=armv8-a -mtune=cortex-a72 -mfpu=neon-fp-armv8 -mfloat-abi=hard" CACHE STRING "" FORCE)
 set(CMAKE_C_FLAGS ${CMAKE_CXX_FLAGS} CACHE STRING "" FORCE) #same flags for C sources
+set(CMAKE_ASM_FLAGS "${CMAKE_CXX_FLAGS} -mthumb -g" CACHE STRING "" FORCE) #same flags for asm sources

--- a/kernels/volk/volk_32f_64f_add_64f.h
+++ b/kernels/volk/volk_32f_64f_add_64f.h
@@ -25,14 +25,16 @@
  *
  * \b Overview
  *
- * Multiplies two input double-precision doubleing point vectors together.
+ * Adds two input vectors and store result as a double-precision vectors. One
+ * of the input vector is defined as a single precision floating point, so
+ * upcasting is performed before the addition
  *
- * c[i] = a[i] * b[i]
+ * c[i] = a[i] + b[i]
  *
  * <b>Dispatcher Prototype</b>
  * \code
- * void volk_32f_64f_add_64f(double* cVector, const double* aVector, const double* bVector, unsigned int num_points)
- * \endcode
+ * void volk_32f_64f_add_64f(double* cVector, const double* aVector, const
+ * double* bVector, unsigned int num_points) \endcode
  *
  * \b Inputs
  * \li aVector: First input vector.
@@ -73,13 +75,12 @@
 
 #include <inttypes.h>
 
-
 #ifdef LV_HAVE_GENERIC
 
-static inline void
-volk_32f_64f_add_64f_generic(double *cVector, const float *aVector,
-                                 const double *bVector, unsigned int num_points)
-{
+static inline void volk_32f_64f_add_64f_generic(double *cVector,
+                                                const float *aVector,
+                                                const double *bVector,
+                                                unsigned int num_points) {
   double *cPtr = cVector;
   const float *aPtr = aVector;
   const double *bPtr = bVector;
@@ -92,20 +93,58 @@ volk_32f_64f_add_64f_generic(double *cVector, const float *aVector,
 
 #endif /* LV_HAVE_GENERIC */
 
-/*
- * Unaligned versions
- */
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
 
+static inline void volk_32f_64f_add_64f_neon(double *cVector,
+                                             const float *aVector,
+                                             const double *bVector,
+                                             unsigned int num_points) {
+  unsigned int number = 0;
+  const unsigned int half_points = num_points / 2;
+
+  double *cPtr = cVector;
+  const float *aPtr = aVector;
+  const double *bPtr = bVector;
+
+  float64x2_t aVal, bVal, cVal;
+  float32x2_t aVal1;
+  for (number = 0; number < half_points; number++) {
+    // Load in to NEON registers
+    aVal1 = vld1_f32(aPtr);
+    bVal = vld1q_f64(bPtr);
+    __VOLK_PREFETCH(aPtr + 2);
+    __VOLK_PREFETCH(bPtr + 2);
+
+    // Vector conversion
+    aVal = vcvt_f64_f32(aVal1);
+    // vector add
+    cVal = vaddq_f64(aVal, bVal);
+    // Store the results back into the C container
+    vst1q_f64(cPtr, cVal);
+
+    aPtr += 2; // q uses quadwords, 4 floats per vadd
+    bPtr += 2;
+    cPtr += 2;
+  }
+
+  number = half_points * 2; // should be = num_points
+  for (; number < num_points; number++) {
+    *cPtr++ = ((double)(*aPtr++)) + (*bPtr++);
+  }
+}
+
+#endif /* LV_HAVE_NEONV8 */
 
 #ifdef LV_HAVE_AVX
 
 #include <immintrin.h>
 #include <xmmintrin.h>
 
-static inline void
-volk_32f_64f_add_64f_u_avx(double *cVector, const float *aVector,
-                               const double *bVector, unsigned int num_points)
-{
+static inline void volk_32f_64f_add_64f_u_avx(double *cVector,
+                                              const float *aVector,
+                                              const double *bVector,
+                                              unsigned int num_points) {
   unsigned int number = 0;
   const unsigned int eighth_points = num_points / 8;
 
@@ -120,7 +159,7 @@ volk_32f_64f_add_64f_u_avx(double *cVector, const float *aVector,
 
     aVal = _mm256_loadu_ps(aPtr);
     bVal1 = _mm256_loadu_pd(bPtr);
-    bVal2 = _mm256_loadu_pd(bPtr+4);
+    bVal2 = _mm256_loadu_pd(bPtr + 4);
 
     aVal1 = _mm256_extractf128_ps(aVal, 0);
     aVal2 = _mm256_extractf128_ps(aVal, 1);
@@ -131,8 +170,10 @@ volk_32f_64f_add_64f_u_avx(double *cVector, const float *aVector,
     cVal1 = _mm256_add_pd(aDbl1, bVal1);
     cVal2 = _mm256_add_pd(aDbl2, bVal2);
 
-    _mm256_storeu_pd(cPtr, cVal1); // Store the results back into the C container
-    _mm256_storeu_pd(cPtr+4, cVal2); // Store the results back into the C container
+    _mm256_storeu_pd(cPtr,
+                     cVal1); // Store the results back into the C container
+    _mm256_storeu_pd(cPtr + 4,
+                     cVal2); // Store the results back into the C container
 
     aPtr += 8;
     bPtr += 8;
@@ -147,16 +188,15 @@ volk_32f_64f_add_64f_u_avx(double *cVector, const float *aVector,
 
 #endif /* LV_HAVE_AVX */
 
-
 #ifdef LV_HAVE_AVX
 
 #include <immintrin.h>
 #include <xmmintrin.h>
 
-static inline void
-volk_32f_64f_add_64f_a_avx(double *cVector, const float *aVector,
-                                const double *bVector, unsigned int num_points)
-{
+static inline void volk_32f_64f_add_64f_a_avx(double *cVector,
+                                              const float *aVector,
+                                              const double *bVector,
+                                              unsigned int num_points) {
   unsigned int number = 0;
   const unsigned int eighth_points = num_points / 8;
 
@@ -171,7 +211,7 @@ volk_32f_64f_add_64f_a_avx(double *cVector, const float *aVector,
 
     aVal = _mm256_load_ps(aPtr);
     bVal1 = _mm256_load_pd(bPtr);
-    bVal2 = _mm256_load_pd(bPtr+4);
+    bVal2 = _mm256_load_pd(bPtr + 4);
 
     aVal1 = _mm256_extractf128_ps(aVal, 0);
     aVal2 = _mm256_extractf128_ps(aVal, 1);
@@ -183,7 +223,8 @@ volk_32f_64f_add_64f_a_avx(double *cVector, const float *aVector,
     cVal2 = _mm256_add_pd(aDbl2, bVal2);
 
     _mm256_store_pd(cPtr, cVal1); // Store the results back into the C container
-    _mm256_store_pd(cPtr+4, cVal2); // Store the results back into the C container
+    _mm256_store_pd(cPtr + 4,
+                    cVal2); // Store the results back into the C container
 
     aPtr += 8;
     bPtr += 8;
@@ -197,7 +238,5 @@ volk_32f_64f_add_64f_a_avx(double *cVector, const float *aVector,
 }
 
 #endif /* LV_HAVE_AVX */
-
-
 
 #endif /* INCLUDED_volk_32f_64f_add_64f_u_H */


### PR DESCRIPTION
Adds Adds Neonv8 protokernel to volk_32f_64f_add_64f. Code in toolchains credited to Albin
Stigo (@ast). Execution improvement shown below
```
ubuntu@ubuntu:~/volk/build$ ./apps/volk_profile -d -R 32f_64f_add

RUN_VOLK_TESTS: volk_32f_64f_add_64f(131071,1987)
generic completed in 1079.18 ms
neon completed in 1056.38 ms
Best aligned arch: neon
Best unaligned arch: neon
Writing /home/ubuntu/.volk/volk_config...
```