### PR TITLE
qa_volk_16i_32fc_dot_prod_32fc: clear the mmx state

### DIFF
--- a/kernels/volk/volk_16i_32fc_dot_prod_32fc.h
+++ b/kernels/volk/volk_16i_32fc_dot_prod_32fc.h
@@ -209,6 +209,8 @@ static inline void volk_16i_32fc_dot_prod_32fc_u_sse(lv_32fc_t* result,
         bPtr += 16;
     }
 
+    _mm_empty(); // clear the mmx technology state
+
     dotProdVal0 = _mm_add_ps(dotProdVal0, dotProdVal1);
     dotProdVal0 = _mm_add_ps(dotProdVal0, dotProdVal2);
     dotProdVal0 = _mm_add_ps(dotProdVal0, dotProdVal3);
@@ -483,6 +485,8 @@ static inline void volk_16i_32fc_dot_prod_32fc_a_sse(lv_32fc_t* result,
         aPtr += 8;
         bPtr += 16;
     }
+
+    _mm_empty(); // clear the mmx technology state
 
     dotProdVal0 = _mm_add_ps(dotProdVal0, dotProdVal1);
     dotProdVal0 = _mm_add_ps(dotProdVal0, dotProdVal2);


### PR DESCRIPTION
This is a fix for issue #385 and compatibility with musl.

The `_mm_cvtpi16_ps` intrinsic in the SSE kernels is using MMX registers. Those are aliasing the x87 FPU registers and need to be cleared before being used by the FPU again. [Intel 64 and IA-32 Architectures Software Developer's Manual](https://software.intel.com/sites/default/files/managed/39/c5/325462-sdm-vol-1-2abcd-3abcd.pdf) sections 9.6.2f contains more details on mixing/transitioning.