### PR TITLE
c11: Remove pre-C11 preprocessor instructions

### DIFF
--- a/include/volk/volk_complex.h
+++ b/include/volk/volk_complex.h
@@ -55,13 +55,8 @@ inline T lv_conj(const T& x)
 
 #else /* __cplusplus */
 
-#if __STDC_VERSION__ >= 199901L /* C99 check */
-/* this allows us to conj in lv_conj without the double detour for single-precision floats
- */
-#include <tgmath.h>
-#endif /* C99 check */
-
 #include <complex.h>
+#include <tgmath.h>
 
 typedef char complex lv_8sc_t;
 typedef short complex lv_16sc_t;


### PR DESCRIPTION
We check for pre-C99 in `volk_complex.h`. But we require C11. Just remove this outdated check.