### PR TITLE
use named predicates in `_mm256_cmp_ps`

### DIFF
--- a/kernels/volk/volk_32f_acos_32f.h
+++ b/kernels/volk/volk_32f_acos_32f.h
@@ -105,10 +105,10 @@ volk_32f_acos_32f_a_avx2_fma(float* bVector, const float* aVector, unsigned int 
     d = aVal;
     aVal = _mm256_div_ps(_mm256_sqrt_ps(_mm256_mul_ps(_mm256_add_ps(fones, aVal), _mm256_sub_ps(fones, aVal))), aVal);
     z = aVal;
-    condition = _mm256_cmp_ps(z, fzeroes,1);
+    condition = _mm256_cmp_ps(z, fzeroes, _CMP_LT_OS);
     z = _mm256_sub_ps(z, _mm256_and_ps(_mm256_mul_ps(z, ftwos), condition));
     x = z;
-    condition = _mm256_cmp_ps(z, fones,1);
+    condition = _mm256_cmp_ps(z, fones, _CMP_LT_OS);
     x = _mm256_add_ps(x, _mm256_and_ps(_mm256_sub_ps(_mm256_div_ps(fones, z), z), condition));
 
     for(i = 0; i < 2; i++)
@@ -119,13 +119,13 @@ volk_32f_acos_32f_a_avx2_fma(float* bVector, const float* aVector, unsigned int 
       y = _mm256_fmadd_ps(y, _mm256_mul_ps(x, x), _mm256_set1_ps(pow(-1,j)/(2*j+1)));
 
     y = _mm256_mul_ps(y, _mm256_mul_ps(x, ffours));
-    condition = _mm256_cmp_ps(z, fones,14);
+    condition = _mm256_cmp_ps(z, fones, _CMP_GT_OS);
 
     y = _mm256_add_ps(y, _mm256_and_ps(_mm256_fnmadd_ps(y, ftwos, pio2), condition));
     arccosine = y;
-    condition = _mm256_cmp_ps(aVal, fzeroes,1);
+    condition = _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS);
     arccosine = _mm256_sub_ps(arccosine, _mm256_and_ps(_mm256_mul_ps(arccosine, ftwos), condition));
-    condition = _mm256_cmp_ps(d, fzeroes,1);
+    condition = _mm256_cmp_ps(d, fzeroes, _CMP_LT_OS);
     arccosine = _mm256_add_ps(arccosine, _mm256_and_ps(pi, condition));
 
     _mm256_store_ps(bPtr, arccosine);
@@ -170,10 +170,10 @@ volk_32f_acos_32f_a_avx(float* bVector, const float* aVector, unsigned int num_p
     d = aVal;
     aVal = _mm256_div_ps(_mm256_sqrt_ps(_mm256_mul_ps(_mm256_add_ps(fones, aVal), _mm256_sub_ps(fones, aVal))), aVal);
     z = aVal;
-    condition = _mm256_cmp_ps(z, fzeroes,1);
+    condition = _mm256_cmp_ps(z, fzeroes, _CMP_LT_OS);
     z = _mm256_sub_ps(z, _mm256_and_ps(_mm256_mul_ps(z, ftwos), condition));
     x = z;
-    condition = _mm256_cmp_ps(z, fones,1);
+    condition = _mm256_cmp_ps(z, fones, _CMP_LT_OS);
     x = _mm256_add_ps(x, _mm256_and_ps(_mm256_sub_ps(_mm256_div_ps(fones, z), z), condition));
 
     for(i = 0; i < 2; i++)
@@ -184,13 +184,13 @@ volk_32f_acos_32f_a_avx(float* bVector, const float* aVector, unsigned int num_p
       y = _mm256_add_ps(_mm256_mul_ps(y, _mm256_mul_ps(x, x)), _mm256_set1_ps(pow(-1,j)/(2*j+1)));
 
     y = _mm256_mul_ps(y, _mm256_mul_ps(x, ffours));
-    condition = _mm256_cmp_ps(z, fones,14);
+    condition = _mm256_cmp_ps(z, fones, _CMP_GT_OS);
 
     y = _mm256_add_ps(y, _mm256_and_ps(_mm256_sub_ps(pio2, _mm256_mul_ps(y, ftwos)), condition));
     arccosine = y;
-    condition = _mm256_cmp_ps(aVal, fzeroes,1);
+    condition = _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS);
     arccosine = _mm256_sub_ps(arccosine, _mm256_and_ps(_mm256_mul_ps(arccosine, ftwos), condition));
-    condition = _mm256_cmp_ps(d, fzeroes,1);
+    condition = _mm256_cmp_ps(d, fzeroes, _CMP_LT_OS);
     arccosine = _mm256_add_ps(arccosine, _mm256_and_ps(pi, condition));
 
     _mm256_store_ps(bPtr, arccosine);
@@ -304,10 +304,10 @@ volk_32f_acos_32f_u_avx2_fma(float* bVector, const float* aVector, unsigned int 
     d = aVal;
     aVal = _mm256_div_ps(_mm256_sqrt_ps(_mm256_mul_ps(_mm256_add_ps(fones, aVal), _mm256_sub_ps(fones, aVal))), aVal);
     z = aVal;
-    condition = _mm256_cmp_ps(z, fzeroes,1);
+    condition = _mm256_cmp_ps(z, fzeroes, _CMP_LT_OS);
     z = _mm256_sub_ps(z, _mm256_and_ps(_mm256_mul_ps(z, ftwos), condition));
     x = z;
-    condition = _mm256_cmp_ps(z, fones,1);
+    condition = _mm256_cmp_ps(z, fones, _CMP_LT_OS);
     x = _mm256_add_ps(x, _mm256_and_ps(_mm256_sub_ps(_mm256_div_ps(fones, z), z), condition));
 
     for(i = 0; i < 2; i++)
@@ -318,13 +318,13 @@ volk_32f_acos_32f_u_avx2_fma(float* bVector, const float* aVector, unsigned int 
       y = _mm256_fmadd_ps(y, _mm256_mul_ps(x, x), _mm256_set1_ps(pow(-1,j)/(2*j+1)));
 
     y = _mm256_mul_ps(y, _mm256_mul_ps(x, ffours));
-    condition = _mm256_cmp_ps(z, fones,14);
+    condition = _mm256_cmp_ps(z, fones, _CMP_GT_OS);
 
     y = _mm256_add_ps(y, _mm256_and_ps(_mm256_fnmadd_ps(y, ftwos, pio2), condition));
     arccosine = y;
-    condition = _mm256_cmp_ps(aVal, fzeroes,1);
+    condition = _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS);
     arccosine = _mm256_sub_ps(arccosine, _mm256_and_ps(_mm256_mul_ps(arccosine, ftwos), condition));
-    condition = _mm256_cmp_ps(d, fzeroes,1);
+    condition = _mm256_cmp_ps(d, fzeroes, _CMP_LT_OS);
     arccosine = _mm256_add_ps(arccosine, _mm256_and_ps(pi, condition));
 
     _mm256_storeu_ps(bPtr, arccosine);
@@ -369,10 +369,10 @@ volk_32f_acos_32f_u_avx(float* bVector, const float* aVector, unsigned int num_p
     d = aVal;
     aVal = _mm256_div_ps(_mm256_sqrt_ps(_mm256_mul_ps(_mm256_add_ps(fones, aVal), _mm256_sub_ps(fones, aVal))), aVal);
     z = aVal;
-    condition = _mm256_cmp_ps(z, fzeroes,1);
+    condition = _mm256_cmp_ps(z, fzeroes, _CMP_LT_OS);
     z = _mm256_sub_ps(z, _mm256_and_ps(_mm256_mul_ps(z, ftwos), condition));
     x = z;
-    condition = _mm256_cmp_ps(z, fones,1);
+    condition = _mm256_cmp_ps(z, fones, _CMP_LT_OS);
     x = _mm256_add_ps(x, _mm256_and_ps(_mm256_sub_ps(_mm256_div_ps(fones, z), z), condition));
 
     for(i = 0; i < 2; i++)
@@ -383,13 +383,13 @@ volk_32f_acos_32f_u_avx(float* bVector, const float* aVector, unsigned int num_p
       y = _mm256_add_ps(_mm256_mul_ps(y, _mm256_mul_ps(x, x)), _mm256_set1_ps(pow(-1,j)/(2*j+1)));
 
     y = _mm256_mul_ps(y, _mm256_mul_ps(x, ffours));
-    condition = _mm256_cmp_ps(z, fones,14);
+    condition = _mm256_cmp_ps(z, fones, _CMP_GT_OS);
 
     y = _mm256_add_ps(y, _mm256_and_ps(_mm256_sub_ps(pio2, _mm256_mul_ps(y, ftwos)), condition));
     arccosine = y;
-    condition = _mm256_cmp_ps(aVal, fzeroes,1);
+    condition = _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS);
     arccosine = _mm256_sub_ps(arccosine, _mm256_and_ps(_mm256_mul_ps(arccosine, ftwos), condition));
-    condition = _mm256_cmp_ps(d, fzeroes,1);
+    condition = _mm256_cmp_ps(d, fzeroes, _CMP_LT_OS);
     arccosine = _mm256_add_ps(arccosine, _mm256_and_ps(pi, condition));
 
     _mm256_storeu_ps(bPtr, arccosine);

--- a/kernels/volk/volk_32f_asin_32f.h
+++ b/kernels/volk/volk_32f_asin_32f.h
@@ -103,10 +103,10 @@ volk_32f_asin_32f_a_avx2_fma(float* bVector, const float* aVector, unsigned int 
     aVal = _mm256_load_ps(aPtr);
     aVal = _mm256_div_ps(aVal, _mm256_sqrt_ps(_mm256_mul_ps(_mm256_add_ps(fones, aVal), _mm256_sub_ps(fones, aVal))));
     z = aVal;
-    condition = _mm256_cmp_ps(z, fzeroes,1);
+    condition = _mm256_cmp_ps(z, fzeroes, _CMP_LT_OS);
     z = _mm256_sub_ps(z, _mm256_and_ps(_mm256_mul_ps(z, ftwos), condition));
     x = z;
-    condition = _mm256_cmp_ps(z, fones,1);
+    condition = _mm256_cmp_ps(z, fones, _CMP_LT_OS);
     x = _mm256_add_ps(x, _mm256_and_ps(_mm256_sub_ps(_mm256_div_ps(fones, z), z), condition));
 
     for(i = 0; i < 2; i++){
@@ -119,11 +119,11 @@ volk_32f_asin_32f_a_avx2_fma(float* bVector, const float* aVector, unsigned int 
     }
 
     y = _mm256_mul_ps(y, _mm256_mul_ps(x, ffours));
-    condition = _mm256_cmp_ps(z, fones,14);
+    condition = _mm256_cmp_ps(z, fones,_CMP_GT_OS);
 
     y = _mm256_add_ps(y, _mm256_and_ps(_mm256_fnmadd_ps(y,ftwos,pio2), condition));
     arcsine = y;
-    condition = _mm256_cmp_ps(aVal, fzeroes,1);
+    condition = _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS);
     arcsine = _mm256_sub_ps(arcsine, _mm256_and_ps(_mm256_mul_ps(arcsine, ftwos), condition));
 
     _mm256_store_ps(bPtr, arcsine);
@@ -166,10 +166,10 @@ volk_32f_asin_32f_a_avx(float* bVector, const float* aVector, unsigned int num_p
     aVal = _mm256_load_ps(aPtr);
     aVal = _mm256_div_ps(aVal, _mm256_sqrt_ps(_mm256_mul_ps(_mm256_add_ps(fones, aVal), _mm256_sub_ps(fones, aVal))));
     z = aVal;
-    condition = _mm256_cmp_ps(z, fzeroes,1);
+    condition = _mm256_cmp_ps(z, fzeroes, _CMP_LT_OS);
     z = _mm256_sub_ps(z, _mm256_and_ps(_mm256_mul_ps(z, ftwos), condition));
     x = z;
-    condition = _mm256_cmp_ps(z, fones,1);
+    condition = _mm256_cmp_ps(z, fones, _CMP_LT_OS);
     x = _mm256_add_ps(x, _mm256_and_ps(_mm256_sub_ps(_mm256_div_ps(fones, z), z), condition));
 
     for(i = 0; i < 2; i++){
@@ -182,11 +182,11 @@ volk_32f_asin_32f_a_avx(float* bVector, const float* aVector, unsigned int num_p
     }
 
     y = _mm256_mul_ps(y, _mm256_mul_ps(x, ffours));
-    condition = _mm256_cmp_ps(z, fones,14);
+    condition = _mm256_cmp_ps(z, fones, _CMP_GT_OS);
 
     y = _mm256_add_ps(y, _mm256_and_ps(_mm256_sub_ps(pio2, _mm256_mul_ps(y, ftwos)), condition));
     arcsine = y;
-    condition = _mm256_cmp_ps(aVal, fzeroes,1);
+    condition = _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS);
     arcsine = _mm256_sub_ps(arcsine, _mm256_and_ps(_mm256_mul_ps(arcsine, ftwos), condition));
 
     _mm256_store_ps(bPtr, arcsine);
@@ -295,10 +295,10 @@ volk_32f_asin_32f_u_avx2_fma(float* bVector, const float* aVector, unsigned int 
     aVal = _mm256_loadu_ps(aPtr);
     aVal = _mm256_div_ps(aVal, _mm256_sqrt_ps(_mm256_mul_ps(_mm256_add_ps(fones, aVal), _mm256_sub_ps(fones, aVal))));
     z = aVal;
-    condition = _mm256_cmp_ps(z, fzeroes,1);
+    condition = _mm256_cmp_ps(z, fzeroes, _CMP_LT_OS);
     z = _mm256_sub_ps(z, _mm256_and_ps(_mm256_mul_ps(z, ftwos), condition));
     x = z;
-    condition = _mm256_cmp_ps(z, fones,1);
+    condition = _mm256_cmp_ps(z, fones, _CMP_LT_OS);
     x = _mm256_add_ps(x, _mm256_and_ps(_mm256_sub_ps(_mm256_div_ps(fones, z), z), condition));
 
     for(i = 0; i < 2; i++){
@@ -311,11 +311,11 @@ volk_32f_asin_32f_u_avx2_fma(float* bVector, const float* aVector, unsigned int 
     }
 
     y = _mm256_mul_ps(y, _mm256_mul_ps(x, ffours));
-    condition = _mm256_cmp_ps(z, fones,14);
+    condition = _mm256_cmp_ps(z, fones, _CMP_GT_OS);
 
     y = _mm256_add_ps(y, _mm256_and_ps(_mm256_fnmadd_ps(y,ftwos,pio2), condition));
     arcsine = y;
-    condition = _mm256_cmp_ps(aVal, fzeroes,1);
+    condition = _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS);
     arcsine = _mm256_sub_ps(arcsine, _mm256_and_ps(_mm256_mul_ps(arcsine, ftwos), condition));
 
     _mm256_storeu_ps(bPtr, arcsine);
@@ -358,10 +358,10 @@ volk_32f_asin_32f_u_avx(float* bVector, const float* aVector, unsigned int num_p
     aVal = _mm256_loadu_ps(aPtr);
     aVal = _mm256_div_ps(aVal, _mm256_sqrt_ps(_mm256_mul_ps(_mm256_add_ps(fones, aVal), _mm256_sub_ps(fones, aVal))));
     z = aVal;
-    condition = _mm256_cmp_ps(z, fzeroes,1);
+    condition = _mm256_cmp_ps(z, fzeroes, _CMP_LT_OS);
     z = _mm256_sub_ps(z, _mm256_and_ps(_mm256_mul_ps(z, ftwos), condition));
     x = z;
-    condition = _mm256_cmp_ps(z, fones,1);
+    condition = _mm256_cmp_ps(z, fones, _CMP_LT_OS);
     x = _mm256_add_ps(x, _mm256_and_ps(_mm256_sub_ps(_mm256_div_ps(fones, z), z), condition));
 
     for(i = 0; i < 2; i++){
@@ -374,11 +374,11 @@ volk_32f_asin_32f_u_avx(float* bVector, const float* aVector, unsigned int num_p
     }
 
     y = _mm256_mul_ps(y, _mm256_mul_ps(x, ffours));
-    condition = _mm256_cmp_ps(z, fones,14);
+    condition = _mm256_cmp_ps(z, fones, _CMP_GT_OS);
 
     y = _mm256_add_ps(y, _mm256_and_ps(_mm256_sub_ps(pio2, _mm256_mul_ps(y, ftwos)), condition));
     arcsine = y;
-    condition = _mm256_cmp_ps(aVal, fzeroes,1);
+    condition = _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS);
     arcsine = _mm256_sub_ps(arcsine, _mm256_and_ps(_mm256_mul_ps(arcsine, ftwos), condition));
 
     _mm256_storeu_ps(bPtr, arcsine);

--- a/kernels/volk/volk_32f_atan_32f.h
+++ b/kernels/volk/volk_32f_atan_32f.h
@@ -102,10 +102,10 @@ volk_32f_atan_32f_a_avx2_fma(float* bVector, const float* aVector, unsigned int 
   for(;number < eighthPoints; number++){
     aVal = _mm256_load_ps(aPtr);
     z = aVal;
-    condition = _mm256_cmp_ps(z, fzeroes,1);
+    condition = _mm256_cmp_ps(z, fzeroes, _CMP_LT_OS);
     z = _mm256_sub_ps(z, _mm256_and_ps(_mm256_mul_ps(z, ftwos), condition));
     x = z;
-    condition = _mm256_cmp_ps(z, fones,1);
+    condition = _mm256_cmp_ps(z, fones, _CMP_LT_OS);
     x = _mm256_add_ps(x, _mm256_and_ps(_mm256_sub_ps(_mm256_div_ps(fones, z), z), condition));
 
     for(i = 0; i < 2; i++){
@@ -118,11 +118,11 @@ volk_32f_atan_32f_a_avx2_fma(float* bVector, const float* aVector, unsigned int 
     }
 
     y = _mm256_mul_ps(y, _mm256_mul_ps(x, ffours));
-    condition = _mm256_cmp_ps(z, fones,14);
+    condition = _mm256_cmp_ps(z, fones, _CMP_GT_OS);
 
     y = _mm256_add_ps(y, _mm256_and_ps(_mm256_fnmadd_ps(y,ftwos,pio2), condition));
     arctangent = y;
-    condition = _mm256_cmp_ps(aVal, fzeroes,1);
+    condition = _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS);
     arctangent = _mm256_sub_ps(arctangent, _mm256_and_ps(_mm256_mul_ps(arctangent, ftwos), condition));
 
     _mm256_store_ps(bPtr, arctangent);
@@ -164,10 +164,10 @@ volk_32f_atan_32f_a_avx(float* bVector, const float* aVector, unsigned int num_p
   for(;number < eighthPoints; number++){
     aVal = _mm256_load_ps(aPtr);
     z = aVal;
-    condition = _mm256_cmp_ps(z, fzeroes,1);
+    condition = _mm256_cmp_ps(z, fzeroes, _CMP_LT_OS);
     z = _mm256_sub_ps(z, _mm256_and_ps(_mm256_mul_ps(z, ftwos), condition));
     x = z;
-    condition = _mm256_cmp_ps(z, fones,1);
+    condition = _mm256_cmp_ps(z, fones, _CMP_LT_OS);
     x = _mm256_add_ps(x, _mm256_and_ps(_mm256_sub_ps(_mm256_div_ps(fones, z), z), condition));
 
     for(i = 0; i < 2; i++){
@@ -180,11 +180,11 @@ volk_32f_atan_32f_a_avx(float* bVector, const float* aVector, unsigned int num_p
     }
 
     y = _mm256_mul_ps(y, _mm256_mul_ps(x, ffours));
-    condition = _mm256_cmp_ps(z, fones,14);
+    condition = _mm256_cmp_ps(z, fones, _CMP_GT_OS);
 
     y = _mm256_add_ps(y, _mm256_and_ps(_mm256_sub_ps(pio2, _mm256_mul_ps(y, ftwos)), condition));
     arctangent = y;
-    condition = _mm256_cmp_ps(aVal, fzeroes,1);
+    condition = _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS);
     arctangent = _mm256_sub_ps(arctangent, _mm256_and_ps(_mm256_mul_ps(arctangent, ftwos), condition));
 
     _mm256_store_ps(bPtr, arctangent);
@@ -291,10 +291,10 @@ volk_32f_atan_32f_u_avx2_fma(float* bVector, const float* aVector, unsigned int 
   for(;number < eighthPoints; number++){
     aVal = _mm256_loadu_ps(aPtr);
     z = aVal;
-    condition = _mm256_cmp_ps(z, fzeroes,1);
+    condition = _mm256_cmp_ps(z, fzeroes, _CMP_LT_OS);
     z = _mm256_sub_ps(z, _mm256_and_ps(_mm256_mul_ps(z, ftwos), condition));
     x = z;
-    condition = _mm256_cmp_ps(z, fones,1);
+    condition = _mm256_cmp_ps(z, fones, _CMP_LT_OS);
     x = _mm256_add_ps(x, _mm256_and_ps(_mm256_sub_ps(_mm256_div_ps(fones, z), z), condition));
 
     for(i = 0; i < 2; i++){
@@ -307,11 +307,11 @@ volk_32f_atan_32f_u_avx2_fma(float* bVector, const float* aVector, unsigned int 
     }
 
     y = _mm256_mul_ps(y, _mm256_mul_ps(x, ffours));
-    condition = _mm256_cmp_ps(z, fones,14);
+    condition = _mm256_cmp_ps(z, fones, _CMP_GT_OS);
 
     y = _mm256_add_ps(y, _mm256_and_ps(_mm256_fnmadd_ps(y,ftwos,pio2), condition));
     arctangent = y;
-    condition = _mm256_cmp_ps(aVal, fzeroes,1);
+    condition = _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS);
     arctangent = _mm256_sub_ps(arctangent, _mm256_and_ps(_mm256_mul_ps(arctangent, ftwos), condition));
 
     _mm256_storeu_ps(bPtr, arctangent);
@@ -353,10 +353,10 @@ volk_32f_atan_32f_u_avx(float* bVector, const float* aVector, unsigned int num_p
   for(;number < eighthPoints; number++){
     aVal = _mm256_loadu_ps(aPtr);
     z = aVal;
-    condition = _mm256_cmp_ps(z, fzeroes,1);
+    condition = _mm256_cmp_ps(z, fzeroes, _CMP_LT_OS);
     z = _mm256_sub_ps(z, _mm256_and_ps(_mm256_mul_ps(z, ftwos), condition));
     x = z;
-    condition = _mm256_cmp_ps(z, fones,1);
+    condition = _mm256_cmp_ps(z, fones, _CMP_LT_OS);
     x = _mm256_add_ps(x, _mm256_and_ps(_mm256_sub_ps(_mm256_div_ps(fones, z), z), condition));
 
     for(i = 0; i < 2; i++){
@@ -369,11 +369,11 @@ volk_32f_atan_32f_u_avx(float* bVector, const float* aVector, unsigned int num_p
     }
 
     y = _mm256_mul_ps(y, _mm256_mul_ps(x, ffours));
-    condition = _mm256_cmp_ps(z, fones,14);
+    condition = _mm256_cmp_ps(z, fones, _CMP_GT_OS);
 
     y = _mm256_add_ps(y, _mm256_and_ps(_mm256_sub_ps(pio2, _mm256_mul_ps(y, ftwos)), condition));
     arctangent = y;
-    condition = _mm256_cmp_ps(aVal, fzeroes,1);
+    condition = _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS);
     arctangent = _mm256_sub_ps(arctangent, _mm256_and_ps(_mm256_mul_ps(arctangent, ftwos), condition));
 
     _mm256_storeu_ps(bPtr, arctangent);

--- a/kernels/volk/volk_32f_binary_slicer_32i.h
+++ b/kernels/volk/volk_32f_binary_slicer_32i.h
@@ -169,7 +169,7 @@ volk_32f_binary_slicer_32i_a_avx(int* cVector, const float* aVector, unsigned in
   for(number = 0; number < quarter_points; number++){
     a_val = _mm256_load_ps(aPtr);
 
-    res_f = _mm256_cmp_ps (a_val, zero_val, 13);
+    res_f = _mm256_cmp_ps (a_val, zero_val, _CMP_GE_OS);
     binary_f = _mm256_and_ps (res_f, one_val);
     binary_i = _mm256_cvtps_epi32(binary_f);
 
@@ -252,7 +252,7 @@ volk_32f_binary_slicer_32i_u_avx(int* cVector, const float* aVector, unsigned in
   for(number = 0; number < quarter_points; number++){
     a_val = _mm256_loadu_ps(aPtr);
 
-    res_f = _mm256_cmp_ps (a_val, zero_val, 13);
+    res_f = _mm256_cmp_ps (a_val, zero_val, _CMP_GE_OS);
     binary_f = _mm256_and_ps (res_f, one_val);
     binary_i = _mm256_cvtps_epi32(binary_f);
 

--- a/kernels/volk/volk_32f_binary_slicer_8i.h
+++ b/kernels/volk/volk_32f_binary_slicer_8i.h
@@ -139,10 +139,10 @@ volk_32f_binary_slicer_8i_a_avx2(int8_t* cVector, const float* aVector,
     a3_val = _mm256_load_ps(aPtr+24);
 
     // compare >= 0; return float
-    res0_f = _mm256_cmp_ps(a0_val, zero_val, 13);
-    res1_f = _mm256_cmp_ps(a1_val, zero_val, 13);
-    res2_f = _mm256_cmp_ps(a2_val, zero_val, 13);
-    res3_f = _mm256_cmp_ps(a3_val, zero_val, 13);
+    res0_f = _mm256_cmp_ps(a0_val, zero_val, _CMP_GE_OS);
+    res1_f = _mm256_cmp_ps(a1_val, zero_val, _CMP_GE_OS);
+    res2_f = _mm256_cmp_ps(a2_val, zero_val, _CMP_GE_OS);
+    res3_f = _mm256_cmp_ps(a3_val, zero_val, _CMP_GE_OS);
 
     // convert to 32i and >> 31
     res0_i = _mm256_srli_epi32(_mm256_cvtps_epi32(res0_f), 31);
@@ -216,10 +216,10 @@ volk_32f_binary_slicer_8i_u_avx2(int8_t* cVector, const float* aVector,
     a3_val = _mm256_loadu_ps(aPtr+24);
 
     // compare >= 0; return float
-    res0_f = _mm256_cmp_ps(a0_val, zero_val, 13);
-    res1_f = _mm256_cmp_ps(a1_val, zero_val, 13);
-    res2_f = _mm256_cmp_ps(a2_val, zero_val, 13);
-    res3_f = _mm256_cmp_ps(a3_val, zero_val, 13);
+    res0_f = _mm256_cmp_ps(a0_val, zero_val, _CMP_GE_OS);
+    res1_f = _mm256_cmp_ps(a1_val, zero_val, _CMP_GE_OS);
+    res2_f = _mm256_cmp_ps(a2_val, zero_val, _CMP_GE_OS);
+    res3_f = _mm256_cmp_ps(a3_val, zero_val, _CMP_GE_OS);
 
     // convert to 32i and >> 31
     res0_i = _mm256_srli_epi32(_mm256_cvtps_epi32(res0_f), 31);

--- a/kernels/volk/volk_32f_cos_32f.h
+++ b/kernels/volk/volk_32f_cos_32f.h
@@ -119,7 +119,7 @@ static inline void
 
     aVal = _mm256_load_ps(aPtr);
     // s = fabs(aVal)
-    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes,1)));
+    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS)));
     // q = (int) (s * (4/pi)), floor(aVal / (pi/4))
     q = _mm256_cvtps_epi32(_mm256_floor_ps(_mm256_mul_ps(s, m4pi)));
     // r = q + q&1, q indicates quadrant, r gives
@@ -207,7 +207,7 @@ static inline void
 
     aVal = _mm256_load_ps(aPtr);
     // s = fabs(aVal)
-    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes,1)));
+    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS)));
     // q = (int) (s * (4/pi)), floor(aVal / (pi/4))
     q = _mm256_cvtps_epi32(_mm256_floor_ps(_mm256_mul_ps(s, m4pi)));
     // r = q + q&1, q indicates quadrant, r gives
@@ -390,7 +390,7 @@ static inline void
 
     aVal = _mm256_loadu_ps(aPtr);
     // s = fabs(aVal)
-    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes,1)));
+    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS)));
     // q = (int) (s * (4/pi)), floor(aVal / (pi/4))
     q = _mm256_cvtps_epi32(_mm256_floor_ps(_mm256_mul_ps(s, m4pi)));
     // r = q + q&1, q indicates quadrant, r gives
@@ -478,7 +478,7 @@ static inline void
 
     aVal = _mm256_loadu_ps(aPtr);
     // s = fabs(aVal)
-    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes,1)));
+    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS)));
     // q = (int) (s * (4/pi)), floor(aVal / (pi/4))
     q = _mm256_cvtps_epi32(_mm256_floor_ps(_mm256_mul_ps(s, m4pi)));
     // r = q + q&1, q indicates quadrant, r gives

