### PR TITLE
bug fixes for volk_32f_index_max_{16,32}u

### DIFF
--- a/kernels/volk/volk_32f_index_max_16u.h
+++ b/kernels/volk/volk_32f_index_max_16u.h
@@ -109,7 +109,7 @@ volk_32f_index_max_16u_a_avx(uint16_t* target, const float* src0,
     currentValues  = _mm256_load_ps(inputPtr); inputPtr += 8;
     currentIndexes = _mm256_add_ps(currentIndexes, indexIncrementValues);
 
-    compareResults = _mm256_cmp_ps(maxValues, currentValues,14);
+    compareResults = _mm256_cmp_ps(currentValues, maxValues, _CMP_LE_OS);
 
     maxValuesIndex = _mm256_blendv_ps(currentIndexes, maxValuesIndex, compareResults);
     maxValues      = _mm256_blendv_ps(currentValues, maxValues, compareResults);
@@ -123,6 +123,9 @@ volk_32f_index_max_16u_a_avx(uint16_t* target, const float* src0,
     if(maxValuesBuffer[number] > max){
       index = maxIndexesBuffer[number];
       max = maxValuesBuffer[number];
+    } else if(maxValuesBuffer[number] == max){
+      if (index > maxIndexesBuffer[number])
+        index = maxIndexesBuffer[number];
     }
   }
 
@@ -170,7 +173,7 @@ volk_32f_index_max_16u_a_sse4_1(uint16_t* target, const float* src0,
     currentValues  = _mm_load_ps(inputPtr); inputPtr += 4;
     currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
 
-    compareResults = _mm_cmpgt_ps(maxValues, currentValues);
+    compareResults = _mm_cmple_ps(currentValues, maxValues);
 
     maxValuesIndex = _mm_blendv_ps(currentIndexes, maxValuesIndex, compareResults);
     maxValues      = _mm_blendv_ps(currentValues, maxValues, compareResults);
@@ -184,6 +187,9 @@ volk_32f_index_max_16u_a_sse4_1(uint16_t* target, const float* src0,
     if(maxValuesBuffer[number] > max){
       index = maxIndexesBuffer[number];
       max = maxValuesBuffer[number];
+    } else if(maxValuesBuffer[number] == max){
+      if (index > maxIndexesBuffer[number])
+        index = maxIndexesBuffer[number];
     }
   }
 
@@ -233,7 +239,7 @@ volk_32f_index_max_16u_a_sse(uint16_t* target, const float* src0,
     currentValues  = _mm_load_ps(inputPtr); inputPtr += 4;
     currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
 
-    compareResults = _mm_cmpgt_ps(maxValues, currentValues);
+    compareResults = _mm_cmple_ps(currentValues, maxValues);
 
     maxValuesIndex = _mm_or_ps(_mm_and_ps(compareResults, maxValuesIndex) , _mm_andnot_ps(compareResults, currentIndexes));
 
@@ -248,6 +254,9 @@ volk_32f_index_max_16u_a_sse(uint16_t* target, const float* src0,
     if(maxValuesBuffer[number] > max){
       index = maxIndexesBuffer[number];
       max = maxValuesBuffer[number];
+    } else if(maxValuesBuffer[number] == max){
+      if (index > maxIndexesBuffer[number])
+        index = maxIndexesBuffer[number];
     }
   }
 
@@ -334,7 +343,7 @@ volk_32f_index_max_16u_u_avx(uint16_t* target, const float* src0,
     currentValues  = _mm256_loadu_ps(inputPtr); inputPtr += 8;
     currentIndexes = _mm256_add_ps(currentIndexes, indexIncrementValues);
 
-    compareResults = _mm256_cmp_ps(maxValues, currentValues,14);
+    compareResults = _mm256_cmp_ps(currentValues, maxValues, _CMP_LE_OS);
 
     maxValuesIndex = _mm256_blendv_ps(currentIndexes, maxValuesIndex, compareResults);
     maxValues      = _mm256_blendv_ps(currentValues, maxValues, compareResults);
@@ -348,6 +357,9 @@ volk_32f_index_max_16u_u_avx(uint16_t* target, const float* src0,
     if(maxValuesBuffer[number] > max){
       index = maxIndexesBuffer[number];
       max = maxValuesBuffer[number];
+    } else if(maxValuesBuffer[number] == max){
+      if (index > maxIndexesBuffer[number])
+        index = maxIndexesBuffer[number];
     }
   }
 

--- a/kernels/volk/volk_32f_index_max_16u.h
+++ b/kernels/volk/volk_32f_index_max_16u.h
@@ -26,7 +26,7 @@
  * \b Overview
  *
  * Returns Argmax_i x[i]. Finds and returns the index which contains
- * the maximum value in the given vector.
+ * the fist maximum value in the given vector.
  *
  * Note that num_points is a uint32_t, but the return value is
  * uint16_t. Providing a vector larger than the max of a uint16_t
@@ -44,7 +44,7 @@
  * \li num_points: The number of data points.
  *
  * \b Outputs
- * \li target: The index of the maximum value in the input buffer.
+ * \li target: The index of the fist maximum value in the input buffer.
  *
  * \b Example
  * \code
@@ -82,7 +82,7 @@
 
 static inline void
 volk_32f_index_max_16u_a_avx(uint16_t* target, const float* src0,
-                                uint32_t num_points)
+                             uint32_t num_points)
 {
   num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
 
@@ -109,10 +109,10 @@ volk_32f_index_max_16u_a_avx(uint16_t* target, const float* src0,
     currentValues  = _mm256_load_ps(inputPtr); inputPtr += 8;
     currentIndexes = _mm256_add_ps(currentIndexes, indexIncrementValues);
 
-    compareResults = _mm256_cmp_ps(currentValues, maxValues, _CMP_LE_OS);
+    compareResults = _mm256_cmp_ps(currentValues, maxValues, _CMP_GT_OS);
 
-    maxValuesIndex = _mm256_blendv_ps(currentIndexes, maxValuesIndex, compareResults);
-    maxValues      = _mm256_blendv_ps(currentValues, maxValues, compareResults);
+    maxValuesIndex = _mm256_blendv_ps(maxValuesIndex, currentIndexes, compareResults);
+    maxValues      = _mm256_blendv_ps(maxValues, currentValues, compareResults);
   }
 
   // Calculate the largest value from the remaining 4 points
@@ -173,10 +173,10 @@ volk_32f_index_max_16u_a_sse4_1(uint16_t* target, const float* src0,
     currentValues  = _mm_load_ps(inputPtr); inputPtr += 4;
     currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
 
-    compareResults = _mm_cmple_ps(currentValues, maxValues);
+    compareResults = _mm_cmpgt_ps(currentValues, maxValues);
 
-    maxValuesIndex = _mm_blendv_ps(currentIndexes, maxValuesIndex, compareResults);
-    maxValues      = _mm_blendv_ps(currentValues, maxValues, compareResults);
+    maxValuesIndex = _mm_blendv_ps(maxValuesIndex, currentIndexes, compareResults);
+    maxValues      = _mm_blendv_ps(maxValues, currentValues, compareResults);
   }
 
   // Calculate the largest value from the remaining 4 points
@@ -239,11 +239,12 @@ volk_32f_index_max_16u_a_sse(uint16_t* target, const float* src0,
     currentValues  = _mm_load_ps(inputPtr); inputPtr += 4;
     currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
 
-    compareResults = _mm_cmple_ps(currentValues, maxValues);
+    compareResults = _mm_cmpgt_ps(currentValues, maxValues);
 
-    maxValuesIndex = _mm_or_ps(_mm_and_ps(compareResults, maxValuesIndex) , _mm_andnot_ps(compareResults, currentIndexes));
-
-    maxValues      = _mm_or_ps(_mm_and_ps(compareResults, maxValues) , _mm_andnot_ps(compareResults, currentValues));
+    maxValuesIndex = _mm_or_ps(_mm_and_ps(compareResults, currentIndexes),
+                               _mm_andnot_ps(compareResults, maxValuesIndex));
+    maxValues      = _mm_or_ps(_mm_and_ps(compareResults, currentValues),
+                               _mm_andnot_ps(compareResults, maxValues));
   }
 
   // Calculate the largest value from the remaining 4 points
@@ -343,10 +344,10 @@ volk_32f_index_max_16u_u_avx(uint16_t* target, const float* src0,
     currentValues  = _mm256_loadu_ps(inputPtr); inputPtr += 8;
     currentIndexes = _mm256_add_ps(currentIndexes, indexIncrementValues);
 
-    compareResults = _mm256_cmp_ps(currentValues, maxValues, _CMP_LE_OS);
+    compareResults = _mm256_cmp_ps(currentValues, maxValues, _CMP_GT_OS);
 
-    maxValuesIndex = _mm256_blendv_ps(currentIndexes, maxValuesIndex, compareResults);
-    maxValues      = _mm256_blendv_ps(currentValues, maxValues, compareResults);
+    maxValuesIndex = _mm256_blendv_ps(maxValuesIndex, currentIndexes, compareResults);
+    maxValues      = _mm256_blendv_ps(maxValues, currentValues, compareResults);
   }
 
   // Calculate the largest value from the remaining 4 points

--- a/kernels/volk/volk_32f_index_max_32u.h
+++ b/kernels/volk/volk_32f_index_max_32u.h
@@ -25,7 +25,7 @@
  *
  * \b Overview
  *
- * Returns Argmax_i x[i]. Finds and returns the index which contains the maximum value in the given vector.
+ * Returns Argmax_i x[i]. Finds and returns the index which contains the first maximum value in the given vector.
  *
  * <b>Dispatcher Prototype</b>
  * \code
@@ -37,7 +37,7 @@
  * \li num_points: The number of data points.
  *
  * \b Outputs
- * \li target: The index of the maximum value in the input buffer.
+ * \li target: The index of the first maximum value in the input buffer.
  *
  * \b Example
  * \code
@@ -99,10 +99,10 @@ volk_32f_index_max_32u_a_sse4_1(uint32_t* target, const float* src0, uint32_t nu
       currentValues  = _mm_load_ps(inputPtr); inputPtr += 4;
       currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
 
-      compareResults = _mm_cmple_ps(currentValues, maxValues);
+      compareResults = _mm_cmpgt_ps(currentValues, maxValues);
 
-      maxValuesIndex = _mm_blendv_ps(currentIndexes, maxValuesIndex, compareResults);
-      maxValues      = _mm_blendv_ps(currentValues, maxValues, compareResults);
+      maxValuesIndex = _mm_blendv_ps(maxValuesIndex, currentIndexes, compareResults);
+      maxValues      = _mm_blendv_ps(maxValues, currentValues, compareResults);
     }
 
     // Calculate the largest value from the remaining 4 points
@@ -164,11 +164,13 @@ volk_32f_index_max_32u_a_sse(uint32_t* target, const float* src0, uint32_t num_p
       currentValues  = _mm_load_ps(inputPtr); inputPtr += 4;
       currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
 
-      compareResults = _mm_cmple_ps(currentValues, maxValues);
+      compareResults = _mm_cmpgt_ps(currentValues, maxValues);
 
-      maxValuesIndex = _mm_or_ps(_mm_and_ps(compareResults, maxValuesIndex) , _mm_andnot_ps(compareResults, currentIndexes));
+      maxValuesIndex = _mm_or_ps(_mm_and_ps(compareResults, currentIndexes),
+                                 _mm_andnot_ps(compareResults, maxValuesIndex));
 
-      maxValues      = _mm_or_ps(_mm_and_ps(compareResults, maxValues) , _mm_andnot_ps(compareResults, currentValues));
+      maxValues      = _mm_or_ps(_mm_and_ps(compareResults, currentValues),
+                                 _mm_andnot_ps(compareResults, maxValues));
     }
 
     // Calculate the largest value from the remaining 4 points
@@ -228,9 +230,9 @@ static inline void volk_32f_index_max_32u_a_avx(uint32_t* target, const float* s
                 {
                     currentValues  = _mm256_load_ps(inputPtr); inputPtr += 8;
                     currentIndexes = _mm256_add_ps(currentIndexes, indexIncrementValues);
-                    compareResults = _mm256_cmp_ps(currentValues, maxValues, _CMP_LE_OS);
-                    maxValuesIndex = _mm256_blendv_ps(currentIndexes, maxValuesIndex, compareResults);
-                    maxValues      = _mm256_blendv_ps(currentValues, maxValues, compareResults);
+                    compareResults = _mm256_cmp_ps(currentValues, maxValues, _CMP_GT_OS);
+                    maxValuesIndex = _mm256_blendv_ps(maxValuesIndex, currentIndexes, compareResults);
+                    maxValues      = _mm256_blendv_ps(maxValues, currentValues, compareResults);
                 }
 
             // Calculate the largest value from the remaining 8 points
@@ -399,9 +401,9 @@ static inline void volk_32f_index_max_32u_u_avx(uint32_t* target, const float* s
                 {
                     currentValues  = _mm256_loadu_ps(inputPtr); inputPtr += 8;
                     currentIndexes = _mm256_add_ps(currentIndexes, indexIncrementValues);
-                    compareResults = _mm256_cmp_ps(currentValues, maxValues, _CMP_LE_OS);
-                    maxValuesIndex = _mm256_blendv_ps(currentIndexes, maxValuesIndex, compareResults);
-                    maxValues      = _mm256_blendv_ps(currentValues, maxValues, compareResults);
+                    compareResults = _mm256_cmp_ps(currentValues, maxValues, _CMP_GT_OS);
+                    maxValuesIndex = _mm256_blendv_ps(maxValuesIndex, currentIndexes, compareResults);
+                    maxValues      = _mm256_blendv_ps(maxValues, currentValues, compareResults);
                 }
 
             // Calculate the largest value from the remaining 8 points
@@ -466,9 +468,9 @@ static inline void volk_32f_index_max_32u_u_sse4_1(uint32_t* target, const float
                 {
                     currentValues  = _mm_loadu_ps(inputPtr); inputPtr += 4;
                     currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
-                    compareResults = _mm_cmple_ps(currentValues, maxValues);
-                    maxValuesIndex = _mm_blendv_ps(currentIndexes, maxValuesIndex, compareResults);
-                    maxValues      = _mm_blendv_ps(currentValues, maxValues, compareResults);
+                    compareResults = _mm_cmpgt_ps(currentValues, maxValues);
+                    maxValuesIndex = _mm_blendv_ps(maxValuesIndex, currentIndexes, compareResults);
+                    maxValues      = _mm_blendv_ps(maxValues, currentValues, compareResults);
                 }
 
             // Calculate the largest value from the remaining 4 points
@@ -532,9 +534,11 @@ static inline void volk_32f_index_max_32u_u_sse(uint32_t* target, const float* s
                 {
                     currentValues  = _mm_loadu_ps(inputPtr); inputPtr += 4;
                     currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
-                    compareResults = _mm_cmple_ps(currentValues, maxValues);
-                    maxValuesIndex = _mm_or_ps(_mm_and_ps(compareResults, maxValuesIndex) , _mm_andnot_ps(compareResults, currentIndexes));
-                    maxValues      = _mm_or_ps(_mm_and_ps(compareResults, maxValues) , _mm_andnot_ps(compareResults, currentValues));
+                    compareResults = _mm_cmpgt_ps(currentValues, maxValues);
+                    maxValuesIndex = _mm_or_ps(_mm_and_ps(compareResults, currentIndexes),
+                                               _mm_andnot_ps(compareResults, maxValuesIndex));
+                    maxValues      = _mm_or_ps(_mm_and_ps(compareResults, currentValues),
+                                               _mm_andnot_ps(compareResults, maxValues));
                 }
 
             // Calculate the largest value from the remaining 4 points

--- a/kernels/volk/volk_32f_index_max_32u.h
+++ b/kernels/volk/volk_32f_index_max_32u.h
@@ -99,7 +99,7 @@ volk_32f_index_max_32u_a_sse4_1(uint32_t* target, const float* src0, uint32_t nu
       currentValues  = _mm_load_ps(inputPtr); inputPtr += 4;
       currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
 
-      compareResults = _mm_cmpgt_ps(maxValues, currentValues);
+      compareResults = _mm_cmple_ps(currentValues, maxValues);
 
       maxValuesIndex = _mm_blendv_ps(currentIndexes, maxValuesIndex, compareResults);
       maxValues      = _mm_blendv_ps(currentValues, maxValues, compareResults);
@@ -113,6 +113,9 @@ volk_32f_index_max_32u_a_sse4_1(uint32_t* target, const float* src0, uint32_t nu
       if(maxValuesBuffer[number] > max){
 	index = maxIndexesBuffer[number];
 	max = maxValuesBuffer[number];
+      } else if(maxValuesBuffer[number] == max){
+        if (index > maxIndexesBuffer[number])
+          index = maxIndexesBuffer[number];
       }
     }
 
@@ -161,7 +164,7 @@ volk_32f_index_max_32u_a_sse(uint32_t* target, const float* src0, uint32_t num_p
       currentValues  = _mm_load_ps(inputPtr); inputPtr += 4;
       currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
 
-      compareResults = _mm_cmpgt_ps(maxValues, currentValues);
+      compareResults = _mm_cmple_ps(currentValues, maxValues);
 
       maxValuesIndex = _mm_or_ps(_mm_and_ps(compareResults, maxValuesIndex) , _mm_andnot_ps(compareResults, currentIndexes));
 
@@ -176,6 +179,9 @@ volk_32f_index_max_32u_a_sse(uint32_t* target, const float* src0, uint32_t num_p
       if(maxValuesBuffer[number] > max){
 	index = maxIndexesBuffer[number];
 	max = maxValuesBuffer[number];
+      } else if(maxValuesBuffer[number] == max){
+        if (index > maxIndexesBuffer[number])
+          index = maxIndexesBuffer[number];
       }
     }
 
@@ -222,7 +228,7 @@ static inline void volk_32f_index_max_32u_a_avx(uint32_t* target, const float* s
                 {
                     currentValues  = _mm256_load_ps(inputPtr); inputPtr += 8;
                     currentIndexes = _mm256_add_ps(currentIndexes, indexIncrementValues);
-                    compareResults = _mm256_cmp_ps(maxValues, currentValues, 0x1e);
+                    compareResults = _mm256_cmp_ps(currentValues, maxValues, _CMP_LE_OS);
                     maxValuesIndex = _mm256_blendv_ps(currentIndexes, maxValuesIndex, compareResults);
                     maxValues      = _mm256_blendv_ps(currentValues, maxValues, compareResults);
                 }
@@ -238,6 +244,10 @@ static inline void volk_32f_index_max_32u_a_avx(uint32_t* target, const float* s
                             index = maxIndexesBuffer[number];
                             max = maxValuesBuffer[number];
                         }
+                    else if(maxValuesBuffer[number] == max){
+                      if (index > maxIndexesBuffer[number])
+                        index = maxIndexesBuffer[number];
+                    }
                 }
 
             number = quarterPoints * 8;
@@ -287,7 +297,7 @@ static inline void volk_32f_index_max_32u_neon(uint32_t* target, const float* sr
                     currentValues    = vld1q_f32(inputPtr); inputPtr += 4;
                     currentIndexes   = vaddq_f32(currentIndexes, indexIncrementValues);
                     currentIndexes_u = vcvtq_u32_f32(currentIndexes);
-                    compareResults   = vcgtq_f32( maxValues, currentValues);
+                    compareResults   = vcleq_f32(currentValues, maxValues);
                     maxValuesIndex   = vorrq_u32( vandq_u32( compareResults, maxValuesIndex ), vbicq_u32(currentIndexes_u, compareResults) );
                     maxValues        = vmaxq_f32(currentValues, maxValues);
                 }
@@ -302,6 +312,10 @@ static inline void volk_32f_index_max_32u_neon(uint32_t* target, const float* sr
                             index = maxIndexesBuffer[number];
                             max = maxValuesBuffer[number];
                         }
+                    else if(maxValues[number] == max){
+                      if (index > maxIndexesBuffer[number])
+                        index = maxIndexesBuffer[number];
+                    }
                 }
 
             number = quarterPoints * 4;
@@ -385,7 +399,7 @@ static inline void volk_32f_index_max_32u_u_avx(uint32_t* target, const float* s
                 {
                     currentValues  = _mm256_loadu_ps(inputPtr); inputPtr += 8;
                     currentIndexes = _mm256_add_ps(currentIndexes, indexIncrementValues);
-                    compareResults = _mm256_cmp_ps(maxValues, currentValues, 0x1e);
+                    compareResults = _mm256_cmp_ps(currentValues, maxValues, _CMP_LE_OS);
                     maxValuesIndex = _mm256_blendv_ps(currentIndexes, maxValuesIndex, compareResults);
                     maxValues      = _mm256_blendv_ps(currentValues, maxValues, compareResults);
                 }
@@ -401,6 +415,10 @@ static inline void volk_32f_index_max_32u_u_avx(uint32_t* target, const float* s
                             index = maxIndexesBuffer[number];
                             max = maxValuesBuffer[number];
                         }
+                    else if(maxValuesBuffer[number] == max){
+                      if (index > maxIndexesBuffer[number])
+                        index = maxIndexesBuffer[number];
+                    }
                 }
 
             number = quarterPoints * 8;
@@ -448,7 +466,7 @@ static inline void volk_32f_index_max_32u_u_sse4_1(uint32_t* target, const float
                 {
                     currentValues  = _mm_loadu_ps(inputPtr); inputPtr += 4;
                     currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
-                    compareResults = _mm_cmpgt_ps(maxValues, currentValues);
+                    compareResults = _mm_cmple_ps(currentValues, maxValues);
                     maxValuesIndex = _mm_blendv_ps(currentIndexes, maxValuesIndex, compareResults);
                     maxValues      = _mm_blendv_ps(currentValues, maxValues, compareResults);
                 }
@@ -464,6 +482,10 @@ static inline void volk_32f_index_max_32u_u_sse4_1(uint32_t* target, const float
                             index = maxIndexesBuffer[number];
                             max = maxValuesBuffer[number];
                         }
+                    else if(maxValuesBuffer[number] == max){
+                      if (index > maxIndexesBuffer[number])
+                        index = maxIndexesBuffer[number];
+                    }
                 }
 
             number = quarterPoints * 4;
@@ -510,7 +532,7 @@ static inline void volk_32f_index_max_32u_u_sse(uint32_t* target, const float* s
                 {
                     currentValues  = _mm_loadu_ps(inputPtr); inputPtr += 4;
                     currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
-                    compareResults = _mm_cmpgt_ps(maxValues, currentValues);
+                    compareResults = _mm_cmple_ps(currentValues, maxValues);
                     maxValuesIndex = _mm_or_ps(_mm_and_ps(compareResults, maxValuesIndex) , _mm_andnot_ps(compareResults, currentIndexes));
                     maxValues      = _mm_or_ps(_mm_and_ps(compareResults, maxValues) , _mm_andnot_ps(compareResults, currentValues));
                 }
@@ -526,6 +548,10 @@ static inline void volk_32f_index_max_32u_u_sse(uint32_t* target, const float* s
                             index = maxIndexesBuffer[number];
                             max = maxValuesBuffer[number];
                         }
+                    else if(maxValuesBuffer[number] == max){
+                      if (index > maxIndexesBuffer[number])
+                        index = maxIndexesBuffer[number];
+                    }
                 }
 
             number = quarterPoints * 4;


### PR DESCRIPTION
There were two problems with these kernels, both occurring only when input vector contains more than one identical number
1. the computation of the mask used in the SIMD kernels was wrong: it selected `<=` instead of `<`
2. when extracting the maximum and the maximum index in the SIMD kernels it was not guaranteed that the first maximum was selected

This should fix https://github.com/gnuradio/volk/issues/169 and CI test failures.