### PR TITLE
Test the rotator kernel with a realistic scalar

### DIFF
--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -32,6 +32,10 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     volk_test_params_t test_params_power(test_params);
     test_params_power.set_scalar(2.5);
 
+    volk_test_params_t test_params_rotator(test_params);
+    test_params_rotator.set_scalar(std::polar(1.0f, 0.1f));
+    test_params_rotator.set_tol(1e-3);
+
     std::vector<volk_test_case_t> test_cases;
     QA(VOLK_INIT_PUPP(volk_64u_popcntpuppet_64u, volk_64u_popcnt, test_params))
     QA(VOLK_INIT_PUPP(volk_64u_popcntpuppet_64u, volk_64u_popcnt, test_params))
@@ -40,8 +44,9 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     QA(VOLK_INIT_PUPP(volk_32u_byteswappuppet_32u, volk_32u_byteswap, test_params))
     QA(VOLK_INIT_PUPP(volk_32u_popcntpuppet_32u, volk_32u_popcnt_32u, test_params))
     QA(VOLK_INIT_PUPP(volk_64u_byteswappuppet_64u, volk_64u_byteswap, test_params))
-    QA(VOLK_INIT_PUPP(
-        volk_32fc_s32fc_rotatorpuppet_32fc, volk_32fc_s32fc_x2_rotator_32fc, test_params))
+    QA(VOLK_INIT_PUPP(volk_32fc_s32fc_rotatorpuppet_32fc,
+                      volk_32fc_s32fc_x2_rotator_32fc,
+                      test_params_rotator))
     QA(VOLK_INIT_PUPP(
         volk_8u_conv_k7_r2puppet_8u, volk_8u_x4_conv_k7_r2_8u, test_params.make_tol(0)))
     QA(VOLK_INIT_PUPP(


### PR DESCRIPTION
#366 reverted the fix that I made in 1e3b65d30481ee3dcfe758eef810ac1d2e88b68a to ensure that the rotator is tested with a realistic scalar. As a result, the default scalar (327.0) is being passed into `rotatorpuppet`, which normalizes the scalar to 1.0, i.e. rotation by zero degrees.

As soon as the scalar is changed to a more realistic value like `std::polar(1.0f, 0.1f)` the tests fail, because the default error tolerance of 1e-6 is exceeded. So it would seem that #366 did not improve the accuracy of the rotator. The tests did not pass until I put it back to 1e-3.

@ghostop14 