--- a/kernels/volk/volk_32f_s32f_32f_fm_detect_32f.h
+++ b/kernels/volk/volk_32f_s32f_32f_fm_detect_32f.h
@@ -103,9 +103,9 @@ static inline void volk_32f_s32f_32f_fm_detect_32f_a_avx(float* outputVector, co
     // Subtract and store:
     next3old1 = _mm256_sub_ps(next4, next3old1);
     // Bound:
-    boundAdjust = _mm256_cmp_ps(next3old1, upperBound, 14);
+    boundAdjust = _mm256_cmp_ps(next3old1, upperBound, _CMP_GT_OS);
     boundAdjust = _mm256_and_ps(boundAdjust, posBoundAdjust);
-    next4 = _mm256_cmp_ps(next3old1, lowerBound, 1);
+    next4 = _mm256_cmp_ps(next3old1, lowerBound, _CMP_LT_OS);
     next4 = _mm256_and_ps(next4, negBoundAdjust);
     boundAdjust = _mm256_or_ps(next4, boundAdjust);
     // Make sure we're in the bounding interval:
@@ -279,9 +279,9 @@ static inline void volk_32f_s32f_32f_fm_detect_32f_u_avx(float* outputVector, co
     // Subtract and store:
     next3old1 = _mm256_sub_ps(next4, next3old1);
     // Bound:
-    boundAdjust = _mm256_cmp_ps(next3old1, upperBound, 14);
+    boundAdjust = _mm256_cmp_ps(next3old1, upperBound, _CMP_GT_OS);
     boundAdjust = _mm256_and_ps(boundAdjust, posBoundAdjust);
-    next4 = _mm256_cmp_ps(next3old1, lowerBound, 1);
+    next4 = _mm256_cmp_ps(next3old1, lowerBound, _CMP_LT_OS);
     next4 = _mm256_and_ps(next4, negBoundAdjust);
     boundAdjust = _mm256_or_ps(next4, boundAdjust);
     // Make sure we're in the bounding interval:

--- a/kernels/volk/volk_32f_s32f_calc_spectral_noise_floor_32f.h
+++ b/kernels/volk/volk_32f_s32f_calc_spectral_noise_floor_32f.h
@@ -127,7 +127,7 @@ volk_32f_s32f_calc_spectral_noise_floor_32f_a_avx(float* noiseFloorAmplitude,
     dataPointsPtr += 8;
 
     // Identify which items do not exceed the mean amplitude
-    compareMask = _mm256_cmp_ps(dataPointsVal, vMeanAmplitudeVector, 18);
+    compareMask = _mm256_cmp_ps(dataPointsVal, vMeanAmplitudeVector, _CMP_LE_OQ);
 
     // Mask off the items that exceed the mean amplitude and add the avg Points that do not exceed the mean amplitude
     avgPointsVal = _mm256_add_ps(avgPointsVal, _mm256_and_ps(compareMask, dataPointsVal));
@@ -407,7 +407,7 @@ volk_32f_s32f_calc_spectral_noise_floor_32f_u_avx(float* noiseFloorAmplitude,
     dataPointsPtr += 8;
 
     // Identify which items do not exceed the mean amplitude
-    compareMask = _mm256_cmp_ps(dataPointsVal, vMeanAmplitudeVector, 18);
+    compareMask = _mm256_cmp_ps(dataPointsVal, vMeanAmplitudeVector, _CMP_LE_OQ);
 
     // Mask off the items that exceed the mean amplitude and add the avg Points that do not exceed the mean amplitude
     avgPointsVal = _mm256_add_ps(avgPointsVal, _mm256_and_ps(compareMask, dataPointsVal));

--- a/kernels/volk/volk_32f_s32f_s32f_mod_range_32f.h
+++ b/kernels/volk/volk_32f_s32f_s32f_mod_range_32f.h
@@ -62,8 +62,8 @@ static inline void volk_32f_s32f_s32f_mod_range_32f_u_avx(float* outputVector, c
   for(counter = 0; counter < eight_points; counter++) {
     input = _mm256_loadu_ps(inPtr);
     // calculate mask: input < lower, input > upper
-    is_smaller = _mm256_cmp_ps(input, lower, 0x11); //0x11: Less than, ordered, non-signalling
-    is_bigger = _mm256_cmp_ps(input, upper, 0x1e); //0x1e: greater than, ordered, non-signalling
+    is_smaller = _mm256_cmp_ps(input, lower, _CMP_LT_OQ); //0x11: Less than, ordered, non-signalling
+    is_bigger = _mm256_cmp_ps(input, upper, _CMP_GT_OQ); //0x1e: greater than, ordered, non-signalling
     // find out how far we are out-of-bound – positive values!
     excess = _mm256_and_ps(_mm256_sub_ps(lower, input), is_smaller);
     excess = _mm256_or_ps(_mm256_and_ps(_mm256_sub_ps(input, upper), is_bigger), excess);
@@ -118,8 +118,8 @@ static inline void volk_32f_s32f_s32f_mod_range_32f_a_avx(float* outputVector, c
   for(counter = 0; counter < eight_points; counter++) {
     input = _mm256_load_ps(inPtr);
     // calculate mask: input < lower, input > upper
-    is_smaller = _mm256_cmp_ps(input, lower, 0x11); //0x11: Less than, ordered, non-signalling
-    is_bigger = _mm256_cmp_ps(input, upper, 0x1e); //0x1e: greater than, ordered, non-signalling
+    is_smaller = _mm256_cmp_ps(input, lower, _CMP_LT_OQ); //0x11: Less than, ordered, non-signalling
+    is_bigger = _mm256_cmp_ps(input, upper, _CMP_GT_OQ); //0x1e: greater than, ordered, non-signalling
     // find out how far we are out-of-bound – positive values!
     excess = _mm256_and_ps(_mm256_sub_ps(lower, input), is_smaller);
     excess = _mm256_or_ps(_mm256_and_ps(_mm256_sub_ps(input, upper), is_bigger), excess);

--- a/kernels/volk/volk_32f_sin_32f.h
+++ b/kernels/volk/volk_32f_sin_32f.h
@@ -113,7 +113,7 @@ volk_32f_sin_32f_a_avx2_fma(float* bVector, const float* aVector, unsigned int n
 
   for(;number < eighthPoints; number++) {
     aVal = _mm256_load_ps(aPtr);
-    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes,1)));
+    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS)));
     q = _mm256_cvtps_epi32(_mm256_floor_ps(_mm256_mul_ps(s, m4pi)));
     r = _mm256_add_epi32(q, _mm256_and_si256(q, ones));
 
@@ -133,8 +133,8 @@ volk_32f_sin_32f_a_avx2_fma(float* bVector, const float* aVector, unsigned int n
     sine = _mm256_sqrt_ps(_mm256_mul_ps(_mm256_sub_ps(ftwos, s), s));
     cosine = _mm256_sub_ps(fones, s);
 
-    condition1 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)), fzeroes,4);
-    condition2 = _mm256_cmp_ps(_mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes,4), _mm256_cmp_ps(aVal, fzeroes,1),4);
+    condition1 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)), fzeroes, _CMP_NEQ_UQ);
+    condition2 = _mm256_cmp_ps(_mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes, _CMP_NEQ_UQ), _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS), _CMP_NEQ_UQ);
     // Need this condition only for cos
     //condition3 = _mm_cmpneq_ps(_mm_cvtepi32_ps(_mm_and_si128(_mm_add_epi32(q, twos), fours)), fzeroes);
 
