### PR TITLE
Fix CMake Python path calculation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ else()
 endif()
 
 if (VOLK_CPU_FEATURES)
-  find_package(CpuFeatures)
+  find_package(CpuFeatures QUIET)
   if(NOT CpuFeatures_FOUND)
     message(STATUS "cpu_features package not found. Requiring cpu_features submodule ...")
     if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/cpu_features/CMakeLists.txt" )

--- a/cmake/Modules/VolkPython.cmake
+++ b/cmake/Modules/VolkPython.cmake
@@ -112,17 +112,26 @@ execute_process(
     COMMAND ${PYTHON_EXECUTABLE} -c "import os
 import sysconfig
 import site
+
 install_dir = None
 prefix = '${CMAKE_INSTALL_PREFIX}'
-#use sites when the prefix is already recognized
+
+#use `site` when the prefix is already recognized
 try:
   paths = [p for p in site.getsitepackages() if p.startswith(prefix)]
   if len(paths) == 1: install_dir = paths[0]
 except AttributeError: pass
+
 if not install_dir:
-    #find where to install the python module
-    install_dir = sysconfig.get_path('platlib')
-    prefix = sysconfig.get_config_var('prefix')
+    # find where to install the python module
+    # for Python 3.11+, we could use the 'venv' scheme for all platforms
+    if os.name == 'nt':
+        scheme = 'nt'
+    else:
+        scheme = 'posix_prefix'
+    install_dir = sysconfig.get_path('platlib', scheme)
+    prefix = sysconfig.get_path('data', scheme)
+
 #strip the prefix to return a relative path
 print(os.path.relpath(install_dir, prefix))"
     OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/cmake/Modules/VolkPython.cmake
+++ b/cmake/Modules/VolkPython.cmake
@@ -114,17 +114,23 @@ import sysconfig
 import site
 
 install_dir = None
+# The next line passes a CMake variable into our script.
 prefix = '${CMAKE_INSTALL_PREFIX}'
 
-#use `site` when the prefix is already recognized
+# We use `site` to identify if our chosen prefix is a default one.
+# https://docs.python.org/3/library/site.html
 try:
-  paths = [p for p in site.getsitepackages() if p.startswith(prefix)]
-  if len(paths) == 1: install_dir = paths[0]
+    # https://docs.python.org/3/library/site.html#site.getsitepackages
+    paths = [p for p in site.getsitepackages() if p.startswith(prefix)]
+    if len(paths) == 1: install_dir = paths[0]
 except AttributeError: pass
 
+# If we found a default install path, `install_dir` is set.
 if not install_dir:
-    # find where to install the python module
-    # for Python 3.11+, we could use the 'venv' scheme for all platforms
+    # We use a custom install prefix!
+    # Determine the correct install path in that prefix on the current platform.
+    # For Python 3.11+, we could use the 'venv' scheme for all platforms
+    # https://docs.python.org/3.11/library/sysconfig.html#installation-paths
     if os.name == 'nt':
         scheme = 'nt'
     else:


### PR DESCRIPTION
Apparently, the Python install path calculation is broken on some new systems, e.g. Fedora 36 and Ubuntu 22.04.

These are two approaches to fix it.
https://github.com/gnuradio/gnuradio/pull/5979
https://github.com/gnuradio/gnuradio/pull/5981

I went with the approach in https://github.com/gnuradio/gnuradio/pull/5981 because it fits better into how we handle things. e.g. the result is a relative path. We use this approach in other places as well.