### PR TITLE
readme: Add section on supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ $ volk_profile
 ```
 
 ## Supported platforms
-
 VOLK aims to be portable to as many platforms as possible. We can only run tests on some platforms.
 
 ### Hardware architectures
@@ -65,11 +64,11 @@ Currently VOLK aims to run with optimized kernels on x86 with SSE/AVX and ARM wi
 
 ### OS / Distro
 We run tests on a variety of Ubuntu versions and aim to support as many current distros as possible.
-The same goal applies to differenct OSes. Although this does only happen rarely, it might occur that VOLK does not work on obsolete distros, e.g. Ubuntu 12.04.
+The same goal applies to different OSes. Although this does only happen rarely, it might occur that VOLK does not work on obsolete distros, e.g. Ubuntu 12.04.
 
 ### Compilers
-We want to make sure VOLK works with C/C++ standard compliant compilers. Most notably GCC and Clang.
-Other compilers that fail to be standard compliant, e.g. MSVC or AppleClang, do also receive attention but some functionality might be missing with these compilers due to lack of standard support.
+We want to make sure VOLK works with C/C++ standard compliant compilers. Of course, as an open source project we focus on open source compilers, most notably GCC and Clang.
+We work want to make sure VOLK compiles on a wide variety of compilers. Thus, we target AppleClang and MSVC as well. Mind that MSVC lacks `aligned_alloc` support for aligned arrays. We use MSVC specific instructions in this case which cannot be `free`'d with `free`.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The same goal applies to different OSes. Although this does only happen rarely, 
 
 ### Compilers
 We want to make sure VOLK works with C/C++ standard compliant compilers. Of course, as an open source project we focus on open source compilers, most notably GCC and Clang.
-We work want to make sure VOLK compiles on a wide variety of compilers. Thus, we target AppleClang and MSVC as well. Mind that MSVC lacks `aligned_alloc` support for aligned arrays. We use MSVC specific instructions in this case which cannot be `free`'d with `free`.
+We want to make sure VOLK compiles on a wide variety of compilers. Thus, we target AppleClang and MSVC as well. Mind that MSVC lacks `aligned_alloc` support for aligned arrays. We use MSVC specific instructions in this case which cannot be `free`'d with `free`.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![Build Status](https://travis-ci.org/gnuradio/volk.svg?branch=master)](https://travis-ci.org/gnuradio/volk) [![Build status](https://ci.appveyor.com/api/projects/status/5o56mgw0do20jlh3/branch/master?svg=true)](https://ci.appveyor.com/project/gnuradio/volk/branch/master)
+![Check PR Formatting](https://github.com/gnuradio/volk/workflows/Check%20PR%20Formatting/badge.svg)
+![Run VOLK tests](https://github.com/gnuradio/volk/workflows/Run%20VOLK%20tests/badge.svg)
 
 ![VOLK Logo](/docs/volk_logo.png)
 
@@ -53,6 +55,22 @@ $ sudo make install
 # volk_profile will profile your system so that the best kernel is used
 $ volk_profile
 ```
+
+## Supported platforms
+
+VOLK aims to be portable to as many platforms as possible. We can only run tests on some platforms.
+
+### Hardware architectures
+Currently VOLK aims to run with optimized kernels on x86 with SSE/AVX and ARM with NEON.
+
+### OS / Distro
+We run tests on a variety of Ubuntu versions and aim to support as many current distros as possible.
+The same goal applies to differenct OSes. Although this does only happen rarely, it might occur that VOLK does not work on obsolete distros, e.g. Ubuntu 12.04.
+
+### Compilers
+We want to make sure VOLK works with C/C++ standard compliant compilers. Most notably GCC and Clang.
+Other compilers that fail to be standard compliant, e.g. MSVC or AppleClang, do also receive attention but some functionality might be missing with these compilers due to lack of standard support.
+
 
 ## License
 


### PR DESCRIPTION
So far, this is kind of a work in progress. I'd like to discuss the
exact wording here.
We run CI on Ubuntu, Windows and MacOS. For Windows and MacOS, we focus
on the latest release and do not make any attempt to support older
releases.
For Linux, we want to have support for distros other than Ubuntu and
older distros to some degree. Though, we decided to drop support for
Ubuntu 16.04 because some bugs make it hard work put a work around in
place for this old distro.