### PR TITLE
alloc: Use C11 aligned_alloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,10 +129,12 @@ endif()
 # For MSVC use `_aligned_malloc`.
 ########################################################################
 include(CheckSymbolExists)
-CHECK_SYMBOL_EXISTS(aligned_alloc stdlib.h USE_ALIGNED_ALLOC)
+if(NOT (${CMAKE_SYSTEM_NAME} MATCHES "Darwin"))
+    CHECK_SYMBOL_EXISTS(aligned_alloc stdlib.h USE_ALIGNED_ALLOC)
+endif()
 if(NOT USE_ALIGNED_ALLOC)
     CHECK_SYMBOL_EXISTS(posix_memalign stdlib.h HAVE_POSIX_MEMALIGN)
-endif(USE_ALIGNED_ALLOC)
+endif()
 
 ########################################################################
 # Check if Orc is available

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,20 @@ else()
     endif()
 endif()
 
-# Orc
+########################################################################
+# check for aligned_alloc, since some compilers lack this C11 feature.
+# For Apple-clang use `posix_memalign`
+# For MSVC use `_aligned_malloc`.
+########################################################################
+include(CheckSymbolExists)
+CHECK_SYMBOL_EXISTS(aligned_alloc stdlib.h USE_ALIGNED_ALLOC)
+if(NOT USE_ALIGNED_ALLOC)
+    CHECK_SYMBOL_EXISTS(posix_memalign stdlib.h HAVE_POSIX_MEMALIGN)
+endif(USE_ALIGNED_ALLOC)
+
+########################################################################
+# Check if Orc is available
+########################################################################
 option(ENABLE_ORC "Enable Orc" True)
 if(ENABLE_ORC)
   find_package(ORC)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -19,6 +19,12 @@
 # Setup profiler
 ########################################################################
 
+# POSIX_MEMALIGN: If we have to fall back to `posix_memalign`.
+if(HAVE_POSIX_MEMALIGN)
+    message(STATUS "Use `posix_memalign` for aligned malloc!")
+    add_definitions(-DHAVE_POSIX_MEMALIGN)
+endif(HAVE_POSIX_MEMALIGN)
+
 # MAKE volk_profile
 add_executable(volk_profile
     ${CMAKE_CURRENT_SOURCE_DIR}/volk_profile.cc

--- a/apps/volk-config-info.cc
+++ b/apps/volk-config-info.cc
@@ -41,12 +41,10 @@ void print_malloc()
   // You don't want to change the volk_malloc code, so just copy the if/else
   // structure from there and give an explanation for the implementations
   std::cout << "Used malloc implementation: ";
-  #if _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || HAVE_POSIX_MEMALIGN
-  std::cout << "posix_memalign" << std::endl;
-  #elif _MSC_VER >= 1400
-  std::cout << "aligned_malloc" << std::endl;
+  #if defined(_MSC_VER)
+  std::cout << "_aligned_malloc" << std::endl;
   #else
-      std::cout << "No standard handler available, using own implementation." << std::endl;
+  std::cout << "C11 aligned_alloc" << std::endl;
   #endif
 }
 

--- a/apps/volk-config-info.cc
+++ b/apps/volk-config-info.cc
@@ -41,7 +41,9 @@ void print_malloc()
   // You don't want to change the volk_malloc code, so just copy the if/else
   // structure from there and give an explanation for the implementations
   std::cout << "Used malloc implementation: ";
-  #if defined(_MSC_VER)
+  #if HAVE_POSIX_MEMALIGN
+  std::cout << "posix_memalign" << std::endl;
+  #elif defined(_MSC_VER)
   std::cout << "_aligned_malloc" << std::endl;
   #else
   std::cout << "C11 aligned_alloc" << std::endl;

--- a/include/volk/volk_malloc.h
+++ b/include/volk/volk_malloc.h
@@ -32,8 +32,20 @@ __VOLK_DECL_BEGIN
  * \brief Allocate \p size bytes of data aligned to \p alignment.
  *
  * \details
