### PR TITLE
fix for volk_32fc_s32f_magnitude_16i (different results of SIMD kernels w.r.t. generic kernel)

### DIFF
--- a/kernels/volk/volk_32fc_s32f_magnitude_16i.h
+++ b/kernels/volk/volk_32fc_s32f_magnitude_16i.h
@@ -124,9 +124,11 @@ volk_32fc_s32f_magnitude_16i_a_avx2(int16_t* magnitudeVector, const lv_32fc_t* c
   number = eighthPoints * 8;
   magnitudeVectorPtr = &magnitudeVector[number];
   for(; number < num_points; number++){
-    float val1Real = *complexVectorPtr++;
-    float val1Imag = *complexVectorPtr++;
-    *magnitudeVectorPtr++ = (int16_t)rintf(sqrtf((val1Real * val1Real) + (val1Imag * val1Imag)) * scalar);
+    volatile float real = *complexVectorPtr++;
+    volatile float imag = *complexVectorPtr++;
+    real *= real;
+    imag *= imag;
+    *magnitudeVectorPtr++ = (int16_t)rintf(scalar*sqrtf(real + imag));
   }
 }
 #endif /* LV_HAVE_AVX2 */
@@ -176,9 +178,11 @@ volk_32fc_s32f_magnitude_16i_a_sse3(int16_t* magnitudeVector, const lv_32fc_t* c
   number = quarterPoints * 4;
   magnitudeVectorPtr = &magnitudeVector[number];
   for(; number < num_points; number++){
-    float val1Real = *complexVectorPtr++;
-    float val1Imag = *complexVectorPtr++;
-    *magnitudeVectorPtr++ = (int16_t)rintf(sqrtf((val1Real * val1Real) + (val1Imag * val1Imag)) * scalar);
+    volatile float real = *complexVectorPtr++;
+    volatile float imag = *complexVectorPtr++;
+    real *= real;
+    imag *= imag;
+    *magnitudeVectorPtr++ = (int16_t)rintf(scalar*sqrtf(real + imag));
   }
 }
 #endif /* LV_HAVE_SSE3 */
@@ -199,7 +203,8 @@ volk_32fc_s32f_magnitude_16i_a_sse(int16_t* magnitudeVector, const lv_32fc_t* co
 
   __m128 vScalar = _mm_set_ps1(scalar);
 
-  __m128 cplxValue1, cplxValue2, iValue, qValue, result;
+  __m128 cplxValue1, cplxValue2, result;
+  volatile __m128 iValue, qValue;
 
   __VOLK_ATTR_ALIGNED(16) float floatBuffer[4];
 
@@ -234,9 +239,11 @@ volk_32fc_s32f_magnitude_16i_a_sse(int16_t* magnitudeVector, const lv_32fc_t* co
   number = quarterPoints * 4;
   magnitudeVectorPtr = &magnitudeVector[number];
   for(; number < num_points; number++){
-    float val1Real = *complexVectorPtr++;
-    float val1Imag = *complexVectorPtr++;
-    *magnitudeVectorPtr++ = (int16_t)rintf(sqrtf((val1Real * val1Real) + (val1Imag * val1Imag)) * scalar);
+    volatile float real = *complexVectorPtr++;
+    volatile float imag = *complexVectorPtr++;
+    real *= real;
+    imag *= imag;
+    *magnitudeVectorPtr++ = (int16_t)rintf(scalar*sqrtf(real + imag));
   }
 }
 #endif /* LV_HAVE_SSE */
@@ -251,9 +258,11 @@ volk_32fc_s32f_magnitude_16i_generic(int16_t* magnitudeVector, const lv_32fc_t* 
   int16_t* magnitudeVectorPtr = magnitudeVector;
   unsigned int number = 0;
   for(number = 0; number < num_points; number++){
-    const float real = *complexVectorPtr++;
-    const float imag = *complexVectorPtr++;
-    *magnitudeVectorPtr++ = (int16_t)rintf(sqrtf((real*real) + (imag*imag)) * scalar);
+    volatile float real = *complexVectorPtr++;
+    volatile float imag = *complexVectorPtr++;
+    real *= real;
+    imag *= imag;
+    *magnitudeVectorPtr++ = (int16_t)rintf(scalar*sqrtf(real + imag));
   }
 }
 #endif /* LV_HAVE_GENERIC */
@@ -315,9 +324,11 @@ volk_32fc_s32f_magnitude_16i_u_avx2(int16_t* magnitudeVector, const lv_32fc_t* c
   number = eighthPoints * 8;
   magnitudeVectorPtr = &magnitudeVector[number];
   for(; number < num_points; number++){
-    float val1Real = *complexVectorPtr++;
-    float val1Imag = *complexVectorPtr++;
-    *magnitudeVectorPtr++ = (int16_t)rintf(sqrtf((val1Real * val1Real) + (val1Imag * val1Imag)) * scalar);
+    volatile float real = *complexVectorPtr++;
+    volatile float imag = *complexVectorPtr++;
+    real *= real;
+    imag *= imag;
+    *magnitudeVectorPtr++ = (int16_t)rintf(scalar*sqrtf(real + imag));
   }
 }
 #endif /* LV_HAVE_AVX2 */

--- a/kernels/volk/volk_32fc_s32f_magnitude_16i.h
+++ b/kernels/volk/volk_32fc_s32f_magnitude_16i.h
@@ -70,6 +70,25 @@
  * \endcode
  */
 
+#ifdef LV_HAVE_GENERIC
+
+static inline void
+volk_32fc_s32f_magnitude_16i_generic(int16_t* magnitudeVector, const lv_32fc_t* complexVector,
+                                     const float scalar, unsigned int num_points)
+{
+  const float* complexVectorPtr = (float*)complexVector;
+  int16_t* magnitudeVectorPtr = magnitudeVector;
+  unsigned int number = 0;
+  for(number = 0; number < num_points; number++){
+    volatile float real = *complexVectorPtr++;
+    volatile float imag = *complexVectorPtr++;
+    real *= real;
+    imag *= imag;
+    *magnitudeVectorPtr++ = (int16_t)rintf(scalar*sqrtf(real + imag));
+  }
+}
+#endif /* LV_HAVE_GENERIC */
+
 #ifndef INCLUDED_volk_32fc_s32f_magnitude_16i_a_H
 #define INCLUDED_volk_32fc_s32f_magnitude_16i_a_H
 
@@ -122,14 +141,7 @@ volk_32fc_s32f_magnitude_16i_a_avx2(int16_t* magnitudeVector, const lv_32fc_t* c
   }
 
   number = eighthPoints * 8;
-  magnitudeVectorPtr = &magnitudeVector[number];
-  for(; number < num_points; number++){
-    volatile float real = *complexVectorPtr++;
-    volatile float imag = *complexVectorPtr++;
-    real *= real;
-    imag *= imag;
-    *magnitudeVectorPtr++ = (int16_t)rintf(scalar*sqrtf(real + imag));
-  }
+  volk_32fc_s32f_magnitude_16i_generic(magnitudeVector+number, complexVector+number, scalar, num_points-number);
 }
 #endif /* LV_HAVE_AVX2 */
 
