### PR TITLE
Fixup underperforming GENERIC kernel for volk_8u_x4_conv_k7_r2_8u

### DIFF
--- a/kernels/volk/volk_8u_x4_conv_k7_r2_8u.h
+++ b/kernels/volk/volk_8u_x4_conv_k7_r2_8u.h
@@ -100,7 +100,7 @@ static inline void BFLY(int i,
 
     int NUMSTATES = 64;
     int RATE = 2;
-    int METRICSHIFT = 1;
+    int METRICSHIFT = 2;
     int PRECISIONSHIFT = 2;
 
     metric = 0;


### PR DESCRIPTION
This addresses https://github.com/gnuradio/volk/issues/473

I ended up comparing this implementation with others open-source implementations such as libcorrect and viterbi_lib from GNU Radio, and accordingly tuned https://github.com/gnuradio/volk/blob/79a111ba600c86ae937830970b00ebe0c711df5a/kernels/volk/volk_8u_x4_conv_k7_r2_8u.h#L103 which seemed to be the only thing really different to me.

To my surprise, this did drastically improve performances to match the SSE / Spiral kernel ignoring a few details. Output from this "fixed?" generic kernel does slightly differ from the spiral implementation, but to a level that is entirely tolerable (down to a few bits on an entire 100Mb file) in my opinion.

Honestly, I do not know exactly how this fixes things in detail and did not have much clue what I was doing, so I would entirely understand if this is not accepted as a valid fix, but it does make this kernel usable compared to previous results and definitely as consistent as I would expect it to be.

I did not notice any degradation or weird behavior in my tests.