### PR TITLE
lgpl: add Pascal to the list

### DIFF
--- a/AUTHORS_RESUBMITTING_UNDER_LGPL_LICENSE.md
+++ b/AUTHORS_RESUBMITTING_UNDER_LGPL_LICENSE.md
@@ -83,4 +83,5 @@ Together with the date of agreement, these authors are:
 | 2021-10-14 | Nicholas Corgan             | ncorgan         | n.corgan@gmail.com, nick.corgan@ettus.com                           |
 | 2021-10-24 | Andy Walls                  | awalls-cx18     | andy@silverblocksystems.net, awalls.cx18@gmail.com, awalls@md.metrocast.net                           |
 | 2021-10-26 | Ettus Research              | N/A             | nick.corgan@ettus.com, nick@ettus.com, ben.hilburn@ettus.com, michael.dickens@ettus.com                                                                    |
+| 2021-10-27 | Pascal Giard                | evilynux        | evilynux@gmail.com, pascal.giard@lacime.etsmtl.ca, pascal.giard@etsmtl.ca, pascal.giard@mail.mcgill.ca                           |
 |            |                             |                 |                                                                     |


### PR DESCRIPTION
We received the following statement:

I, Pascal Giard, hereby resubmit all my contributions to the VOLK
project and repository under the terms of the LGPL-3.0-or-later.
My GitHub handle is evilynux.
My email addresses used for contributions are: evilynux@gmail.com, pascal.giard@lacime.etsmtl.ca, pascal.giard@etsmtl.ca, pascal.giard@mail.mcgill.ca.

I hereby agree that contributions made by me in the past, to previous
versions of VOLK, may be re-used for inclusion in VOLK 3. I understand
that VOLK 3 will be relicensed under LGPL-3.0-or-later.

Signed-off-by: Michael Dickens <michael.dickens@ettus.com>