### PR TITLE
lgpl: Add Albin to the list

### DIFF
--- a/AUTHORS_RESUBMITTING_UNDER_LGPL_LICENSE.md
+++ b/AUTHORS_RESUBMITTING_UNDER_LGPL_LICENSE.md
@@ -68,4 +68,5 @@ Together with the date of agreement, these authors are:
 | 2021-09-24 | Ron Economos                | drmpeg          | w6rz@comcast.net                                                    |
 | 2021-09-26 | Marc Lichtman               | 777arc          | marcll@vt.edu                                                       |
 | 2021-09-28 | Stefan Wunsch               | stwunsch        | stefan.wunsch@student.kit.edu                                       |
+| 2021-10-02 | Albin Stigö                 | ast             | albin.stigo@gmail.com                                               |
 |            |                             |                 |                                                                     |


### PR DESCRIPTION
We received the following statement:

I, Albin Stigö, hereby resubmit all my contributions to the VOLK
project and repository under the terms of the LGPL-3.0-or-later.
My GitHub handle is ast.
My email addresses used for contributions are: albin.stigo@gmail.com.

I hereby agree that contributions made by me in the past, to previous
versions of VOLK, may be re-used for inclusion in VOLK 3. I understand
that VOLK 3 will be relicensed under LGPL-3.0-or-later.