### PR TITLE
Treat the mod_range puppet as such

### DIFF
--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -149,8 +149,9 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     QA(VOLK_INIT_TEST(volk_32f_binary_slicer_8i, test_params))
     QA(VOLK_INIT_TEST(volk_32u_reverse_32u, test_params))
     QA(VOLK_INIT_TEST(volk_32f_tanh_32f, test_params_inacc))
-    QA(VOLK_INIT_TEST(volk_32f_s32f_mod_rangepuppet_32f, test_params))
     QA(VOLK_INIT_TEST(volk_32fc_x2_s32fc_multiply_conjugate_add_32fc, test_params))
+    QA(VOLK_INIT_PUPP(
+        volk_32f_s32f_mod_rangepuppet_32f, volk_32f_s32f_s32f_mod_range_32f, test_params))
     QA(VOLK_INIT_PUPP(
         volk_8u_x3_encodepolarpuppet_8u, volk_8u_x3_encodepolar_8u_x2, test_params))
     QA(VOLK_INIT_PUPP(volk_32f_8u_polarbutterflypuppet_32f,


### PR DESCRIPTION
Currently `volk_32f_s32f_mod_rangepuppet_32f` is tested with `VOLK_INIT_TEST` instead of `VOLK_INIT_PUPP`. As a result, `volk_profile` writes the name of the puppet into `~/.volk/volk_config` instead of the underlying kernel (`volk_32f_s32f_s32f_mod_range_32f`). I've fixed the problem by switching to `VOLK_INIT_PUPP`.