### PR TITLE
Fix armeabi-v7a on Android (volk_32fc_convert_16ic_neon)

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: 
-          - { name: armeabi-v7a, allow_fail: true }
+          - { name: armeabi-v7a, allow_fail: false }
           - { name: arm64-v8a, allow_fail: false }
           - { name: x86, allow_fail: false }
           - { name: x86_64, allow_fail: false }

--- a/kernels/volk/volk_32fc_convert_16ic.h
+++ b/kernels/volk/volk_32fc_convert_16ic.h
@@ -150,20 +150,11 @@ static inline void volk_32fc_convert_16ic_a_sse2(lv_16sc_t* outputVector,
 #if LV_HAVE_NEONV7
 #include <arm_neon.h>
 
-#define VCVTRQ_S32_F32(res, val)                \
-    __VOLK_ASM("VCVTR.S32.F32 %[r0], %[v0]\n\t" \
-               : [r0] "=w"(res[0])              \
-               : [v0] "w"(val[0])               \
-               :);                              \
-    __VOLK_ASM("VCVTR.S32.F32 %[r1], %[v1]\n\t" \
-               : [r1] "=w"(res[1])              \
-               : [v1] "w"(val[1])               \
-               :);                              \
-    __VOLK_ASM("VCVTR.S32.F32 %[r2], %[v2]\n\t" \
-               : [r2] "=w"(res[2])              \
-               : [v2] "w"(val[2])               \
-               :);                              \
-    __VOLK_ASM("VCVTR.S32.F32 %[r3], %[v3]\n\t" : [r3] "=w"(res[3]) : [v3] "w"(val[3]) :);
+#define VCVTRQ_S32_F32(result, value)                                       \
+    __VOLK_ASM("VCVTR.S32.F32 %0, %1" : "=t"(result[0]) : "t"(value[0]) :); \
+    __VOLK_ASM("VCVTR.S32.F32 %0, %1" : "=t"(result[1]) : "t"(value[1]) :); \
+    __VOLK_ASM("VCVTR.S32.F32 %0, %1" : "=t"(result[2]) : "t"(value[2]) :); \
+    __VOLK_ASM("VCVTR.S32.F32 %0, %1" : "=t"(result[3]) : "t"(value[3]) :);
 
 static inline void volk_32fc_convert_16ic_neon(lv_16sc_t* outputVector,
                                                const lv_32fc_t* inputVector,


### PR DESCRIPTION
See https://github.com/gnuradio/volk/issues/589.

I have tested this on both an armeabi-v7a Linux box and Android, tests passed and build suceeds. 