### PR TITLE
versioning: Remove .Maint from libvolk version

### DIFF
--- a/cmake/Modules/VolkVersion.cmake
+++ b/cmake/Modules/VolkVersion.cmake
@@ -77,11 +77,7 @@ else()
     # VERSION: 1.1{.x}
     # DOCVER:  1.1{.x}
     # LIBVER:  1.1{.x}
-    if("${MAINT_VERSION}" STREQUAL "0")
-        set(VERSION "${MAJOR_VERSION}.${MINOR_VERSION}")
-    else()
-        set(VERSION "${MAJOR_VERSION}.${MINOR_VERSION}.${MAINT_VERSION}")
-    endif()
+    set(VERSION "${MAJOR_VERSION}.${MINOR_VERSION}")
     set(DOCVER "${VERSION}")
     set(LIBVER "${VERSION}")
     set(RC_MINOR_VERSION ${MINOR_VERSION})


### PR DESCRIPTION
We use SemVer for our releases with Major.Minor.Maint logic.
Since we want Maint releases to be 100% ABI compatible, check with ABI
compliance checker, we can drop the Maint version from
`libvolk.so.major.minor`. The idea is to make it easier for maintainers
to release a new maint version.