### PR TITLE
ci: Move tests from TravisCI to Actions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build-ubuntu:
+    name: Build on ubuntu-latest ${{ matrix.compiler.name }}
 
     strategy:
       matrix:
@@ -48,7 +49,103 @@ jobs:
         cd build
         ctest -V
 
+  build-ubuntu-arm:
+    # The host should always be linux
+    # see: https://github.com/uraimo/run-on-arch-action
+    runs-on: ubuntu-latest
+    name: Build on ${{ matrix.distro }} ${{ matrix.arch }} ${{ matrix.compiler.name }}
+
+    # Run steps on a matrix of compilers and possibly archs.
+    strategy:
+      matrix:
+        include:
+          - arch: aarch64
+            distro: ubuntu20.04
+            compiler: { name: g++-8, cc: gcc-8, cxx: g++-8 }
+          - arch: aarch64
+            distro: ubuntu20.04
+            compiler: { name: g++-9, cc: gcc-9, cxx: g++-9 }
+          - arch: aarch64
+            distro: ubuntu20.04
+            compiler: { name: g++-10, cc: gcc-10, cxx: g++-10 }
+          # This test failed with a stl filesystem issue. 
+          # - arch: aarch64
+          #   distro: ubuntu20.04
+          #   compiler: { name: clang-8, cc: clang-8, cxx: clang++-8 }
+          - arch: aarch64
+            distro: ubuntu20.04
+            compiler: { name: clang-9, cc: clang-9, cxx: clang++-9 }
+          - arch: aarch64
+            distro: ubuntu20.04
+            compiler: { name: clang-10, cc: clang-10, cxx: clang++-10 }
+          # CMake fails to detect compiler on armv7 ...
+          # - arch: armv7
+          #   distro: ubuntu20.04
+          #   compiler: { name: g++-10, cc: gcc-10, cxx: g++-10 }
+          # - arch: armv7
+          #   distro: ubuntu20.04
+          #   compiler: { name: clang-10, cc: clang-10, cxx: clang++-10 }
+          # - arch: ppc64le
+          #   distro: ubuntu20.04
+          # - arch: s390x
+          #   distro: ubuntu20.04
+
+    steps:
+      - uses: actions/checkout@v2.1.0
+      - name: Checkout submodules
+        uses: srt32/git-actions@v0.0.3
+        with:
+          args: git submodule update --init --recursive
+      - uses: uraimo/run-on-arch-action@v2.0.5
+        name: Build in non-x86 container
+        id: build
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ${{ matrix.distro }}
+
+          # Not required, but speeds up builds
+          githubToken: ${{ github.token }}
+
+          setup: |
+            mkdir -p "${PWD}/build"
+
+          dockerRunArgs: |
+            --volume "${PWD}:/volk"
+
+          env: | # YAML, but pipe character is necessary
+            CC: ${{ matrix.compiler.cc }}
+            CXX: ${{ matrix.compiler.cxx }}
+
+          shell: /bin/sh
+
+          install: |
+            case "${{ matrix.distro }}" in
+              ubuntu*|jessie|stretch|buster)
+                apt-get update -q -y
+                apt-get install -q -y git cmake python3-distutils python3-mako liborc-dev ${{ matrix.compiler.name }}
+                ;;
+              fedora*)
+                dnf -y update
+                dnf -y install git which
+                ;;
+            esac
+
+          run: |
+            cd /volk
+            cd build
+            cmake -DCMAKE_CXX_FLAGS="-Werror" ..
+            make -j$(nproc)
+            ./cpu_features/list_cpu_features
+            ./apps/volk-config-info --alignment
+            ./apps/volk-config-info --avail-machines
+            ./apps/volk-config-info --all-machines
+            ./apps/volk-config-info --malloc
+            ./apps/volk-config-info --cc
+            ctest -V
+
+
   build-ubuntu-static:
+    name: Build static on ubuntu-latest
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,22 +5,48 @@ on: [push, pull_request]
 jobs:
   build-ubuntu:
 
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: 
+          - { name: gcc-7, cc: gcc-7, cxx: g++-7 }
+          - { name: gcc-8, cc: gcc-8, cxx: g++-8 }
+          - { name: gcc-9, cc: gcc-9, cxx: g++-9 }
+          - { name: gcc-10, cc: gcc-10, cxx: g++-10 }
+          - { name: clang-7, cc: clang-7, cxx: clang++-7 }
+          - { name: clang-8, cc: clang-8, cxx: clang++-8 }
+          - { name: clang-9, cc: clang-9, cxx: clang++-9 }
+          - { name: clang-10, cc: clang-10, cxx: clang++-10 }
+          # - { name: clang-11, cc: clang-11, cxx: clang++-11 }
 
