### PR TITLE
Add __clang__ specific attributes

### DIFF
--- a/include/volk/volk_common.h
+++ b/include/volk/volk_common.h
@@ -4,7 +4,20 @@
 ////////////////////////////////////////////////////////////////////////
 // Cross-platform attribute macros
 ////////////////////////////////////////////////////////////////////////
-#if defined __GNUC__
+#if defined __clang__
+// AppleClang also defines __GNUC__, so do this check first.  These
+// will probably be the same as for __GNUC__, but let's keep them
+// separate just to be safe.
+#  define __VOLK_ATTR_ALIGNED(x) __attribute__((aligned(x)))
+#  define __VOLK_ATTR_UNUSED     __attribute__((unused))
+#  define __VOLK_ATTR_INLINE     __attribute__((always_inline))
+#  define __VOLK_ATTR_DEPRECATED __attribute__((deprecated))
+#  define __VOLK_ASM             __asm__
+#  define __VOLK_VOLATILE        __volatile__
+#  define __VOLK_ATTR_EXPORT     __attribute__((visibility("default")))
+#  define __VOLK_ATTR_IMPORT     __attribute__((visibility("default")))
+#  define __VOLK_PREFETCH(addr)  __builtin_prefetch(addr)
+#elif defined __GNUC__
 #  define __VOLK_ATTR_ALIGNED(x) __attribute__((aligned(x)))
 #  define __VOLK_ATTR_UNUSED     __attribute__((unused))
 #  define __VOLK_ATTR_INLINE     __attribute__((always_inline))


### PR DESCRIPTION
From the comment in the code: AppleClang also defines __GNUC__, so do this check first.  These will probably be the same as for __GNUC__, but let's keep them separate just to be safe.