### PR TITLE
Fix broken neon kernels

### DIFF
--- a/kernels/volk/volk_32f_x3_sum_of_poly_32f.h
+++ b/kernels/volk/volk_32f_x3_sum_of_poly_32f.h
@@ -493,8 +493,8 @@ volk_32f_x3_sum_of_poly_32f_neonvert(float* __restrict target,
     float thrd = 0.0;
     float frth = 0.0;
 
-    for (i = 4 * num_points / 4; i < num_points; ++i) {
-        fst = src0[i];
+    for (i = 4 * (num_points / 4); i < num_points; ++i) {
+        fst = *src0++;
         fst = MAX(fst, *cutoff);
 
         sq = fst * fst;

--- a/kernels/volk/volk_32fc_index_max_32u.h
+++ b/kernels/volk/volk_32fc_index_max_32u.h
@@ -477,10 +477,10 @@ volk_32fc_index_max_32u_neon(uint32_t* target, lv_32fc_t* src0, uint32_t num_poi
     uint32x4_t vec_max_indices = vec_indices;
 
     if (num_points) {
-        float max = *src0Ptr;
+        float max = FLT_MIN;
         uint32_t index = 0;
 
-        float32x4_t vec_max = vdupq_n_f32(*src0Ptr);
+        float32x4_t vec_max = vdupq_n_f32(FLT_MIN);
 
         for (; number < quarter_points; number++) {
             // Load complex and compute magnitude squared
@@ -509,8 +509,9 @@ volk_32fc_index_max_32u_neon(uint32_t* target, lv_32fc_t* src0, uint32_t num_poi
         for (number = quarter_points * 4; number < num_points; number++) {
             const float re = lv_creal(*src0Ptr);
             const float im = lv_cimag(*src0Ptr);
-            if ((re * re + im * im) > max) {
-                max = *src0Ptr;
+            const float sq_dist = re * re + im * im;
+            if (sq_dist > max) {
+                max = sq_dist;
                 index = number;
             }
             src0Ptr++;

--- a/kernels/volk/volk_32fc_index_min_32u.h
+++ b/kernels/volk/volk_32fc_index_min_32u.h
@@ -504,8 +504,9 @@ static inline void volk_32fc_index_min_32u_neon(uint32_t* target,
         for (uint32_t number = quarter_points * 4; number < num_points; number++) {
             const float re = lv_creal(*sourcePtr);
             const float im = lv_cimag(*sourcePtr);
-            if ((re * re + im * im) < min) {
-                min = *sourcePtr;
+            const float sq_dist = re * re + im * im;
+            if (sq_dist < min) {
+                min = sq_dist;
                 index = number;
             }
             sourcePtr++;


### PR DESCRIPTION
Running `volk_profile` with various vector lengths (e.g. `for i in {16..31}; do echo $i; for j in {1..1000}; do apps/volk_profile -n -v $i -i 1 | grep -E 'fail|offset|^  '; done; done` on a Raspberry Pi shows that some Neon kernels are broken:

* `volk_32f_x3_sum_of_poly_32f_neonvert` ignores trailing values completely.
* `volk_32fc_index_min_32u_neon` writes the wrong value to the running minimum while handling trailing values, forgetting to compute the squared magnitude.
* `volk_32fc_index_max_32u_neon` writes the wrong starting value to the running maximum, and writes the wrong value to the running maximum while handling trailing values, forgetting to compute the squared magnitude.

I've fixed those problems here.

Signed-off-by: Clayton Smith <argilo@gmail.com>