### PR TITLE
ci: Add Github CI Action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,50 @@
+name: Run VOLK tests
+
+on: [push, pull_request]
+
+jobs:
+  build-ubuntu:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: dependencies
+      run: sudo apt install python3-mako liborc-dev
+    - name: configure
+      run: mkdir build && cd build && cmake -DCMAKE_CXX_FLAGS="-Werror" ..
+    - name: build
+      run: cmake --build build
+    - name: test
+      run: cd build && ctest -V
+
+  build-windows:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: dependencies
+      run: pip install mako
+    - name: configure
+      run: mkdir build && cd build && cmake ..
+    - name: build
+      run: cmake --build build --config Release --target INSTALL
+    - name: test
+      run: cd build && ctest -V -C Release
+
+
+  build-macos:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: dependencies
+      run: pip3 install mako
+    - name: configure
+      run: mkdir build && cd build && cmake ..
+    - name: build
+      run: cmake --build build --config Debug
+    - name: test
+      run: cd build && ctest -V


### PR DESCRIPTION
This commit adds CI tests for GitHub Actions for Linux, Windows and MacOS.

Fixes #336 

Since we use GitHub for code hosting, it is worthwhile to have CI tests that run in every VOLK repo on push. 

Be aware that Windows and MacOS CI does only run generic kernels at the moment because it cannot find `xgetbv`.