### PR TITLE
Check for lib64 versus lib and set LIB_SUFFIX accordingly.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,13 @@ if(DOXYGEN_FOUND)
 endif(DOXYGEN_FOUND)
 
 ########################################################################
+# Detect /lib versus /lib64
+########################################################################
+if (${CMAKE_INSTALL_LIBDIR} MATCHES lib64)
+    set(LIB_SUFFIX 64)
+endif()
+
+########################################################################
 # Setup the package config file
 ########################################################################
 #set variables found in the pc.in file


### PR DESCRIPTION
OE passes CMAKE_INSTALL_LIBDIR to the build. Use this variable to set
LIB_SUFFIX. It is very possible we could rewrite cmake to use this directly.

Signed-off-by: Philip Balister <philip@balister.org>