### PR TITLE
Clang Attribute Fix

### DIFF
--- a/include/volk/volk_common.h
+++ b/include/volk/volk_common.h
@@ -4,7 +4,7 @@
 ////////////////////////////////////////////////////////////////////////
 // Cross-platform attribute macros
 ////////////////////////////////////////////////////////////////////////
-#if defined __clang__
+#if defined(__clang__) && (!defined(_MSC_VER))
 // AppleClang also defines __GNUC__, so do this check first.  These
 // will probably be the same as for __GNUC__, but let's keep them
 // separate just to be safe.


### PR DESCRIPTION
For attribute, change from clang to "clang but not MSC".

MSC attributes are covered in a later clause

Simple / trivial change.

Ref: https://github.com/gnuradio/volk/commit/7abdaa5da2ab236ed8acfe361d04021050146778#commitcomment-36706063