### PR TITLE
omit build path

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -454,6 +454,7 @@ message(STATUS "Loading version ${VERSION} into constants...")
 
 #double escape for windows backslash path separators
 string(REPLACE "\\" "\\\\" prefix "${prefix}")
+string(REPLACE "${CMAKE_SOURCE_DIR}" "$BUILD_DIR" COMPILER_INFO "${COMPILER_INFO}")
 
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/constants.c.in


### PR DESCRIPTION
Closes #597 

Have CMake filter out build path from COMPILER_INFO
before using the string in constants.c

Signed-off-by: A. Maitland Bottoms <bottoms@debian.org>