### PR TITLE
Remove _mm256_zeroupper() calls

### DIFF
--- a/kernels/volk/volk_16ic_convert_32fc.h
+++ b/kernels/volk/volk_16ic_convert_32fc.h
@@ -160,7 +160,7 @@ static inline void volk_16ic_convert_32fc_a_avx(lv_32fc_t* outputVector,
         _in += 4;
         _out += 4;
     }
-    _mm256_zeroupper();
+
     for (i = 0; i < (num_points % 4); ++i) {
         *_out++ = lv_cmake((float)lv_creal(*_in), (float)lv_cimag(*_in));
         _in++;
@@ -308,7 +308,7 @@ static inline void volk_16ic_convert_32fc_u_avx(lv_32fc_t* outputVector,
         _in += 4;
         _out += 4;
     }
-    _mm256_zeroupper();
+
     for (i = 0; i < (num_points % 4); ++i) {
         *_out++ = lv_cmake((float)lv_creal(*_in), (float)lv_cimag(*_in));
         _in++;

--- a/kernels/volk/volk_16ic_x2_dot_prod_16ic.h
+++ b/kernels/volk/volk_16ic_x2_dot_prod_16ic.h
@@ -364,7 +364,6 @@ static inline void volk_16ic_x2_dot_prod_16ic_u_axv2(lv_16sc_t* out,
 
         _mm256_storeu_si256((__m256i*)dotProductVector,
                             result); // Store the results back into the dot product vector
-        _mm256_zeroupper();
 
         for (number = 0; number < 8; ++number) {
             dotProduct = lv_cmake(
@@ -507,7 +506,6 @@ static inline void volk_16ic_x2_dot_prod_16ic_a_axv2(lv_16sc_t* out,
 
         _mm256_store_si256((__m256i*)dotProductVector,
                            result); // Store the results back into the dot product vector
-        _mm256_zeroupper();
 
         for (number = 0; number < 8; ++number) {
             dotProduct = lv_cmake(

--- a/kernels/volk/volk_16ic_x2_multiply_16ic.h
+++ b/kernels/volk/volk_16ic_x2_multiply_16ic.h
@@ -296,7 +296,7 @@ static inline void volk_16ic_x2_multiply_16ic_u_avx2(lv_16sc_t* out,
         _in_b += 8;
         _out += 8;
     }
-    _mm256_zeroupper();
+
     number = avx2_points * 8;
     for (; number < num_points; number++) {
         *_out++ = (*_in_a++) * (*_in_b++);
@@ -417,7 +417,7 @@ static inline void volk_16ic_x2_multiply_16ic_a_avx2(lv_16sc_t* out,
         _in_b += 8;
         _out += 8;
     }
-    _mm256_zeroupper();
+
     number = avx2_points * 8;
     for (; number < num_points; number++) {
         *_out++ = (*_in_a++) * (*_in_b++);

--- a/kernels/volk/volk_16u_byteswap.h
+++ b/kernels/volk/volk_16u_byteswap.h
@@ -99,8 +99,6 @@ static inline void volk_16u_byteswap_a_avx2(uint16_t* intsToSwap, unsigned int n
         inputPtr += nPerSet;
     }
 
-    _mm256_zeroupper();
-
     // Byteswap any remaining points:
     for (number = nPerSet * nSets; number < num_points; number++) {
         uint16_t outputVal = *inputPtr;
@@ -138,8 +136,6 @@ static inline void volk_16u_byteswap_u_avx2(uint16_t* intsToSwap, unsigned int n
         _mm256_storeu_si256((__m256i*)inputPtr, output);
         inputPtr += nPerSet;
     }
-
-    _mm256_zeroupper();
 
     // Byteswap any remaining points:
     for (number = nPerSet * nSets; number < num_points; number++) {

--- a/kernels/volk/volk_32f_8u_polarbutterfly_32f.h
+++ b/kernels/volk/volk_32f_8u_polarbutterfly_32f.h
@@ -246,7 +246,6 @@ static inline void volk_32f_8u_polarbutterfly_32f_u_avx(float* llrs,
         memcpy(u_temp, u + u_num - stage_size, sizeof(unsigned char) * stage_size);
 
         if (stage_size > 15) {
-            _mm256_zeroupper();
             volk_8u_x2_encodeframepolar_8u_u_ssse3(u_target, u_temp, stage_size);
         } else {
             volk_8u_x2_encodeframepolar_8u_generic(u_target, u_temp, stage_size);
@@ -259,7 +258,6 @@ static inline void volk_32f_8u_polarbutterfly_32f_u_avx(float* llrs,
 
         int p;
         for (p = 0; p < stage_size; p += 8) {
-            _mm256_zeroupper();
             fbits = _mm_loadu_si128((__m128i*)u_target);
             u_target += 8;
 
@@ -347,7 +345,6 @@ static inline void volk_32f_8u_polarbutterfly_32f_u_avx2(float* llrs,
         memcpy(u_temp, u + u_num - stage_size, sizeof(unsigned char) * stage_size);
 
         if (stage_size > 15) {
-            _mm256_zeroupper();
             volk_8u_x2_encodeframepolar_8u_u_ssse3(u_target, u_temp, stage_size);
         } else {
             volk_8u_x2_encodeframepolar_8u_generic(u_target, u_temp, stage_size);
@@ -360,7 +357,6 @@ static inline void volk_32f_8u_polarbutterfly_32f_u_avx2(float* llrs,
 
         int p;
         for (p = 0; p < stage_size; p += 8) {
-            _mm256_zeroupper();
             fbits = _mm_loadu_si128((__m128i*)u_target);
             u_target += 8;
 

--- a/kernels/volk/volk_32f_x2_dot_prod_32f.h
+++ b/kernels/volk/volk_32f_x2_dot_prod_32f.h
@@ -416,7 +416,6 @@ static inline void volk_32f_x2_dot_prod_32f_u_avx2_fma(float* result,
     __VOLK_ATTR_ALIGNED(32) float dotProductVector[8];
     _mm256_storeu_ps(dotProductVector,
                      dotProdVal); // Store the results back into the dot product vector
-    _mm256_zeroupper();
 
     float dotProduct = dotProductVector[0] + dotProductVector[1] + dotProductVector[2] +
                        dotProductVector[3] + dotProductVector[4] + dotProductVector[5] +
@@ -825,7 +824,6 @@ static inline void volk_32f_x2_dot_prod_32f_a_avx2_fma(float* result,
     __VOLK_ATTR_ALIGNED(32) float dotProductVector[8];
     _mm256_store_ps(dotProductVector,
                     dotProdVal); // Store the results back into the dot product vector
-    _mm256_zeroupper();
 
     float dotProduct = dotProductVector[0] + dotProductVector[1] + dotProductVector[2] +
                        dotProductVector[3] + dotProductVector[4] + dotProductVector[5] +

--- a/kernels/volk/volk_32fc_x2_multiply_32fc.h
+++ b/kernels/volk/volk_32fc_x2_multiply_32fc.h
@@ -120,8 +120,6 @@ static inline void volk_32fc_x2_multiply_32fc_u_avx2_fma(lv_32fc_t* cVector,
         c += 4;
     }
 
-    _mm256_zeroupper();
-
     number = quarterPoints * 4;
     for (; number < num_points; number++) {
         *c++ = (*a++) * (*b++);
@@ -276,8 +274,6 @@ static inline void volk_32fc_x2_multiply_32fc_a_avx2_fma(lv_32fc_t* cVector,
         b += 4;
         c += 4;
     }
-
-    _mm256_zeroupper();
 
     number = quarterPoints * 4;
     for (; number < num_points; number++) {

--- a/kernels/volk/volk_32u_byteswap.h
+++ b/kernels/volk/volk_32u_byteswap.h
@@ -97,7 +97,6 @@ static inline void volk_32u_byteswap_u_avx2(uint32_t* intsToSwap, unsigned int n
         _mm256_storeu_si256((__m256i*)inputPtr, output);
         inputPtr += nPerSet;
     }
-    _mm256_zeroupper();
 
     // Byteswap any remaining points:
     for (number = nSets * nPerSet; number < num_points; number++) {
@@ -299,7 +298,6 @@ static inline void volk_32u_byteswap_a_avx2(uint32_t* intsToSwap, unsigned int n
         _mm256_store_si256((__m256i*)inputPtr, output);
         inputPtr += nPerSet;
     }
-    _mm256_zeroupper();
 
     // Byteswap any remaining points:
     for (number = nSets * nPerSet; number < num_points; number++) {

--- a/kernels/volk/volk_64u_byteswap.h
+++ b/kernels/volk/volk_64u_byteswap.h
@@ -175,7 +175,6 @@ static inline void volk_64u_byteswap_a_avx2(uint64_t* intsToSwap, unsigned int n
         /*  inputPtr is 32bit so increment twice  */
         inputPtr += 2 * nPerSet;
     }
-    _mm256_zeroupper();
 
     // Byteswap any remaining points:
     for (number = nSets * nPerSet; number < num_points; ++number) {
@@ -423,7 +422,6 @@ static inline void volk_64u_byteswap_u_avx2(uint64_t* intsToSwap, unsigned int n
         /*  inputPtr is 32bit so increment twice  */
         inputPtr += 2 * nPerSet;
     }
-    _mm256_zeroupper();
 
     // Byteswap any remaining points:
     for (number = nSets * nPerSet; number < num_points; ++number) {


### PR DESCRIPTION
See commit message and discussion in #384 for details. TLDR: manual usage of `_mm256_zeroupper()` is not required and leads to miscompilation with GCC 10.2 and optimization level `-O3`.

This fixes #384.
This fixes #382.