@@ -189,7 +189,7 @@ volk_32f_sin_32f_a_avx2(float* bVector, const float* aVector, unsigned int num_p
 
   for(;number < eighthPoints; number++) {
     aVal = _mm256_load_ps(aPtr);
-    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes,1)));
+    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS)));
     q = _mm256_cvtps_epi32(_mm256_floor_ps(_mm256_mul_ps(s, m4pi)));
     r = _mm256_add_epi32(q, _mm256_and_si256(q, ones));
 
@@ -209,8 +209,8 @@ volk_32f_sin_32f_a_avx2(float* bVector, const float* aVector, unsigned int num_p
     sine = _mm256_sqrt_ps(_mm256_mul_ps(_mm256_sub_ps(ftwos, s), s));
     cosine = _mm256_sub_ps(fones, s);
 
-    condition1 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)), fzeroes,4);
-    condition2 = _mm256_cmp_ps(_mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes,4), _mm256_cmp_ps(aVal, fzeroes,1),4);
+    condition1 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)), fzeroes, _CMP_NEQ_UQ);
+    condition2 = _mm256_cmp_ps(_mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes, _CMP_NEQ_UQ), _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS), _CMP_NEQ_UQ);
     // Need this condition only for cos
     //condition3 = _mm_cmpneq_ps(_mm_cvtepi32_ps(_mm_and_si128(_mm_add_epi32(q, twos), fours)), fzeroes);
 
