### PR TITLE
Add puppet for power spectral density kernel

### DIFF
--- a/kernels/volk/volk_32fc_s32f_power_spectral_densitypuppet_32f.h
+++ b/kernels/volk/volk_32fc_s32f_power_spectral_densitypuppet_32f.h
@@ -1,0 +1,76 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2020 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * GNU Radio is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * GNU Radio is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNU Radio; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+
+#ifndef INCLUDED_volk_32fc_s32f_power_spectral_densitypuppet_32f_a_H
+#define INCLUDED_volk_32fc_s32f_power_spectral_densitypuppet_32f_a_H
+
+
+#include <volk/volk_32fc_s32f_x2_power_spectral_density_32f.h>
+
+
+#ifdef LV_HAVE_AVX
+
+static inline void
+volk_32fc_s32f_power_spectral_densitypuppet_32f_a_avx(float* logPowerOutput,
+                                                      const lv_32fc_t* complexFFTInput,
+                                                      const float normalizationFactor,
+                                                      unsigned int num_points)
+{
+    volk_32fc_s32f_x2_power_spectral_density_32f_a_avx(
+        logPowerOutput, complexFFTInput, normalizationFactor, 2.5, num_points);
+}
+
+#endif /* LV_HAVE_AVX */
+
+
+#ifdef LV_HAVE_SSE3
+
+static inline void
+volk_32fc_s32f_power_spectral_densitypuppet_32f_a_sse3(float* logPowerOutput,
+                                                       const lv_32fc_t* complexFFTInput,
+                                                       const float normalizationFactor,
+                                                       unsigned int num_points)
+{
+    volk_32fc_s32f_x2_power_spectral_density_32f_a_sse3(
+        logPowerOutput, complexFFTInput, normalizationFactor, 2.5, num_points);
+}
+
+#endif /* LV_HAVE_SSE3 */
+
+
+#ifdef LV_HAVE_GENERIC
+
+static inline void
+volk_32fc_s32f_power_spectral_densitypuppet_32f_generic(float* logPowerOutput,
+                                                        const lv_32fc_t* complexFFTInput,
+                                                        const float normalizationFactor,
+                                                        unsigned int num_points)
+{
+    volk_32fc_s32f_x2_power_spectral_density_32f_generic(
+        logPowerOutput, complexFFTInput, normalizationFactor, 2.5, num_points);
+}
+
+#endif /* LV_HAVE_GENERIC */
+
+
+#endif /* INCLUDED_volk_32fc_s32f_power_spectral_densitypuppet_32f_a_H */

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -156,6 +156,9 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     QA(VOLK_INIT_PUPP(volk_32f_8u_polarbutterflypuppet_32f,
                       volk_32f_8u_polarbutterfly_32f,
                       test_params))
+    QA(VOLK_INIT_PUPP(volk_32fc_s32f_power_spectral_densitypuppet_32f,
+                      volk_32fc_s32f_x2_power_spectral_density_32f,
+                      test_params))
     // no one uses these, so don't test them
     // VOLK_PROFILE(volk_16i_x5_add_quad_16i_x4, 1e-4, 2046, 10000, &results,
     // benchmark_mode, kernel_regex); VOLK_PROFILE(volk_16i_branch_4_state_8, 1e-4, 2046,
@@ -166,8 +169,6 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     // 0, 2046, 10000, &results, benchmark_mode, kernel_regex);
     // VOLK_PROFILE(volk_16i_x4_quad_max_star_16i, 1e-4, 0, 2046, 10000, &results,
     // benchmark_mode, kernel_regex);
-    // we need a puppet for this one
-    //(VOLK_INIT_TEST(volk_32fc_s32f_x2_power_spectral_density_32f,   test_params))
 
 
     return test_cases;


### PR DESCRIPTION
@ghostop14 and I noticed that the power spectrum & power spectral density kernels are very slow (#361). One impediment to improving them is that the power spectral density kernels are not tested since they lack a puppet:

https://github.com/gnuradio/volk/blob/aae9fed1cd15f0f1695d5adad04c65cf8bbd3cc0/lib/kernel_tests.h#L154-L155

I've corrected that here. Here's the puppet in action:

```
$ apps/volk_profile -R power_spectral_density

RUN_VOLK_TESTS: volk_32fc_s32f_power_spectral_densitypuppet_32f(131071,1987)
a_avx completed in 3552.97 ms
a_sse3 completed in 3774.37 ms
generic completed in 3968.91 ms
Best aligned arch: a_avx
Best unaligned arch: generic
Writing /home/argilo/.volk/volk_config...
```