### PR TITLE
Drop Python 2 support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ build:
   # instead of calling g++ directly you can also use some build toolkit like make
   # install the necessary build tools when needed
   before_script:
-     - apt update && apt -y install make cmake python python-pip libboost-all-dev && pip install six mako
+     - apt update && apt -y install make cmake python python-pip libboost-all-dev && pip install mako
   script:
     - mkdir build && cd build && cmake .. && make -j
   artifacts:
@@ -24,7 +24,7 @@ build:
 test:
   stage: test
   before_script:
-    - apt update && apt -y install cmake python python-pip libboost-all-dev && pip install six mako
+    - apt update && apt -y install cmake python python-pip libboost-all-dev && pip install mako
   script:
     - cd build && ctest -V
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
     packages: &common_packages
       - python-mako
       - python3-mako
-      - python3-six
       - liborc-dev
       - libboost-system-dev
       - libboost-filesystem-dev
@@ -63,37 +62,37 @@ matrix:
       addons: {apt: {packages: [*common_packages]}}
     # Job 8 .. gcc-7 py3
     - env: MATRIX_EVAL="CC=gcc-7 && CXX=g++-7 && CMAKE_ARG=-DPYTHON_EXECUTABLE=/usr/bin/python3"
-      addons: {apt: {sources: "ubuntu-toolchain-r-test", packages: [*common_packages, g++-7, python3, python3-mako, python3-six]}}
+      addons: {apt: {sources: "ubuntu-toolchain-r-test", packages: [*common_packages, g++-7, python3, python3-mako]}}
     - name: Linux arm64 GCC
       arch: arm64
       dist: bionic
       env: MATRIX_EVAL="CMAKE_ARG=-DPYTHON_EXECUTABLE=/usr/bin/python3"
-      addons: {apt: {packages: [*common_packages, python3, python3-distutils, python3-mako, python3-six]}}
+      addons: {apt: {packages: [*common_packages, python3, python3-distutils, python3-mako]}}
     - name: Linux arm64 Clang
       dist: bionic
       arch: arm64
       env: MATRIX_EVAL="CC=clang && CXX=clang++ && CMAKE_ARG=-DPYTHON_EXECUTABLE=/usr/bin/python3"
-      addons: {apt: {packages: [*common_packages, python3, python3-distutils, python3-mako, python3-six]}}
+      addons: {apt: {packages: [*common_packages, python3, python3-distutils, python3-mako]}}
     - name: Linux ppc64le GCC
       dist: bionic
       arch: ppc64le
       env: MATRIX_EVAL="CMAKE_ARG=-DPYTHON_EXECUTABLE=/usr/bin/python3"
-      addons: {apt: {packages: [*common_packages, python3, python3-distutils, python3-mako, python3-six]}}
+      addons: {apt: {packages: [*common_packages, python3, python3-distutils, python3-mako]}}
     - name: Linux ppc64le Clang
       dist: bionic
       arch: ppc64le
       env: MATRIX_EVAL="CC=clang && CXX=clang++ && CMAKE_ARG=-DPYTHON_EXECUTABLE=/usr/bin/python3"
-      addons: {apt: {packages: [*common_packages, python3, python3-distutils, python3-mako, python3-six]}}
+      addons: {apt: {packages: [*common_packages, python3, python3-distutils, python3-mako]}}
     - name: Linux s390x GCC
       dist: bionic
       arch: s390x
       env: MATRIX_EVAL="CMAKE_ARG=-DPYTHON_EXECUTABLE=/usr/bin/python3"
-      addons: {apt: {packages: [*common_packages, python3, python3-distutils, python3-mako, python3-six]}}
+      addons: {apt: {packages: [*common_packages, python3, python3-distutils, python3-mako]}}
     - name: Linux s390x Clang
       dist: bionic
       arch: s390x
       env: MATRIX_EVAL="CC=clang && CXX=clang++ && CMAKE_ARG=-DPYTHON_EXECUTABLE=/usr/bin/python3"
-      addons: {apt: {packages: [*common_packages, python3, python3-distutils, python3-mako, python3-six]}}
+      addons: {apt: {packages: [*common_packages, python3, python3-distutils, python3-mako]}}
   allow_failures:
     - arch: s390x
     - arch: ppc64le

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,6 @@ endif(MSVC)
 include(VolkPython) #sets PYTHON_EXECUTABLE and PYTHON_DASH_B
 VOLK_PYTHON_CHECK_MODULE("python >= 3.4" sys "sys.version.split()[0] >= '3.4'" PYTHON_MIN_VER_FOUND)
 VOLK_PYTHON_CHECK_MODULE("mako >= 0.4.2" mako "mako.__version__ >= '0.4.2'" MAKO_FOUND)
