### PR TITLE
kernel: Fix typo in implementation name

### DIFF
--- a/kernels/volk/volk_16ic_x2_dot_prod_16ic.h
+++ b/kernels/volk/volk_16ic_x2_dot_prod_16ic.h
@@ -244,7 +244,7 @@ static inline void volk_16ic_x2_dot_prod_16ic_u_sse2(lv_16sc_t* out,
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
 
-static inline void volk_16ic_x2_dot_prod_16ic_u_axv2(lv_16sc_t* out,
+static inline void volk_16ic_x2_dot_prod_16ic_u_avx2(lv_16sc_t* out,
                                                      const lv_16sc_t* in_a,
                                                      const lv_16sc_t* in_b,
                                                      unsigned int num_points)
@@ -386,7 +386,7 @@ static inline void volk_16ic_x2_dot_prod_16ic_u_axv2(lv_16sc_t* out,
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
 
-static inline void volk_16ic_x2_dot_prod_16ic_a_axv2(lv_16sc_t* out,
+static inline void volk_16ic_x2_dot_prod_16ic_a_avx2(lv_16sc_t* out,
                                                      const lv_16sc_t* in_a,
                                                      const lv_16sc_t* in_b,
                                                      unsigned int num_points)


### PR DESCRIPTION
The AVX2 kernels in `volk_16ic_x2_dot_prod_16ic` were named incorrectly.
Instead of `_avx2` the function names ended with `_axv2`. This commit
fixes the typo.

However, this does change two function names in files that we install.
This might require us to add a wrapper with the old name that just calls
the new, and correct, name.