### PR TITLE
configpath: Abort read/write if path not found

### DIFF
--- a/apps/volk_profile.cc
+++ b/apps/volk_profile.cc
@@ -157,6 +157,10 @@ void read_results(std::vector<volk_test_results_t> *results)
 {
     char path[1024];
     volk_get_config_path(path, true);
+    if(path[0] == 0){
+        std::cout << "No prior test results found ..." << std::endl;
+        return;
+    }
 
     read_results(results, std::string(path));
 }
@@ -214,6 +218,10 @@ void write_results(const std::vector<volk_test_results_t> *results, bool update_
 {
     char path[1024];
     volk_get_config_path(path, false);
+    if(path[0] == 0){
+        std::cout << "Aborting 'No config save path found' ..." << std::endl;
+        return;
+    }
 
     write_results( results, update_result, std::string(path));
 }


### PR DESCRIPTION
This commit fixes #259.
After a call to `volk_get_config_path` check if `path[0] == 0`. If yes,
return because we could not find a volk config path.