### PR TITLE
ci: Remove Ubuntu 16.04 GCC5 test on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,26 +26,20 @@ matrix:
           - ${TRAVIS_BUILD_DIR}/cache
       before_script:
         - cd ${TRAVIS_BUILD_DIR} && ./scripts/ci/download_intel_sde.sh
-    
+
     # Job 2 ... gcc-4.8
     - name: Linux Ubuntu 14.04 (trusty) x86 GCC 4.8
       dist: trusty
       env: MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
       addons: {apt: {packages: [*common_packages, g++-4.8, libboost-system-dev, libboost-filesystem-dev]}}
 
-    # Job 3 ... gcc-5
-    - name: Linux Ubuntu 16.04 (xenial) x86 GCC 5
-      dist: xenial
-      env: MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-      addons: {apt: {sources: "ubuntu-toolchain-r-test", packages: [*common_packages, g++-5]}}
-    
     # Job 4 ... gcc-6
     - name: Linux x86 GCC 6
       env: MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
       addons: {apt: {sources: "ubuntu-toolchain-r-test", packages: [*common_packages, g++-6]}}
-    
+
     # Job 5 ... gcc-7
-    - name: Linux x86 GCC 7 
+    - name: Linux x86 GCC 7
       env: MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
       addons: {apt: {sources: "ubuntu-toolchain-r-test", packages: [*common_packages, g++-7]}}
 
@@ -53,23 +47,23 @@ matrix:
     - name: Linux x86 GCC 8
       env: MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
       addons: {apt: {sources: "ubuntu-toolchain-r-test", packages: [*common_packages, g++-8]}}
-    
+
     # Job 7 ... ARMv7 cross compile
     - name: Linux ARMv7 Qemu GCC 7
       env: MATRIX_EVAL="CC=gcc-7 && CXX=g++-7 && CMAKE_ARG=-DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/arm-linux-gnueabihf.cmake"
       addons: {apt: {sources: "ubuntu-toolchain-r-test", packages: [*common_packages, g++-arm-linux-gnueabihf, qemu-user]}}
-    
+
     # Job 8 ... ARMv8 (aarch64) cross compile
     - name: Linux ARMv8 (aarch64) Qemu GCC 7
       env: MATRIX_EVAL="CC=gcc-7 && CXX=g++-7 && CMAKE_ARG=-DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/aarch64-linux-gnu.cmake"
       addons: {apt: {sources: "ubuntu-toolchain-r-test", packages: [*common_packages, g++-aarch64-linux-gnu, qemu-user]}}
- 
+
     # Job 9 ... clang
     - name: Linux x86 Clang 6
       env: MATRIX_EVAL="CC=\"clang -fprofile-instr-generate -fcoverage-mapping\" && CXX=\"clang++ -fprofile-instr-generate -fcoverage-mapping\""
       addons: {apt: {packages: [*common_packages, ]}}
 
-    - name: Linux ARMv8 (aarch64) GCC 7 
+    - name: Linux ARMv8 (aarch64) GCC 7
       arch: arm64
       env: MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
       addons: {apt: {packages: [*common_packages, ]}}
@@ -106,9 +100,7 @@ matrix:
 script:
   - eval "${MATRIX_EVAL}"
   - lscpu
-  - mkdir build && cd build && BOOST_ROOT=$BOOST_ROOT 
-  - cmake ${CMAKE_ARG} ../ 
+  - mkdir build && cd build && BOOST_ROOT=$BOOST_ROOT
+  - cmake ${CMAKE_ARG} ../
   - make
   - ctest -V
-
-


### PR DESCRIPTION
This particular combination of Ubuntu and GCC does not compile due
to some bug in this Ubuntu version. Since this is a really old
Ubuntu version we decided to drop this test.

Users who want to use VOLK with this distro are adviced to stick with
older versions. It would be too much of a burden to work around a bug in
outdated software.