### PR TITLE
volk_8u_conv_k7_r2puppet_8u: initialize decisions to zero

### DIFF
--- a/kernels/volk/volk_8u_conv_k7_r2puppet_8u.h
+++ b/kernels/volk/volk_8u_conv_k7_r2puppet_8u.h
@@ -155,8 +155,11 @@ static inline void volk_8u_conv_k7_r2puppet_8u_spiral(unsigned char* syms, unsig
     once = 0;
   }
 
-    //unbias the old_metrics
+  //unbias the old_metrics
   memset(X, 31, d_numstates);
+
+  // initialize decisions
+  memset(D, 0, (d_numstates/8) * (framebits + 6));
 
   volk_8u_x4_conv_k7_r2_8u_spiral(Y, X, syms, D, framebits/2 - excess, excess, Branchtab);
 
@@ -228,8 +231,11 @@ static inline void volk_8u_conv_k7_r2puppet_8u_avx2(unsigned char* syms, unsigne
     once = 0;
   }
 
-    //unbias the old_metrics
+  //unbias the old_metrics
   memset(X, 31, d_numstates);
+
+  // initialize decisions
+  memset(D, 0, (d_numstates/8) * (framebits + 6));
 
   volk_8u_x4_conv_k7_r2_8u_avx2(Y, X, syms, D, framebits/2 - excess, excess, Branchtab);
 
@@ -302,11 +308,11 @@ static inline void volk_8u_conv_k7_r2puppet_8u_generic(unsigned char* syms, unsi
     once = 0;
   }
 
-
-
-
-    //unbias the old_metrics
+  //unbias the old_metrics
   memset(X, 31, d_numstates);
+
+  // initialize decisions
+  memset(D, 0, (d_numstates/8) * (framebits + 6));
 
   volk_8u_x4_conv_k7_r2_8u_generic(Y, X, syms, D, framebits/2 - excess, excess, Branchtab);
 


### PR DESCRIPTION
The array of decisions it not initialized. When running volk_profile with this kernel alone I did not observe any failures, but when running volk_profile for all kernels, `volk_8u_conv_k7_r2puppet_8u` fails quite consistently. In the latter case it is more likely that memory is reused and its contents are not guaranteed to be zero.

@jessica-iwamoto: is it correct to initialize it to zero? (I guess yes, because these are updated using `|=`)

This PR is supposed to fix the following issues: 
https://github.com/gnuradio/volk/issues/266
https://github.com/gnuradio/volk/issues/117