### PR TITLE
Fix the generic float to int conversion.

### DIFF
--- a/kernels/volk/volk_32f_s32f_convert_32i.h
+++ b/kernels/volk/volk_32f_s32f_convert_32i.h
@@ -431,14 +431,17 @@ static inline void volk_32f_s32f_convert_32i_a_generic(int32_t* outputVector,
     float min_val = INT_MIN;
     float max_val = INT_MAX;
     float r;
+    int s;
 
     for (number = 0; number < num_points; number++) {
         r = *inputVectorPtr++ * scalar;
-        if (r > max_val)
-            r = max_val;
+        if (r >= max_val)
+            s = INT_MAX;
         else if (r < min_val)
-            r = min_val;
-        *outputVectorPtr++ = (int32_t)rintf(r);
+            s = INT_MIN;
+	else
+            s = (int32_t)rintf(r);
+        *outputVectorPtr++ = s;
     }
 }
 


### PR DESCRIPTION
Please ignore this PR - I've just submitted a better patch for the same issue.
===============





Signed-off-by: Michael Roe <michael-roe@users.noreply.github.com>

This fixes the bug in float to integer conversion in which values greater than or equal to 0x1.0p31 led to undefined behavior. The bug was that when INT_MAX is cast to a float, it might be rounded up (will be, with IEEE 754 floating point and round to nearest tie even rounding mode), and when this value is rounded to the nearest integer the result is greater than INT_MAX. This leads to C undefined behavior in rint(r).

Argument that the new version is correct:
if r is strictly less than max_val, it is also less than INT_MAX. (If there was a representable float greater than INT_MAX but less than max_val, then INT_MAX could have been rounded to that value, instead).
So if r is rounded up to the nearest integer, the result is still less than or equal to INT_MAX, and so is in range.
If r gets rounded down, the result is also less than INT_MAX, and so is in range.