### PR TITLE
Adds Neonv8 support to 32fc_deinterleave_64f_x2 and 32fc_deinterleave_real_64f

### DIFF
--- a/cmake/Toolchains/arm_cortex_a72_hardfp_native.cmake
+++ b/cmake/Toolchains/arm_cortex_a72_hardfp_native.cmake
@@ -4,6 +4,6 @@
 ########################################################################
 set(CMAKE_CXX_COMPILER g++)
 set(CMAKE_C_COMPILER  gcc)
-set(CMAKE_CXX_FLAGS "-ffast-math -march=armv8-a -mtune=cortex-a72 -mfpu=neon-fp-armv8 -mfloat-abi=hard" CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS "-march=armv8-a -mtune=cortex-a72 -mfpu=neon-fp-armv8 -mfloat-abi=hard" CACHE STRING "" FORCE)
 set(CMAKE_C_FLAGS ${CMAKE_CXX_FLAGS} CACHE STRING "" FORCE) #same flags for C sources
 set(CMAKE_ASM_FLAGS "${CMAKE_CXX_FLAGS} -mthumb -g" CACHE STRING "" FORCE) #same flags for asm sources

--- a/cmake/Toolchains/arm_cortex_a72_hardfp_native.cmake
+++ b/cmake/Toolchains/arm_cortex_a72_hardfp_native.cmake
@@ -4,5 +4,6 @@
 ########################################################################
 set(CMAKE_CXX_COMPILER g++)
 set(CMAKE_C_COMPILER  gcc)
-set(CMAKE_CXX_FLAGS "-march=armv8-a -mtune=cortex-a72 -mfpu=neon-fp-armv8 -mfloat-abi=hard" CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS "-ffast-math -march=armv8-a -mtune=cortex-a72 -mfpu=neon-fp-armv8 -mfloat-abi=hard" CACHE STRING "" FORCE)
 set(CMAKE_C_FLAGS ${CMAKE_CXX_FLAGS} CACHE STRING "" FORCE) #same flags for C sources
+set(CMAKE_ASM_FLAGS "${CMAKE_CXX_FLAGS} -mthumb -g" CACHE STRING "" FORCE) #same flags for asm sources

