### PR TITLE
Fix allocated size not a multiple of alignment

### DIFF
--- a/lib/volk_malloc.c
+++ b/lib/volk_malloc.c
@@ -50,6 +50,17 @@
 
 void* volk_malloc(size_t size, size_t alignment)
 {
+    if ((size == 0) || (alignment == 0)) {
+        fprintf(stderr, "VOLK: Error allocating memory: either size or alignment is 0");
+        return NULL;
+    }
+    // Tweak size to satisfy ASAN (the GCC address sanitizer).
+    // Calling 'volk_malloc' might therefor result in the allocation of more memory than
+    // requested for correct alignment. Any allocation size change here will in general not
+    // impact the end result since initial size alignment is required either way.
+    if (size % alignment) {
+        size += alignment - (size % alignment);
+    }
 #if HAVE_POSIX_MEMALIGN
     // quoting posix_memalign() man page:
     // "alignment must be a power of two and a multiple of sizeof(void *)"


### PR DESCRIPTION
In some cases, it is required that the allocated size is a multiple of the alignment size.

When using `-fsanitize=address` to do memory debugging with libasan, it errors out complaining about the size of the allocation not being a multiple of the alignment. This makes memory debugging basically impossible. I've confirmed that this fix lets me use the address sanitizer properly.

This pull request ensured that this requirement is always met.