### PR TITLE
cpu_features: Make cpu_features submodule optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,22 +139,27 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES
 else()
   option(VOLK_CPU_FEATURES "Volk uses cpu_features" OFF)
 endif()
+
 if (VOLK_CPU_FEATURES)
-  if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/cpu_features/CMakeLists.txt" )
-    message(FATAL_ERROR "cpu_features/CMakeLists.txt not found. Did you forget to git clone recursively?\nFix with: git submodule update --init")
+  find_package(CpuFeatures)
+  if(NOT CpuFeatures_FOUND)
+    message(STATUS "cpu_features package not found. Requiring cpu_features submodule ...")
+    if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/cpu_features/CMakeLists.txt" )
+      message(FATAL_ERROR "cpu_features/CMakeLists.txt not found. Did you forget to git clone recursively?\nFix with: git submodule update --init")
+    endif()
+    message(STATUS "Building Volk with cpu_features")
+    set(BUILD_TESTING OFF CACHE BOOL "Build cpu_features without tests." FORCE)
+    set(BUILD_PIC ON CACHE BOOL 
+      "Build cpu_features with Position Independent Code (PIC)." 
+      FORCE)
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON CACHE BOOL
+      "Build cpu_features with Position Independent Code (PIC)."
+      FORCE)
+    set(BUILD_SHARED_LIBS_SAVED "${BUILD_SHARED_LIBS}")
+    set(BUILD_SHARED_LIBS OFF)
+    add_subdirectory(cpu_features)
+    set(BUILD_SHARED_LIBS "${BUILD_SHARED_LIBS_SAVED}")
   endif()
-  message(STATUS "Building Volk with cpu_features")
-  set(BUILD_TESTING OFF CACHE BOOL "Build cpu_features without tests." FORCE)
-  set(BUILD_PIC ON CACHE BOOL 
-    "Build cpu_features with Position Independent Code (PIC)." 
-    FORCE)
-  set(CMAKE_POSITION_INDEPENDENT_CODE ON CACHE BOOL
-    "Build cpu_features with Position Independent Code (PIC)."
-    FORCE)
-  set(BUILD_SHARED_LIBS_SAVED "${BUILD_SHARED_LIBS}")
-  set(BUILD_SHARED_LIBS OFF)
-  add_subdirectory(cpu_features)
-  set(BUILD_SHARED_LIBS "${BUILD_SHARED_LIBS_SAVED}")
 else()
   message(STATUS "Building Volk without cpu_features")
 endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -516,9 +516,15 @@ target_include_directories(volk_obj
 )
 if(VOLK_CPU_FEATURES)
   set_source_files_properties(volk_cpu.c PROPERTIES COMPILE_DEFINITIONS "VOLK_CPU_FEATURES=1")
-  target_include_directories(volk_obj
-    PRIVATE $<TARGET_PROPERTY:cpu_features,INTERFACE_INCLUDE_DIRECTORIES>
-)
+  if(CpuFeatures_FOUND)
+    target_include_directories(volk_obj
+        PRIVATE $<TARGET_PROPERTY:CpuFeatures::cpu_features,INTERFACE_INCLUDE_DIRECTORIES>
+    )
+  else()
+    target_include_directories(volk_obj
+        PRIVATE $<TARGET_PROPERTY:cpu_features,INTERFACE_INCLUDE_DIRECTORIES>
+    )
+  endif()
 endif()
 
 #Configure object target properties


### PR DESCRIPTION
Since cpu_features is available as a package in recent distributions, we'd like to use the distro provided package.

We try to find the CMake CpuFeatures package and build against it, if we can't find one, we try to use the git submodule. If both options fail, we emit an error message.

Fix #556