### PR TITLE
lgpl: add The Aerospace Corporation to the list

### DIFF
--- a/AUTHORS_RESUBMITTING_UNDER_LGPL_LICENSE.md
+++ b/AUTHORS_RESUBMITTING_UNDER_LGPL_LICENSE.md
@@ -54,7 +54,7 @@ Together with the date of agreement, these authors are:
 | 2021-09-09 | Vasil Velichkov             | velichkov       | vvvelichkov@gmail.com                                               |
 | 2021-09-09 | Takehiro Sekine             | bstalk          | takehiro.sekine@ps23.jp                                             |
 | 2021-09-10 | Vanya Sergeev               | vsergeev        | vsergeev@gmail.com                                                  |
-| 2021-09-10 | Ben Hilburn                 | bhilburn        | bhilburn@gnuradio.org, bhilburn@gmail.com, ben@ettus.com, ben@hilburn.dev          |
+| 2021-09-10 | Ben Hilburn                 | bhilburn        | bhilburn@gnuradio.org, bhilburn@gmail.com, ben@ettus.com, ben@hilburn.dev |
 | 2021-09-09 | Philip Balister             | balister        | philip@balister.org, root@usrp-e1xx.(none)                          |
 | 2021-09-12 | Andrey Rodionov             | dernasherbrezon | rodionovamp@mail.ru                                                 |
 | 2021-09-13 | Clayton Smith               | argilo          | argilo@gmail.com                                                    |
@@ -81,7 +81,7 @@ Together with the date of agreement, these authors are:
 | 2021-10-13 | Alexey Slokva               | Alesha72003     | Alesha72003@ya.ru                                                   |
 | 2021-10-17 | Josh Blum                   | guruofquality   | josh@joshknows.com                                                  |
 | 2021-10-14 | Nicholas Corgan             | ncorgan         | n.corgan@gmail.com, nick.corgan@ettus.com                           |
-| 2021-10-24 | Andy Walls                  | awalls-cx18     | andy@silverblocksystems.net, awalls.cx18@gmail.com, awalls@md.metrocast.net                           |
-| 2021-10-26 | Ettus Research              | N/A             | nick.corgan@ettus.com, nick@ettus.com, ben.hilburn@ettus.com, michael.dickens@ettus.com                                                                    |
-| 2021-10-27 | Pascal Giard                | evilynux        | evilynux@gmail.com, pascal.giard@lacime.etsmtl.ca, pascal.giard@etsmtl.ca, pascal.giard@mail.mcgill.ca                           |
-|            |                             |                 |                                                                     |
+| 2021-10-24 | Andy Walls                  | awalls-cx18     | andy@silverblocksystems.net, awalls.cx18@gmail.com, awalls@md.metrocast.net |
+| 2021-10-26 | Ettus Research              | N/A             | nick.corgan@ettus.com, nick@ettus.com, ben.hilburn@ettus.com, michael.dickens@ettus.com |
+| 2021-10-27 | Pascal Giard                | evilynux        | evilynux@gmail.com, pascal.giard@lacime.etsmtl.ca, pascal.giard@etsmtl.ca, pascal.giard@mail.mcgill.ca |
+| 2021-10-27 | The Aerospace Corporation   | N/A             | oss@aero.org, damian.miralles@aero.org, jessica.iwamoto@aero.org    |


### PR DESCRIPTION
I, Kyle Logue, as a representative of The Aerospace Corporation, ("Aerospace")
on behalf of all Aerospace contributors, hereby resubmit all of our
contributions to the VOLK project and repository under the terms of the
LGPLv3+. GitHub handles associated with Aerospace contributors include but are
not limited to 'jessica-iwamoto' and 'dmiralles2009' and include all @aero.org
email addresses.

I, on behalf of all Aerospace contributors, hereby agree that contributions
made by Aerospace in the past, to previous versions of VOLK, may be re-used for
inclusion in VOLK 3. I understand that VOLK 3 will be relicensed under LGPLv3+.

Signed-off-by: Kyle Logue <oss@aero.org>

This closes #492 for us.