### PR TITLE
Improve performance of generic kernels with complex multiply

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,19 @@ set(CMAKE_CXX_STANDARD 11)
 
 enable_testing()
 
+# Disable complex math NaN/INFO range checking for performance
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag(-fcx-limited-range HAVE_CX_LIMITED_RANGE)
+if(HAVE_CX_LIMITED_RANGE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcx-limited-range")
+endif(HAVE_CX_LIMITED_RANGE)
+
+include(CheckCCompilerFlag)
+check_c_compiler_flag(-fcx-limited-range HAVE_C_LIMITED_RANGE)
+if(HAVE_C_LIMITED_RANGE)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fcx-limited-range")
+endif(HAVE_C_LIMITED_RANGE)
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 add_definitions(-D_GLIBCXX_USE_CXX11_ABI=1)


### PR DESCRIPTION
This PR incorporates the cx-limited-range checks for complex
multiply similar to GR pull request 3114.  Native complex
multiply math has a significant amount of processing overhead
ensuring that INF and NAN conditions are not encountered.
In some tests on a modern processor, these extra tests cause
a simle c = a * b complex calculation to take as much as 20%
of the processing time in a loop.  The -fcx-limited-range
compiler flag, when available ensures that the c = a * b
calculation is reduced to just the appropriate math.  The
changes to the makefile ensure that the compiler supports it
before enabling it.  On embedded debian-based platforms where
the generic kernel may get chosen, this should have a significant
positive impact performance for complex multiply kernels.