### PR TITLE
cpu_features: Update submodule pointer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,11 +144,12 @@ if (VOLK_CPU_FEATURES)
     message(FATAL_ERROR "cpu_features/CMakeLists.txt not found. Did you forget to git clone recursively?\nFix with: git submodule update --init")
   endif()
   message(STATUS "Building Volk with cpu_features")
-  set(BUILD_PIC ON CACHE BOOL
-    "Build cpu_features with Position Independent Code (PIC)."
+  set(BUILD_TESTING OFF CACHE BOOL "Build cpu_features without tests." FORCE)
+  set(BUILD_PIC ON CACHE BOOL 
+    "Build cpu_features with Position Independent Code (PIC)." 
     FORCE)
-  set(BUILD_TESTING OFF CACHE BOOL
-    "Build cpu_features without tests."
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON CACHE BOOL
+    "Build cpu_features with Position Independent Code (PIC)."
     FORCE)
   set(BUILD_SHARED_LIBS_SAVED "${BUILD_SHARED_LIBS}")
   set(BUILD_SHARED_LIBS OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,9 @@ if (VOLK_CPU_FEATURES)
   set(BUILD_PIC ON CACHE BOOL
     "Build cpu_features with Position Independent Code (PIC)."
     FORCE)
+  set(BUILD_TESTING OFF CACHE BOOL
+    "Build cpu_features without tests."
+    FORCE)
   set(BUILD_SHARED_LIBS_SAVED "${BUILD_SHARED_LIBS}")
   set(BUILD_SHARED_LIBS OFF)
   add_subdirectory(cpu_features)


### PR DESCRIPTION
We have 3 issues that should be fixed with this commit.

Fix #428
Should be fixed because cpu_features detects `arm64` now. Thus, VOLK builds with cpu_features on MacOS and reports M1 capabilities.

Fix #478
Fix #484
cpu_features received quite a bit of contributions for FreeBSD. All the issues we had should be fixed now. However, this might require further evaluation.