### PR TITLE
Refactor reported 'shadowed' variables

### DIFF
--- a/apps/volk_option_helpers.cc
+++ b/apps/volk_option_helpers.cc
@@ -1,6 +1,25 @@
-//
-// Created by nathan on 2/1/18.
-//
+/* -*- c++ -*- */
+/*
+ * Copyright 2018-2020 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
 
 #include "volk_option_helpers.h"
 
@@ -14,68 +33,74 @@
 /*
  * Option type
  */
-option_t::option_t(std::string longform,
-                   std::string shortform,
-                   std::string msg,
-                   void (*callback)())
-    : longform("--" + longform), shortform("-" + shortform), msg(msg), callback(callback)
+option_t::option_t(std::string t_longform,
+                   std::string t_shortform,
+                   std::string t_msg,
+                   void (*t_callback)())
+    : longform("--" + t_longform),
+      shortform("-" + t_shortform),
+      msg(t_msg),
+      callback(t_callback)
 {
     option_type = VOID_CALLBACK;
 }
 
-option_t::option_t(std::string longform,
-                   std::string shortform,
-                   std::string msg,
-                   void (*callback)(int))
-    : longform("--" + longform),
-      shortform("-" + shortform),
-      msg(msg),
-      callback((void (*)())callback)
+option_t::option_t(std::string t_longform,
+                   std::string t_shortform,
+                   std::string t_msg,
+                   void (*t_callback)(int))
+    : longform("--" + t_longform),
+      shortform("-" + t_shortform),
+      msg(t_msg),
+      callback((void (*)())t_callback)
 {
     option_type = INT_CALLBACK;
 }
 
-option_t::option_t(std::string longform,
-                   std::string shortform,
-                   std::string msg,
-                   void (*callback)(float))
-    : longform("--" + longform),
-      shortform("-" + shortform),
-      msg(msg),
-      callback((void (*)())callback)
+option_t::option_t(std::string t_longform,
+                   std::string t_shortform,
+                   std::string t_msg,
+                   void (*t_callback)(float))
+    : longform("--" + t_longform),
+      shortform("-" + t_shortform),
+      msg(t_msg),
+      callback((void (*)())t_callback)
 {
     option_type = FLOAT_CALLBACK;
 }
 
-option_t::option_t(std::string longform,
-                   std::string shortform,
-                   std::string msg,
-                   void (*callback)(bool))
-    : longform("--" + longform),
-      shortform("-" + shortform),
-      msg(msg),
-      callback((void (*)())callback)
+option_t::option_t(std::string t_longform,
+                   std::string t_shortform,
+                   std::string t_msg,
+                   void (*t_callback)(bool))
+    : longform("--" + t_longform),
+      shortform("-" + t_shortform),
+      msg(t_msg),
+      callback((void (*)())t_callback)
 {
     option_type = BOOL_CALLBACK;
 }
 
-option_t::option_t(std::string longform,
-                   std::string shortform,
-                   std::string msg,
-                   void (*callback)(std::string))
-    : longform("--" + longform),
-      shortform("-" + shortform),
-      msg(msg),
-      callback((void (*)())callback)
+option_t::option_t(std::string t_longform,
+                   std::string t_shortform,
+                   std::string t_msg,
+                   void (*t_callback)(std::string))
+    : longform("--" + t_longform),
+      shortform("-" + t_shortform),
+      msg(t_msg),
+      callback((void (*)())t_callback)
 {
     option_type = STRING_CALLBACK;
 }
 
-option_t::option_t(std::string longform,
-                   std::string shortform,
-                   std::string msg,
-                   std::string printval)
-    : longform("--" + longform), shortform("-" + shortform), msg(msg), printval(printval)
+option_t::option_t(std::string t_longform,
+                   std::string t_shortform,
+                   std::string t_msg,
+                   std::string t_printval)
+    : longform("--" + t_longform),
+      shortform("-" + t_shortform),
+      msg(t_msg),
+      printval(t_printval)
 {
     option_type = STRING;
 }
