### PR TITLE
Update README Install Instructions for Successful `volk_profile` Upon Build/Install Completion 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,12 @@ $ make
 $ make test
 $ sudo make install
 
-# Link and cache shared library
+# Perform post-installation steps
+
+# Linux OS: Link and cache shared library
 $ sudo ldconfig
+
+# macOS/Windows: Update PATH environment variable to point to lib install location
 
 # volk_profile will profile your system so that the best kernel is used
 $ volk_profile

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ $ make
 $ make test
 $ sudo make install
 
+# Link and cache shared library
+$ sudo ldconfig
+
 # volk_profile will profile your system so that the best kernel is used
 $ volk_profile
 ```


### PR DESCRIPTION
The current VOLK build instructions do not explicitly instruct the user to run a `sudo ldconfig` command post VOLK build/installation. Without the ldconfig command, the `volk_profile` scrip will say that it can't find the libvolk shared object, causing the user to think something went wrong in the build process. This simple README change will clarify the install instructions and decrease user frustration.