### PR TITLE
Lower require CMake to 3.7.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.7.2)
 set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "Choose build type: None Debug Release RelWithDebInfo MinSizeRel")
 project(volk)
 


### PR DESCRIPTION
Raspbian only has CMake 3.7.2 in the official repos, but this project requires 3.8.

I tried lowering the required CMake version by hand, building, and testing. It passed all tests. Seems to be working fine.