### PR TITLE
lgpl: Ignore clang-format commit

### DIFF
--- a/scripts/licensing/count_contrib.sh
+++ b/scripts/licensing/count_contrib.sh
@@ -28,7 +28,7 @@ fi
 
 allfiles=`git ls-files $rootdir`
 lgplers="$(sed -ne 's/^|[^|]*|[^|]*| \([^|]*\)|/\1/ip' $authorfile)"
-authorcounts="$(echo "$allfiles" | while read f; do git blame --line-porcelain $f 2>/dev/null | sed -ne 's/^author-mail <\([^>]*\)>/\1/p'; done | sort -f | uniq -ic | sort -n)"
+authorcounts="$(echo "$allfiles" | while read f; do git blame --line-porcelain --ignore-rev 092a59997a1e1d5f421a0a5f87ee655ad173b93f $f 2>/dev/null | sed -ne 's/^author-mail <\([^>]*\)>/\1/p'; done | sort -f | uniq -ic | sort -n)"
 
 total_loc=0
 missing_loc=0


### PR DESCRIPTION
With [commit 092a59997a1e1d5f421a0a5f87ee655ad173b93f](https://github.com/gnuradio/volk/commit/092a59997a1e1d5f421a0a5f87ee655ad173b93f) we reformatted the VOLK code base. Now, the script to count lines of code that are not re-submitted under LGPL ignores that commit. This makes the LOC count more accurate.