### PR TITLE
armv7: Re-activate non-x86 CI for ARMv7

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -131,7 +131,9 @@ jobs:
           run: |
             cd /volk
             cd build
-            cmake -DCMAKE_CXX_FLAGS="-Werror" ..
+            ${{ matrix.compiler.cc }} --version
+            ${{ matrix.compiler.cxx }} --version
+            cmake -DCMAKE_CXX_FLAGS="-Werror" -DCMAKE_C_COMPILER=${{ matrix.compiler.cc }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cxx }} ..
             make -j$(nproc)
             ./cpu_features/list_cpu_features
             ./apps/volk-config-info --alignment

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -79,12 +79,12 @@ jobs:
             distro: ubuntu20.04
             compiler: { name: clang-10, cc: clang-10, cxx: clang++-10 }
           # CMake fails to detect compiler on armv7 ...
-          # - arch: armv7
-          #   distro: ubuntu20.04
-          #   compiler: { name: g++-10, cc: gcc-10, cxx: g++-10 }
-          # - arch: armv7
-          #   distro: ubuntu20.04
-          #   compiler: { name: clang-10, cc: clang-10, cxx: clang++-10 }
+          - arch: armv7
+            distro: ubuntu20.04
+            compiler: { name: g++-10, cc: gcc-10, cxx: g++-10 }
+          - arch: armv7
+            distro: ubuntu20.04
+            compiler: { name: clang-10, cc: clang-10, cxx: clang++-10 }
           # - arch: ppc64le
           #   distro: ubuntu20.04
           # - arch: s390x
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@v3.0.0
         with:
           submodules: 'recursive'
-      - uses: uraimo/run-on-arch-action@v2.0.5
+      - uses: uraimo/run-on-arch-action@v2.2.0
         name: Build in non-x86 container
         id: build
         with:


### PR DESCRIPTION
Previously, this part of our CI wasn't run because it always failed. However, we've seen recent changes that may allow it to run again.