- * Internally, we use C11 `aligned_alloc` to allocate aligned memory.
- * Thus, we rely on C11 syntax and compilers.
+ * We use C11 and want to rely on C11 library features,
+ * namely we use `aligned_alloc` to allocate aligned memory.
+ * see: https://en.cppreference.com/w/c/memory/aligned_alloc
+ *
+ * Not all platforms support this feature.
+ * For Apple Clang, we fall back to `posix_memalign`.
+ * see: https://linux.die.net/man/3/aligned_alloc
+ * For MSVC, we fall back to `_aligned_malloc`.
+ * see: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-malloc?view=vs-2019
+ *
+ * Because of the ways in which volk_malloc may allocate memory, it is
+ * important to always free volk_malloc pointers using volk_free.
+ * Mainly, in case MSVC is used. Consult corresponding documentation
+ * in case you use MSVC.
  *
  * \param size The number of bytes to allocate.
  * \param alignment The byte alignment of the allocated memory.

--- a/include/volk/volk_malloc.h
+++ b/include/volk/volk_malloc.h
@@ -32,22 +32,8 @@ __VOLK_DECL_BEGIN
  * \brief Allocate \p size bytes of data aligned to \p alignment.
  *
  * \details
- * Because we don't have a standard method to allocate buffers in
- * memory that are guaranteed to be on an alignment, VOLK handles this
- * itself. The volk_malloc function behaves like malloc in that it
- * returns a pointer to the allocated memory. However, it also takes
- * in an alignment specification, which is usually something like 16 or
- * 32 to ensure that the aligned memory is located on a particular
- * byte boundary for use with SIMD.
- *
- * Internally, the volk_malloc first checks if the compiler is C11
- * compliant and uses the new aligned_alloc method. If not, it checks
- * if the system is POSIX compliant and uses posix_memalign. If that
- * fails, volk_malloc handles the memory allocation and alignment
- * internally.
- *
- * Because of the ways in which volk_malloc may allocate memory, it is
- * important to always free volk_malloc pointers using volk_free.
+ * Internally, we use C11 `aligned_alloc` to allocate aligned memory.
+ * Thus, we rely on C11 syntax and compilers.
  *
  * \param size The number of bytes to allocate.
  * \param alignment The byte alignment of the allocated memory.
@@ -57,7 +43,13 @@ VOLK_API void *volk_malloc(size_t size, size_t alignment);
 
 /*!
  * \brief Free's memory allocated by volk_malloc.
- * \param aptr The aligned pointer allocaed by volk_malloc.
+ *
+ * \details
+ * We rely on C11 syntax and compilers and just call `free`
+ * on memory that was allocated with `aligned_alloc`.
+ * Thus, `volk_free` inherits the same behavoir `free` exhibits.
+ *
+ * \param aptr The aligned pointer allocated by volk_malloc.
  */
 VOLK_API void volk_free(void *aptr);
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -66,18 +66,6 @@ if(COMPILER_NAME MATCHES "GNU")
 endif()
 
 ########################################################################
-# check for posix_memalign, since some OSs do not internally define
-# _XOPEN_SOURCE or _POSIX_C_SOURCE; they leave this to the user.
-########################################################################
-
-include(CheckSymbolExists)
-CHECK_SYMBOL_EXISTS(posix_memalign stdlib.h HAVE_POSIX_MEMALIGN)
-
-if(HAVE_POSIX_MEMALIGN)
-      add_definitions(-DHAVE_POSIX_MEMALIGN)
-endif(HAVE_POSIX_MEMALIGN)
-
-########################################################################
 # detect x86 flavor of CPU
 ########################################################################
 if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(i.86|x86|x86_64|amd64|AMD64)$")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -66,6 +66,15 @@ if(COMPILER_NAME MATCHES "GNU")
 endif()
 
 ########################################################################
