### PR TITLE
LGPL licensing permission

### DIFF
--- a/AUTHORS_RESUBMITTING_UNDER_LGPL_LICENSE.md
+++ b/AUTHORS_RESUBMITTING_UNDER_LGPL_LICENSE.md
@@ -50,4 +50,5 @@ Together with the date of agreement, these authors are:
 | 2021-09-08 | Ryan Volz                   | ryanvolz        | ryan.volz@gmail.com, rvolz@mit.edu                                  |
 | 2021-09-08 | Douglas Anderson            | djanderson      | douglas.j.anderson@gmail.com, djanderson@users.noreply.github.com   |
 | 2021-09-09 | Jaroslav Škarvada           | yarda           | jskarvad@redhat.com                                                 |
+| 2021-09-09 | Takehiro Sekine             | bstalk          | takehiro.sekine@ps23.jp                                             |
 |            |                             |                 |                                                                     |


### PR DESCRIPTION
I, Takehiro Sekine, hereby resubmit all my contributions to the VOLK
project and repository under the terms of the LGPL-3.0-or-later.
My GitHub handle is bstalk.
My email addresses used for contributions are: takehiro.sekine@ps23.jp

I hereby agree that contributions made by me in the past, to previous
versions of VOLK, may be re-used for inclusion in VOLK 3. I understand
that VOLK 3 will be relicensed under LGPL-3.0-or-later.