### PR TITLE
release: Update release script

### DIFF
--- a/scripts/tools/release.sh
+++ b/scripts/tools/release.sh
@@ -14,7 +14,7 @@ releaseprefix="v"
 #Remote to push to
 remote="origin"
 #Name of the Changelog file
-changelog="CHANGELOG.md"
+changelog="docs/CHANGELOG.md"
 #Name of the file where the last release tag is stored
 lastreleasefile=".lastrelease"
 


### PR DESCRIPTION
The changelog was moved to the `docs` folder. Consequently, the release script needs an update.