+    runs-on: ubuntu-latest
+    
     steps:
     - uses: actions/checkout@v1
-    - name: dependencies
-      run: sudo apt install python3-mako liborc-dev
+    - name: Install dependencies
+      run: sudo apt install python3-mako liborc-dev ${{ matrix.compiler.name }}
     - name: Checkout submodules
       uses: srt32/git-actions@v0.0.3
       with:
         args: git submodule update --init --recursive
-    - name: configure
+    - name: Configure
+      env:
+        CC: ${{ matrix.compiler.cc }}
+        CXX: ${{ matrix.compiler.cxx }}
       run: mkdir build && cd build && cmake -DCMAKE_CXX_FLAGS="-Werror" ..
-    - name: build
+    - name: Build
       run: cmake --build build
-    - name: test
-      run: cd build && ctest -V
+    - name: Print info
+      run: |
+        ./build/cpu_features/list_cpu_features
+        ./build/apps/volk-config-info --alignment
+        ./build/apps/volk-config-info --avail-machines
+        ./build/apps/volk-config-info --all-machines
+        ./build/apps/volk-config-info --malloc
+        ./build/apps/volk-config-info --cc
+    - name: Test 
+      run: |
+        cd build
+        ctest -V
 
   build-ubuntu-static:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,40 +37,6 @@ matrix:
       env: MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
       addons: {apt: {sources: "ubuntu-toolchain-r-test", packages: [*common_packages, g++-6]}}
 
-    # Job 5 ... gcc-7
-    - name: Linux x86 GCC 7
-      env: MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
-      addons: {apt: {sources: "ubuntu-toolchain-r-test", packages: [*common_packages, g++-7]}}
-
-    # Job 6 ... gcc-8
-    - name: Linux x86 GCC 8
-      env: MATRIX_EVAL="CC=gcc-8 && CXX=g++-8"
-      addons: {apt: {sources: "ubuntu-toolchain-r-test", packages: [*common_packages, g++-8]}}
-
-    # Job 6.1 ... gcc-9
-    - name: Linux Ubuntu 20.04 (focal) x86 GCC 9
-      dist: focal
-      env: MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
-      addons: {apt: {packages: [*common_packages, g++-9]}}
-
-    # Job 6.2 ... clang 9
-    - name: Linux Ubuntu 20.04 (focal) x86 Clang 8
-      dist: focal
-      env: MATRIX_EVAL="CC=clang-8 && CXX=clang++-8"
-      addons: {apt: {packages: [*common_packages, clang-8]}}
-
-    # Job 6.3 ... clang 9
-    - name: Linux Ubuntu 20.04 (focal) x86 Clang 9
-      dist: focal
-      env: MATRIX_EVAL="CC=clang-9 && CXX=clang++-9"
-      addons: {apt: {packages: [*common_packages, clang-9]}}
-
-    # Job 6.4 ... clang 10
-    - name: Linux Ubuntu 20.04 (focal) x86 Clang 10
-      dist: focal
-      env: MATRIX_EVAL="CC=clang-10 && CXX=clang++-10"
-      addons: {apt: {packages: [*common_packages, clang-10]}}
-
     # Job 7 ... ARMv7 cross compile
     - name: Linux ARMv7 Qemu GCC 7
       env: MATRIX_EVAL="CMAKE_ARG=-DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/arm-linux-gnueabihf.cmake"


### PR DESCRIPTION
We see issues with TravisCI because of their open source policy change. Here, I start to move tests to Github Actions. Particularly the default builds with clang and GCC are now on GH Actions.

What's available: GCC/Clang 7, 8, 9, 10
That's an improvement over the previous situation where we only had GCC 7 on GH Actions because TravisCI is unavailable.

Apparently, Actions does not yet support Clang 11. Also, old compilers are left out. Anything before GCC/Clang 7 is excluded. For GCC, CMake reports issues and some packages seem to be missing. For Clang, packages for these compilers are missing.
    
Actions does not support ARM etc. Thus, only x86 is supported. We might be able to add QEMU + cross-compiles. Also, ARM support seems to be on their roadmap for Q1'21.
    
Another step is included in the CI chain that prints the current configuration and hardware info as found by `list_cpu_features` and `volk-config-info`.

Missing features:
- QEMU cross compiles for ARM
- Intel SDE tests. Though, Actions seems to have AVX512 available and we might get away without this test.
- Native ARM builds. This might change in the near future. Support for ARM is on their roadmap.
- Older GCC/Clang before version 7. GCC 7.1 was released 2017-05-02. Clang 7 was released 2018-09-19. Is it worth the effort to add them back?