### PR TITLE
Include git submodules (i.e. cpu_features) in release tarball

### DIFF
--- a/scripts/tools/release.sh
+++ b/scripts/tools/release.sh
@@ -83,6 +83,12 @@ git tag --annotate --cleanup=verbatim -F "${annotationfile}" "${releaseprefix}${
 tarprefix="${project}-${version}"
 outfile="${tempdir}/${tarprefix}.tar"
 git archive "--output=${outfile}" "--prefix=${tarprefix}/" HEAD
+# Append submodule archives
+git submodule foreach --recursive "git archive --output ${tempdir}/${tarprefix}-sub-\${sha1}.tar --prefix=${tarprefix}/\${sm_path}/ HEAD"
+if [[ $(ls ${tempdir}/${tarprefix}-sub*.tar | wc -l) != 0  ]]; then
+  # combine all archives into one tar
+  tar --concatenate --file ${outfile} ${tempdir}/${tarprefix}-sub*.tar
+fi
 echo "Created tape archive '${outfile}' of size $(du -h ${outfile})."
 
 # 6. compress


### PR DESCRIPTION
Currently with cpu_features included as a submodule, using the release tarballs directly to build volk fails because the contents of the submodule are not included in the tarball. This is an issue for the conda-forge packages I maintain, because by policy those must be built from a tarball and not a git repository.

This PR adds to the release script so that the contents of the git submodules are added to the tarballs that are generated. The github-generated archives attached to every tagged version will still lack the contents of any submodules; this is apparently a known limitation with the only remedy being to attach your own release tarballs, which is already standard practice here.

As for the just-released version 2.4.0, it would be great to get new tarballs uploaded (with a "post" version?) that include the contents of cpu_features, but I can probably work around it for conda-forge if that's too messy.