### PR TITLE
zenodo: Add metadata file

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,261 @@
+{
+    "title": "Vector-Optimized Library of Kernels (VOLK)",
+    "description": "VOLK is the Vector-Optimized Library of Kernels. It is a free library that contains kernels of hand-written SIMD code for different mathematical operations. Since each SIMD architecture can be very different and no compiler has yet come along to handle vectorization properly or highly efficiently, VOLK approaches the problem differently. For each architecture or platform that a developer wishes to vectorize for, a new proto-kernel is added to VOLK. At runtime, VOLK will select the correct proto-kernel. In this way, the users of VOLK call a kernel for performing the operation that is platform/architecture agnostic. This allows us to write portable SIMD code that is optimized for a variety of platforms.",
+    "license": {
+        "id": "GPL-3.0-or-later"
+    },
+    "keywords": [
+        "communication",
+        "software radio",
+        "SDR",
+        "C",
+        "C++",
+        "SIMD",
+        "library"
+    ],
+    "creators": [
+        {
+            "name": "Aang23"
+        },
+        {
+            "name": "AlexandreRouma"
+        },
+        {
+            "name": "Anderson, Douglas"
+        },
+        {
+            "name": "Andrew"
+        },
+        {
+            "name": "Ashton, Brennan"
+        },
+        {
+            "name": "Balister, Philip"
+        },
+        {
+            "name": "Behar, Doron"
+        },
+        {
+            "name": "Behnke, Steven"
+        },
+        {
+            "name": "Bekhit, Amr"
+        },
+        {
+            "affiliation": "Carnegie Mellon University, IIT Bombay",
+            "name": "Bhowmick, Abhishek"
+        },
+        {
+            "name": "Blossom, Eric"
+        },
+        {
+            "name": "Blum, Josh"
+        },
+        {
+            "name": "Bottoms, A. Maitland"
+        },
+        {
+            "name": "Briggs, Elliot"
+        },
+        {
+            "name": "Cardoso, Jeison"
+        },
+        {
+            "name": "Cercueil, Paul"
+        },
+        {
+            "affiliation": "Corgan Labs",
+            "name": "Corgan, Johnathan"
+        },
+        {
+            "affiliation": "Skylark Wireless (@skylarkwireless)",
+            "name": "Corgan, Nicholas"
+        },
+        {
+            "name": "Cruz, Luigi"
+        },
+        {
+            "affiliation": "Department of Communications Engineering, University of Bremen, Germany",
+            "name": "Demel, Johannes",
+            "orcid": "0000-0002-5434-7232"
+        },
+        {
+            "name": "Dickens, Michael"
+        },
+        {
+            "name": "Economos, Ron"
+        },
+        {
+            "name": "Enochs, Brandon P."
+        },
+        {
+            "affiliation": "Centre Tecnol\u00f2gic de Telecomunicacions de Catalunya (CTTC)",
+            "name": "Fernandez, Carles"
+        },
+        {
+            "name": "Fischer, Moritz"
+        },
+        {
+            "name": "Foster, Nick"
+        },
+        {
+            "name": "Geiger, Douglas"
+        },
+        {
+            "name": "Giard, Pascal"
+        },
+        {
+            "name": "Goavec-Merou, Gwenhael"
+        },
+        {
+            "name": "Hilburn, Ben"
+        },
+        {
+            "name": "Holguin, Albert"
+        },
+        {
+            "name": "Iwamoto, Jessica"
+        },
+        {
+            "name": "Kaesberger, Martin"
+        },
+        {
+            "name": "Lichtman, Marc"
+        },
+        {
+            "name": "Logue, Kyle A"
+        },
+        {
+            "name": "Lundmark, Magnus"
+        },
+        {
+            "name": "Markgraf, Steve"
+        },
+        {
+            "name": "Mayer, Christoph"
+        },
+        {
+            "name": "McCarthy, Nicholas"
+        },
+        {
+            "name": "McCarthy, Nick"
+        },
+        {
+            "affiliation": "University of Colorado Boulder",
+            "name": "Miralles, Damian"
+        },
+        {
+            "name": "Munaut, Sylvain"
+        },
+        {
+            "name": "M\u00fcller, Marcus"
+        },
+        {
+            "affiliation": "GCN Development",
+            "name": "Nieboer, Geof"
+        },
+        {
+            "affiliation": "@deepsig",
+            "name": "O'Shea, Tim"
+        },
+        {
+            "name": "Olivain, Julien"
+        },
+        {
+            "name": "Oltmanns, Stefan"
+        },
+        {
+            "name": "Pinkava, Jiri"
+        },
+        {
+            "name": "Piscopo, Mike"
+        },
+        {
+            "name": "Quiceno, Jam M. Hernandez"
+        },
+        {
+            "name": "Rene, Mathieu"
+        },
+        {
+            "name": "Ritterhoff, Florian"
+        },
+        {
+            "name": "Robertson, Dan"
+        },
+        {
+            "name": "Rocca, Federico 'Larroca' La"
+        },
+        {
+            "name": "Rode, Andrej"
+        },
+        {
+            "name": "Rodionov, Andrey"
+        },
+        {
+            "affiliation": "GNU Radio",
+            "name": "Rondeau, Tom"
+        },
+        {
+            "name": "Sekine, Takehiro"
+        },
+        {
+            "name": "Semich, Karl"
+        },
+        {
+            "name": "Sergeev, Vanya"
+        },
+        {
+            "name": "Slokva, Alexey"
+        },
+        {
+            "name": "Smith, Clayton"
+        },
+        {
+            "affiliation": "Medurit AB",
+            "name": "Stigo, Albin"
+        },
+        {
+            "name": "Thompson, Adam"
+        },
+        {
+            "name": "Thompson, Roy"
+        },
+        {
+            "name": "Velichkov, Vasil"
+        },
+        {
+            "affiliation": "@MITHaystack",
+            "name": "Volz, Ryan"
+        },
+        {
+            "name": "Walls, Andy"
+        },
+        {
+            "name": "Ward, Don"
+        },
+        {
+            "name": "West, Nathan"
+        },
+        {
+            "name": "Wiedemann, Bernhard M."
+        },
+        {
+            "name": "Wunsch, Stefan"
+        },
+        {
+            "name": "Zapodovnikov, Valerii"
+        },
+        {
+            "name": "Zlika"
+        },
+        {
+            "name": "luz.paz"
+        },
+        {
+            "name": "rear1019"
+        },
+        {
+            "name": "\u0160karvada, Jaroslav"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build Status](https://travis-ci.com/gnuradio/volk.svg?branch=master)](https://travis-ci.com/gnuradio/volk) [![Build status](https://ci.appveyor.com/api/projects/status/5o56mgw0do20jlh3/branch/master?svg=true)](https://ci.appveyor.com/project/gnuradio/volk/branch/master)
 ![Check PR Formatting](https://github.com/gnuradio/volk/workflows/Check%20PR%20Formatting/badge.svg)
 ![Run VOLK tests](https://github.com/gnuradio/volk/workflows/Run%20VOLK%20tests/badge.svg)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3360942.svg)](https://doi.org/10.5281/zenodo.3360942)
 
 ![VOLK Logo](/docs/volk_logo.png)
 
@@ -98,10 +99,10 @@ We want to make sure VOLK compiles on a wide variety of compilers. Thus, we targ
 
 ## License
 
-VOLK is migrating from the GNU General Public License v3.0 or later (GPL-3.0-or-later) 
+VOLK is migrating from the GNU General Public License v3.0 or later (GPL-3.0-or-later)
 to the GNU Lesser General Public License v3.0 or later (LGPL-3.0-or-later).
 At this point in time, much of the code in the repository is still GPL-licensed.
-New contributors are required to use the LGPLv3+ for their code contributions. 
+New contributors are required to use the LGPLv3+ for their code contributions.
 Existing contributors are very kindly requested to re-submit their GPL-3.0-or-later license code contributions to LGPL-3.0-or-later by
-adding their name, GitHub handle, and email address(es) used for VOLK commits 
+adding their name, GitHub handle, and email address(es) used for VOLK commits
 to the file `AUTHORS_RESUBMITTING_UNDER_LGPL_LICENSE.md`.

--- a/scripts/tools/run_citations_update.py
+++ b/scripts/tools/run_citations_update.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright 2022 Johannes Demel.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+#
+
+import argparse
+import regex
+import json
+import pathlib
+
+
+def parse_name(contributor):
+    name_pattern = "(.*?) <"
+    name = regex.search(name_pattern, contributor).group().replace(" <", "")
+    email_pattern = "<(.*?)>"
+    email = regex.search(email_pattern, contributor).group().replace(
+        "<", "").replace(">", "")
+    return name, email
+
+
+def parse_contributors(contributors):
+    result = []
+    for c in contributors:
+        name, email = parse_name(c)
+        result.append({"name": name, "email": email})
+    return result
+
+
+name_aliases = {
+    'alesha72003': "Alexey Slokva",
+    'dernasherbrezon': "Andrey Rodionov",
+    'Doug': "Douglas Geiger",
+    'Doug Geiger': "Douglas Geiger",
+    "Federico 'Larroca' La Rocca": "Federico Larroca",
+    'git-artes': "Federico 'Larroca' La Rocca",
+    'ghostop14': "Mike Piscopo",
+    'gnieboer': "Geof Nieboer",
+    'Jam Quiceno': "Jam M. Hernandez Quiceno",
+    'jdemel': "Johannes Demel",
+    'Marc L': "Marc Lichtman",
+    'Marcus Mueller': "Marcus Müller",
+    'Michael L Dickens': "Michael Dickens",
+    'Micheal Dickens': "Michael Dickens",
+    'namccart': "Nicholas McCarthy",
+    'hcab14': "Christoph Mayer",
+    'cmayer': "Christoph Mayer",
+    'root': "Philip Balister", }
+
+
+def fix_known_names(contributors):
+    for c in contributors:
+        c['name'] = name_aliases.get(c['name'], c['name'])
+    return contributors
+
+
+def merge_names(contributors):
+    results = []
+    names = sorted(list(set([c['name'] for c in contributors])))
+    for name in names:
+        emails = []
+        for c in contributors:
+            if name == c['name']:
+                emails.append(c['email'])
+        results.append({'name': name, 'email': emails})
+    return results
+
+
+def normalize_names(contributors):
+    for c in contributors:
+        name = c['name'].split(' ')
+        if len(name) > 1:
+            name = f'{name[-1]}, {" ".join(name[0:-1])}'
+        else:
+            name = name[0]
+        c['name'] = name
+
+    return contributors
+
+
+def find_citation_file(filename='.zenodo.json'):
+    # careful! This function makes quite specific folder structure assumptions!
+    file_loc = pathlib.Path(__file__).absolute()
+    file_loc = file_loc.parent
+    citation_file = next(file_loc.glob(f'../../{filename}'))
+    return citation_file.resolve()
+
+
+def load_citation_file(filename):
+    with open(filename, 'r') as file:
+        citation_file = json.load(file)
+    return citation_file
+
+
+def update_citation_file(filename, citation_data):
+    with open(filename, 'w')as file:
+        json.dump(citation_data, file, indent=4)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Update citation file')
+    parser.add_argument('contributors', metavar='N', type=str, nargs='+',
+                        help='contributors with emails: Name <email>')
+    args = parser.parse_args()
+
+    contributors = args.contributors[0].split("\n")
+    contributors = parse_contributors(contributors)
+    contributors = fix_known_names(contributors)
+    contributors = merge_names(contributors)
+    contributors = normalize_names(contributors)
+
+    citation_file_name = find_citation_file()
+    citation_file = load_citation_file(citation_file_name)
+
+    creators = citation_file['creators']
+
+    git_names = sorted([c['name'] for c in contributors])
+    cite_names = sorted([c['name'] for c in creators])
+    git_only_names = []
+    for n in git_names:
+        if n not in cite_names:
+            git_only_names.append(n)
+
+    for name in git_only_names:
+        creators.append({'name': name})
+
+    # make sure all contributors are sorted alphabetically by their family name.
+    creators = sorted(creators, key=lambda x: x['name'])
+
+    citation_file['creators'] = creators
+    update_citation_file(citation_file_name, citation_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tools/update_citations.sh
+++ b/scripts/tools/update_citations.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Find all contributors according to git and update `.zenodo.json` accordingly.
+
+script_name=$0
+script_full_path=$(dirname "$0")
+python_script=$"$script_full_path/run_citations_update.py"
+
+contributors_list="$(git log --pretty="%an <%ae>" | sort | uniq)"
+
+# Run a Python script to make things easier.
+python3 $python_script "$contributors_list"


### PR DESCRIPTION
Zenodo is a CERN operated service. It's purpose is to provide a repository of open materials, mainly software and datasets, and make them easily citable.
GitHub and Zenodo are fairly well integrated.

VOLK already has an entry:
https://zenodo.org/record/4903136

However, the provided information is inaccurate. The new `.zenodo.json` file improves more accurate metadata. Further, new releases are automatically added to Zenodo as well.

There's even a DOI for all versions [10.5281/zenodo.3360942](https://doi.org/10.5281/zenodo.3360942)
A batch is added to the top-level README.

The provided scripts make it easy to add more citation metadata to `.zenodo.json` (e.g. ORCID, affiliation) while contributor names may be added programmatically before a new release from git data.