### PR TITLE
build: Enable to not install volk_modtool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,7 +370,10 @@ add_subdirectory(lib)
 # And the utility apps
 ########################################################################
 add_subdirectory(apps)
-add_subdirectory(python/volk_modtool)
+option(ENABLE_MODTOOL "Enable volk_modtool python utility" True)
+if(ENABLE_MODTOOL)
+  add_subdirectory(python/volk_modtool)
+endif()
 
 ########################################################################
 # Print summary


### PR DESCRIPTION
Sometimes, for instance when building volk for usage with gnuradio, these files reference python, and you may wish to not have them on the machine.