### PR TITLE
Fix out-of-bounds read in AVX2 square dist kernel

### DIFF
--- a/kernels/volk/volk_32fc_x2_square_dist_32f.h
+++ b/kernels/volk/volk_32fc_x2_square_dist_32f.h
@@ -344,26 +344,22 @@ volk_32fc_x2_square_dist_32f_u_avx2(float* target, lv_32fc_t* src0, lv_32fc_t* p
 
   __m256i idx = _mm256_set_epi32(7,6,3,2,5,4,1,0);
   xmm1 = _mm256_setzero_ps();
-  xmm2 = _mm256_loadu_ps((float*)&points[0]);
   xmm0 = _mm_loadu_ps((float*)src0);
   xmm0 = _mm_permute_ps(xmm0, 0b01000100);
   xmm1 = _mm256_insertf128_ps(xmm1, xmm0, 0);
   xmm1 = _mm256_insertf128_ps(xmm1, xmm0, 1);
-  xmm3 = _mm256_loadu_ps((float*)&points[4]);
 
   for(; i < bound; ++i) {
+    xmm2 = _mm256_loadu_ps((float*)&points[0]);
+    xmm3 = _mm256_loadu_ps((float*)&points[4]);
     xmm4 = _mm256_sub_ps(xmm1, xmm2);
     xmm5 = _mm256_sub_ps(xmm1, xmm3);
     points += 8;
     xmm6 = _mm256_mul_ps(xmm4, xmm4);
     xmm7 = _mm256_mul_ps(xmm5, xmm5);
 
-    xmm2 = _mm256_loadu_ps((float*)&points[0]);
-
     xmm4 = _mm256_hadd_ps(xmm6, xmm7);
     xmm4 = _mm256_permutevar8x32_ps(xmm4, idx);
-
-    xmm3 = _mm256_loadu_ps((float*)&points[4]);
 
     _mm256_storeu_ps(target, xmm4);
 


### PR DESCRIPTION
`valgrind apps/volk_profile -v 16 -i 1` shows an invalid read in `volk_32fc_x2_square_dist_32f_u_avx2`:
```
==9237== Invalid read of size 16
==9237==    at 0x5062C70: volk_32fc_x2_square_dist_32f_u_avx2 (in /home/argilo/git/volk/build/lib/libvolk.so.2.2)
==9237==    by 0x125493: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, float, std::complex<float>, unsigned int, unsigned int, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, bool) (in /home/argilo/git/volk/build/apps/volk_profile)
==9237==    by 0x1260AC: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, volk_test_params_t, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (in /home/argilo/git/volk/build/apps/volk_profile)
==9237==    by 0x113299: main (in /home/argilo/git/volk/build/apps/volk_profile)
==9237==  Address 0x62c0830 is 8 bytes after a block of size 168 alloc'd
==9237==    at 0x4C320A6: memalign (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==9237==    by 0x4E8EBEE: volk_malloc (in /home/argilo/git/volk/build/lib/libvolk.so.2.2)
==9237==    by 0x123B93: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, float, std::complex<float>, unsigned int, unsigned int, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, bool) (in /home/argilo/git/volk/build/apps/volk_profile)
==9237==    by 0x1260AC: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, volk_test_params_t, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (in /home/argilo/git/volk/build/apps/volk_profile)
==9237==    by 0x113299: main (in /home/argilo/git/volk/build/apps/volk_profile)
==9237== 
```
This happens because the main loop loads points one iteration in advance, without checking whether there will be another iteration. To fix the problem, I changed the loop to load points in the same iteration they'll be used in.