--- a/kernels/volk/volk_32f_64f_add_64f.h
+++ b/kernels/volk/volk_32f_64f_add_64f.h
@@ -115,6 +115,8 @@ static inline void volk_32f_64f_add_64f_neon(double *cVector,
     bVal = vld1q_f64(bPtr);
     __VOLK_PREFETCH(aPtr + 2);
     __VOLK_PREFETCH(bPtr + 2);
+    aPtr += 2; // q uses quadwords, 4 floats per vadd
+    bPtr += 2;
 
     // Vector conversion
     aVal = vcvt_f64_f32(aVal1);
@@ -123,8 +125,6 @@ static inline void volk_32f_64f_add_64f_neon(double *cVector,
     // Store the results back into the C container
     vst1q_f64(cPtr, cVal);
 
-    aPtr += 2; // q uses quadwords, 4 floats per vadd
-    bPtr += 2;
     cPtr += 2;
   }
 

--- a/kernels/volk/volk_32f_64f_add_64f.h
+++ b/kernels/volk/volk_32f_64f_add_64f.h
@@ -25,14 +25,16 @@
  *
  * \b Overview
  *
- * Multiplies two input double-precision doubleing point vectors together.
+ * Adds two input vectors and store result as a double-precision vectors. One
+ * of the input vector is defined as a single precision floating point, so
+ * upcasting is performed before the addition
  *
- * c[i] = a[i] * b[i]
+ * c[i] = a[i] + b[i]
  *
  * <b>Dispatcher Prototype</b>
  * \code
- * void volk_32f_64f_add_64f(double* cVector, const double* aVector, const double* bVector, unsigned int num_points)
- * \endcode
+ * void volk_32f_64f_add_64f(double* cVector, const double* aVector, const
+ * double* bVector, unsigned int num_points) \endcode
  *
  * \b Inputs
  * \li aVector: First input vector.
@@ -73,13 +75,12 @@
 
 #include <inttypes.h>
 
-
 #ifdef LV_HAVE_GENERIC
 
-static inline void
-volk_32f_64f_add_64f_generic(double *cVector, const float *aVector,
-                                 const double *bVector, unsigned int num_points)
-{
+static inline void volk_32f_64f_add_64f_generic(double *cVector,
+                                                const float *aVector,
+                                                const double *bVector,
+                                                unsigned int num_points) {
   double *cPtr = cVector;
   const float *aPtr = aVector;
   const double *bPtr = bVector;
@@ -92,20 +93,58 @@ volk_32f_64f_add_64f_generic(double *cVector, const float *aVector,
 
 #endif /* LV_HAVE_GENERIC */
 
-/*
- * Unaligned versions
- */
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
 
+static inline void volk_32f_64f_add_64f_neon(double *cVector,
+                                             const float *aVector,
+                                             const double *bVector,
+                                             unsigned int num_points) {
+  unsigned int number = 0;
+  const unsigned int half_points = num_points / 2;
+
+  double *cPtr = cVector;
+  const float *aPtr = aVector;
+  const double *bPtr = bVector;
+
+  float64x2_t aVal, bVal, cVal;
+  float32x2_t aVal1;
+  for (number = 0; number < half_points; number++) {
+    // Load in to NEON registers
+    aVal1 = vld1_f32(aPtr);
+    bVal = vld1q_f64(bPtr);
+    __VOLK_PREFETCH(aPtr + 2);
+    __VOLK_PREFETCH(bPtr + 2);
+
+    // Vector conversion
+    aVal = vcvt_f64_f32(aVal1);
+    // vector add
+    cVal = vaddq_f64(aVal, bVal);
+    // Store the results back into the C container
+    vst1q_f64(cPtr, cVal);
+
+    aPtr += 2; // q uses quadwords, 4 floats per vadd
+    bPtr += 2;
+    cPtr += 2;
+  }
+
+  number = half_points * 2; // should be = num_points
+  for (; number < num_points; number++) {
+    *cPtr++ = ((double)(*aPtr++)) + (*bPtr++);
+  }
+}
+
+#endif /* LV_HAVE_NEONV8 */
 
 #ifdef LV_HAVE_AVX
 
 #include <immintrin.h>
 #include <xmmintrin.h>
 
-static inline void
-volk_32f_64f_add_64f_u_avx(double *cVector, const float *aVector,
-                               const double *bVector, unsigned int num_points)
-{
+static inline void volk_32f_64f_add_64f_u_avx(double *cVector,
+                                              const float *aVector,
+                                              const double *bVector,
+                                              unsigned int num_points) {
   unsigned int number = 0;
   const unsigned int eighth_points = num_points / 8;
 
@@ -120,7 +159,7 @@ volk_32f_64f_add_64f_u_avx(double *cVector, const float *aVector,
 
     aVal = _mm256_loadu_ps(aPtr);
     bVal1 = _mm256_loadu_pd(bPtr);
-    bVal2 = _mm256_loadu_pd(bPtr+4);
+    bVal2 = _mm256_loadu_pd(bPtr + 4);
 
     aVal1 = _mm256_extractf128_ps(aVal, 0);
     aVal2 = _mm256_extractf128_ps(aVal, 1);
@@ -131,8 +170,10 @@ volk_32f_64f_add_64f_u_avx(double *cVector, const float *aVector,
     cVal1 = _mm256_add_pd(aDbl1, bVal1);
     cVal2 = _mm256_add_pd(aDbl2, bVal2);
 
-    _mm256_storeu_pd(cPtr, cVal1); // Store the results back into the C container
-    _mm256_storeu_pd(cPtr+4, cVal2); // Store the results back into the C container
+    _mm256_storeu_pd(cPtr,
+                     cVal1); // Store the results back into the C container
+    _mm256_storeu_pd(cPtr + 4,
+                     cVal2); // Store the results back into the C container
 
     aPtr += 8;
     bPtr += 8;
@@ -147,16 +188,15 @@ volk_32f_64f_add_64f_u_avx(double *cVector, const float *aVector,
 
 #endif /* LV_HAVE_AVX */
 
-
 #ifdef LV_HAVE_AVX
 
 #include <immintrin.h>
 #include <xmmintrin.h>
 
-static inline void
-volk_32f_64f_add_64f_a_avx(double *cVector, const float *aVector,
-                                const double *bVector, unsigned int num_points)
-{
+static inline void volk_32f_64f_add_64f_a_avx(double *cVector,
+                                              const float *aVector,
+                                              const double *bVector,
+                                              unsigned int num_points) {
   unsigned int number = 0;
   const unsigned int eighth_points = num_points / 8;
 
@@ -171,7 +211,7 @@ volk_32f_64f_add_64f_a_avx(double *cVector, const float *aVector,
 
     aVal = _mm256_load_ps(aPtr);
     bVal1 = _mm256_load_pd(bPtr);
-    bVal2 = _mm256_load_pd(bPtr+4);
+    bVal2 = _mm256_load_pd(bPtr + 4);
 
     aVal1 = _mm256_extractf128_ps(aVal, 0);
     aVal2 = _mm256_extractf128_ps(aVal, 1);
@@ -183,7 +223,8 @@ volk_32f_64f_add_64f_a_avx(double *cVector, const float *aVector,
     cVal2 = _mm256_add_pd(aDbl2, bVal2);
 
     _mm256_store_pd(cPtr, cVal1); // Store the results back into the C container
-    _mm256_store_pd(cPtr+4, cVal2); // Store the results back into the C container
+    _mm256_store_pd(cPtr + 4,
+                    cVal2); // Store the results back into the C container
 
     aPtr += 8;
     bPtr += 8;
@@ -197,7 +238,5 @@ volk_32f_64f_add_64f_a_avx(double *cVector, const float *aVector,
 }
 
 #endif /* LV_HAVE_AVX */
-
-
 
 #endif /* INCLUDED_volk_32f_64f_add_64f_u_H */

--- a/kernels/volk/volk_32fc_deinterleave_64f_x2.h
+++ b/kernels/volk/volk_32fc_deinterleave_64f_x2.h
@@ -30,8 +30,8 @@
  *
  * <b>Dispatcher Prototype</b>
  * \code
- * void volk_32fc_deinterleave_64f_x2(double* iBuffer, double* qBuffer, const lv_32fc_t* complexVector, unsigned int num_points)
- * \endcode
+ * void volk_32fc_deinterleave_64f_x2(double* iBuffer, double* qBuffer, const
+ * lv_32fc_t* complexVector, unsigned int num_points) \endcode
  *
  * \b Inputs
  * \li complexVector: The complex input vector.
@@ -80,21 +80,21 @@
 #include <immintrin.h>
 
 static inline void
-volk_32fc_deinterleave_64f_x2_u_avx(double* iBuffer, double* qBuffer, const lv_32fc_t* complexVector,
-                                    unsigned int num_points)
-{
+volk_32fc_deinterleave_64f_x2_u_avx(double *iBuffer, double *qBuffer,
+                                    const lv_32fc_t *complexVector,
+                                    unsigned int num_points) {
   unsigned int number = 0;
 
-  const float* complexVectorPtr = (float*)complexVector;
-  double* iBufferPtr = iBuffer;
-  double* qBufferPtr = qBuffer;
+  const float *complexVectorPtr = (float *)complexVector;
+  double *iBufferPtr = iBuffer;
+  double *qBufferPtr = qBuffer;
 
   const unsigned int quarterPoints = num_points / 4;
   __m256 cplxValue;
   __m128 complexH, complexL, fVal;
   __m256d dVal;
 
-  for(;number < quarterPoints; number++){
+  for (; number < quarterPoints; number++) {
 
     cplxValue = _mm256_loadu_ps(complexVectorPtr);
     complexVectorPtr += 8;
@@ -103,12 +103,12 @@ volk_32fc_deinterleave_64f_x2_u_avx(double* iBuffer, double* qBuffer, const lv_3
     complexL = _mm256_extractf128_ps(cplxValue, 0);
 
     // Arrange in i1i2i1i2 format
-    fVal = _mm_shuffle_ps(complexL, complexH, _MM_SHUFFLE(2,0,2,0));
+    fVal = _mm_shuffle_ps(complexL, complexH, _MM_SHUFFLE(2, 0, 2, 0));
     dVal = _mm256_cvtps_pd(fVal);
     _mm256_storeu_pd(iBufferPtr, dVal);
 
     // Arrange in q1q2q1q2 format
-    fVal = _mm_shuffle_ps(complexL, complexH, _MM_SHUFFLE(3,1,3,1));
+    fVal = _mm_shuffle_ps(complexL, complexH, _MM_SHUFFLE(3, 1, 3, 1));
     dVal = _mm256_cvtps_pd(fVal);
     _mm256_storeu_pd(qBufferPtr, dVal);
 
@@ -117,7 +117,7 @@ volk_32fc_deinterleave_64f_x2_u_avx(double* iBuffer, double* qBuffer, const lv_3
   }
 
   number = quarterPoints * 4;
-  for(; number < num_points; number++){
+  for (; number < num_points; number++) {
     *iBufferPtr++ = *complexVectorPtr++;
     *qBufferPtr++ = *complexVectorPtr++;
   }
@@ -128,31 +128,31 @@ volk_32fc_deinterleave_64f_x2_u_avx(double* iBuffer, double* qBuffer, const lv_3
 #include <emmintrin.h>
 
 static inline void
-volk_32fc_deinterleave_64f_x2_u_sse2(double* iBuffer, double* qBuffer, const lv_32fc_t* complexVector,
-                                     unsigned int num_points)
-{
+volk_32fc_deinterleave_64f_x2_u_sse2(double *iBuffer, double *qBuffer,
+                                     const lv_32fc_t *complexVector,
+                                     unsigned int num_points) {
   unsigned int number = 0;
 
-  const float* complexVectorPtr = (float*)complexVector;
-  double* iBufferPtr = iBuffer;
-  double* qBufferPtr = qBuffer;
+  const float *complexVectorPtr = (float *)complexVector;
+  double *iBufferPtr = iBuffer;
+  double *qBufferPtr = qBuffer;
 
   const unsigned int halfPoints = num_points / 2;
   __m128 cplxValue, fVal;
   __m128d dVal;
 
-  for(;number < halfPoints; number++){
+  for (; number < halfPoints; number++) {
 
     cplxValue = _mm_loadu_ps(complexVectorPtr);
     complexVectorPtr += 4;
 
     // Arrange in i1i2i1i2 format
-    fVal = _mm_shuffle_ps(cplxValue, cplxValue, _MM_SHUFFLE(2,0,2,0));
+    fVal = _mm_shuffle_ps(cplxValue, cplxValue, _MM_SHUFFLE(2, 0, 2, 0));
     dVal = _mm_cvtps_pd(fVal);
     _mm_storeu_pd(iBufferPtr, dVal);
 
     // Arrange in q1q2q1q2 format
-    fVal = _mm_shuffle_ps(cplxValue, cplxValue, _MM_SHUFFLE(3,1,3,1));
+    fVal = _mm_shuffle_ps(cplxValue, cplxValue, _MM_SHUFFLE(3, 1, 3, 1));
     dVal = _mm_cvtps_pd(fVal);
     _mm_storeu_pd(qBufferPtr, dVal);
 
@@ -161,7 +161,7 @@ volk_32fc_deinterleave_64f_x2_u_sse2(double* iBuffer, double* qBuffer, const lv_
   }
 
   number = halfPoints * 2;
-  for(; number < num_points; number++){
+  for (; number < num_points; number++) {
     *iBufferPtr++ = *complexVectorPtr++;
     *qBufferPtr++ = *complexVectorPtr++;
   }
@@ -171,23 +171,20 @@ volk_32fc_deinterleave_64f_x2_u_sse2(double* iBuffer, double* qBuffer, const lv_
 #ifdef LV_HAVE_GENERIC
 
 static inline void
-volk_32fc_deinterleave_64f_x2_generic(double* iBuffer, double* qBuffer, const lv_32fc_t* complexVector,
-                                      unsigned int num_points)
-{
+volk_32fc_deinterleave_64f_x2_generic(double *iBuffer, double *qBuffer,
+                                      const lv_32fc_t *complexVector,
+                                      unsigned int num_points) {
   unsigned int number = 0;
-  const float* complexVectorPtr = (float*)complexVector;
-  double* iBufferPtr = iBuffer;
-  double* qBufferPtr = qBuffer;
+  const float *complexVectorPtr = (float *)complexVector;
+  double *iBufferPtr = iBuffer;
+  double *qBufferPtr = qBuffer;
 
-  for(number = 0; number < num_points; number++){
+  for (number = 0; number < num_points; number++) {
     *iBufferPtr++ = (double)*complexVectorPtr++;
     *qBufferPtr++ = (double)*complexVectorPtr++;
   }
 }
 #endif /* LV_HAVE_GENERIC */
-
-
-
 
 #endif /* INCLUDED_volk_32fc_deinterleave_64f_x2_u_H */
 #ifndef INCLUDED_volk_32fc_deinterleave_64f_x2_a_H
@@ -200,21 +197,21 @@ volk_32fc_deinterleave_64f_x2_generic(double* iBuffer, double* qBuffer, const lv
 #include <immintrin.h>
 
 static inline void
-volk_32fc_deinterleave_64f_x2_a_avx(double* iBuffer, double* qBuffer, const lv_32fc_t* complexVector,
-                                    unsigned int num_points)
-{
+volk_32fc_deinterleave_64f_x2_a_avx(double *iBuffer, double *qBuffer,
+                                    const lv_32fc_t *complexVector,
+                                    unsigned int num_points) {
   unsigned int number = 0;
 
-  const float* complexVectorPtr = (float*)complexVector;
-  double* iBufferPtr = iBuffer;
-  double* qBufferPtr = qBuffer;
+  const float *complexVectorPtr = (float *)complexVector;
+  double *iBufferPtr = iBuffer;
+  double *qBufferPtr = qBuffer;
 
   const unsigned int quarterPoints = num_points / 4;
   __m256 cplxValue;
   __m128 complexH, complexL, fVal;
   __m256d dVal;
 
-  for(;number < quarterPoints; number++){
+  for (; number < quarterPoints; number++) {
 
     cplxValue = _mm256_load_ps(complexVectorPtr);
     complexVectorPtr += 8;
@@ -223,12 +220,12 @@ volk_32fc_deinterleave_64f_x2_a_avx(double* iBuffer, double* qBuffer, const lv_3
     complexL = _mm256_extractf128_ps(cplxValue, 0);
 
     // Arrange in i1i2i1i2 format
-    fVal = _mm_shuffle_ps(complexL, complexH, _MM_SHUFFLE(2,0,2,0));
+    fVal = _mm_shuffle_ps(complexL, complexH, _MM_SHUFFLE(2, 0, 2, 0));
     dVal = _mm256_cvtps_pd(fVal);
     _mm256_store_pd(iBufferPtr, dVal);
 
     // Arrange in q1q2q1q2 format
-    fVal = _mm_shuffle_ps(complexL, complexH, _MM_SHUFFLE(3,1,3,1));
+    fVal = _mm_shuffle_ps(complexL, complexH, _MM_SHUFFLE(3, 1, 3, 1));
     dVal = _mm256_cvtps_pd(fVal);
     _mm256_store_pd(qBufferPtr, dVal);
 
@@ -237,7 +234,7 @@ volk_32fc_deinterleave_64f_x2_a_avx(double* iBuffer, double* qBuffer, const lv_3
   }
 
   number = quarterPoints * 4;
-  for(; number < num_points; number++){
+  for (; number < num_points; number++) {
     *iBufferPtr++ = *complexVectorPtr++;
     *qBufferPtr++ = *complexVectorPtr++;
   }
@@ -248,31 +245,31 @@ volk_32fc_deinterleave_64f_x2_a_avx(double* iBuffer, double* qBuffer, const lv_3
 #include <emmintrin.h>
 
 static inline void
-volk_32fc_deinterleave_64f_x2_a_sse2(double* iBuffer, double* qBuffer, const lv_32fc_t* complexVector,
-                                     unsigned int num_points)
-{
+volk_32fc_deinterleave_64f_x2_a_sse2(double *iBuffer, double *qBuffer,
+                                     const lv_32fc_t *complexVector,
+                                     unsigned int num_points) {
   unsigned int number = 0;
 
-  const float* complexVectorPtr = (float*)complexVector;
-  double* iBufferPtr = iBuffer;
-  double* qBufferPtr = qBuffer;
+  const float *complexVectorPtr = (float *)complexVector;
+  double *iBufferPtr = iBuffer;
+  double *qBufferPtr = qBuffer;
 
   const unsigned int halfPoints = num_points / 2;
   __m128 cplxValue, fVal;
   __m128d dVal;
 
-  for(;number < halfPoints; number++){
+  for (; number < halfPoints; number++) {
 
     cplxValue = _mm_load_ps(complexVectorPtr);
     complexVectorPtr += 4;
 
     // Arrange in i1i2i1i2 format
-    fVal = _mm_shuffle_ps(cplxValue, cplxValue, _MM_SHUFFLE(2,0,2,0));
+    fVal = _mm_shuffle_ps(cplxValue, cplxValue, _MM_SHUFFLE(2, 0, 2, 0));
     dVal = _mm_cvtps_pd(fVal);
     _mm_store_pd(iBufferPtr, dVal);
 
     // Arrange in q1q2q1q2 format
-    fVal = _mm_shuffle_ps(cplxValue, cplxValue, _MM_SHUFFLE(3,1,3,1));
+    fVal = _mm_shuffle_ps(cplxValue, cplxValue, _MM_SHUFFLE(3, 1, 3, 1));
     dVal = _mm_cvtps_pd(fVal);
     _mm_store_pd(qBufferPtr, dVal);
 
@@ -281,7 +278,7 @@ volk_32fc_deinterleave_64f_x2_a_sse2(double* iBuffer, double* qBuffer, const lv_
   }
 
   number = halfPoints * 2;
-  for(; number < num_points; number++){
+  for (; number < num_points; number++) {
     *iBufferPtr++ = *complexVectorPtr++;
     *qBufferPtr++ = *complexVectorPtr++;
   }
@@ -291,20 +288,55 @@ volk_32fc_deinterleave_64f_x2_a_sse2(double* iBuffer, double* qBuffer, const lv_
 #ifdef LV_HAVE_GENERIC
 
 static inline void
-volk_32fc_deinterleave_64f_x2_a_generic(double* iBuffer, double* qBuffer, const lv_32fc_t* complexVector,
-                                        unsigned int num_points)
-{
+volk_32fc_deinterleave_64f_x2_a_generic(double *iBuffer, double *qBuffer,
+                                        const lv_32fc_t *complexVector,
+                                        unsigned int num_points) {
   unsigned int number = 0;
-  const float* complexVectorPtr = (float*)complexVector;
-  double* iBufferPtr = iBuffer;
-  double* qBufferPtr = qBuffer;
+  const float *complexVectorPtr = (float *)complexVector;
+  double *iBufferPtr = iBuffer;
+  double *qBufferPtr = qBuffer;
 
-  for(number = 0; number < num_points; number++){
+  for (number = 0; number < num_points; number++) {
     *iBufferPtr++ = (double)*complexVectorPtr++;
     *qBufferPtr++ = (double)*complexVectorPtr++;
   }
 }
 #endif /* LV_HAVE_GENERIC */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void
+volk_32fc_deinterleave_64f_x2_neon(double *iBuffer, double *qBuffer,
+                                   const lv_32fc_t *complexVector,
+                                   unsigned int num_points) {
+  unsigned int number = 0;
+  unsigned int half_points = half_points / 2;
+  const float *complexVectorPtr = (float *)complexVector;
+  double *iBufferPtr = iBuffer;
+  double *qBufferPtr = qBuffer;
+  float32x2x2_t complexInput;
+  float64x2_t iVal, qVal;
+
+  for (number = 0; number < half_points; number++) {
+    complexInput = vld2_f32(complexVectorPtr);
+
+    iVal = vcvt_f64_f32(complexInput.val[0]);
+    qVal = vcvt_f64_f32(complexInput.val[1]);
+
+    vst1q_f64(iBufferPtr, iVal);
+    vst1q_f64(qBufferPtr, qVal);
+
+    complexVectorPtr += 4;
+    iBufferPtr += 2;
+    qBufferPtr += 2;
+  }
+
+  for (number = half_points * 2; number < num_points; number++) {
+    *iBufferPtr++ = *complexVectorPtr++;
+    *qBufferPtr++ = *complexVectorPtr++;
+  }
+}
+#endif /* LV_HAVE_NEONV8 */
 
 #endif /* INCLUDED_volk_32fc_deinterleave_64f_x2_a_H */

--- a/kernels/volk/volk_32fc_deinterleave_64f_x2.h
+++ b/kernels/volk/volk_32fc_deinterleave_64f_x2.h
@@ -311,7 +311,7 @@ volk_32fc_deinterleave_64f_x2_neon(double *iBuffer, double *qBuffer,
                                    const lv_32fc_t *complexVector,
                                    unsigned int num_points) {
   unsigned int number = 0;
-  unsigned int half_points = half_points / 2;
+  unsigned int half_points = num_points / 2;
   const float *complexVectorPtr = (float *)complexVector;
   double *iBufferPtr = iBuffer;
   double *qBufferPtr = qBuffer;
@@ -333,8 +333,8 @@ volk_32fc_deinterleave_64f_x2_neon(double *iBuffer, double *qBuffer,
   }
 
   for (number = half_points * 2; number < num_points; number++) {
-    *iBufferPtr++ = *complexVectorPtr++;
-    *qBufferPtr++ = *complexVectorPtr++;
+    *iBufferPtr++ = (double)*complexVectorPtr++;
+    *qBufferPtr++ = (double)*complexVectorPtr++;
   }
 }
 #endif /* LV_HAVE_NEONV8 */

--- a/kernels/volk/volk_32fc_deinterleave_real_64f.h
+++ b/kernels/volk/volk_32fc_deinterleave_real_64f.h
@@ -30,8 +30,8 @@
  *
  * <b>Dispatcher Prototype</b>
  * \code
- * void volk_32fc_deinterleave_real_64f(double* iBuffer, const lv_32fc_t* complexVector, unsigned int num_points)
- * \endcode
+ * void volk_32fc_deinterleave_real_64f(double* iBuffer, const lv_32fc_t*
+ * complexVector, unsigned int num_points) \endcode
  *
  * \b Inputs
  * \li complexVector: The complex input vector.
@@ -77,21 +77,19 @@
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
 
-static inline void
-volk_32fc_deinterleave_real_64f_a_avx2(double* iBuffer, const lv_32fc_t* complexVector,
-                                       unsigned int num_points)
-{
+static inline void volk_32fc_deinterleave_real_64f_a_avx2(
+    double *iBuffer, const lv_32fc_t *complexVector, unsigned int num_points) {
   unsigned int number = 0;
 
-  const float* complexVectorPtr = (float*)complexVector;
-  double* iBufferPtr = iBuffer;
+  const float *complexVectorPtr = (float *)complexVector;
+  double *iBufferPtr = iBuffer;
 
   const unsigned int quarterPoints = num_points / 4;
   __m256 cplxValue;
   __m128 fVal;
   __m256d dVal;
-  __m256i idx = _mm256_set_epi32(0,0,0,0,6,4,2,0);
-  for(;number < quarterPoints; number++){
+  __m256i idx = _mm256_set_epi32(0, 0, 0, 0, 6, 4, 2, 0);
+  for (; number < quarterPoints; number++) {
 
     cplxValue = _mm256_load_ps(complexVectorPtr);
     complexVectorPtr += 8;
@@ -106,7 +104,7 @@ volk_32fc_deinterleave_real_64f_a_avx2(double* iBuffer, const lv_32fc_t* complex
   }
 
   number = quarterPoints * 4;
-  for(; number < num_points; number++){
+  for (; number < num_points; number++) {
     *iBufferPtr++ = (double)*complexVectorPtr++;
     complexVectorPtr++;
   }
@@ -116,25 +114,23 @@ volk_32fc_deinterleave_real_64f_a_avx2(double* iBuffer, const lv_32fc_t* complex
 #ifdef LV_HAVE_SSE2
 #include <emmintrin.h>
 
-static inline void
-volk_32fc_deinterleave_real_64f_a_sse2(double* iBuffer, const lv_32fc_t* complexVector,
-                                       unsigned int num_points)
-{
+static inline void volk_32fc_deinterleave_real_64f_a_sse2(
+    double *iBuffer, const lv_32fc_t *complexVector, unsigned int num_points) {
   unsigned int number = 0;
 
-  const float* complexVectorPtr = (float*)complexVector;
-  double* iBufferPtr = iBuffer;
+  const float *complexVectorPtr = (float *)complexVector;
+  double *iBufferPtr = iBuffer;
 
   const unsigned int halfPoints = num_points / 2;
   __m128 cplxValue, fVal;
   __m128d dVal;
-  for(;number < halfPoints; number++){
+  for (; number < halfPoints; number++) {
 
     cplxValue = _mm_load_ps(complexVectorPtr);
     complexVectorPtr += 4;
 
     // Arrange in i1i2i1i2 format
-    fVal = _mm_shuffle_ps(cplxValue, cplxValue, _MM_SHUFFLE(2,0,2,0));
+    fVal = _mm_shuffle_ps(cplxValue, cplxValue, _MM_SHUFFLE(2, 0, 2, 0));
     dVal = _mm_cvtps_pd(fVal);
     _mm_store_pd(iBufferPtr, dVal);
 
@@ -142,32 +138,67 @@ volk_32fc_deinterleave_real_64f_a_sse2(double* iBuffer, const lv_32fc_t* complex
   }
 
   number = halfPoints * 2;
-  for(; number < num_points; number++){
+  for (; number < num_points; number++) {
     *iBufferPtr++ = (double)*complexVectorPtr++;
     complexVectorPtr++;
   }
 }
 #endif /* LV_HAVE_SSE */
 
-
 #ifdef LV_HAVE_GENERIC
 
-static inline void
-volk_32fc_deinterleave_real_64f_generic(double* iBuffer, const lv_32fc_t* complexVector,
-                                        unsigned int num_points)
-{
+static inline void volk_32fc_deinterleave_real_64f_generic(
+    double *iBuffer, const lv_32fc_t *complexVector, unsigned int num_points) {
   unsigned int number = 0;
-  const float* complexVectorPtr = (float*)complexVector;
-  double* iBufferPtr = iBuffer;
-  for(number = 0; number < num_points; number++){
+  const float *complexVectorPtr = (float *)complexVector;
+  double *iBufferPtr = iBuffer;
+  for (number = 0; number < num_points; number++) {
     *iBufferPtr++ = (double)*complexVectorPtr++;
     complexVectorPtr++;
   }
 }
 #endif /* LV_HAVE_GENERIC */
 
-#endif /* INCLUDED_volk_32fc_deinterleave_real_64f_a_H */
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
 
+static inline void volk_32fc_deinterleave_real_64f_neon(
+    double *iBuffer, const lv_32fc_t *complexVector, unsigned int num_points) {
+  unsigned int number = 0;
+  unsigned int quarter_points = num_points / 4;
+  const float *complexVectorPtr = (float *)complexVector;
+  double *iBufferPtr = iBuffer;
+  float32x2x4_t complexInput;
+  float64x2_t iVal1;
+  float64x2_t iVal2;
+  float64x2x2_t iVal;
+
+  for (number = 0; number < quarter_points; number++) {
+    // Load data into register
+    complexInput = vld4_f32(complexVectorPtr);
+
+    // Perform single to double precision conversion
+    iVal1 = vcvt_f64_f32(complexInput.val[0]);
+    iVal2 = vcvt_f64_f32(complexInput.val[2]);
+    iVal.val[0] = iVal1;
+    iVal.val[1] = iVal2;
+
+    // Store results into memory buffer
+    vst2q_f64(iBufferPtr, iVal);
+
+    // Update pointers
+    iBufferPtr += 4;
+    complexVectorPtr += 8;
+  }
+
+  for (number = quarter_points * 4; number < num_points; number++) {
+    *iBufferPtr++ = (double)*complexVectorPtr++;
+    complexVectorPtr++;
+  }
+}
+#endif /* LV_HAVE_NEON */
+
+#endif /* INCLUDED_volk_32fc_deinterleave_real_64f_a_H */
 
 #ifndef INCLUDED_volk_32fc_deinterleave_real_64f_u_H
 #define INCLUDED_volk_32fc_deinterleave_real_64f_u_H
@@ -178,21 +209,19 @@ volk_32fc_deinterleave_real_64f_generic(double* iBuffer, const lv_32fc_t* comple
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
 
-static inline void
-volk_32fc_deinterleave_real_64f_u_avx2(double* iBuffer, const lv_32fc_t* complexVector,
-                                       unsigned int num_points)
-{
+static inline void volk_32fc_deinterleave_real_64f_u_avx2(
+    double *iBuffer, const lv_32fc_t *complexVector, unsigned int num_points) {
   unsigned int number = 0;
 
-  const float* complexVectorPtr = (float*)complexVector;
-  double* iBufferPtr = iBuffer;
+  const float *complexVectorPtr = (float *)complexVector;
+  double *iBufferPtr = iBuffer;
 
   const unsigned int quarterPoints = num_points / 4;
   __m256 cplxValue;
   __m128 fVal;
   __m256d dVal;
-  __m256i idx = _mm256_set_epi32(0,0,0,0,6,4,2,0);
-  for(;number < quarterPoints; number++){
+  __m256i idx = _mm256_set_epi32(0, 0, 0, 0, 6, 4, 2, 0);
+  for (; number < quarterPoints; number++) {
 
     cplxValue = _mm256_loadu_ps(complexVectorPtr);
     complexVectorPtr += 8;
@@ -207,7 +236,7 @@ volk_32fc_deinterleave_real_64f_u_avx2(double* iBuffer, const lv_32fc_t* complex
   }
 
   number = quarterPoints * 4;
-  for(; number < num_points; number++){
+  for (; number < num_points; number++) {
     *iBufferPtr++ = (double)*complexVectorPtr++;
     complexVectorPtr++;
   }
@@ -215,5 +244,3 @@ volk_32fc_deinterleave_real_64f_u_avx2(double* iBuffer, const lv_32fc_t* complex
 #endif /* LV_HAVE_AVX2 */
 
 #endif /* INCLUDED_volk_32fc_deinterleave_real_64f_u_H */
-
-


### PR DESCRIPTION
Adds Neonv8 support to `32fc_deinterleave_64f_x2` and `32fc_deinterleave_real_64f`. The execution speed improvements are shown below

```
RUN_VOLK_TESTS: volk_32fc_deinterleave_real_64f(131071,1987)
generic completed in 715.809 ms
neon completed in 682.527 ms
Best aligned arch: neon
Best unaligned arch: neon

RUN_VOLK_TESTS: volk_32fc_deinterleave_64f_x2(131071,1987)
generic completed in 1410.47 ms
a_generic completed in 1299.5 ms
neon completed in 1257.89 ms
Best aligned arch: neon
Best unaligned arch: neon
```