### PR TITLE
rotator: Refactor AVX kernels

### DIFF
--- a/include/volk/volk_avx_intrinsics.h
+++ b/include/volk/volk_avx_intrinsics.h
@@ -56,12 +56,11 @@ _mm256_complexconjugatemul_ps(__m256 x, __m256 y){
 static inline __m256
 _mm256_normalize_ps(__m256 val)
 {
-  __m256 tmp1, tmp2;
-  tmp1 = _mm256_mul_ps(val, val);
-  tmp2 = _mm256_hadd_ps(tmp1, tmp1);
-  tmp1 = _mm256_shuffle_ps(tmp2, tmp2, 0xD8);
-  tmp2 = _mm256_sqrt_ps(tmp1);
-  return _mm256_div_ps(val, tmp2);
+  __m256 tmp1 = _mm256_mul_ps(val, val);
+  tmp1 = _mm256_hadd_ps(tmp1, tmp1);
+  tmp1 = _mm256_shuffle_ps(tmp1, tmp1, _MM_SHUFFLE(3, 1, 2, 0)); // equals 0xD8
+  tmp1 = _mm256_sqrt_ps(tmp1);
+  return _mm256_div_ps(val, tmp1);
 }
 
 static inline __m256

--- a/include/volk/volk_avx_intrinsics.h
+++ b/include/volk/volk_avx_intrinsics.h
@@ -54,6 +54,17 @@ _mm256_complexconjugatemul_ps(__m256 x, __m256 y){
 }
 
 static inline __m256
+_mm256_normalize_ps(__m256 val)
+{
+  __m256 tmp1, tmp2;
+  tmp1 = _mm256_mul_ps(val, val);
+  tmp2 = _mm256_hadd_ps(tmp1, tmp1);
+  tmp1 = _mm256_shuffle_ps(tmp2, tmp2, 0xD8);
+  tmp2 = _mm256_sqrt_ps(tmp1);
+  return _mm256_div_ps(val, tmp2);
+}
+
+static inline __m256
 _mm256_magnitudesquared_ps(__m256 cplxValue1, __m256 cplxValue2){
   __m256 complex1, complex2;
   cplxValue1 = _mm256_mul_ps(cplxValue1, cplxValue1); // Square the values

--- a/kernels/volk/volk_32fc_s32fc_rotatorpuppet_32fc.h
+++ b/kernels/volk/volk_32fc_s32fc_rotatorpuppet_32fc.h
@@ -34,7 +34,9 @@
 
 static inline void volk_32fc_s32fc_rotatorpuppet_32fc_generic(lv_32fc_t* outVector, const lv_32fc_t* inVector, const lv_32fc_t phase_inc, unsigned int num_points){
     lv_32fc_t phase[1] = {lv_cmake(.3, 0.95393)};
-    volk_32fc_s32fc_x2_rotator_32fc_generic(outVector, inVector, phase_inc, phase, num_points);
+    (*phase) /= hypotf(lv_creal(*phase), lv_cimag(*phase));
+    const lv_32fc_t phase_inc_n = phase_inc / hypotf(lv_creal(phase_inc), lv_cimag(phase_inc));
+    volk_32fc_s32fc_x2_rotator_32fc_generic(outVector, inVector, phase_inc_n, phase, num_points);
 
 }
 
@@ -47,7 +49,9 @@ static inline void volk_32fc_s32fc_rotatorpuppet_32fc_generic(lv_32fc_t* outVect
 
 static inline void volk_32fc_s32fc_rotatorpuppet_32fc_neon(lv_32fc_t* outVector, const lv_32fc_t* inVector, const lv_32fc_t phase_inc, unsigned int num_points){
     lv_32fc_t phase[1] = {lv_cmake(.3, 0.95393)};
-    volk_32fc_s32fc_x2_rotator_32fc_neon(outVector, inVector, phase_inc, phase, num_points);
+    (*phase) /= hypotf(lv_creal(*phase), lv_cimag(*phase));
+    const lv_32fc_t phase_inc_n = phase_inc / hypotf(lv_creal(phase_inc), lv_cimag(phase_inc));
+    volk_32fc_s32fc_x2_rotator_32fc_neon(outVector, inVector, phase_inc_n, phase, num_points);
     
 }
 
@@ -59,7 +63,9 @@ static inline void volk_32fc_s32fc_rotatorpuppet_32fc_neon(lv_32fc_t* outVector,
 
 static inline void volk_32fc_s32fc_rotatorpuppet_32fc_a_sse4_1(lv_32fc_t* outVector, const lv_32fc_t* inVector, const lv_32fc_t phase_inc, unsigned int num_points){
     lv_32fc_t phase[1] = {lv_cmake(.3, .95393)};
-    volk_32fc_s32fc_x2_rotator_32fc_a_sse4_1(outVector, inVector, phase_inc, phase, num_points);
+    (*phase) /= hypotf(lv_creal(*phase), lv_cimag(*phase));
+    const lv_32fc_t phase_inc_n = phase_inc / hypotf(lv_creal(phase_inc), lv_cimag(phase_inc));
+    volk_32fc_s32fc_x2_rotator_32fc_a_sse4_1(outVector, inVector, phase_inc_n, phase, num_points);
 
 }
 
@@ -70,7 +76,9 @@ static inline void volk_32fc_s32fc_rotatorpuppet_32fc_a_sse4_1(lv_32fc_t* outVec
 #include <smmintrin.h>
 static inline void volk_32fc_s32fc_rotatorpuppet_32fc_u_sse4_1(lv_32fc_t* outVector, const lv_32fc_t* inVector, const lv_32fc_t phase_inc, unsigned int num_points){
     lv_32fc_t phase[1] = {lv_cmake(.3, .95393)};
-    volk_32fc_s32fc_x2_rotator_32fc_u_sse4_1(outVector, inVector, phase_inc, phase, num_points);
+    (*phase) /= hypotf(lv_creal(*phase), lv_cimag(*phase));
+    const lv_32fc_t phase_inc_n = phase_inc / hypotf(lv_creal(phase_inc), lv_cimag(phase_inc));
+    volk_32fc_s32fc_x2_rotator_32fc_u_sse4_1(outVector, inVector, phase_inc_n, phase, num_points);
 
 }
 
@@ -82,7 +90,9 @@ static inline void volk_32fc_s32fc_rotatorpuppet_32fc_u_sse4_1(lv_32fc_t* outVec
 
 static inline void volk_32fc_s32fc_rotatorpuppet_32fc_a_avx(lv_32fc_t* outVector, const lv_32fc_t* inVector, const lv_32fc_t phase_inc, unsigned int num_points){
     lv_32fc_t phase[1] = {lv_cmake(.3, .95393)};
-    volk_32fc_s32fc_x2_rotator_32fc_a_avx(outVector, inVector, phase_inc, phase, num_points);
+    (*phase) /= hypotf(lv_creal(*phase), lv_cimag(*phase));
+    const lv_32fc_t phase_inc_n = phase_inc / hypotf(lv_creal(phase_inc), lv_cimag(phase_inc));
+    volk_32fc_s32fc_x2_rotator_32fc_a_avx(outVector, inVector, phase_inc_n, phase, num_points);
 }
 
 #endif /* LV_HAVE_AVX */
@@ -93,7 +103,9 @@ static inline void volk_32fc_s32fc_rotatorpuppet_32fc_a_avx(lv_32fc_t* outVector
 
 static inline void volk_32fc_s32fc_rotatorpuppet_32fc_u_avx(lv_32fc_t* outVector, const lv_32fc_t* inVector, const lv_32fc_t phase_inc, unsigned int num_points){
     lv_32fc_t phase[1] = {lv_cmake(.3, .95393)};
-    volk_32fc_s32fc_x2_rotator_32fc_u_avx(outVector, inVector, phase_inc, phase, num_points);
+    (*phase) /= hypotf(lv_creal(*phase), lv_cimag(*phase));
+    const lv_32fc_t phase_inc_n = phase_inc / hypotf(lv_creal(phase_inc), lv_cimag(phase_inc));
+    volk_32fc_s32fc_x2_rotator_32fc_u_avx(outVector, inVector, phase_inc_n, phase, num_points);
 }
 
 #endif /* LV_HAVE_AVX */
@@ -103,7 +115,9 @@ static inline void volk_32fc_s32fc_rotatorpuppet_32fc_u_avx(lv_32fc_t* outVector
 
 static inline void volk_32fc_s32fc_rotatorpuppet_32fc_a_avx_fma(lv_32fc_t* outVector, const lv_32fc_t* inVector, const lv_32fc_t phase_inc, unsigned int num_points){
     lv_32fc_t phase[1] = {lv_cmake(.3, .95393)};
-    volk_32fc_s32fc_x2_rotator_32fc_a_avx_fma(outVector, inVector, phase_inc, phase, num_points);
+    (*phase) /= hypotf(lv_creal(*phase), lv_cimag(*phase));
+    const lv_32fc_t phase_inc_n = phase_inc / hypotf(lv_creal(phase_inc), lv_cimag(phase_inc));
+    volk_32fc_s32fc_x2_rotator_32fc_a_avx_fma(outVector, inVector, phase_inc_n, phase, num_points);
 }
 
 #endif /* LV_HAVE_AVX && LV_HAVE_FMA*/
@@ -114,7 +128,9 @@ static inline void volk_32fc_s32fc_rotatorpuppet_32fc_a_avx_fma(lv_32fc_t* outVe
 
 static inline void volk_32fc_s32fc_rotatorpuppet_32fc_u_avx_fma(lv_32fc_t* outVector, const lv_32fc_t* inVector, const lv_32fc_t phase_inc, unsigned int num_points){
     lv_32fc_t phase[1] = {lv_cmake(.3, .95393)};
-    volk_32fc_s32fc_x2_rotator_32fc_u_avx_fma(outVector, inVector, phase_inc, phase, num_points);
+    (*phase) /= hypotf(lv_creal(*phase), lv_cimag(*phase));
+    const lv_32fc_t phase_inc_n = phase_inc / hypotf(lv_creal(phase_inc), lv_cimag(phase_inc));
+    volk_32fc_s32fc_x2_rotator_32fc_u_avx_fma(outVector, inVector, phase_inc_n, phase, num_points);
 }
 
 #endif /* LV_HAVE_AVX && LV_HAVE_FMA*/

--- a/kernels/volk/volk_32fc_s32fc_x2_rotator_32fc.h
+++ b/kernels/volk/volk_32fc_s32fc_x2_rotator_32fc.h
@@ -98,18 +98,17 @@ static inline void volk_32fc_s32fc_x2_rotator_32fc_generic(lv_32fc_t* outVector,
             *outVector++ = *inVector++ * (*phase);
             (*phase) *= phase_inc;
         }
-#ifdef __cplusplus
-        (*phase) /= std::abs((*phase));
-#else
-        //(*phase) /= cabsf((*phase));
+
         (*phase) /= hypotf(lv_creal(*phase), lv_cimag(*phase));
-#endif
     }
     for(i = 0; i < num_points%ROTATOR_RELOAD; ++i) {
         *outVector++ = *inVector++ * (*phase);
         (*phase) *= phase_inc;
     }
-
+    if(i){
+        // Make sure, we normalize phase on every call!
+        (*phase) /= hypotf(lv_creal(*phase), lv_cimag(*phase));
+    }
 }
 
 #endif /* LV_HAVE_GENERIC */
@@ -418,11 +417,12 @@ static inline void volk_32fc_s32fc_x2_rotator_32fc_u_sse4_1(lv_32fc_t* outVector
 
 #ifdef LV_HAVE_AVX
 #include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
 
 static inline void volk_32fc_s32fc_x2_rotator_32fc_a_avx(lv_32fc_t* outVector, const lv_32fc_t* inVector, const lv_32fc_t phase_inc, lv_32fc_t* phase, unsigned int num_points){
     lv_32fc_t* cPtr = outVector;
     const lv_32fc_t* aPtr = inVector;
-    lv_32fc_t incr = 1;
+    lv_32fc_t incr = lv_cmake(1.0, 0.0);
     lv_32fc_t phase_Ptr[4] = {(*phase), (*phase), (*phase), (*phase)};
 
     unsigned int i, j = 0;
@@ -432,69 +432,38 @@ static inline void volk_32fc_s32fc_x2_rotator_32fc_a_avx(lv_32fc_t* outVector, c
         incr *= (phase_inc);
     }
 
-    /*printf("%f, %f\n", lv_creal(phase_Ptr[0]), lv_cimag(phase_Ptr[0]));
-    printf("%f, %f\n", lv_creal(phase_Ptr[1]), lv_cimag(phase_Ptr[1]));
-    printf("%f, %f\n", lv_creal(phase_Ptr[2]), lv_cimag(phase_Ptr[2]));
-    printf("%f, %f\n", lv_creal(phase_Ptr[3]), lv_cimag(phase_Ptr[3]));
-    printf("incr: %f, %f\n", lv_creal(incr), lv_cimag(incr));*/
-    __m256 aVal, phase_Val, inc_Val, yl, yh, tmp1, tmp2, z, ylp, yhp, tmp1p, tmp2p;
+    __m256 aVal, phase_Val, z;
 
     phase_Val = _mm256_loadu_ps((float*)phase_Ptr);
-    inc_Val = _mm256_set_ps(lv_cimag(incr), lv_creal(incr),lv_cimag(incr), lv_creal(incr),lv_cimag(incr), lv_creal(incr),lv_cimag(incr), lv_creal(incr));
-    const unsigned int fourthPoints = num_points / 4;
+    
+    const __m256 inc_Val = _mm256_set_ps(lv_cimag(incr), lv_creal(incr),
+                                         lv_cimag(incr), lv_creal(incr),
+                                         lv_cimag(incr), lv_creal(incr),
+                                         lv_cimag(incr), lv_creal(incr));
 
+    const unsigned int fourthPoints = num_points / 4;
 
     for(i = 0; i < (unsigned int)(fourthPoints/ROTATOR_RELOAD); i++) {
         for(j = 0; j < ROTATOR_RELOAD; ++j) {
 
             aVal = _mm256_load_ps((float*)aPtr);
 
-            yl = _mm256_moveldup_ps(phase_Val);
-            yh = _mm256_movehdup_ps(phase_Val);
-            ylp = _mm256_moveldup_ps(inc_Val);
-            yhp = _mm256_movehdup_ps(inc_Val);
-
-            tmp1 = _mm256_mul_ps(aVal, yl);
-            tmp1p = _mm256_mul_ps(phase_Val, ylp);
-
-            aVal = _mm256_shuffle_ps(aVal, aVal, 0xB1);
-            phase_Val = _mm256_shuffle_ps(phase_Val, phase_Val, 0xB1);
-            tmp2 = _mm256_mul_ps(aVal, yh);
-            tmp2p = _mm256_mul_ps(phase_Val, yhp);
-
-            z = _mm256_addsub_ps(tmp1, tmp2);
-            phase_Val = _mm256_addsub_ps(tmp1p, tmp2p);
+            z = _mm256_complexmul_ps(aVal, phase_Val);
+            phase_Val = _mm256_complexmul_ps(phase_Val, inc_Val);
 
             _mm256_store_ps((float*)cPtr, z);
 
             aPtr += 4;
             cPtr += 4;
         }
-        tmp1 = _mm256_mul_ps(phase_Val, phase_Val);
-        tmp2 = _mm256_hadd_ps(tmp1, tmp1);
-        tmp1 = _mm256_shuffle_ps(tmp2, tmp2, 0xD8);
-        tmp2 = _mm256_sqrt_ps(tmp1);
-        phase_Val = _mm256_div_ps(phase_Val, tmp2);
+        phase_Val = _mm256_normalize_ps(phase_Val);
     }
+    
     for(i = 0; i < fourthPoints%ROTATOR_RELOAD; ++i) {
         aVal = _mm256_load_ps((float*)aPtr);
 
-        yl = _mm256_moveldup_ps(phase_Val);
-        yh = _mm256_movehdup_ps(phase_Val);
-        ylp = _mm256_moveldup_ps(inc_Val);
-        yhp = _mm256_movehdup_ps(inc_Val);
-
-        tmp1 = _mm256_mul_ps(aVal, yl);
-
-        tmp1p = _mm256_mul_ps(phase_Val, ylp);
-
-        aVal = _mm256_shuffle_ps(aVal, aVal, 0xB1);
-        phase_Val = _mm256_shuffle_ps(phase_Val, phase_Val, 0xB1);
-        tmp2 = _mm256_mul_ps(aVal, yh);
-        tmp2p = _mm256_mul_ps(phase_Val, yhp);
-
-        z = _mm256_addsub_ps(tmp1, tmp2);
-        phase_Val = _mm256_addsub_ps(tmp1p, tmp2p);
+        z = _mm256_complexmul_ps(aVal, phase_Val);
+        phase_Val = _mm256_complexmul_ps(phase_Val, inc_Val);
 
         _mm256_store_ps((float*)cPtr, z);
 
@@ -502,21 +471,12 @@ static inline void volk_32fc_s32fc_x2_rotator_32fc_a_avx(lv_32fc_t* outVector, c
         cPtr += 4;
     }
     if (i) {
-        tmp1 = _mm256_mul_ps(phase_Val, phase_Val);
-        tmp2 = _mm256_hadd_ps(tmp1, tmp1);
-        tmp1 = _mm256_shuffle_ps(tmp2, tmp2, 0xD8);
-        tmp2 = _mm256_sqrt_ps(tmp1);
-        phase_Val = _mm256_div_ps(phase_Val, tmp2);
+        phase_Val = _mm256_normalize_ps(phase_Val);
     }
-
+    
     _mm256_storeu_ps((float*)phase_Ptr, phase_Val);
-    for(i = 0; i < num_points%4; ++i) {
-        *cPtr++ = *aPtr++ * phase_Ptr[0];
-        phase_Ptr[0] *= (phase_inc);
-    }
-
     (*phase) = phase_Ptr[0];
-
+    volk_32fc_s32fc_x2_rotator_32fc_generic(cPtr, aPtr, phase_inc, phase, num_points%4);
 }
 
 #endif /* LV_HAVE_AVX for aligned */
@@ -524,11 +484,12 @@ static inline void volk_32fc_s32fc_x2_rotator_32fc_a_avx(lv_32fc_t* outVector, c
 
 #ifdef LV_HAVE_AVX
 #include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
 
 static inline void volk_32fc_s32fc_x2_rotator_32fc_u_avx(lv_32fc_t* outVector, const lv_32fc_t* inVector, const lv_32fc_t phase_inc, lv_32fc_t* phase, unsigned int num_points){
     lv_32fc_t* cPtr = outVector;
     const lv_32fc_t* aPtr = inVector;
-    lv_32fc_t incr = 1;
+    lv_32fc_t incr = lv_cmake(1.0, 0.0);
     lv_32fc_t phase_Ptr[4] = {(*phase), (*phase), (*phase), (*phase)};
 
     unsigned int i, j = 0;
@@ -538,69 +499,39 @@ static inline void volk_32fc_s32fc_x2_rotator_32fc_u_avx(lv_32fc_t* outVector, c
         incr *= (phase_inc);
     }
 
-    /*printf("%f, %f\n", lv_creal(phase_Ptr[0]), lv_cimag(phase_Ptr[0]));
-    printf("%f, %f\n", lv_creal(phase_Ptr[1]), lv_cimag(phase_Ptr[1]));
-    printf("%f, %f\n", lv_creal(phase_Ptr[2]), lv_cimag(phase_Ptr[2]));
-    printf("%f, %f\n", lv_creal(phase_Ptr[3]), lv_cimag(phase_Ptr[3]));
-    printf("incr: %f, %f\n", lv_creal(incr), lv_cimag(incr));*/
-    __m256 aVal, phase_Val, inc_Val, yl, yh, tmp1, tmp2, z, ylp, yhp, tmp1p, tmp2p;
+    __m256 aVal, phase_Val, z;
 
     phase_Val = _mm256_loadu_ps((float*)phase_Ptr);
-    inc_Val = _mm256_set_ps(lv_cimag(incr), lv_creal(incr),lv_cimag(incr), lv_creal(incr),lv_cimag(incr), lv_creal(incr),lv_cimag(incr), lv_creal(incr));
+    
+    const __m256 inc_Val = _mm256_set_ps(lv_cimag(incr), lv_creal(incr),
+                                         lv_cimag(incr), lv_creal(incr),
+                                         lv_cimag(incr), lv_creal(incr),
+                                         lv_cimag(incr), lv_creal(incr));
+    
     const unsigned int fourthPoints = num_points / 4;
 
-
-    for(i = 0; i < (unsigned int)(fourthPoints/ROTATOR_RELOAD); i++) {
+    for(i = 0; i < (unsigned int)(fourthPoints/ROTATOR_RELOAD); ++i) {
         for(j = 0; j < ROTATOR_RELOAD; ++j) {
 
             aVal = _mm256_loadu_ps((float*)aPtr);
-
-            yl = _mm256_moveldup_ps(phase_Val);
-            yh = _mm256_movehdup_ps(phase_Val);
-            ylp = _mm256_moveldup_ps(inc_Val);
-            yhp = _mm256_movehdup_ps(inc_Val);
-
-            tmp1 = _mm256_mul_ps(aVal, yl);
-            tmp1p = _mm256_mul_ps(phase_Val, ylp);
-
-            aVal = _mm256_shuffle_ps(aVal, aVal, 0xB1);
-            phase_Val = _mm256_shuffle_ps(phase_Val, phase_Val, 0xB1);
-            tmp2 = _mm256_mul_ps(aVal, yh);
-            tmp2p = _mm256_mul_ps(phase_Val, yhp);
-
-            z = _mm256_addsub_ps(tmp1, tmp2);
-            phase_Val = _mm256_addsub_ps(tmp1p, tmp2p);
+            
+            z = _mm256_complexmul_ps(aVal, phase_Val);
+            phase_Val = _mm256_complexmul_ps(phase_Val, inc_Val);
 
             _mm256_storeu_ps((float*)cPtr, z);
 
             aPtr += 4;
             cPtr += 4;
         }
-        tmp1 = _mm256_mul_ps(phase_Val, phase_Val);
-        tmp2 = _mm256_hadd_ps(tmp1, tmp1);
-        tmp1 = _mm256_shuffle_ps(tmp2, tmp2, 0xD8);
-        tmp2 = _mm256_sqrt_ps(tmp1);
-        phase_Val = _mm256_div_ps(phase_Val, tmp2);
+        phase_Val = _mm256_normalize_ps(phase_Val);
+        
     }
-    for(i = 0; i < fourthPoints%ROTATOR_RELOAD; ++i) {
+    
+    for(i = 0; i < num_points%ROTATOR_RELOAD; ++i) {
         aVal = _mm256_loadu_ps((float*)aPtr);
 
-        yl = _mm256_moveldup_ps(phase_Val);
-        yh = _mm256_movehdup_ps(phase_Val);
-        ylp = _mm256_moveldup_ps(inc_Val);
-        yhp = _mm256_movehdup_ps(inc_Val);
-
-        tmp1 = _mm256_mul_ps(aVal, yl);
-
-        tmp1p = _mm256_mul_ps(phase_Val, ylp);
-
-        aVal = _mm256_shuffle_ps(aVal, aVal, 0xB1);
-        phase_Val = _mm256_shuffle_ps(phase_Val, phase_Val, 0xB1);
-        tmp2 = _mm256_mul_ps(aVal, yh);
-        tmp2p = _mm256_mul_ps(phase_Val, yhp);
-
-        z = _mm256_addsub_ps(tmp1, tmp2);
-        phase_Val = _mm256_addsub_ps(tmp1p, tmp2p);
+        z = _mm256_complexmul_ps(aVal, phase_Val);
+        phase_Val = _mm256_complexmul_ps(phase_Val, inc_Val);
 
         _mm256_storeu_ps((float*)cPtr, z);
 
@@ -608,21 +539,12 @@ static inline void volk_32fc_s32fc_x2_rotator_32fc_u_avx(lv_32fc_t* outVector, c
         cPtr += 4;
     }
     if (i) {
-        tmp1 = _mm256_mul_ps(phase_Val, phase_Val);
-        tmp2 = _mm256_hadd_ps(tmp1, tmp1);
-        tmp1 = _mm256_shuffle_ps(tmp2, tmp2, 0xD8);
-        tmp2 = _mm256_sqrt_ps(tmp1);
-        phase_Val = _mm256_div_ps(phase_Val, tmp2);
+        phase_Val = _mm256_normalize_ps(phase_Val);
     }
 
     _mm256_storeu_ps((float*)phase_Ptr, phase_Val);
-    for(i = 0; i < num_points%4; ++i) {
-        *cPtr++ = *aPtr++ * phase_Ptr[0];
-        phase_Ptr[0] *= (phase_inc);
-    }
-
     (*phase) = phase_Ptr[0];
-
+    volk_32fc_s32fc_x2_rotator_32fc_generic(cPtr, aPtr, phase_inc, phase, num_points%4);
 }
 
 #endif /* LV_HAVE_AVX */


### PR DESCRIPTION
Fix #331

This started as some work to track down the root cause of #329 . As a first result, it fixes #331 .
Apparently, these two issues are not as closely related as previously suspected.

Besides a fix for the generic kernel, this PR includes quite a bit of refactoring for better readibility of the AVX u/a rotator kernels. 