@@ -347,7 +347,7 @@ volk_32f_sin_32f_u_avx2_fma(float* bVector, const float* aVector, unsigned int n
 
   for(;number < eighthPoints; number++) {
     aVal = _mm256_loadu_ps(aPtr);
-    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes,1)));
+    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS)));
     q = _mm256_cvtps_epi32(_mm256_floor_ps(_mm256_mul_ps(s, m4pi)));
     r = _mm256_add_epi32(q, _mm256_and_si256(q, ones));
 
@@ -367,8 +367,8 @@ volk_32f_sin_32f_u_avx2_fma(float* bVector, const float* aVector, unsigned int n
     sine = _mm256_sqrt_ps(_mm256_mul_ps(_mm256_sub_ps(ftwos, s), s));
     cosine = _mm256_sub_ps(fones, s);
 
-    condition1 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)), fzeroes,4);
-    condition2 = _mm256_cmp_ps(_mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes,4), _mm256_cmp_ps(aVal, fzeroes,1),4);
+    condition1 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)), fzeroes, _CMP_NEQ_UQ);
+    condition2 = _mm256_cmp_ps(_mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes, _CMP_NEQ_UQ), _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS), _CMP_NEQ_UQ);
     // Need this condition only for cos
     //condition3 = _mm_cmpneq_ps(_mm_cvtepi32_ps(_mm_and_si128(_mm_add_epi32(q, twos), fours)), fzeroes);
 
