### PR TITLE
docs: Add hints how to handle required submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ $ make
 $ make test
 $ sudo make install
 
+# You might want to explore "make -j[SOMEVALUE]" options for your multicore CPU.
+
 # Perform post-installation steps
 
 # Linux OS: Link and cache shared library
@@ -44,9 +46,23 @@ $ sudo ldconfig
 $ volk_profile
 ```
 
+#### Missing submodule
+We use [cpu_features](https://github.com/google/cpu_features) as a git submodule to detect CPU features, e.g. AVX.
+There are two options to get the required code:
+```bash
+git clone --recursive https://github.com/gnuradio/volk.git
+```
+will automatically clone submodules as well.
+In case you missed that, you can just run:
+```bash
+git submmodule update --init --recursive
+```
+that'll pull in missing submodules.
+
+
 ### Building on Raspberry Pi and other ARM boards
 
-To build for these boards you need specify the correct cmake toolchain file for best performace.
+To build for these boards you need specify the correct cmake toolchain file for best performance.
 
 * Raspberry Pi 4 `arm_cortex_a72_hardfp_native.cmake`
 * Raspberry Pi 3 `arm_cortex_a53_hardfp_native.cmake`


### PR DESCRIPTION
Now that we use `cpu_features`, we need to do a recursive `git
checkout`. That might be a stumbling block for some users. This commit
should help with some hints.