### PR TITLE
lgpl: Add Jeison

### DIFF
--- a/AUTHORS_RESUBMITTING_UNDER_LGPL_LICENSE.md
+++ b/AUTHORS_RESUBMITTING_UNDER_LGPL_LICENSE.md
@@ -44,4 +44,5 @@ Together with the date of agreement, these authors are:
 | 2021-09-08 | Federico 'Larroca' La Rocca | git-artes       | flarroca@fing.edu.uy                                                |
 | 2021-09-08 | A. Maitland Bottoms         | maitbot         | bottoms@debian.org                                                  |
 | 2021-09-08 | Paul Cercueil               | pcercuei        | paul.cercueil@analog.com                                            |
+| 2021-09-08 | Jeison Cardoso              | jsonzilla, 0unit| cardoso.jeison@gmail.com                                            |
 |            |                             |                 |                                                                     |


### PR DESCRIPTION
We received the following statement:

> I, Jeison Cardoso, hereby resubmit all my contributions to the VOLK
> project and repository under the terms of the LGPL-3.0-or-later.
> My GitHub handle is jsonzilla, the old is 0unit
> My email addresses used for contributions are: cardoso.jeison@gmail.com, ... .
> 
> I hereby agree that contributions made by me in the past, to previous
> versions of VOLK, may be re-used for inclusion in VOLK 3. I understand
> that VOLK 3 will be relicensed under LGPL-3.0-or-later.

