### PR TITLE
zenodo: Re-organize .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -15,16 +15,15 @@
     ],
     "creators": [
         {
-            "name": "Aang23"
+            "affiliation": "Department of Communications Engineering, University of Bremen, Germany",
+            "name": "Demel, Johannes",
+            "orcid": "0000-0002-5434-7232"
         },
         {
-            "name": "AlexandreRouma"
+            "name": "Dickens, Michael"
         },
         {
             "name": "Anderson, Douglas"
-        },
-        {
-            "name": "Andrew"
         },
         {
             "name": "Ashton, Brennan"
@@ -73,14 +72,6 @@
         },
         {
             "name": "Cruz, Luigi"
-        },
-        {
-            "affiliation": "Department of Communications Engineering, University of Bremen, Germany",
-            "name": "Demel, Johannes",
-            "orcid": "0000-0002-5434-7232"
-        },
-        {
-            "name": "Dickens, Michael"
         },
         {
             "name": "Economos, Ron"
@@ -246,6 +237,18 @@
             "name": "Zapodovnikov, Valerii"
         },
         {
+            "name": "\u0160karvada, Jaroslav"
+        },
+        {
+            "name": "Aang23"
+        },
+        {
+            "name": "AlexandreRouma"
+        },
+        {
+            "name": "Andrew"
+        },
+        {
             "name": "Zlika"
         },
         {
@@ -253,9 +256,6 @@
         },
         {
             "name": "rear1019"
-        },
-        {
-            "name": "\u0160karvada, Jaroslav"
         }
     ]
 }

--- a/scripts/tools/run_citations_update.py
+++ b/scripts/tools/run_citations_update.py
@@ -7,6 +7,7 @@
 #
 
 import argparse
+from pprint import pprint
 import regex
 import json
 import pathlib
@@ -128,6 +129,13 @@ def main():
 
     # make sure all contributors are sorted alphabetically by their family name.
     creators = sorted(creators, key=lambda x: x['name'])
+    maintainers = ["Demel, Johannes", "Dickens, Michael"]
+    maintainer_list = list(filter(lambda x: x['name'] in maintainers, creators))
+    creators = list(filter(lambda x: x['name'] not in maintainers, creators))
+    nick_list = list(filter(lambda x: ', ' not in x['name'], creators))
+    fullname_list = list(filter(lambda x: ', ' in x['name'], creators))
+
+    creators = maintainer_list + fullname_list + nick_list
 
     citation_file['creators'] = creators
     update_citation_file(citation_file_name, citation_file)


### PR DESCRIPTION
Instead of a solely alphabetical order, we introduce three categories.
The names of the current maintainers go first.
Next, all contributors where full names (first and last) are available.
Finally, all contributors where we only have GitHub handles are listed.