### PR TITLE
spdx: Update cmake for with SPDX license identifier

### DIFF
--- a/cmake/Modules/CMakeParseArgumentsCopy.cmake
+++ b/cmake/Modules/CMakeParseArgumentsCopy.cmake
@@ -1,3 +1,10 @@
+# Copyright 2014, 2018 Free Software Foundation, Inc.
+#
+# This file is part of VOLK.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
 # CMAKE_PARSE_ARGUMENTS(<prefix> <options> <one_value_keywords> <multi_value_keywords> args...)
 #
 # CMAKE_PARSE_ARGUMENTS() is intended to be used in macros or functions for

--- a/cmake/Modules/FindFILESYSTEM.cmake
+++ b/cmake/Modules/FindFILESYSTEM.cmake
@@ -1,21 +1,9 @@
 # Copyright 2019 Free Software Foundation, Inc.
 #
-# This file is part of Volk
+# This file is part of VOLK.
 #
-# Volk is free software; you can redistribute it and/or modify it
-# under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 3, or (at your option)
-# any later version.
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
-# Volk is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
-# License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Volk; see the file COPYING.  If not, write to the Free
-# Software Foundation, Inc., 51 Franklin Street, Boston, MA
-# 02110-1301, USA.
 
 # Original code from https://github.com/vector-of-bool/CMakeCM and modified
 # by C. Fernandez. The original code is distributed under the OSI-approved

--- a/cmake/Modules/FindORC.cmake
+++ b/cmake/Modules/FindORC.cmake
@@ -1,3 +1,10 @@
+# Copyright 2014, 2019, 2020 Free Software Foundation, Inc.
+#
+# This file is part of VOLK.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
 FIND_PACKAGE(PkgConfig)
 PKG_CHECK_MODULES(PC_ORC "orc-0.4 > 0.4.11")
 

--- a/cmake/Modules/VolkAddTest.cmake
+++ b/cmake/Modules/VolkAddTest.cmake
@@ -1,21 +1,9 @@
 # Copyright 2015 Free Software Foundation, Inc.
 #
-# This file is part of Volk
+# This file is part of VOLK.
 #
-# Volk is free software; you can redistribute it and/or modify it
-# under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 3, or (at your option)
-# any later version.
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
-# Volk is distributed in the hope that it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
-# License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Volk; see the file COPYING.  If not, write to the Free
-# Software Foundation, Inc., 51 Franklin Street, Boston, MA
-# 02110-1301, USA.
 
 if(DEFINED __INCLUDED_VOLK_ADD_TEST)
     return()

--- a/cmake/Modules/VolkBuildTypes.cmake
+++ b/cmake/Modules/VolkBuildTypes.cmake
@@ -2,20 +2,8 @@
 #
 # This file is part of VOLK
 #
-# VOLK is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 3, or (at your option)
-# any later version.
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
-# VOLK is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with GNU Radio; see the file COPYING.  If not, write to
-# the Free Software Foundation, Inc., 51 Franklin Street,
-# Boston, MA 02110-1301, USA.
 
 if(DEFINED __INCLUDED_VOLK_BUILD_TYPES_CMAKE)
     return()

--- a/cmake/Modules/VolkConfig.cmake.in
+++ b/cmake/Modules/VolkConfig.cmake.in
@@ -1,3 +1,10 @@
+# Copyright 2016, 2018 - 2020 Free Software Foundation, Inc.
+#
+# This file is part of VOLK.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
 get_filename_component(VOLK_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 
 if(NOT TARGET Volk::volk)

--- a/cmake/Modules/VolkConfigVersion.cmake.in
+++ b/cmake/Modules/VolkConfigVersion.cmake.in
@@ -1,21 +1,9 @@
-# Copyright 2014 Free Software Foundation, Inc.
+# Copyright 2014, 2015, 2018, 2020 Free Software Foundation, Inc.
 #
 # This file is part of VOLK.
 #
-# VOLK is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 3, or (at your option)
-# any later version.
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
-# VOLK is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with VOLK; see the file COPYING.  If not, write to
-# the Free Software Foundation, Inc., 51 Franklin Street,
-# Boston, MA 02110-1301, USA.
 
 set(MAJOR_VERSION @VERSION_INFO_MAJOR_VERSION@)
 set(MINOR_VERSION @VERSION_INFO_MINOR_VERSION@)

--- a/cmake/Modules/VolkPython.cmake
+++ b/cmake/Modules/VolkPython.cmake
@@ -1,21 +1,9 @@
 # Copyright 2010-2011,2013 Free Software Foundation, Inc.
 #
-# This file is part of GNU Radio
+# This file is part of VOLK.
 #
-# GNU Radio is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 3, or (at your option)
-# any later version.
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
-# GNU Radio is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with GNU Radio; see the file COPYING.  If not, write to
-# the Free Software Foundation, Inc., 51 Franklin Street,
-# Boston, MA 02110-1301, USA.
 
 if(DEFINED __INCLUDED_VOLK_PYTHON_CMAKE)
     return()

--- a/cmake/Modules/VolkVersion.cmake
+++ b/cmake/Modules/VolkVersion.cmake
@@ -2,20 +2,8 @@
 #
 # This file is part of VOLK.
 #
-# VOLK is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 3, or (at your option)
-# any later version.
+# SPDX-License-Identifier: GPL-3.0-or-later
 #
-# VOLK is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with VOLK; see the file COPYING.  If not, write to
-# the Free Software Foundation, Inc., 51 Franklin Street,
-# Boston, MA 02110-1301, USA.
 
 if(DEFINED __INCLUDED_VOLK_VERSION_CMAKE)
     return()

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -1,3 +1,10 @@
+# Copyright 2014 Free Software Foundation, Inc.
+#
+# This file is part of VOLK.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
 # http://www.vtk.org/Wiki/CMake_FAQ#Can_I_do_.22make_uninstall.22_with_CMake.3F
 
 IF(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")


### PR DESCRIPTION
All appropriate files in the `cmake` folder hold an identifier now. The `msvc` and `Toolchains` folders are skipped.

This commit includes new license headers for some files because they were missing. Copyright data is derived from the git log in these cases.
