### PR TITLE
fix: Adjust min/max for 32f_s32f_convert_8i kernel

### DIFF
--- a/kernels/volk/volk_32f_s32f_convert_8i.h
+++ b/kernels/volk/volk_32f_s32f_convert_8i.h
@@ -104,8 +104,8 @@ static inline void volk_32f_s32f_convert_8i_u_avx2(int8_t* outputVector,
     const float* inputVectorPtr = (const float*)inputVector;
     int8_t* outputVectorPtr = outputVector;
 
-    float min_val = CHAR_MIN;
-    float max_val = CHAR_MAX;
+    float min_val = INT8_MIN;
+    float max_val = INT8_MAX;
     float r;
 
     __m256 vScalar = _mm256_set1_ps(scalar);
@@ -176,8 +176,8 @@ static inline void volk_32f_s32f_convert_8i_u_sse2(int8_t* outputVector,
     const float* inputVectorPtr = (const float*)inputVector;
     int8_t* outputVectorPtr = outputVector;
 
-    float min_val = CHAR_MIN;
-    float max_val = CHAR_MAX;
+    float min_val = INT8_MIN;
+    float max_val = INT8_MAX;
     float r;
 
     __m128 vScalar = _mm_set_ps1(scalar);
@@ -245,8 +245,8 @@ static inline void volk_32f_s32f_convert_8i_u_sse(int8_t* outputVector,
     const float* inputVectorPtr = (const float*)inputVector;
     int8_t* outputVectorPtr = outputVector;
 
-    float min_val = CHAR_MIN;
-    float max_val = CHAR_MAX;
+    float min_val = INT8_MIN;
+    float max_val = INT8_MAX;
     float r;
 
     __m128 vScalar = _mm_set_ps1(scalar);
@@ -321,8 +321,8 @@ static inline void volk_32f_s32f_convert_8i_a_avx2(int8_t* outputVector,
     const float* inputVectorPtr = (const float*)inputVector;
     int8_t* outputVectorPtr = outputVector;
 
-    float min_val = CHAR_MIN;
-    float max_val = CHAR_MAX;
+    float min_val = INT8_MIN;
+    float max_val = INT8_MAX;
     float r;
 
     __m256 vScalar = _mm256_set1_ps(scalar);
@@ -393,8 +393,8 @@ static inline void volk_32f_s32f_convert_8i_a_sse2(int8_t* outputVector,
     const float* inputVectorPtr = (const float*)inputVector;
     int8_t* outputVectorPtr = outputVector;
 
-    float min_val = CHAR_MIN;
-    float max_val = CHAR_MAX;
+    float min_val = INT8_MIN;
+    float max_val = INT8_MAX;
     float r;
 
     __m128 vScalar = _mm_set_ps1(scalar);
@@ -460,8 +460,8 @@ static inline void volk_32f_s32f_convert_8i_a_sse(int8_t* outputVector,
 
     const float* inputVectorPtr = (const float*)inputVector;
 
-    float min_val = CHAR_MIN;
-    float max_val = CHAR_MAX;
+    float min_val = INT8_MIN;
+    float max_val = INT8_MAX;
     float r;
 
     int8_t* outputVectorPtr = outputVector;

--- a/kernels/volk/volk_32f_s32f_convert_8i.h
+++ b/kernels/volk/volk_32f_s32f_convert_8i.h
@@ -25,7 +25,7 @@
  *
  * \b Overview
  *
- * Converts a floating point number to a 8-bit char after applying a
+ * Converts a floating point number to a 8-bit int after applying a
  * scaling factor.
  *
  * <b>Dispatcher Prototype</b>

--- a/kernels/volk/volk_32f_s32f_convert_8i.h
+++ b/kernels/volk/volk_32f_s32f_convert_8i.h
@@ -78,8 +78,8 @@
 
 static inline void volk_32f_s32f_convert_8i_single(int8_t* out, const float in)
 {
-    float min_val = CHAR_MIN;
-    float max_val = CHAR_MAX;
+    float min_val = INT8_MIN;
+    float max_val = INT8_MAX;
     if (in > max_val) {
         *out = (int8_t)(max_val);
     } else if (in < min_val) {


### PR DESCRIPTION
This kernel used `CHAR_MIN` to determine the minimum value which may be
0. It is expected that this value is -127. Thus, we move to `INT8_MIN`.

Fix #390