### PR TITLE
relicense: Add Federico

### DIFF
--- a/AUTHORS_RESUBMITTING_UNDER_LGPL_LICENSE.md
+++ b/AUTHORS_RESUBMITTING_UNDER_LGPL_LICENSE.md
@@ -41,4 +41,5 @@ Together with the date of agreement, these authors are:
 | 2021-09-04 | Michael Dickens             | michaelld       | mlk@alum.mit.edu, michael.dickens@ettus.com                         |
 | 2021-09-05 | Andrej Rode                 | noc0lour        | mail@andrejro.de                                                    |
 | 2021-09-06 | rear1019                    | rear1019        | rear1019@posteo.de                                                  |
+| 2021-09-08 | Federico 'Larroca' La Rocca | git-artes       | flarroca@fing.edu.uy                                                |
 |            |                             |                 |                                                                     |


### PR DESCRIPTION
We received the following statement from Federico

> I, Federico 'Larroca' La Rocca, hereby resubmit all my contributions to the VOLK
> project and repository under the terms of the LGPL-3.0-or-later.
> My GitHub handle is git-artes.
> My email addresses used for contributions are: flarroca@fing.edu.uy.
> 
> I hereby agree that contributions made by me in the past, to previous
> versions of VOLK, may be re-used for inclusion in VOLK 3. I understand
> that VOLK 3 will be relicensed under LGPL-3.0-or-later.

Thus, we add him to the list.