### PR TITLE
index: Fix volk_get_index

### DIFF
--- a/lib/volk_rank_archs.c
+++ b/lib/volk_rank_archs.c
@@ -22,13 +22,16 @@ int volk_get_index(const char* impl_names[], // list of implementations by name
 {
     unsigned int i;
     for (i = 0; i < n_impls; i++) {
-        if (!strncmp(impl_names[i], impl_name, 20)) {
+        if (!strncmp(impl_names[i], impl_name, 42)) {
             return i;
         }
     }
     // TODO return -1;
     // something terrible should happen here
     fprintf(stderr, "Volk warning: no arch found, returning generic impl\n");
+    if (strncmp(impl_name, "generic", 20)) {
+        return -1;
+    }
     return volk_get_index(impl_names, n_impls, "generic"); // but we'll fake it for now
 }
 

--- a/lib/volk_rank_archs.c
+++ b/lib/volk_rank_archs.c
@@ -22,7 +22,7 @@ int volk_search_index(const char* impl_names[],
 {
     unsigned int i;
     for (i = 0; i < n_impls; i++) {
-        if (strncmp(impl_names[i], impl_name, 42) != 0) {
+        if (!strncmp(impl_names[i], impl_name, 42)) {
             return i;
         }
     }
@@ -48,10 +48,10 @@ int volk_get_index(const char* impl_names[], // list of implementations by name
     idx = volk_search_index(impl_names, n_impls, "generic");
     if (idx >= 0) {
         fprintf(stderr, "Volk warning: no arch found, returning generic impl\n");
-        return idx;
+    } else {
+        fprintf(stderr, "Volk ERROR: no arch found. generic impl missing!\n");
     }
-    fprintf(stderr, "Volk warning: no arch found, returning -1 aka not found!\n");
-    return -1;
+    return idx;
 }
 
 int volk_rank_archs(const char* kern_name,    // name of the kernel to rank


### PR DESCRIPTION
This function results in an infinite loop on Debian 11 for some impls.
This is a first step to fix it.

@mbr0wn , @marcusmueller does that fix the reported issue? If you could point me to a CI script for Debian 11 that we can integrate here, that'd be very helpful.

Fix #516

EDIT
This is a minimal Debian 11 Container to test things.
```docker
FROM debian:bullseye

RUN apt-get update \
        && apt-get install -y \
        build-essential git cmake python3-mako python3-distutils liborc-dev
```
[GNU Radio CI container for Debian 11](https://hub.docker.com/layers/gnuradio/ci/debian-11-3.10/images/sha256-d3de16fb91a50ee2472d35bd1fb27e18715e4dba69098bf3b99e0109aaf0c62c?context=explore) where `volk_profile` hangs on `volk_32f_8u_polarbutterflypuppet_32f`.
The corresponding Dockerfile: [Dockerfile](https://github.com/gnuradio/gnuradio-docker/blob/master/ci/ci-debian-11-3.10/Dockerfile).