@@ -423,7 +423,7 @@ volk_32f_sin_32f_u_avx2(float* bVector, const float* aVector, unsigned int num_p
 
   for(;number < eighthPoints; number++) {
     aVal = _mm256_loadu_ps(aPtr);
-    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes,1)));
+    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS)));
     q = _mm256_cvtps_epi32(_mm256_floor_ps(_mm256_mul_ps(s, m4pi)));
     r = _mm256_add_epi32(q, _mm256_and_si256(q, ones));
 
@@ -443,8 +443,8 @@ volk_32f_sin_32f_u_avx2(float* bVector, const float* aVector, unsigned int num_p
     sine = _mm256_sqrt_ps(_mm256_mul_ps(_mm256_sub_ps(ftwos, s), s));
     cosine = _mm256_sub_ps(fones, s);
 
-    condition1 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)), fzeroes,4);
-    condition2 = _mm256_cmp_ps(_mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes,4), _mm256_cmp_ps(aVal, fzeroes,1),4);
+    condition1 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)), fzeroes, _CMP_NEQ_UQ);
+    condition2 = _mm256_cmp_ps(_mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes, _CMP_NEQ_UQ), _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS), _CMP_NEQ_UQ);
     // Need this condition only for cos
     //condition3 = _mm_cmpneq_ps(_mm_cvtepi32_ps(_mm_and_si128(_mm_add_epi32(q, twos), fours)), fzeroes);
 

