### PR TITLE
gnuradio/volk/#430 move log2f_non_ieee back to kernel header

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ git submodule update --init --recursive
 that'll pull in missing submodules.
 
 
-### Building on Raspberry Pi and other ARM boards
+### Building on Raspberry Pi and other ARM boards (32 bit)
 
 To build for these boards you need specify the correct cmake toolchain file for best performance.
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ that'll pull in missing submodules.
 
 To build for these boards you need specify the correct cmake toolchain file for best performance.
 
+_Note: There is no need for adding extra options to the compiler for 64 bit._
+
 * Raspberry Pi 4 `arm_cortex_a72_hardfp_native.cmake`
 * Raspberry Pi 3 `arm_cortex_a53_hardfp_native.cmake`
 
@@ -87,7 +89,7 @@ Currently VOLK aims to run with optimized kernels on x86 with SSE/AVX and ARM wi
 
 ### OS / Distro
 We run tests on a variety of Ubuntu versions and aim to support as many current distros as possible.
-The same goal applies to different OSes. Although this does only happen rarely, it might occur that VOLK does not work on obsolete distros, e.g. Ubuntu 12.04.
+The same goal applies to different OSes. Although this does only rarely happen, it might occur that VOLK does not work on obsolete distros, e.g. Ubuntu 12.04.
 
 ### Compilers
 We want to make sure VOLK works with C/C++ standard compliant compilers. Of course, as an open source project we focus on open source compilers, most notably GCC and Clang.

--- a/include/volk/volk_common.h
+++ b/include/volk/volk_common.h
@@ -145,13 +145,23 @@ union bit256 {
 ////////////////////////////////////////////////////////////////////////
 // log2f
 ////////////////////////////////////////////////////////////////////////
+#ifdef __cplusplus
+#include <cmath>
+#else
 #include <math.h>
+#endif
 // +-Inf -> +-127.0f in order to match the behaviour of the SIMD kernels
 static inline float log2f_non_ieee(float f)
 {
+#ifdef __cplusplus
+    float const result = std::log2f(f);
+    return std::isinf(result) ? std::copysignf(127.0f, result) : result;
+#else
     float const result = log2f(f);
     return isinf(result) ? copysignf(127.0f, result) : result;
+#endif
 }
+
 
 ////////////////////////////////////////////////////////////////////////
 // Constant used to do log10 calculations as faster log2


### PR DESCRIPTION
This minor change allows VOLK to build with older versions of GCC. Currently GCC6 is the minimum, and some developers are stuck using older tools.

Project fully builds for x86-64 as well as armv7. Tested by running volk_profile on both targets.