+# POSIX_MEMALIGN: If we have to fall back to `posix_memalign`,
+# make it known to the compiler.
+########################################################################
+if(HAVE_POSIX_MEMALIGN)
+    message(STATUS "Use `posix_memalign` for aligned malloc!")
+    add_definitions(-DHAVE_POSIX_MEMALIGN)
+endif(HAVE_POSIX_MEMALIGN)
+
+########################################################################
 # detect x86 flavor of CPU
 ########################################################################
 if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^(i.86|x86|x86_64|amd64|AMD64)$")

--- a/lib/volk_malloc.c
+++ b/lib/volk_malloc.c
@@ -29,33 +29,23 @@
 /*
  * For #defines used to determine support for allocation functions,
  * see: http://linux.die.net/man/3/aligned_alloc
+ *
+ * C11 features:
+ * see: https://en.cppreference.com/w/c/memory/aligned_alloc
 */
 
-// Otherwise, test if we are a POSIX or X/Open system
-// This only has a restriction that alignment be a power of 2 and a
-// multiple of sizeof(void *).
-#if _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || HAVE_POSIX_MEMALIGN
 
 void *volk_malloc(size_t size, size_t alignment)
 {
-  void *ptr;
-
-  // quoting posix_memalign() man page:
-  // "alignment must be a power of two and a multiple of sizeof(void *)"
-  // volk_get_alignment() could return 1 for some machines (e.g. generic_orc)
-  if (alignment == 1)
+  if (alignment == 1){
     return malloc(size);
+  }
 
-  int err = posix_memalign(&ptr, alignment, size);
-  if(err == 0) {
-    return ptr;
+  void *ptr = aligned_alloc(alignment, size);
+  if(ptr == NULL) {
+    fprintf(stderr, "VOLK: Error allocating memory (aligned_alloc was POSIX)\n");
   }
-  else {
-    fprintf(stderr,
-            "VOLK: Error allocating memory "
-            "(posix_memalign: error %d: %s)\n", err, strerror(err));
-    return NULL;
-  }
+  return ptr;
 }
 
 void volk_free(void *ptr)
@@ -63,68 +53,6 @@ void volk_free(void *ptr)
   free(ptr);
 }
 
-// _aligned_malloc has no restriction on size,
-// available on Windows since Visual C++ 2005
-#elif _MSC_VER >= 1400
 
-void *volk_malloc(size_t size, size_t alignment)
-{
-  void *ptr = _aligned_malloc(size, alignment);
-  if(ptr == NULL) {
-    fprintf(stderr, "VOLK: Error allocating memory (_aligned_malloc)\n");
-  }
-  return ptr;
-}
-
-void volk_free(void *ptr)
-{
-  _aligned_free(ptr);
-}
-
-// No standard handlers; we'll do it ourselves.
-#else // _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || HAVE_POSIX_MEMALIGN
-
-struct block_info
-{
-  void *real;
-};
-
-void *
-volk_malloc(size_t size, size_t alignment)
-{
-  void *real, *user;
-  struct block_info *info;
-
-  /* At least align to sizeof our struct */
-  if (alignment < sizeof(struct block_info))
-    alignment = sizeof(struct block_info);
-
-  /* Alloc */
-  real = malloc(size + (2 * alignment - 1));
-
-  /* Get pointer to the various zones */
-  user = (void *)((((uintptr_t) real) + sizeof(struct block_info) + alignment - 1) & ~(alignment - 1));
-  info = (struct block_info *)(((uintptr_t)user) - sizeof(struct block_info));
-
-  /* Store the info for the free */
-  info->real = real;
-
-  /* Return pointer to user */
-  return user;
-}
-
-void
-volk_free(void *ptr)
-{
-  struct block_info *info;
-
-  /* Get the real pointer */
-  info = (struct block_info *)(((uintptr_t)ptr) - sizeof(struct block_info));
-
-  /* Release real pointer */
-  free(info->real);
-}
-
-#endif // _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || HAVE_POSIX_MEMALIGN
 
 //#endif // _ISOC11_SOURCE


### PR DESCRIPTION
We require C11. Thus, we can now rely on `aligned_alloc` and `free`.
[aligned_alloc](https://en.cppreference.com/w/c/memory/aligned_alloc)
Also, the documentation is updated accordingly.

Closes #193 