--- a/kernels/volk/volk_32f_tan_32f.h
+++ b/kernels/volk/volk_32f_tan_32f.h
@@ -115,7 +115,7 @@ volk_32f_tan_32f_a_avx2_fma(float* bVector, const float* aVector,
 
   for(;number < eighthPoints; number++){
     aVal = _mm256_load_ps(aPtr);
-    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes,1)));
+    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS)));
     q = _mm256_cvtps_epi32(_mm256_floor_ps(_mm256_mul_ps(s, m4pi)));
     r = _mm256_add_epi32(q, _mm256_and_si256(q, ones));
 
@@ -135,9 +135,9 @@ volk_32f_tan_32f_a_avx2_fma(float* bVector, const float* aVector,
     sine = _mm256_sqrt_ps(_mm256_mul_ps(_mm256_sub_ps(ftwos, s), s));
     cosine = _mm256_sub_ps(fones, s);
 
-    condition1 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)), fzeroes,4);
-    condition2 = _mm256_cmp_ps(_mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes,4), _mm256_cmp_ps(aVal, fzeroes,1),4);
-    condition3 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, twos), fours)), fzeroes,4);
+    condition1 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)), fzeroes, _CMP_NEQ_UQ);
+    condition2 = _mm256_cmp_ps(_mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes, _CMP_NEQ_UQ), _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS), _CMP_NEQ_UQ);
+    condition3 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, twos), fours)), fzeroes, _CMP_NEQ_UQ);
 
     __m256 temp = cosine;
     cosine = _mm256_add_ps(cosine, _mm256_and_ps(_mm256_sub_ps(sine, cosine), condition1));
@@ -195,7 +195,7 @@ volk_32f_tan_32f_a_avx2(float* bVector, const float* aVector,
 
   for(;number < eighthPoints; number++){
     aVal = _mm256_load_ps(aPtr);
-    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes,1)));
+    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS)));
     q = _mm256_cvtps_epi32(_mm256_floor_ps(_mm256_mul_ps(s, m4pi)));
     r = _mm256_add_epi32(q, _mm256_and_si256(q, ones));
 
@@ -215,9 +215,9 @@ volk_32f_tan_32f_a_avx2(float* bVector, const float* aVector,
     sine = _mm256_sqrt_ps(_mm256_mul_ps(_mm256_sub_ps(ftwos, s), s));
     cosine = _mm256_sub_ps(fones, s);
 
-    condition1 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)), fzeroes,4);
-    condition2 = _mm256_cmp_ps(_mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes,4), _mm256_cmp_ps(aVal, fzeroes,1),4);
-    condition3 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, twos), fours)), fzeroes,4);
+    condition1 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)), fzeroes, _CMP_NEQ_UQ);
+    condition2 = _mm256_cmp_ps(_mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes, _CMP_NEQ_UQ), _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS), _CMP_NEQ_UQ);
+    condition3 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, twos), fours)), fzeroes, _CMP_NEQ_UQ);
 
     __m256 temp = cosine;
     cosine = _mm256_add_ps(cosine, _mm256_and_ps(_mm256_sub_ps(sine, cosine), condition1));
@@ -361,7 +361,7 @@ volk_32f_tan_32f_u_avx2_fma(float* bVector, const float* aVector,
 
   for(;number < eighthPoints; number++){
     aVal = _mm256_loadu_ps(aPtr);
-    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes,1)));
+    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS)));
     q = _mm256_cvtps_epi32(_mm256_floor_ps(_mm256_mul_ps(s, m4pi)));
     r = _mm256_add_epi32(q, _mm256_and_si256(q, ones));
 