@@ -176,14 +188,7 @@ volk_32fc_s32f_magnitude_16i_a_sse3(int16_t* magnitudeVector, const lv_32fc_t* c
   }
 
   number = quarterPoints * 4;
-  magnitudeVectorPtr = &magnitudeVector[number];
-  for(; number < num_points; number++){
-    volatile float real = *complexVectorPtr++;
-    volatile float imag = *complexVectorPtr++;
-    real *= real;
-    imag *= imag;
-    *magnitudeVectorPtr++ = (int16_t)rintf(scalar*sqrtf(real + imag));
-  }
+  volk_32fc_s32f_magnitude_16i_generic(magnitudeVector+number, complexVector+number, scalar, num_points-number);
 }
 #endif /* LV_HAVE_SSE3 */
 
@@ -237,35 +242,9 @@ volk_32fc_s32f_magnitude_16i_a_sse(int16_t* magnitudeVector, const lv_32fc_t* co
   }
 
   number = quarterPoints * 4;
-  magnitudeVectorPtr = &magnitudeVector[number];
-  for(; number < num_points; number++){
-    volatile float real = *complexVectorPtr++;
-    volatile float imag = *complexVectorPtr++;
-    real *= real;
-    imag *= imag;
-    *magnitudeVectorPtr++ = (int16_t)rintf(scalar*sqrtf(real + imag));
-  }
+  volk_32fc_s32f_magnitude_16i_generic(magnitudeVector+number, complexVector+number, scalar, num_points-number);
 }
 #endif /* LV_HAVE_SSE */
-
-#ifdef LV_HAVE_GENERIC
-
-static inline void
-volk_32fc_s32f_magnitude_16i_generic(int16_t* magnitudeVector, const lv_32fc_t* complexVector,
-                                     const float scalar, unsigned int num_points)
-{
-  const float* complexVectorPtr = (float*)complexVector;
-  int16_t* magnitudeVectorPtr = magnitudeVector;
-  unsigned int number = 0;
-  for(number = 0; number < num_points; number++){
-    volatile float real = *complexVectorPtr++;
-    volatile float imag = *complexVectorPtr++;
-    real *= real;
-    imag *= imag;
-    *magnitudeVectorPtr++ = (int16_t)rintf(scalar*sqrtf(real + imag));
-  }
-}
-#endif /* LV_HAVE_GENERIC */
 
 
 #endif /* INCLUDED_volk_32fc_s32f_magnitude_16i_a_H */
@@ -322,14 +301,7 @@ volk_32fc_s32f_magnitude_16i_u_avx2(int16_t* magnitudeVector, const lv_32fc_t* c
   }
 
   number = eighthPoints * 8;
-  magnitudeVectorPtr = &magnitudeVector[number];
-  for(; number < num_points; number++){
-    volatile float real = *complexVectorPtr++;
-    volatile float imag = *complexVectorPtr++;
-    real *= real;
-    imag *= imag;
-    *magnitudeVectorPtr++ = (int16_t)rintf(scalar*sqrtf(real + imag));
-  }
+  volk_32fc_s32f_magnitude_16i_generic(magnitudeVector+number, complexVector+number, scalar, num_points-number);
 }
 #endif /* LV_HAVE_AVX2 */
 


### PR DESCRIPTION
This is an attempt to fix `volk_32fc_s32f_magnitude_16i` which is broken, as can be seen by running the following command
```
while [ 1 ]; do volk_profile -i 1 -n -v 13100071 -R volk_32fc_s32f_magnitude_16i ; done |grep fail
```

Unfortunately I do not completely understand why the proposed changes seem to work. Adding the `volatile` keywords seems to prevent the compiler from making optimizations which break the agreement between the generic implementation and the SIMD implementations.