### PR TITLE
Add deprecations for untested kernels

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -476,7 +476,7 @@ list(APPEND volk_sources ${CMAKE_CURRENT_BINARY_DIR}/constants.c)
 ########################################################################
 if(NOT WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden -Wno-deprecated-declarations")
 endif()
 
 list(APPEND volk_sources

--- a/tmpl/volk.tmpl.h
+++ b/tmpl/volk.tmpl.h
@@ -72,10 +72,15 @@ VOLK_API size_t volk_get_alignment(void);
  */
 VOLK_API bool volk_is_aligned(const void *ptr);
 
+// Just drop the deprecated attribute in case we are on Windows. Clang and GCC support `__attribute__`.
+// We just assume the compiler and the system are tight together as far as Mako templates are concerned.
 <%
 deprecated_kernels = ('volk_16i_x5_add_quad_16i_x4', 'volk_16i_branch_4_state_8', 
                       'volk_16i_max_star_16i', 'volk_16i_max_star_horizontal_16i', 
                       'volk_16i_permute_and_scalar_add', 'volk_16i_x4_quad_max_star_16i')
+from platform import system
+if system() == 'Windows':
+    deprecated_kernels = ()
 %>
 %for kern in kernels:
 

--- a/tmpl/volk.tmpl.h
+++ b/tmpl/volk.tmpl.h
@@ -72,9 +72,29 @@ VOLK_API size_t volk_get_alignment(void);
  */
 VOLK_API bool volk_is_aligned(const void *ptr);
 
-
+<%
+deprecated_kernels = ('volk_16i_x5_add_quad_16i_x4', 'volk_16i_branch_4_state_8', 
+                      'volk_16i_max_star_16i', 'volk_16i_max_star_horizontal_16i', 
+                      'volk_16i_permute_and_scalar_add', 'volk_16i_x4_quad_max_star_16i')
+%>
 %for kern in kernels:
 
+% if kern.name in deprecated_kernels:
+//! A function pointer to the dispatcher implementation
+extern VOLK_API ${kern.pname} ${kern.name} __attribute__((deprecated));
+
+//! A function pointer to the fastest aligned implementation
+extern VOLK_API ${kern.pname} ${kern.name}_a __attribute__((deprecated));
+
+//! A function pointer to the fastest unaligned implementation
+extern VOLK_API ${kern.pname} ${kern.name}_u __attribute__((deprecated));
+
+//! Call into a specific implementation given by name
+extern VOLK_API void ${kern.name}_manual(${kern.arglist_full}, const char* impl_name) __attribute__((deprecated));
+
+//! Get description parameters for this kernel
+extern VOLK_API volk_func_desc_t ${kern.name}_get_func_desc(void) __attribute__((deprecated));
+% else:
 //! A function pointer to the dispatcher implementation
 extern VOLK_API ${kern.pname} ${kern.name};
 
@@ -89,6 +109,8 @@ extern VOLK_API void ${kern.name}_manual(${kern.arglist_full}, const char* impl_
 
 //! Get description parameters for this kernel
 extern VOLK_API volk_func_desc_t ${kern.name}_get_func_desc(void);
+% endif
+
 %endfor
 
 __VOLK_DECL_END


### PR DESCRIPTION
We have six kernels:
- `volk_16i_x5_add_quad_16i_x4`
- `volk_16i_branch_4_state_8`
- `volk_16i_max_star_16i`
- `volk_16i_max_star_horizontal_16i`
- `volk_16i_permute_and_scalar_add`
- `volk_16i_x4_quad_max_star_16i`

that we don't test. They should be marked deprecated. If nobody complains, we can remove them in a future VOLK version. Otherwise, we need proper tests for those kernels because they are currently untested.

We assume that MSVC is the compiler on Windows and thus, we don't add deprecation warnings. Other platforms receive these warnings though. Ideas on how to improve these warnings are appreciated.

Fix #549 