### PR TITLE
Fixups: Various Boost and include ordering

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -26,6 +26,12 @@ add_executable(volk_profile
     ${CMAKE_CURRENT_SOURCE_DIR}/volk_option_helpers.cc
 )
 
+if(MSVC)
+    target_include_directories(volk_profile
+        PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/cmake/msvc>
+    )
+endif(MSVC)
+
 target_include_directories(volk_profile
     PRIVATE $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
     PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
@@ -33,20 +39,14 @@ target_include_directories(volk_profile
     PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib>
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-    PUBLIC $<INSTALL_INTERFACE:include>
 )
 
 if(NOT FILESYSTEM_FOUND)
     target_include_directories(volk_profile
         PUBLIC ${Boost_INCLUDE_DIRS}
     )
+    target_link_libraries(volk_profile PRIVATE ${Boost_LIBRARIES})
 endif()
-
-if(MSVC)
-    target_include_directories(volk_profile
-        PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/cmake/msvc>
-    )
-endif(MSVC)
 
 if(FILESYSTEM_FOUND)
     add_definitions(-DHAS_STD_FILESYSTEM=1)
@@ -57,10 +57,10 @@ if(FILESYSTEM_FOUND)
 endif()
 
 if(ENABLE_STATIC_LIBS)
-    target_link_libraries(volk_profile PRIVATE volk_static ${Boost_LIBRARIES})
+    target_link_libraries(volk_profile PRIVATE volk_static)
     set_target_properties(volk_profile PROPERTIES LINK_FLAGS "-static")
 else()
-    target_link_libraries(volk_profile PRIVATE volk ${Boost_LIBRARIES})
+    target_link_libraries(volk_profile PRIVATE volk)
 endif()
 
 install(

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -18,19 +18,6 @@
 ########################################################################
 # Setup profiler
 ########################################################################
-if(MSVC)
-    include_directories(${PROJECT_SOURCE_DIR}/cmake/msvc)
-endif(MSVC)
-
-include_directories(
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${PROJECT_SOURCE_DIR}/include
-    ${PROJECT_BINARY_DIR}/include
-    ${PROJECT_SOURCE_DIR}/lib
-    ${PROJECT_BINARY_DIR}/lib
-    ${Boost_INCLUDE_DIRS}
-)
 
 # MAKE volk_profile
 add_executable(volk_profile
@@ -39,7 +26,29 @@ add_executable(volk_profile
     ${CMAKE_CURRENT_SOURCE_DIR}/volk_option_helpers.cc
 )
 
-if(${FILESYSTEM_FOUND})
+target_include_directories(volk_profile
+    PRIVATE $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+    PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    PRIVATE $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/lib>
+    PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/lib>
+    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+    PUBLIC $<INSTALL_INTERFACE:include>
+)
+
+if(NOT FILESYSTEM_FOUND)
+    target_include_directories(volk_profile
+        PUBLIC ${Boost_INCLUDE_DIRS}
+    )
+endif()
+
+if(MSVC)
+    target_include_directories(volk_profile
+        PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/cmake/msvc>
+    )
+endif(MSVC)
+
+if(FILESYSTEM_FOUND)
     add_definitions(-DHAS_STD_FILESYSTEM=1)
     if(${find_experimental})
         add_definitions(-DHAS_STD_FILESYSTEM_EXPERIMENTAL=1)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -602,14 +602,7 @@ endif(ENABLE_STATIC_LIBS)
 ########################################################################
 if(ENABLE_TESTING)
 
-    #include Boost headers
-    include_directories(${Boost_INCLUDE_DIRS})
     make_directory(${CMAKE_CURRENT_BINARY_DIR}/.unittest)
-    set_source_files_properties(
-        ${CMAKE_CURRENT_SOURCE_DIR}/testqa.cc PROPERTIES
-        COMPILE_DEFINITIONS "BOOST_TEST_DYN_LINK;BOOST_TEST_MAIN"
-    )
-
     include(VolkAddTest)
     VOLK_GEN_TEST("volk_test_all"
         SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/testqa.cc

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -533,37 +533,51 @@ if(MSVC)
     set_source_files_properties(${volk_sources} PROPERTIES LANGUAGE CXX)
 endif()
 
-#Create a volk object library
+#Create an object to reference Volk source and object files.
+#
+#NOTE: This object cannot be used to propagate include directories or
+#library linkage, but we have to define them here for compiling to
+#work. There are options starting with CMake 3.13 for using the OBJECT
+#to propagate this information.
 add_library(volk_obj OBJECT ${volk_sources})
 target_include_directories(volk_obj
-  PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
-  PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-  PUBLIC $<INSTALL_INTERFACE:include>
-  PRIVATE ${PROJECT_SOURCE_DIR}/kernels
-  PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  )
+    PRIVATE $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+    PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/kernels>
+    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+#Configure object target properties
+if(NOT MSVC)
+  set_target_properties(volk_obj PROPERTIES COMPILE_FLAGS "-fPIC")
+endif()
 
 #Add dynamic library
+#
+#NOTE: The PUBLIC include directories and library linkage will be
+#propagated when this target is used to build other targets. Also, the
+#PUBLIC library linkage and include directories INSTALL_INTERFACE will
+#be used to create the target import information. Ordering of the
+#include directories is taken as provided; it -might- matter, but
+#probably doesn't.
 add_library(volk SHARED $<TARGET_OBJECTS:volk_obj>)
-target_link_libraries(volk ${volk_libraries})
+target_link_libraries(volk PUBLIC ${volk_libraries})
 target_include_directories(volk
-  PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
-  PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-  PUBLIC $<INSTALL_INTERFACE:include>
-  PRIVATE ${PROJECT_SOURCE_DIR}/kernels
-  PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  )
+    PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+    PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/kernels>
+    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+    PUBLIC $<INSTALL_INTERFACE:include>
+)
 
 #Configure target properties
 if(NOT MSVC)
-  set_target_properties(volk_obj PROPERTIES COMPILE_FLAGS "-fPIC")
-  target_link_libraries(volk m)
+  target_link_libraries(volk PUBLIC m)
 endif()
 set_target_properties(volk PROPERTIES SOVERSION ${LIBVER})
 set_target_properties(volk PROPERTIES DEFINE_SYMBOL "volk_EXPORTS")
-
 
 #Install locations
 install(TARGETS volk
@@ -574,20 +588,27 @@ install(TARGETS volk
   )
 
 #Configure static library
+#
+#NOTE: The PUBLIC include directories and library linkage will be
+#propagated when this target is used to build other targets. Also, the
+#PUBLIC library linkage and include directories INSTALL_INTERFACE will
+#be used to create the target import information. Ordering of the
+#include directories is taken as provided; it -might- matter, but
+#probably doesn't.
 if(ENABLE_STATIC_LIBS)
   add_library(volk_static STATIC $<TARGET_OBJECTS:volk_obj>)
-  target_link_libraries(volk_static ${volk_libraries} pthread)
+  target_link_libraries(volk_static PUBLIC ${volk_libraries} pthread)
   if(NOT MSVC)
-    target_link_libraries(volk_static m)
+    target_link_libraries(volk_static PUBLIC m)
   endif()
   target_include_directories(volk_static
     PUBLIC $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
     PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    PUBLIC $<INSTALL_INTERFACE:include>
-    PRIVATE ${PROJECT_SOURCE_DIR}/kernels
+    PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/kernels>
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-    )
+    PUBLIC $<INSTALL_INTERFACE:include>
+  )
 
   set_target_properties(volk_static PROPERTIES OUTPUT_NAME volk)
 
@@ -612,7 +633,7 @@ if(ENABLE_TESTING)
     foreach(kernel ${h_files})
       get_filename_component(kernel ${kernel} NAME)
       string(REPLACE ".h" "" kernel ${kernel})
-      VOLK_ADD_TEST(${kernel} "volk_test_all")
+      VOLK_ADD_TEST(${kernel} volk_test_all)
     endforeach()
 
 endif(ENABLE_TESTING)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -604,7 +604,7 @@ if(ENABLE_TESTING)
 
     make_directory(${CMAKE_CURRENT_BINARY_DIR}/.unittest)
     include(VolkAddTest)
-    VOLK_GEN_TEST("volk_test_all"
+    VOLK_GEN_TEST(volk_test_all
         SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/testqa.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/qa_utils.cc
         TARGET_DEPS volk

--- a/lib/qa_utils.h
+++ b/lib/qa_utils.h
@@ -142,14 +142,6 @@ bool run_volk_tests(
         bool benchmark_mode = false
 );
 
-
-#define VOLK_RUN_TESTS(func, tol, scalar, len, iter) \
-    BOOST_AUTO_TEST_CASE(func##_test) { \
-        BOOST_CHECK_EQUAL(run_volk_tests( \
-            func##_get_func_desc(), (void (*)())func##_manual, \
-            std::string(#func), tol, scalar, len, iter, 0, "NULL"), \
-          0); \
-    }
 #define VOLK_PROFILE(func, test_params, results) run_volk_tests(func##_get_func_desc(), (void (*)())func##_manual, std::string(#func), test_params, results, "NULL")
 #define VOLK_PUPPET_PROFILE(func, puppet_master_func, test_params, results) run_volk_tests(func##_get_func_desc(), (void (*)())func##_manual, std::string(#func), test_params, results, std::string(#puppet_master_func))
 typedef void (*volk_fn_1arg)(void *, unsigned int, const char*); //one input, operate in place

--- a/python/volk_modtool/volk_modtool_generate.py
+++ b/python/volk_modtool/volk_modtool_generate.py
@@ -31,7 +31,6 @@ class volk_modtool(object):
         self.volk = re.compile('volk')
         self.remove_after_underscore = re.compile("_.*")
         self.volk_included = re.compile('INCLUDED_VOLK')
-        self.volk_run_tests = re.compile(r'^\s*VOLK_RUN_TESTS.*\n', re.MULTILINE)
         self.volk_profile = re.compile(r'^\s*(VOLK_PROFILE|VOLK_PUPPET_PROFILE).*\n', re.MULTILINE)
         self.volk_kernel_tests = re.compile(r'^\s*\((VOLK_INIT_TEST|VOLK_INIT_PUPP).*\n', re.MULTILINE)
         self.volk_null_kernel = re.compile(r'^\s*;\n', re.MULTILINE)


### PR DESCRIPTION
Closes: https://github.com/gnuradio/volk/issues/234

Remove Boost usage from `lib`, and fix it in `apps` to be used only if `std::filesystem` is not found.

Tweak include directories ordering slightly, and be more precise in specifying whether they are PUBLIC or PRIVATE, and add verbose notes as to why.

Some whilespace tweaks and removing unnecessary ""s too.