### PR TITLE
add volk_version.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2011,2018,2019 Free Software Foundation, Inc.
+# Copyright 2011-2020 Free Software Foundation, Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -48,10 +48,33 @@ VOLK_CHECK_BUILD_TYPE(${CMAKE_BUILD_TYPE})
 set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "")
 message(STATUS "Build type set to ${CMAKE_BUILD_TYPE}.")
 
+########################################################################
+# Version setup
+########################################################################
+
 set(VERSION_INFO_MAJOR_VERSION 2)
 set(VERSION_INFO_MINOR_VERSION 1)
 set(VERSION_INFO_MAINT_VERSION 0)
 include(VolkVersion) #setup version info
+
+macro(set_version_str VAR)
+  set(IN_VER ${VERSION_INFO_${VAR}_VERSION})
+  string(LENGTH "${IN_VER}" VER_LEN)
+  if(${VER_LEN} EQUAL 1)
+    set(VOLK_VERSION_${VAR} "0${IN_VER}")
+  else()
+    set(VOLK_VERSION_${VAR} "${IN_VER}")
+  endif()
+endmacro()
+
+set_version_str(MAJOR)
+set_version_str(MINOR)
+set_version_str(MAINT)
+
+configure_file(
+    ${CMAKE_SOURCE_DIR}/include/volk/volk_version.h.in
+    ${CMAKE_BINARY_DIR}/include/volk/volk_version.h
+@ONLY)
 
 ########################################################################
 # Environment setup
@@ -197,6 +220,7 @@ install(FILES
     ${CMAKE_BINARY_DIR}/include/volk/volk_config_fixed.h
     ${CMAKE_BINARY_DIR}/include/volk/volk_typedefs.h
     ${CMAKE_SOURCE_DIR}/include/volk/volk_malloc.h
+    ${CMAKE_BINARY_DIR}/include/volk/volk_version.h
     ${CMAKE_SOURCE_DIR}/include/volk/constants.h
     DESTINATION include/volk
     COMPONENT "volk_devel"

--- a/include/volk/volk_version.h.in
+++ b/include/volk/volk_version.h.in
@@ -1,0 +1,50 @@
+/* -*- C -*- */
+/*
+ * Copyright 2020 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_VOLK_VERSION_H
+#define INCLUDED_VOLK_VERSION_H
+
+#include <volk/volk_common.h>
+
+__VOLK_DECL_BEGIN
+
+/*
+ * define macros for the Volk version, which can then be used by any
+ * project that #include's this header, e.g., to determine whether
+ * some specific API is present and functional.
+ */
+
+#define VOLK_VERSION_MAJOR @VOLK_VERSION_MAJOR@
+#define VOLK_VERSION_MINOR @VOLK_VERSION_MINOR@
+#define VOLK_VERSION_MAINT @VOLK_VERSION_MAINT@
+
+/*
+ * VOLK_VERSION % 100 is the MAINT version
+ * (VOLK_VERSION / 100) % 100 is the MINOR version
+ * (VOLK_VERSION / 100) / 100 is the MAJOR version
+ */
+
+#define VOLK_VERSION @VOLK_VERSION_MAJOR@@VOLK_VERSION_MINOR@@VOLK_VERSION_MAINT@
+
+__VOLK_DECL_END
+
+#endif /* INCLUDED_VOLK_VERSION_H */

--- a/tmpl/volk.tmpl.h
+++ b/tmpl/volk.tmpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011-2012 Free Software Foundation, Inc.
+ * Copyright 2011-2020 Free Software Foundation, Inc.
  *
  * This file is part of GNU Radio
  *
@@ -27,6 +27,7 @@
 #include <volk/volk_common.h>
 #include <volk/volk_complex.h>
 #include <volk/volk_malloc.h>
+#include <volk/volk_version.h>
 
 #include <stdlib.h>
 #include <stdbool.h>


### PR DESCRIPTION
subject says it all. standard CMake substitutions. resulting `VOLK_VERSION` will be in the format `MAMIMT`: MA == major; MI == minor; MT == maint; any will have a preceding `0` if the number is otherwise a single digit (e.g., MA of "2" will result in "02" here, but "11" will just be "11"). This is the same style as done by Boost and other projects, since it makes for simple macro-based comparisons in C / C++ code.

Closes: #338 