-VOLK_PYTHON_CHECK_MODULE("six - python 2 and 3 compatibility library" six "True" SIX_FOUND)
 
 if(NOT PYTHON_MIN_VER_FOUND)
     message(FATAL_ERROR "Python 3.4 or greater required to build VOLK")
@@ -93,10 +92,6 @@ if(NOT MAKO_FOUND)
     message(FATAL_ERROR "Mako templates required to build VOLK")
 endif()
 
-# Six
-if(NOT SIX_FOUND)
-    message(FATAL_ERROR "six - python 2 and 3 compatibility library required to build VOLK")
-endif()
 
 # Boost
 if(MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,12 +80,12 @@ endif(MSVC)
 
 # Python
 include(VolkPython) #sets PYTHON_EXECUTABLE and PYTHON_DASH_B
-VOLK_PYTHON_CHECK_MODULE("python >= 2.7" sys "sys.version.split()[0] >= '2.7'" PYTHON_MIN_VER_FOUND)
+VOLK_PYTHON_CHECK_MODULE("python >= 3.4" sys "sys.version.split()[0] >= '3.4'" PYTHON_MIN_VER_FOUND)
 VOLK_PYTHON_CHECK_MODULE("mako >= 0.4.2" mako "mako.__version__ >= '0.4.2'" MAKO_FOUND)
 VOLK_PYTHON_CHECK_MODULE("six - python 2 and 3 compatibility library" six "True" SIX_FOUND)
 
 if(NOT PYTHON_MIN_VER_FOUND)
-    message(FATAL_ERROR "Python 2.7 or greater required to build VOLK")
+    message(FATAL_ERROR "Python 3.4 or greater required to build VOLK")
 endif()
 
 # Mako

--- a/apps/plot_best_vs_generic.py
+++ b/apps/plot_best_vs_generic.py
@@ -47,9 +47,11 @@ with open(filename) as json_file:
                 generic_time = test['results']['u_generic']['time']
             metrics.append(extension_performance[np.argmin(extension_performance)]/generic_time)
 
+
 plt.bar(np.arange(len(metrics)), metrics)
 plt.hlines(1.0, -1, len(metrics), colors='r', linestyles='dashed')
 plt.axis([-1, len(metrics), 0, 2])
 plt.xticks(np.arange(len(operations)), operations, rotation=90)
 plt.ylabel('Time taken of fastest kernel relative to generic kernel')
+plt.tight_layout()
 plt.show()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,6 @@ install:
       print(sys.platform, platform.machine(), struct.calcsize('P')*8)"
     - pip --version
     - pip install mako
-    - pip install six
 before_build:
     - cmake -G "%CMAKE_GENERATOR% Win64" \
         -DBoost_CHRONO_LIBRARY_RELEASE:FILEPATH=%CD%/packages/boost_chrono-%VC_VERSION%.%BOOST_VERSION%.0/lib/native/address-model-64/lib/boost_chrono-%VC_VERSION%-mt-%BOOST_FILENAME_VERSION%.lib \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ before_build:
 build_script:
     - cmake --build . --config Release --target INSTALL
 test_script:
-    - ctest --output-on-failure -C Release
+    - ctest -V --output-on-failure -C Release
 after_test:
     - cd "c:\Program Files"
     - 7z a "c:\libvolk-x64-%VC_VERSION%.zip" volk

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,11 +7,13 @@ environment:
   BOOST_VERSION: 1.59.0
   environment:
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - job_name: VS 12 2013 / python 3.4
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CMAKE_GENERATOR: Visual Studio 12 2013
       VC_VERSION: vc120
       PYTHON: "C:\\Python34-x64"
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - job_name: VS 14 2015 / python 3.8
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CMAKE_GENERATOR: Visual Studio 14 2015
       VC_VERSION: vc140
       PYTHON: "C:\\Python38-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,11 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CMAKE_GENERATOR: Visual Studio 12 2013
       VC_VERSION: vc120
+      PYTHON: "C:\\Python34-x64"
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       CMAKE_GENERATOR: Visual Studio 14 2015
       VC_VERSION: vc140
+      PYTHON: "C:\\Python38-x64"
 
 install:
     - nuget install boost_system-%VC_VERSION% -Version %BOOST_VERSION% -OutputDirectory %CD%/packages
@@ -20,7 +22,13 @@ install:
     - nuget install boost_chrono-%VC_VERSION% -Version %BOOST_VERSION% -OutputDirectory %CD%/packages
     - nuget install boost_program_options-%VC_VERSION% -Version %BOOST_VERSION% -OutputDirectory %CD%/packages
     - nuget install boost_unit_test_framework-%VC_VERSION% -Version %BOOST_VERSION% -OutputDirectory %CD%/packages
-    - pip install Cheetah
+    # Prepend the selected Python to the PATH of this build
+    - SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
+    # Display version information about selected python and pip
+    - python --version
+    - python -c "import sys, platform, struct;
+      print(sys.platform, platform.machine(), struct.calcsize('P')*8)"
+    - pip --version
     - pip install mako
     - pip install six
 before_build:

--- a/cmake/Modules/VolkPython.cmake
+++ b/cmake/Modules/VolkPython.cmake
@@ -33,7 +33,7 @@ set(__INCLUDED_VOLK_PYTHON_CMAKE TRUE)
 #if(PYTHON_EXECUTABLE)
 #    set(Python_EXECUTABLE ${PYTHON_EXECUTABLE})
 #else(PYTHON_EXECUTABLE)
-#    find_package(Python COMPONENTS Interpreter)
+#    find_package(Python3 COMPONENTS Interpreter)
 #endif(PYTHON_EXECUTABLE)
 #
 ##make the path to the executable appear in the cmake gui
@@ -51,13 +51,9 @@ else(PYTHON_EXECUTABLE)
     set(Python_ADDITIONAL_VERSIONS 3.4 3.5 3.6 3.7 3.8)
     find_package(PythonInterp 3)
 
-    if(NOT PYTHONINTERP_FOUND)
-        find_package(PythonInterp 2.7)
-    endif(NOT PYTHONINTERP_FOUND)
-
     #and if that fails use the find program routine
     if(NOT PYTHONINTERP_FOUND)
-        find_program(PYTHON_EXECUTABLE NAMES python3 python python2 python2.7)
+        find_program(PYTHON_EXECUTABLE NAMES python3 python)
         if(PYTHON_EXECUTABLE)
             set(PYTHONINTERP_FOUND TRUE)
         endif(PYTHON_EXECUTABLE)

--- a/gen/volk_arch_defs.py
+++ b/gen/volk_arch_defs.py
@@ -17,7 +17,6 @@
 
 from __future__ import print_function
 
-import six
 
 archs = list()
 arch_dict = dict()
@@ -81,9 +80,8 @@ for arch_xml in archs_xml:
         name = flag_xml.attributes["compiler"].value
         if name not in flags: flags[name] = list()
         flags[name].append(flag_xml.firstChild.data)
-    #force kwargs keys to be of type str, not unicode for py25
-    kwargs = dict((str(k), v) for k, v in six.iteritems(kwargs))
     register_arch(flags=flags, checks=checks, **kwargs)
 
 if __name__ == '__main__':
     print(archs)
+    

--- a/gen/volk_arch_defs.py
+++ b/gen/volk_arch_defs.py
@@ -15,8 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import print_function
-
 
 archs = list()
 arch_dict = dict()

--- a/gen/volk_compile_utils.py
+++ b/gen/volk_compile_utils.py
@@ -16,11 +16,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import print_function
-
-import optparse
+import argparse
 import volk_arch_defs
 import volk_machine_defs
+
 
 def do_arch_flags_list(compiler):
     output = list()
@@ -30,6 +29,7 @@ def do_arch_flags_list(compiler):
         output.append(','.join(fields))
     print(';'.join(output))
 
+
 def do_machines_list(arch_names):
     output = list()
     for machine in volk_machine_defs.machines:
@@ -38,6 +38,7 @@ def do_machines_list(arch_names):
             output.append(machine.name)
     print(';'.join(output))
 
+
 def do_machine_flags_list(compiler, machine_name):
     output = list()
     machine = volk_machine_defs.machine_dict[machine_name]
@@ -45,16 +46,19 @@ def do_machine_flags_list(compiler, machine_name):
         output.extend(arch.get_flags(compiler))
     print(' '.join(output))
 
+
 def main():
-    parser = optparse.OptionParser()
-    parser.add_option('--mode', type='string')
-    parser.add_option('--compiler', type='string')
-    parser.add_option('--archs', type='string')
-    parser.add_option('--machine', type='string')
-    (opts, args) = parser.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--mode', type=str)
+    parser.add_argument('--compiler', type=str)
+    parser.add_argument('--archs', type=str)
+    parser.add_argument('--machine', type=str)
+    args = parser.parse_args()
 
-    if opts.mode == 'arch_flags': return do_arch_flags_list(opts.compiler.lower())
-    if opts.mode == 'machines': return do_machines_list(opts.archs.split(';'))
-    if opts.mode == 'machine_flags': return do_machine_flags_list(opts.compiler.lower(), opts.machine)
+    if args.mode == 'arch_flags': return do_arch_flags_list(args.compiler.lower())
+    if args.mode == 'machines': return do_machines_list(args.archs.split(';'))
+    if args.mode == 'machine_flags': return do_machine_flags_list(args.compiler.lower(), args.machine)
 
-if __name__ == '__main__': main()
+if __name__ == '__main__': 
+    main()
+    

--- a/gen/volk_kernel_defs.py
+++ b/gen/volk_kernel_defs.py
@@ -19,8 +19,6 @@
 # Boston, MA 02110-1301, USA.
 #
 
-from __future__ import print_function
-
 import os
 import re
 import sys
@@ -209,3 +207,4 @@ kernels = list(map(kernel_class, kernel_files))
 
 if __name__ == '__main__':
     print(kernels)
+    

--- a/gen/volk_machine_defs.py
+++ b/gen/volk_machine_defs.py
@@ -15,9 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-from __future__ import print_function
-
-
 from volk_arch_defs import arch_dict
 
 machines = list()

--- a/gen/volk_machine_defs.py
+++ b/gen/volk_machine_defs.py
@@ -17,7 +17,6 @@
 
 from __future__ import print_function
 
-import six
 
 from volk_arch_defs import arch_dict
 
@@ -70,8 +69,6 @@ for machine_xml in machines_xml:
             kwargs[name] = val
         except: pass
     kwargs['archs'] = kwargs['archs'].split()
-    #force kwargs keys to be of type str, not unicode for py25
-    kwargs = dict((str(k), v) for k, v in six.iteritems(kwargs))
     register_machine(**kwargs)
 
 if __name__ == '__main__':

--- a/gen/volk_tmpl_utils.py
+++ b/gen/volk_tmpl_utils.py
@@ -20,16 +20,15 @@
 # Boston, MA 02110-1301, USA.
 #
 
-from __future__ import print_function
-
 import os
 import re
 import sys
-import optparse
+import argparse
 import volk_arch_defs
 import volk_machine_defs
 import volk_kernel_defs
 from mako.template import Template
+
 
 def __parse_tmpl(_tmpl, **kwargs):
     defs = {
@@ -47,14 +46,18 @@ def __parse_tmpl(_tmpl, **kwargs):
 """ + _tmpl
     return str(Template(_tmpl).render(**defs))
 
-def main():
-    parser = optparse.OptionParser()
-    parser.add_option('--input', type='string')
-    parser.add_option('--output', type='string')
-    (opts, args) = parser.parse_args()
 
-    output = __parse_tmpl(open(opts.input).read(), args=args)
-    if opts.output: open(opts.output, 'w').write(output)
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--input', type=str)
+    parser.add_argument('--output', type=str)
+    args, extras = parser.parse_known_args()
+
+    output = __parse_tmpl(open(args.input).read(), args=extras)
+    if args.output: open(args.output, 'w').write(output)
     else: print(output)
 
-if __name__ == '__main__': main()
+
+if __name__ == '__main__': 
+    main()
+    

--- a/python/volk_modtool/cfg.py
+++ b/python/volk_modtool/cfg.py
@@ -20,13 +20,10 @@
 # Boston, MA 02110-1301, USA.
 #
 
-from __future__ import print_function
-
+import configparser
 import sys
 import os
 import re
-
-from six.moves import configparser, input
 
 
 class volk_modtool_config(object):

--- a/python/volk_modtool/volk_modtool
+++ b/python/volk_modtool/volk_modtool
@@ -20,7 +20,7 @@
 # Boston, MA 02110-1301, USA.
 #
 
-from __future__ import print_function
+
 from volk_modtool import volk_modtool, volk_modtool_config
 from optparse import OptionParser, OptionGroup
 

--- a/python/volk_modtool/volk_modtool_generate.py
+++ b/python/volk_modtool/volk_modtool_generate.py
@@ -19,8 +19,6 @@
 # Boston, MA 02110-1301, USA.
 #
 
-from __future__ import print_function
-
 import os
 import re
 import glob


### PR DESCRIPTION
The minimum required Python version is 3.4 now. Before it was either Python2.7 or Python3.4+. It is 2020 and the pythonclock ran out, thus we drop Python2 support.   

With Python2 support dropped, we can also
- remove `six` as a dependency.
- replace `optparse` by `argparse` because `optparse` is deprecated.
- remove `from __future__` imports because they are obsolete now.

CI update
- Remove obsolete packages, `six`, `Cheetah`, `python2`. 
- Move to newer distro 'bionic' by default.

Update: I broke the CI system. Thus, I removed all CI system changes. This would probably be better as a separate PR.