### PR TITLE
LGPL: add all ettus.com per Directory approval

### DIFF
--- a/AUTHORS_RESUBMITTING_UNDER_LGPL_LICENSE.md
+++ b/AUTHORS_RESUBMITTING_UNDER_LGPL_LICENSE.md
@@ -82,4 +82,5 @@ Together with the date of agreement, these authors are:
 | 2021-10-17 | Josh Blum                   | guruofquality   | josh@joshknows.com                                                  |
 | 2021-10-14 | Nicholas Corgan             | ncorgan         | n.corgan@gmail.com, nick.corgan@ettus.com                           |
 | 2021-10-24 | Andy Walls                  | awalls-cx18     | andy@silverblocksystems.net, awalls.cx18@gmail.com, awalls@md.metrocast.net                           |
+| 2021-10-26 | Ettus Research              | N/A             | nick.corgan@ettus.com, nick@ettus.com, ben.hilburn@ettus.com, michael.dickens@ettus.com                                                                    |
 |            |                             |                 |                                                                     |


### PR DESCRIPTION
We received approval for the following statement:

I, Steven Bassett, NI Senior Director Product Planning as of the date of writing, as an authorized representative of Ettus Research, a National Instruments brand, ("Ettus") on behalf of all Ettus contributors, hereby resubmit all of our contributions to the VOLK project and repository under the terms of the LGPL-3.0-or-later. GitHub handles associated with Ettus contributors include but are not limited to 'ncorgan' and 'michaelld'. Email addresses used for contributions are: nick.corgan@ettus.com, nick@ettus.com, ben.hilburn@ettus.com, and michael.dickens@ettus.com .

I, on behalf of all Ettus contributors, hereby agree that contributions made by Ettus in the past, to previous versions of VOLK, may be re-used for inclusion in VOLK 3. I understand that VOLK 3 will be relicensed under LGPL-3.0-or-later.

Signed-off-by: Michael Dickens <michael.dickens@ettus.com>