### PR TITLE
relicensing: Add Albert to the list

### DIFF
--- a/AUTHORS_RESUBMITTING_UNDER_LGPL_LICENSE.md
+++ b/AUTHORS_RESUBMITTING_UNDER_LGPL_LICENSE.md
@@ -100,4 +100,5 @@ Together with the date of agreement, these authors are:
 | 2021-11-19 | Abhishek Bhowmick           | abhowmick22     | abhowmick22@gmail.com                                               |
 | 2021-11-29 | Aang23 (Alan)               | Aang23          | qwerty15@gmx.fr, aang23@altillimity.com                             |
 | 2022-02-06 | Nathan West                 | n-west          | nwest@deepsig.io, nate.ewest@gmail.com, nathan.west@gnuradio.org, nathan.west@nrl.navy.mil, nathan.west@okstate.edu, nathan@pepper                             |
+| 2022-04-01 | Albert Holguin              | hades-          | aholguin_77@yahoo.com, codename.hash@gmail.com                      |
 |            |                             |                 |                                                                     |


### PR DESCRIPTION
We received the following statement:

I, Albert Holguin, hereby resubmit all my contributions to the VOLK
project and repository under the terms of the LGPL-3.0-or-later.
My GitHub handle is "hades-".
My email addresses used for contributions are: aholguin_77@yahoo.com, codename.hash@gmail.com.

I hereby agree that contributions made by me in the past, to previous
versions of VOLK, may be re-used for inclusion in VOLK 3. I understand
that VOLK 3 will be relicensed under LGPL-3.0-or-later.