### PR TITLE
lgpl: Update Carles email addresses

### DIFF
--- a/AUTHORS_RESUBMITTING_UNDER_LGPL_LICENSE.md
+++ b/AUTHORS_RESUBMITTING_UNDER_LGPL_LICENSE.md
@@ -36,7 +36,7 @@ Together with the date of agreement, these authors are:
 | 2021-07-01 | Marcus Müller               | marcusmueller   | marcus@hostalia.de, mmueller@gnuradio.org, mueller@kit.edu          |
 | 2021-08-01 | Johannes Demel              | jdemel          | ufcsy@student.kit.edu, demel@uni-bremen.de, demel@ant.uni-bremen.de |
 | 2021-08-25 | Martin Braun                | mbr0wn          | martin@gnuradio.org, martin.braun@ettus.com                         |
-| 2021-08-27 | Carles Fernandez            | carlesfernandez | carles.fernandez@cttc.es                                            |
+| 2021-08-27 | Carles Fernandez            | carlesfernandez | carles.fernandez@cttc.es, carles.fernandez@gmail.com, carlesfernandez@gmail.com |
 | 2021-08-27 | Magnus Lundmark             | Ka-zam          | magnus@skysense.io                                                  |
 | 2021-09-04 | Michael Dickens             | michaelld       | mlk@alum.mit.edu, michael.dickens@ettus.com                         |
 | 2021-09-05 | Andrej Rode                 | noc0lour        | mail@andrejro.de                                                    |


### PR DESCRIPTION
This commit updates Carles' email addresses in the list. This should
cover all his commits.

we received the following statement:

I, Carles Fernandez, hereby resubmit all my contributions to the VOLK project and repository under the terms of the LGPL-3.0-or-later.
My GitHub handle is carlesfernandez.
My email addresses used for contributions are:  carles.fernandez@gmail.com, carlesfernandez@gmail.com

I hereby agree that contributions made by me in the past, to previous versions of VOLK, may be re-used for inclusion in VOLK 3. I understand that VOLK 3 will be relicensed under LGPL-3.0-or-later.