### PR TITLE
travis: Add native tests on arm64, s390x and ppc64le architectures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: cpp
 
+os: linux
 dist: trusty
 sudo: false
 
@@ -61,6 +62,39 @@ matrix:
     # Job 8 .. gcc-7 py3
     - env: MATRIX_EVAL="CC=gcc-7 && CXX=g++-7 && CMAKE_ARG=-DPYTHON_EXECUTABLE=/usr/bin/python3"
       addons: {apt: {sources: "ubuntu-toolchain-r-test", packages: [*common_packages, g++-7, python3, python3-mako, python3-six]}}
+    - name: Linux arm64 GCC
+      arch: arm64
+      dist: bionic
+      env: MATRIX_EVAL="CMAKE_ARG=-DPYTHON_EXECUTABLE=/usr/bin/python3"
+      addons: {apt: {packages: [*common_packages, python3, python3-distutils, python3-mako, python3-six]}}
+    - name: Linux arm64 Clang
+      dist: bionic
+      arch: arm64
+      env: MATRIX_EVAL="CC=clang && CXX=clang++ && CMAKE_ARG=-DPYTHON_EXECUTABLE=/usr/bin/python3"
+      addons: {apt: {packages: [*common_packages, python3, python3-distutils, python3-mako, python3-six]}}
+    - name: Linux ppc64le GCC
+      dist: bionic
+      arch: ppc64le
+      env: MATRIX_EVAL="CMAKE_ARG=-DPYTHON_EXECUTABLE=/usr/bin/python3"
+      addons: {apt: {packages: [*common_packages, python3, python3-distutils, python3-mako, python3-six]}}
+    - name: Linux ppc64le Clang
+      dist: bionic
+      arch: ppc64le
+      env: MATRIX_EVAL="CC=clang && CXX=clang++ && CMAKE_ARG=-DPYTHON_EXECUTABLE=/usr/bin/python3"
+      addons: {apt: {packages: [*common_packages, python3, python3-distutils, python3-mako, python3-six]}}
+    - name: Linux s390x GCC
+      dist: bionic
+      arch: s390x
+      env: MATRIX_EVAL="CMAKE_ARG=-DPYTHON_EXECUTABLE=/usr/bin/python3"
+      addons: {apt: {packages: [*common_packages, python3, python3-distutils, python3-mako, python3-six]}}
+    - name: Linux s390x Clang
+      dist: bionic
+      arch: s390x
+      env: MATRIX_EVAL="CC=clang && CXX=clang++ && CMAKE_ARG=-DPYTHON_EXECUTABLE=/usr/bin/python3"
+      addons: {apt: {packages: [*common_packages, python3, python3-distutils, python3-mako, python3-six]}}
+  allow_failures:
+    - arch: s390x
+    - arch: ppc64le
 
 #      before_install:
 #        - pip install --user codecov
@@ -69,4 +103,5 @@ matrix:
 
 script:
   - eval "${MATRIX_EVAL}"
+  - lscpu
   - mkdir build && cd build && BOOST_ROOT=$BOOST_ROOT cmake ${CMAKE_ARG} ../ && make && ctest -V && cd ..


### PR DESCRIPTION
See https://docs.travis-ci.com/user/multi-cpu-architectures

- Test with both gcc and clang
- Add ppc64le and s390x to allow_failures as currently two tests fail
  on these two architectures

 89: Segmentation fault (core dumped)
 89/130 Test  #89: qa_volk_32fc_s32fc_multiply_32fc ...................***Failed    1.13 sec

 90: Segmentation fault (core dumped)
 90/130 Test  #90: qa_volk_32fc_s32fc_rotatorpuppet_32fc ..............***Failed    0.15 sec