### PR TITLE
travis CI: Add more modern compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,12 @@ matrix:
       env: MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
       addons: {apt: {sources: "ubuntu-toolchain-r-test", packages: [*common_packages, g++-8]}}
 
+    # Job 6.1 ... gcc-9
+    - name: Linux Ubuntu 20.04 (focal) x86 GCC 9
+      dist: focal
+      env: MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
+      addons: {apt: {packages: [*common_packages, g++-9]}}
+
     # Job 7 ... ARMv7 cross compile
     - name: Linux ARMv7 Qemu GCC 7
       env: MATRIX_EVAL="CC=gcc-7 && CXX=g++-7 && CMAKE_ARG=-DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/arm-linux-gnueabihf.cmake"

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,24 @@ matrix:
       env: MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
       addons: {apt: {packages: [*common_packages, g++-9]}}
 
+    # Job 6.2 ... clang 9
+    - name: Linux Ubuntu 20.04 (focal) x86 Clang 8
+      dist: focal
+      env: MATRIX_EVAL="CC=clang-8 && CXX=clang-8"
+      addons: {apt: {packages: [*common_packages, clang-8]}}
+
+    # Job 6.3 ... clang 9
+    - name: Linux Ubuntu 20.04 (focal) x86 Clang 9
+      dist: focal
+      env: MATRIX_EVAL="CC=clang-9 && CXX=clang-9"
+      addons: {apt: {packages: [*common_packages, clang-9]}}
+
+    # Job 6.4 ... clang 10
+    - name: Linux Ubuntu 20.04 (focal) x86 Clang 10
+      dist: focal
+      env: MATRIX_EVAL="CC=clang-10 && CXX=clang-10"
+      addons: {apt: {packages: [*common_packages, clang-10]}}
+
     # Job 7 ... ARMv7 cross compile
     - name: Linux ARMv7 Qemu GCC 7
       env: MATRIX_EVAL="CC=gcc-7 && CXX=g++-7 && CMAKE_ARG=-DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/arm-linux-gnueabihf.cmake"

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,19 +56,19 @@ matrix:
     # Job 6.2 ... clang 9
     - name: Linux Ubuntu 20.04 (focal) x86 Clang 8
       dist: focal
-      env: MATRIX_EVAL="CC=clang-8 && CXX=clang-8"
+      env: MATRIX_EVAL="CC=clang-8 && CXX=clang++-8"
       addons: {apt: {packages: [*common_packages, clang-8]}}
 
     # Job 6.3 ... clang 9
     - name: Linux Ubuntu 20.04 (focal) x86 Clang 9
       dist: focal
-      env: MATRIX_EVAL="CC=clang-9 && CXX=clang-9"
+      env: MATRIX_EVAL="CC=clang-9 && CXX=clang++-9"
       addons: {apt: {packages: [*common_packages, clang-9]}}
 
     # Job 6.4 ... clang 10
     - name: Linux Ubuntu 20.04 (focal) x86 Clang 10
       dist: focal
-      env: MATRIX_EVAL="CC=clang-10 && CXX=clang-10"
+      env: MATRIX_EVAL="CC=clang-10 && CXX=clang++-10"
       addons: {apt: {packages: [*common_packages, clang-10]}}
 
     # Job 7 ... ARMv7 cross compile


### PR DESCRIPTION
This PR adds test for more modern compilers for Travis CI.
Specifically on focal:
- GCC 9
- clang 8
- clang 9
- clang10