### PR TITLE
qa: Remove repeating tests

### DIFF
--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -38,8 +38,6 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
 
     std::vector<volk_test_case_t> test_cases;
     QA(VOLK_INIT_PUPP(volk_64u_popcntpuppet_64u, volk_64u_popcnt, test_params))
-    QA(VOLK_INIT_PUPP(volk_64u_popcntpuppet_64u, volk_64u_popcnt, test_params))
-    QA(VOLK_INIT_PUPP(volk_64u_popcntpuppet_64u, volk_64u_popcnt, test_params))
     QA(VOLK_INIT_PUPP(volk_16u_byteswappuppet_16u, volk_16u_byteswap, test_params))
     QA(VOLK_INIT_PUPP(volk_32u_byteswappuppet_32u, volk_32u_byteswap, test_params))
     QA(VOLK_INIT_PUPP(volk_32u_popcntpuppet_32u, volk_32u_popcnt_32u, test_params))


### PR DESCRIPTION
We ran the QA and benchmarks for `volk_64u_popcnt` thrice. This commit
removes the 2 duplicate lines and thus makes it more sane.