@@ -381,9 +381,9 @@ volk_32f_tan_32f_u_avx2_fma(float* bVector, const float* aVector,
     sine = _mm256_sqrt_ps(_mm256_mul_ps(_mm256_sub_ps(ftwos, s), s));
     cosine = _mm256_sub_ps(fones, s);
 
-    condition1 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)), fzeroes,4);
-    condition2 = _mm256_cmp_ps(_mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes,4), _mm256_cmp_ps(aVal, fzeroes,1),4);
-    condition3 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, twos), fours)), fzeroes,4);
+    condition1 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)), fzeroes, _CMP_NEQ_UQ);
+    condition2 = _mm256_cmp_ps(_mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes, _CMP_NEQ_UQ), _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS), _CMP_NEQ_UQ);
+    condition3 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, twos), fours)), fzeroes, _CMP_NEQ_UQ);
 
     __m256 temp = cosine;
     cosine = _mm256_add_ps(cosine, _mm256_and_ps(_mm256_sub_ps(sine, cosine), condition1));
@@ -441,7 +441,7 @@ volk_32f_tan_32f_u_avx2(float* bVector, const float* aVector,
 
   for(;number < eighthPoints; number++){
     aVal = _mm256_loadu_ps(aPtr);
-    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes,1)));
+    s = _mm256_sub_ps(aVal, _mm256_and_ps(_mm256_mul_ps(aVal, ftwos), _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS)));
     q = _mm256_cvtps_epi32(_mm256_floor_ps(_mm256_mul_ps(s, m4pi)));
     r = _mm256_add_epi32(q, _mm256_and_si256(q, ones));
 
@@ -461,9 +461,9 @@ volk_32f_tan_32f_u_avx2(float* bVector, const float* aVector,
     sine = _mm256_sqrt_ps(_mm256_mul_ps(_mm256_sub_ps(ftwos, s), s));
     cosine = _mm256_sub_ps(fones, s);
 
-    condition1 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)), fzeroes,4);
-    condition2 = _mm256_cmp_ps(_mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes,4), _mm256_cmp_ps(aVal, fzeroes,1),4);
-    condition3 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, twos), fours)), fzeroes,4);
+    condition1 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)), fzeroes, _CMP_NEQ_UQ);
+    condition2 = _mm256_cmp_ps(_mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes, _CMP_NEQ_UQ), _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS), _CMP_NEQ_UQ);
+    condition3 = _mm256_cmp_ps(_mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, twos), fours)), fzeroes, _CMP_NEQ_UQ);
 
     __m256 temp = cosine;
     cosine = _mm256_add_ps(cosine, _mm256_and_ps(_mm256_sub_ps(sine, cosine), condition1));

--- a/kernels/volk/volk_32f_x2_pow_32f.h
+++ b/kernels/volk/volk_32f_x2_pow_32f.h
@@ -161,7 +161,7 @@ volk_32f_x2_pow_32f_a_avx2_fma(float* cVector, const float* bVector,
     emm0 = _mm256_cvttps_epi32(fx);
     tmp = _mm256_cvtepi32_ps(emm0);
 
-    mask = _mm256_and_ps(_mm256_cmp_ps(tmp, fx, 14), one);
+    mask = _mm256_and_ps(_mm256_cmp_ps(tmp, fx, _CMP_GT_OS), one);
     fx = _mm256_sub_ps(tmp, mask);
 
     tmp = _mm256_fnmadd_ps(fx, exp_C1, bVal);
@@ -279,7 +279,7 @@ volk_32f_x2_pow_32f_a_avx2(float* cVector, const float* bVector,
     emm0 = _mm256_cvttps_epi32(fx);
     tmp = _mm256_cvtepi32_ps(emm0);
 
-    mask = _mm256_and_ps(_mm256_cmp_ps(tmp, fx, 14), one);
+    mask = _mm256_and_ps(_mm256_cmp_ps(tmp, fx, _CMP_GT_OS), one);
     fx = _mm256_sub_ps(tmp, mask);
 
     tmp = _mm256_sub_ps(bVal, _mm256_mul_ps(fx, exp_C1));
@@ -665,7 +665,7 @@ volk_32f_x2_pow_32f_u_avx2_fma(float* cVector, const float* bVector,
     emm0 = _mm256_cvttps_epi32(fx);
     tmp = _mm256_cvtepi32_ps(emm0);
 
-    mask = _mm256_and_ps(_mm256_cmp_ps(tmp, fx, 14), one);
+    mask = _mm256_and_ps(_mm256_cmp_ps(tmp, fx, _CMP_GT_OS), one);
     fx = _mm256_sub_ps(tmp, mask);
 
     tmp = _mm256_fnmadd_ps(fx, exp_C1, bVal);
@@ -783,7 +783,7 @@ volk_32f_x2_pow_32f_u_avx2(float* cVector, const float* bVector,
     emm0 = _mm256_cvttps_epi32(fx);
     tmp = _mm256_cvtepi32_ps(emm0);
 
-    mask = _mm256_and_ps(_mm256_cmp_ps(tmp, fx, 14), one);
+    mask = _mm256_and_ps(_mm256_cmp_ps(tmp, fx, _CMP_GT_OS), one);
     fx = _mm256_sub_ps(tmp, mask);
 
     tmp = _mm256_sub_ps(bVal, _mm256_mul_ps(fx, exp_C1));

--- a/kernels/volk/volk_32fc_index_max_16u.h
+++ b/kernels/volk/volk_32fc_index_max_16u.h
@@ -133,8 +133,8 @@ volk_32fc_index_max_16u_a_avx2(uint16_t* target, lv_32fc_t* src0,
 
     xmm3 = _mm256_max_ps(xmm1, xmm3);
 
-    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, 1);
-    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, 0);
+    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_LT_OS);
+    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_EQ_OQ);
 
     xmm11 = _mm256_and_si256(xmm8, xmm5.int_vec);
     xmm12 = _mm256_and_si256(xmm9, xmm4.int_vec);
@@ -156,8 +156,8 @@ volk_32fc_index_max_16u_a_avx2(uint16_t* target, lv_32fc_t* src0,
 
     xmm3 = _mm256_max_ps(xmm1, xmm3);
 
-    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, 1);
-    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, 0);
+    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_LT_OS);
+    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_EQ_OQ);
 
     xmm11 = _mm256_and_si256(xmm8, xmm5.int_vec);
     xmm12 = _mm256_and_si256(xmm9, xmm4.int_vec);
@@ -183,8 +183,8 @@ volk_32fc_index_max_16u_a_avx2(uint16_t* target, lv_32fc_t* src0,
 
       xmm3 = _mm256_max_ps(xmm1, xmm3);
 
-      xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3,1);
-      xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3,0);
+      xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_LT_OS);
+      xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_EQ_OQ);
 
       xmm11 = _mm256_and_si256(xmm8, xmm5.int_vec);
       xmm12 = _mm256_and_si256(xmm9, xmm4.int_vec);
@@ -210,8 +210,8 @@ volk_32fc_index_max_16u_a_avx2(uint16_t* target, lv_32fc_t* src0,
     xmm3 = _mm256_max_ps(xmm3, xmm2);//only lowest 32bit value
     xmm3 = _mm256_permutevar8x32_ps(xmm3, idx);
 
-    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, 1);
-    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, 0);
+    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_LT_OS);
+    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_EQ_OQ);
 
     xmm8 = _mm256_permutevar8x32_epi32(xmm8, idx);
 
@@ -488,8 +488,8 @@ volk_32fc_index_max_16u_u_avx2(uint16_t* target, lv_32fc_t* src0,
 
     xmm3 = _mm256_max_ps(xmm1, xmm3);
 
-    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, 1);
-    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, 0);
+    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_LT_OS);
+    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_EQ_OQ);
 
     xmm11 = _mm256_and_si256(xmm8, xmm5.int_vec);
     xmm12 = _mm256_and_si256(xmm9, xmm4.int_vec);
