### PR TITLE
Fix length checks in AVX2 index max kernels

### DIFF
--- a/kernels/volk/volk_32fc_index_max_32u.h
+++ b/kernels/volk/volk_32fc_index_max_32u.h
@@ -132,7 +132,7 @@ volk_32fc_index_max_32u_a_avx2(uint32_t* target, lv_32fc_t* src0,
   }
 
   xmm10 = _mm256_set1_epi32(4);
-  if (num_bytes >> 4 & 1) {
+  if (num_bytes >> 5 & 1) {
     xmm1 = _mm256_load_ps((float*)src0);
 
     xmm1 = _mm256_mul_ps(xmm1, xmm1);
@@ -446,7 +446,7 @@ volk_32fc_index_max_32u_u_avx2(uint32_t* target, lv_32fc_t* src0,
   }
 
   xmm10 = _mm256_set1_epi32(4);
-  if (num_bytes >> 4 & 1) {
+  if (num_bytes >> 5 & 1) {
     xmm1 = _mm256_loadu_ps((float*)src0);
 
     xmm1 = _mm256_mul_ps(xmm1, xmm1);


### PR DESCRIPTION
`apps/volk_profile -v 30 -i 1` shows failures in the AVX2 index max kernels:
```
volk_32fc_index_max_32u: fail on arch a_avx2
volk_32fc_index_max_32u: fail on arch u_avx2
```
And `valgrind apps/volk_profile -v 26 -i 1` shows that these kernels read uninitialized memory:
```
==12598== Conditional jump or move depends on uninitialised value(s)
==12598==    at 0x506DB43: volk_32fc_index_max_32u_a_avx2 (in /home/argilo/git/volk/build/lib/libvolk.so.2.2)
==12598==    by 0x125597: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, float, std::complex<float>, unsigned int, unsigned int, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, bool) (in /home/argilo/git/volk/build/apps/volk_profile)
==12598==    by 0x1260AC: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, volk_test_params_t, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (in /home/argilo/git/volk/build/apps/volk_profile)
==12598==    by 0x113299: main (in /home/argilo/git/volk/build/apps/volk_profile)
==12598== 
==12598== Conditional jump or move depends on uninitialised value(s)
==12598==    at 0x506DB5D: volk_32fc_index_max_32u_a_avx2 (in /home/argilo/git/volk/build/lib/libvolk.so.2.2)
==12598==    by 0x125597: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, float, std::complex<float>, unsigned int, unsigned int, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, bool) (in /home/argilo/git/volk/build/apps/volk_profile)
==12598==    by 0x1260AC: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, volk_test_params_t, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (in /home/argilo/git/volk/build/apps/volk_profile)
==12598==    by 0x113299: main (in /home/argilo/git/volk/build/apps/volk_profile)
==12598== 
==12598== Conditional jump or move depends on uninitialised value(s)
==12598==    at 0x506DB78: volk_32fc_index_max_32u_a_avx2 (in /home/argilo/git/volk/build/lib/libvolk.so.2.2)
==12598==    by 0x125597: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, float, std::complex<float>, unsigned int, unsigned int, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, bool) (in /home/argilo/git/volk/build/apps/volk_profile)
==12598==    by 0x1260AC: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, volk_test_params_t, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (in /home/argilo/git/volk/build/apps/volk_profile)
==12598==    by 0x113299: main (in /home/argilo/git/volk/build/apps/volk_profile)
==12598== 

==12598== Conditional jump or move depends on uninitialised value(s)
==12598==    at 0x506DD2F: volk_32fc_index_max_32u_u_avx2 (in /home/argilo/git/volk/build/lib/libvolk.so.2.2)
==12598==    by 0x125597: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, float, std::complex<float>, unsigned int, unsigned int, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, bool) (in /home/argilo/git/volk/build/apps/volk_profile)
==12598==    by 0x1260AC: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, volk_test_params_t, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (in /home/argilo/git/volk/build/apps/volk_profile)
==12598==    by 0x113299: main (in /home/argilo/git/volk/build/apps/volk_profile)
==12598== 
==12598== Conditional jump or move depends on uninitialised value(s)
==12598==    at 0x506DD49: volk_32fc_index_max_32u_u_avx2 (in /home/argilo/git/volk/build/lib/libvolk.so.2.2)
==12598==    by 0x125597: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, float, std::complex<float>, unsigned int, unsigned int, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, bool) (in /home/argilo/git/volk/build/apps/volk_profile)
==12598==    by 0x1260AC: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, volk_test_params_t, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (in /home/argilo/git/volk/build/apps/volk_profile)
==12598==    by 0x113299: main (in /home/argilo/git/volk/build/apps/volk_profile)
==12598== 
==12598== Conditional jump or move depends on uninitialised value(s)
==12598==    at 0x506DD64: volk_32fc_index_max_32u_u_avx2 (in /home/argilo/git/volk/build/lib/libvolk.so.2.2)
==12598==    by 0x125597: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, float, std::complex<float>, unsigned int, unsigned int, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, bool) (in /home/argilo/git/volk/build/apps/volk_profile)
==12598==    by 0x1260AC: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, volk_test_params_t, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (in /home/argilo/git/volk/build/apps/volk_profile)
==12598==    by 0x113299: main (in /home/argilo/git/volk/build/apps/volk_profile)
==12598== 
```
These problems happen because these kernels read the wrong bit from `num_bytes` when determining whether or not there are 4 points (= 32 bytes) remaining in the vector. 32 is 2^5, not 2^4.