### PR TITLE
python: Switch to sysconfig module

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -124,7 +124,7 @@ jobs:
             case "${{ matrix.distro }}" in
               ubuntu*|jessie|stretch|buster)
                 apt-get update -q -y
-                apt-get install -q -y git cmake python3-distutils python3-mako liborc-dev ${{ matrix.compiler.name }}
+                apt-get install -q -y git cmake python3-mako liborc-dev ${{ matrix.compiler.name }}
                 ;;
               fedora*)
                 dnf -y update


### PR DESCRIPTION
The `distutils` module is deprecated and will be removed in Python 3.12.
We follow GNU Radio's example as well as the recommendations in PEP 632
and switch from `distutils.sysconfig` to `sysconfig`. Along with that
change comes one fewer package dependency on Debian. We no longer need
`python3-distutils` as well as an improvement to better distinguish
between `dist-packages` and `site-packages`.

**UPDATE**
A few more references to this issue.
[PEP632](https://www.python.org/dev/peps/pep-0632/) that started the deprecation process.
A discussion on [site vs dist packages on Debian](https://ffy00.github.io/blog/02-python-debian-and-the-install-locations/) that we hope to fix too.

**UPDATE 2**
[Python sysconfig](https://docs.python.org/3/library/sysconfig.html) was introduced in Python 3.2. We rely on Python 3.4+ and thus, we can assume `sysconfig` is always present.