@@ -511,8 +511,8 @@ volk_32fc_index_max_16u_u_avx2(uint16_t* target, lv_32fc_t* src0,
 
     xmm3 = _mm256_max_ps(xmm1, xmm3);
 
-    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, 1);
-    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, 0);
+    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_LT_OS);
+    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_EQ_OQ);
 
     xmm11 = _mm256_and_si256(xmm8, xmm5.int_vec);
     xmm12 = _mm256_and_si256(xmm9, xmm4.int_vec);
@@ -538,8 +538,8 @@ volk_32fc_index_max_16u_u_avx2(uint16_t* target, lv_32fc_t* src0,
 
       xmm3 = _mm256_max_ps(xmm1, xmm3);
 
-      xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3,1);
-      xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3,0);
+      xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_LT_OS);
+      xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_EQ_OQ);
 
       xmm11 = _mm256_and_si256(xmm8, xmm5.int_vec);
       xmm12 = _mm256_and_si256(xmm9, xmm4.int_vec);

--- a/kernels/volk/volk_32fc_index_max_32u.h
+++ b/kernels/volk/volk_32fc_index_max_32u.h
@@ -121,8 +121,8 @@ volk_32fc_index_max_32u_a_avx2(uint32_t* target, lv_32fc_t* src0,
 
     xmm3 = _mm256_max_ps(xmm1, xmm3);
 
-    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, 1);
-    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, 0);
+    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_LT_OS);
+    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_EQ_OQ);
 
     xmm11 = _mm256_and_si256(xmm8, xmm5.int_vec);
     xmm12 = _mm256_and_si256(xmm9, xmm4.int_vec);
@@ -144,8 +144,8 @@ volk_32fc_index_max_32u_a_avx2(uint32_t* target, lv_32fc_t* src0,
 
     xmm3 = _mm256_max_ps(xmm1, xmm3);
 
-    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, 1);
-    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, 0);
+    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_LT_OS);
+    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_EQ_OQ);
 
     xmm11 = _mm256_and_si256(xmm8, xmm5.int_vec);
     xmm12 = _mm256_and_si256(xmm9, xmm4.int_vec);
@@ -171,8 +171,8 @@ volk_32fc_index_max_32u_a_avx2(uint32_t* target, lv_32fc_t* src0,
 
     xmm3 = _mm256_max_ps(xmm1, xmm3);
 
-    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, 1);
-    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, 0);
+    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_LT_OS);
+    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_EQ_OQ);
 
     xmm11 = _mm256_and_si256(xmm8, xmm5.int_vec);
     xmm12 = _mm256_and_si256(xmm9, xmm4.int_vec);
@@ -438,8 +438,8 @@ volk_32fc_index_max_32u_u_avx2(uint32_t* target, lv_32fc_t* src0,
 
     xmm3 = _mm256_max_ps(xmm1, xmm3);
 
-    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, 1);
-    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, 0);
+    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_LT_OS);
+    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_EQ_OQ);
 
     xmm11 = _mm256_and_si256(xmm8, xmm5.int_vec);
     xmm12 = _mm256_and_si256(xmm9, xmm4.int_vec);
@@ -461,8 +461,8 @@ volk_32fc_index_max_32u_u_avx2(uint32_t* target, lv_32fc_t* src0,
 
     xmm3 = _mm256_max_ps(xmm1, xmm3);
 
-    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, 1);
-    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, 0);
+    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_LT_OS);
+    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_EQ_OQ);
 
     xmm11 = _mm256_and_si256(xmm8, xmm5.int_vec);
     xmm12 = _mm256_and_si256(xmm9, xmm4.int_vec);
@@ -488,8 +488,8 @@ volk_32fc_index_max_32u_u_avx2(uint32_t* target, lv_32fc_t* src0,
 
     xmm3 = _mm256_max_ps(xmm1, xmm3);
 
-    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, 1);
-    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, 0);
+    xmm4.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_LT_OS);
+    xmm5.float_vec = _mm256_cmp_ps(xmm1, xmm3, _CMP_EQ_OQ);
 
     xmm11 = _mm256_and_si256(xmm8, xmm5.int_vec);
     xmm12 = _mm256_and_si256(xmm9, xmm4.int_vec);


### PR DESCRIPTION
rather trivial and quite tedious.. but hopefully this improves the readability of the code.

For reference (see avxintrin.h)
```c
/* Compare */
#define _CMP_EQ_OQ    0x00 /* Equal (ordered, non-signaling)  */
#define _CMP_LT_OS    0x01 /* Less-than (ordered, signaling)  */
#define _CMP_LE_OS    0x02 /* Less-than-or-equal (ordered, signaling)  */
#define _CMP_UNORD_Q  0x03 /* Unordered (non-signaling)  */
#define _CMP_NEQ_UQ   0x04 /* Not-equal (unordered, non-signaling)  */
#define _CMP_NLT_US   0x05 /* Not-less-than (unordered, signaling)  */
#define _CMP_NLE_US   0x06 /* Not-less-than-or-equal (unordered, signaling)  */
#define _CMP_ORD_Q    0x07 /* Ordered (nonsignaling)   */
#define _CMP_EQ_UQ    0x08 /* Equal (unordered, non-signaling)  */
#define _CMP_NGE_US   0x09 /* Not-greater-than-or-equal (unord, signaling)  */
#define _CMP_NGT_US   0x0a /* Not-greater-than (unordered, signaling)  */
#define _CMP_FALSE_OQ 0x0b /* False (ordered, non-signaling)  */
#define _CMP_NEQ_OQ   0x0c /* Not-equal (ordered, non-signaling)  */
#define _CMP_GE_OS    0x0d /* Greater-than-or-equal (ordered, signaling)  */
#define _CMP_GT_OS    0x0e /* Greater-than (ordered, signaling)  */
#define _CMP_TRUE_UQ  0x0f /* True (unordered, non-signaling)  */
#define _CMP_EQ_OS    0x10 /* Equal (ordered, signaling)  */
#define _CMP_LT_OQ    0x11 /* Less-than (ordered, non-signaling)  */
#define _CMP_LE_OQ    0x12 /* Less-than-or-equal (ordered, non-signaling)  */
#define _CMP_UNORD_S  0x13 /* Unordered (signaling)  */
#define _CMP_NEQ_US   0x14 /* Not-equal (unordered, signaling)  */
#define _CMP_NLT_UQ   0x15 /* Not-less-than (unordered, non-signaling)  */
#define _CMP_NLE_UQ   0x16 /* Not-less-than-or-equal (unord, non-signaling)  */
#define _CMP_ORD_S    0x17 /* Ordered (signaling)  */
#define _CMP_EQ_US    0x18 /* Equal (unordered, signaling)  */
#define _CMP_NGE_UQ   0x19 /* Not-greater-than-or-equal (unord, non-sign)  */
#define _CMP_NGT_UQ   0x1a /* Not-greater-than (unordered, non-signaling)  */
#define _CMP_FALSE_OS 0x1b /* False (ordered, signaling)  */
#define _CMP_NEQ_OS   0x1c /* Not-equal (ordered, signaling)  */
#define _CMP_GE_OQ    0x1d /* Greater-than-or-equal (ordered, non-signaling)  */
#define _CMP_GT_OQ    0x1e /* Greater-than (ordered, non-signaling)  */
#define _CMP_TRUE_US  0x1f /* True (unordered, signaling)  */
```