@@ -85,29 +110,29 @@ option_t::option_t(std::string longform,
  * Option List
  */
 
-option_list::option_list(std::string program_name) : program_name(program_name)
+option_list::option_list(std::string program_name) : d_program_name(program_name)
 {
-    internal_list = std::vector<option_t>();
+    d_internal_list = std::vector<option_t>();
 }
 
 
-void option_list::add(option_t opt) { internal_list.push_back(opt); }
+void option_list::add(option_t opt) { d_internal_list.push_back(opt); }
 
 void option_list::parse(int argc, char** argv)
 {
     for (int arg_number = 0; arg_number < argc; ++arg_number) {
-        for (std::vector<option_t>::iterator this_option = internal_list.begin();
-             this_option != internal_list.end();
+        for (std::vector<option_t>::iterator this_option = d_internal_list.begin();
+             this_option != d_internal_list.end();
              this_option++) {
             int int_val = INT_MIN;
             if (this_option->longform == std::string(argv[arg_number]) ||
                 this_option->shortform == std::string(argv[arg_number])) {
 
-                if (present_options.count(this_option->longform) == 0) {
-                    present_options.insert(
+                if (d_present_options.count(this_option->longform) == 0) {
+                    d_present_options.insert(
                         std::pair<std::string, int>(this_option->longform, 1));
                 } else {
-                    present_options[this_option->longform] += 1;
+                    d_present_options[this_option->longform] += 1;
                 }
                 switch (this_option->option_type) {
                 case VOID_CALLBACK:
@@ -184,7 +209,7 @@ void option_list::parse(int argc, char** argv)
         }
         if (std::string("--help") == std::string(argv[arg_number]) ||
             std::string("-h") == std::string(argv[arg_number])) {
-            present_options.insert(std::pair<std::string, int>("--help", 1));
+            d_present_options.insert(std::pair<std::string, int>("--help", 1));
             help();
         }
     }
@@ -192,7 +217,7 @@ void option_list::parse(int argc, char** argv)
 
 bool option_list::present(std::string option_name)
 {
-    if (present_options.count("--" + option_name)) {
+    if (d_present_options.count("--" + option_name)) {
         return true;
     } else {
         return false;
@@ -201,10 +226,10 @@ bool option_list::present(std::string option_name)
 
 void option_list::help()
 {
-    std::cout << program_name << std::endl;
+    std::cout << d_program_name << std::endl;
     std::cout << "  -h [ --help ] \t\tdisplay this help message" << std::endl;
-    for (std::vector<option_t>::iterator this_option = internal_list.begin();
-         this_option != internal_list.end();
+    for (std::vector<option_t>::iterator this_option = d_internal_list.begin();
+         this_option != d_internal_list.end();
          this_option++) {
         std::string help_line("  ");
         if (this_option->shortform == "-") {

--- a/apps/volk_option_helpers.h
+++ b/apps/volk_option_helpers.h
@@ -1,6 +1,24 @@
-//
-// Created by nathan on 2/1/18.
-//
+/* -*- c++ -*- */
+/*
+ * Copyright 2018-2020 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
 
 #ifndef VOLK_VOLK_OPTION_HELPERS_H
 #define VOLK_VOLK_OPTION_HELPERS_H
@@ -23,30 +41,30 @@ typedef enum {
 class option_t
 {
 public:
-    option_t(std::string longform,
-             std::string shortform,
-             std::string msg,
-             void (*callback)());
-    option_t(std::string longform,
-             std::string shortform,
-             std::string msg,
-             void (*callback)(int));
-    option_t(std::string longform,
-             std::string shortform,
-             std::string msg,
-             void (*callback)(float));
-    option_t(std::string longform,
-             std::string shortform,
-             std::string msg,
-             void (*callback)(bool));
-    option_t(std::string longform,
-             std::string shortform,
-             std::string msg,
-             void (*callback)(std::string));
-    option_t(std::string longform,
-             std::string shortform,
-             std::string msg,
-             std::string printval);
+    option_t(std::string t_longform,
+             std::string t_shortform,
+             std::string t_msg,
+             void (*t_callback)());
+    option_t(std::string t_longform,
+             std::string t_shortform,
+             std::string t_msg,
+             void (*t_callback)(int));
+    option_t(std::string t_longform,
+             std::string t_shortform,
+             std::string t_msg,
+             void (*t_callback)(float));
+    option_t(std::string t_longform,
+             std::string t_shortform,
+             std::string t_msg,
+             void (*t_callback)(bool));
+    option_t(std::string t_longform,
+             std::string t_shortform,
+             std::string t_msg,
+             void (*t_callback)(std::string));
+    option_t(std::string t_longform,
+             std::string t_shortform,
+             std::string t_msg,
+             std::string t_printval);
 
     std::string longform;
     std::string shortform;
@@ -69,9 +87,9 @@ public:
     void help();
 
 private:
-    std::string program_name;
-    std::vector<option_t> internal_list;
-    std::map<std::string, int> present_options;
+    std::string d_program_name;
+    std::vector<option_t> d_internal_list;
+    std::map<std::string, int> d_present_options;
 };
 
 

--- a/apps/volk_profile.cc
+++ b/apps/volk_profile.cc
@@ -231,10 +231,10 @@ void read_results(std::vector<volk_test_results_t>* results, std::string path)
                     found = 127;
                 }
                 str_size = config_str.size();
-                char buffer[128] = { '\0' };
-                config_str.copy(buffer, found + 1, 0);
-                buffer[found] = '\0';
-                single_kernel_result.push_back(std::string(buffer));
+                char line_buffer[128] = { '\0' };
+                config_str.copy(line_buffer, found + 1, 0);
+                line_buffer[found] = '\0';
+                single_kernel_result.push_back(std::string(line_buffer));
                 config_str.erase(0, found + 1);
             }
 

--- a/apps/volk_profile.h
+++ b/apps/volk_profile.h
@@ -1,4 +1,24 @@
-
+/* -*- c++ -*- */
+/*
+ * Copyright 2012-2014 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
 
 #include <stdbool.h> // for bool
 #include <iosfwd>    // for ofstream

--- a/kernels/volk/volk_16u_byteswap.h
+++ b/kernels/volk/volk_16u_byteswap.h
@@ -56,6 +56,22 @@
 #include <inttypes.h>
 #include <stdio.h>
 
+#ifdef LV_HAVE_GENERIC
+
+static inline void volk_16u_byteswap_generic(uint16_t* intsToSwap,
+                                             unsigned int num_points)
+{
+    uint16_t* inputPtr = intsToSwap;
+    for (unsigned int point = 0; point < num_points; point++) {
+        uint16_t output = *inputPtr;
+        output = (((output >> 8) & 0xff) | ((output << 8) & 0xff00));
+        *inputPtr = output;
+        inputPtr++;
+    }
+}
+#endif /* LV_HAVE_GENERIC */
+
+
 #if LV_HAVE_AVX2
 #include <immintrin.h>
 static inline void volk_16u_byteswap_a_avx2(uint16_t* intsToSwap, unsigned int num_points)
@@ -170,21 +186,6 @@ static inline void volk_16u_byteswap_u_sse2(uint16_t* intsToSwap, unsigned int n
 }
 #endif /* LV_HAVE_SSE2 */
 
-#ifdef LV_HAVE_GENERIC
-
-static inline void volk_16u_byteswap_generic(uint16_t* intsToSwap,
-                                             unsigned int num_points)
-{
-    unsigned int point;
-    uint16_t* inputPtr = intsToSwap;
-    for (point = 0; point < num_points; point++) {
-        uint16_t output = *inputPtr;
-        output = (((output >> 8) & 0xff) | ((output << 8) & 0xff00));
-        *inputPtr = output;
-        inputPtr++;
-    }
-}
-#endif /* LV_HAVE_GENERIC */
 
 #endif /* INCLUDED_volk_16u_byteswap_u_H */
 #ifndef INCLUDED_volk_16u_byteswap_a_H
@@ -198,12 +199,11 @@ static inline void volk_16u_byteswap_generic(uint16_t* intsToSwap,
 
 static inline void volk_16u_byteswap_a_sse2(uint16_t* intsToSwap, unsigned int num_points)
 {
-    unsigned int number = 0;
     uint16_t* inputPtr = intsToSwap;
     __m128i input, left, right, output;
 
     const unsigned int eighthPoints = num_points / 8;
-    for (; number < eighthPoints; number++) {
+    for (unsigned int number = 0; number < eighthPoints; number++) {
         // Load the 16t values, increment inputPtr later since we're doing it in-place.
         input = _mm_load_si128((__m128i*)inputPtr);
         // Do the two shifts
@@ -216,15 +216,8 @@ static inline void volk_16u_byteswap_a_sse2(uint16_t* intsToSwap, unsigned int n
         inputPtr += 8;
     }
 
-
     // Byteswap any remaining points:
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        uint16_t outputVal = *inputPtr;
-        outputVal = (((outputVal >> 8) & 0xff) | ((outputVal << 8) & 0xff00));
-        *inputPtr = outputVal;
-        inputPtr++;
-    }
+    volk_16u_byteswap_generic(inputPtr, num_points - eighthPoints * 8);
 }
 #endif /* LV_HAVE_SSE2 */
 
@@ -246,12 +239,7 @@ static inline void volk_16u_byteswap_neon(uint16_t* intsToSwap, unsigned int num
         inputPtr += 8;
     }
 
-    for (number = eighth_points * 8; number < num_points; number++) {
-        uint16_t output = *inputPtr;
-        output = (((output >> 8) & 0xff) | ((output << 8) & 0xff00));
-        *inputPtr = output;
-        inputPtr++;
-    }
+    volk_16u_byteswap_generic(inputPtr, num_points - eighth_points * 8);
 }
 #endif /* LV_HAVE_NEON */
 
@@ -296,12 +284,7 @@ static inline void volk_16u_byteswap_neon_table(uint16_t* intsToSwap,
         inputPtr += 16;
     }
 
-    for (number = n16points * 16; number < num_points; ++number) {
-        uint16_t output = *inputPtr;
-        output = (((output >> 8) & 0xff) | ((output << 8) & 0xff00));
-        *inputPtr = output;
-        inputPtr++;
-    }
+    volk_16u_byteswap_generic(inputPtr, num_points - n16points * 16);
 }
 #endif /* LV_HAVE_NEON */
 
@@ -310,9 +293,8 @@ static inline void volk_16u_byteswap_neon_table(uint16_t* intsToSwap,
 static inline void volk_16u_byteswap_a_generic(uint16_t* intsToSwap,
                                                unsigned int num_points)
 {
-    unsigned int point;
     uint16_t* inputPtr = intsToSwap;
-    for (point = 0; point < num_points; point++) {
+    for (unsigned int point = 0; point < num_points; point++) {
         uint16_t output = *inputPtr;
         output = (((output >> 8) & 0xff) | ((output << 8) & 0xff00));
         *inputPtr = output;

--- a/kernels/volk/volk_32f_tanh_32f.h
+++ b/kernels/volk/volk_32f_tanh_32f.h
@@ -73,6 +73,7 @@
 #include <stdio.h>
 #include <string.h>
 
+
 #ifdef LV_HAVE_GENERIC
 
 static inline void
@@ -94,10 +95,9 @@ volk_32f_tanh_32f_generic(float* cVector, const float* aVector, unsigned int num
 static inline void
 volk_32f_tanh_32f_series(float* cVector, const float* aVector, unsigned int num_points)
 {
-    unsigned int number = 0;
     float* cPtr = cVector;
     const float* aPtr = aVector;
-    for (; number < num_points; number++) {
+    for (unsigned int number = 0; number < num_points; number++) {
         if (*aPtr > 4.97)
             *cPtr++ = 1;
         else if (*aPtr <= -4.97)
@@ -161,19 +161,7 @@ volk_32f_tanh_32f_a_sse(float* cVector, const float* aVector, unsigned int num_p
     }
 
     number = quarterPoints * 4;
-    for (; number < num_points; number++) {
-        if (*aPtr > 4.97)
-            *cPtr++ = 1;
-        else if (*aPtr <= -4.97)
-            *cPtr++ = -1;
-        else {
-            float x2 = (*aPtr) * (*aPtr);
-            float a = (*aPtr) * (135135.0f + x2 * (17325.0f + x2 * (378.0f + x2)));
-            float b = 135135.0f + x2 * (62370.0f + x2 * (3150.0f + x2 * 28.0f));
-            *cPtr++ = a / b;
-            aPtr++;
-        }
-    }
+    volk_32f_tanh_32f_series(cPtr, aPtr, num_points - number);
 }
 #endif /* LV_HAVE_SSE */
 
@@ -228,19 +216,7 @@ volk_32f_tanh_32f_a_avx(float* cVector, const float* aVector, unsigned int num_p
     }
 
     number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        if (*aPtr > 4.97)
-            *cPtr++ = 1;
-        else if (*aPtr <= -4.97)
-            *cPtr++ = -1;
-        else {
-            float x2 = (*aPtr) * (*aPtr);
-            float a = (*aPtr) * (135135.0f + x2 * (17325.0f + x2 * (378.0f + x2)));
-            float b = 135135.0f + x2 * (62370.0f + x2 * (3150.0f + x2 * 28.0f));
-            *cPtr++ = a / b;
-            aPtr++;
-        }
-    }
+    volk_32f_tanh_32f_series(cPtr, aPtr, num_points - number);
 }
 #endif /* LV_HAVE_AVX */
 
@@ -284,19 +260,7 @@ volk_32f_tanh_32f_a_avx_fma(float* cVector, const float* aVector, unsigned int n
     }
 
     number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        if (*aPtr > 4.97)
-            *cPtr++ = 1;
-        else if (*aPtr <= -4.97)
-            *cPtr++ = -1;
-        else {
-            float x2 = (*aPtr) * (*aPtr);
-            float a = (*aPtr) * (135135.0f + x2 * (17325.0f + x2 * (378.0f + x2)));
-            float b = 135135.0f + x2 * (62370.0f + x2 * (3150.0f + x2 * 28.0f));
-            *cPtr++ = a / b;
-            aPtr++;
-        }
-    }
+    volk_32f_tanh_32f_series(cPtr, aPtr, num_points - number);
 }
 #endif /* LV_HAVE_AVX && LV_HAVE_FMA */
 
@@ -358,19 +322,7 @@ volk_32f_tanh_32f_u_sse(float* cVector, const float* aVector, unsigned int num_p
     }
 
     number = quarterPoints * 4;
-    for (; number < num_points; number++) {
-        if (*aPtr > 4.97)
-            *cPtr++ = 1;
-        else if (*aPtr <= -4.97)
-            *cPtr++ = -1;
-        else {
-            float x2 = (*aPtr) * (*aPtr);
-            float a = (*aPtr) * (135135.0f + x2 * (17325.0f + x2 * (378.0f + x2)));
-            float b = 135135.0f + x2 * (62370.0f + x2 * (3150.0f + x2 * 28.0f));
-            *cPtr++ = a / b;
-            aPtr++;
-        }
-    }
+    volk_32f_tanh_32f_series(cPtr, aPtr, num_points - number);
 }
 #endif /* LV_HAVE_SSE */
 
@@ -425,19 +377,7 @@ volk_32f_tanh_32f_u_avx(float* cVector, const float* aVector, unsigned int num_p
     }
 
     number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        if (*aPtr > 4.97)
-            *cPtr++ = 1;
-        else if (*aPtr <= -4.97)
-            *cPtr++ = -1;
-        else {
-            float x2 = (*aPtr) * (*aPtr);
-            float a = (*aPtr) * (135135.0f + x2 * (17325.0f + x2 * (378.0f + x2)));
-            float b = 135135.0f + x2 * (62370.0f + x2 * (3150.0f + x2 * 28.0f));
-            *cPtr++ = a / b;
-            aPtr++;
-        }
-    }
+    volk_32f_tanh_32f_series(cPtr, aPtr, num_points - number);
 }
 #endif /* LV_HAVE_AVX */
 
@@ -481,19 +421,7 @@ volk_32f_tanh_32f_u_avx_fma(float* cVector, const float* aVector, unsigned int n
     }
 
     number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        if (*aPtr > 4.97)
-            *cPtr++ = 1;
-        else if (*aPtr <= -4.97)
-            *cPtr++ = -1;
-        else {
-            float x2 = (*aPtr) * (*aPtr);
-            float a = (*aPtr) * (135135.0f + x2 * (17325.0f + x2 * (378.0f + x2)));
-            float b = 135135.0f + x2 * (62370.0f + x2 * (3150.0f + x2 * 28.0f));
-            *cPtr++ = a / b;
-            aPtr++;
-        }
-    }
+    volk_32f_tanh_32f_series(cPtr, aPtr, num_points - number);
 }
 #endif /* LV_HAVE_AVX && LV_HAVE_FMA */
 

--- a/lib/qa_utils.h
+++ b/lib/qa_utils.h
@@ -116,22 +116,22 @@ public:
     volk_test_params_t test_parameters() { return _test_parameters; };
     // normal ctor
     volk_test_case_t(volk_func_desc_t desc,
-                     void (*kernel_ptr)(),
+                     void (*t_kernel_ptr)(),
                      std::string name,
                      volk_test_params_t test_parameters)
         : _desc(desc),
-          _kernel_ptr(kernel_ptr),
+          _kernel_ptr(t_kernel_ptr),
           _name(name),
           _test_parameters(test_parameters),
           _puppet_master_name("NULL"){};
     // ctor for puppets
     volk_test_case_t(volk_func_desc_t desc,
-                     void (*kernel_ptr)(),
+                     void (*t_kernel_ptr)(),
                      std::string name,
                      std::string puppet_master_name,
                      volk_test_params_t test_parameters)
         : _desc(desc),
-          _kernel_ptr(kernel_ptr),
+          _kernel_ptr(t_kernel_ptr),
           _name(name),
           _test_parameters(test_parameters),
           _puppet_master_name(puppet_master_name){};


### PR DESCRIPTION
If VOLK is compiled with `-Wshadow` a lot of shadowed variables are reported. This PR is an effort to reduce the number of those reports. It would be great to eliminate all such occurrences and also compile with more warnings enabled.