### PR TITLE
Add contributing guidelines and switch to DCO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,13 +59,6 @@ VOLK unit tests compare the results of each kernel version to the generic versio
 Keep the generic kernel version as simple as possible and verify your optimized
 kernels against the generic version.
 
-## GitHub-specific Actions
-
-VOLK is currently hosted at GitHub, where we've added some mechanics that
-help with getting code merged. If you intend to develop code more than once,
-request being accepted into the [gr-devs][gr-devs] group. Members of this group
-can change labels and approve pull requests or request changes.
-
 ## The Buddy Principle: Submit One, Review One
 
 When you've submitted a pull request, please take the time to review another

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to VOLK
+
+Welcome! You are reading about how to contribute code to VOLK. First of
+all, we are very happy that you're about to contribute, and welcome your
+submissions! We hope many more will come.
+
+In this document, we will explain the main things to consider when submitting
+pull requests against VOLK. Reading this first will help a lot with
+streamlining the process of getting your code merged.
+
+There is also a [wiki-based version of this file][wikicontrib], which contains
+more detail. VOLK is part of the GNU Radio project and as such, it follows the 
+same contribution guidelines.  This file is an [adopted GNU Radio checklist][gnuradiocontrib].
+
+## What about non-code contributions?
+
+Those are at least as important as code contributions: Emails to the mailing
+list, answers on Stack Overflow, Wiki page edits, examples... We very much
+appreciate those. However, this document is specifically about contributing
+code.
+
+## DCO Signed?
+
+Any code contributions going into VOLK will become part of a GPL-licensed,
+open source repository. It is therefore imperative that code submissions belong
+to the authors, and that submitters have the authority to merge that code into
+the public VOLK codebase.
+
+For that purpose, we use the [Developer's Certificate of Origin](DCO.txt). It
+is the same document used by other projects. Signing the DCO states that there
+are no legal reasons to not merge your code.
+
+To sign the DCO, suffix your git commits with a "Signed-off-by" line. When
+using the command line, you can use `git commit -s` to automatically add this
+line. If there were multiple authors of the code, or other types of
+stakeholders, make sure that all are listed, each with a separate Signed-off-by
+line.
+
+## Coding Guidelines
+
+We have codified our coding guidelines in [GNU Radio GREP1][grep1]. Please read them, 
+and stick to them. For C/C++ code, use clang-format. For Python, PEP8 is your friend
+(but again, check the actual coding guidelines).
+
+## Git commit messages are very important
+
+We follow standard git commit message guidelines, similar to many other open
+source projects. See the [coding guidelines][grep1] for more details. In a
+nutshell:
+- Keep the lines below 72 characters
+- Subject line has the component prepended (e.g., `kernelname:`)
+- Avoid empty git commit messages
+- The git commit message explains the change, the code only explains the current
+  state
+
+## Unit Tests
+
+VOLK unit tests compare the results of each kernel version to the generic version.
+Keep the generic kernel version as simple as possible and verify your optimized
+kernels against the generic version.
+
+## GitHub-specific Actions
+
+VOLK is currently hosted at GitHub, where we've added some mechanics that
+help with getting code merged. If you intend to develop code more than once,
+request being accepted into the [gr-devs][gr-devs] group. Members of this group
+can change labels and approve pull requests or request changes.
+
+## The Buddy Principle: Submit One, Review One
+
+When you've submitted a pull request, please take the time to review another
+one. This helps make sure that there are always a number of reviews at least
+equal to the number of pull requests, which means the maintainers don't get
+overwhelmed when a lot is being contributed.
+
+## Standard command line options
+
+When writing programs that are executable from the command line,
+please follow existing examples regarding their command line arguments, and
+reuse them.
+
+[grep1]: https://github.com/gnuradio/greps/blob/master/grep-0001-coding-guidelines.md
+[wikicontrib]: https://wiki.gnuradio.org/index.php/Development
+[gr-devs]: https://github.com/orgs/gnuradio/teams/gr-devs
+[gnuradiocontrib]: https://github.com/gnuradio/gnuradio/blob/master/CONTRIBUTING.md

--- a/DCO.txt
+++ b/DCO.txt
@@ -1,0 +1,37 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
It is recommended good practice to have a CONTRIBUTING.md file. I used the GNU Radio file as a template and adopted and simplified it a bit. Since GNU Radio switch to DCO, I assume it is a welcome improvement for VOLK as well.

Still, be aware that this is quite a big step for VOLK besides the fact this is just another PR.

I added a DCO.txt as well. I suggest we move from a CLA based contribution system to a DCO based one. I hope this decreases the entry hurdle to new contributors.

Just like GNU Radio I'd like to use [DCObot](https://probot.github.io/apps/dco/) for VOLK as well.