### PR TITLE
ci: Fix MacOS GH Action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -223,10 +223,9 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3.0.0
+    - uses: actions/checkout@v3.0.2
       with:
         submodules: 'recursive'
-    - uses: actions/checkout@v1
     - name: dependencies
       run: pip3 install mako
     - name: configure


### PR DESCRIPTION
This test seems to cause an error because of a stray "checkout" action.