### PR TITLE
license: Fix SPDX identifiers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # This file is part of VOLK
 #
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-License-Identifier: LGPL-3.0-or-later
 #
 
 ########################################################################

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # This file is part of VOLK
 #
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-License-Identifier: LGPL-3.0-or-later
 #
 
 ########################################################################

--- a/cmake/Modules/VolkConfig.cmake.in
+++ b/cmake/Modules/VolkConfig.cmake.in
@@ -2,7 +2,7 @@
 #
 # This file is part of VOLK.
 #
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-License-Identifier: LGPL-3.0-or-later
 #
 
 get_filename_component(VOLK_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)

--- a/cmake/Modules/VolkConfigVersion.cmake.in
+++ b/cmake/Modules/VolkConfigVersion.cmake.in
@@ -2,7 +2,7 @@
 #
 # This file is part of VOLK.
 #
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-License-Identifier: LGPL-3.0-or-later
 #
 
 set(MAJOR_VERSION @VERSION_INFO_MAJOR_VERSION@)

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -2,7 +2,7 @@
 #
 # This file is part of VOLK.
 #
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-License-Identifier: LGPL-3.0-or-later
 #
 
 # http://www.vtk.org/Wiki/CMake_FAQ#Can_I_do_.22make_uninstall.22_with_CMake.3F

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -2,7 +2,7 @@
 #
 # Copyright 2022 Johannes Demel.
 #
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-License-Identifier: LGPL-3.0-or-later
 #
 
 find_package(Doxygen)

--- a/include/volk/volk_version.h.in
+++ b/include/volk/volk_version.h.in
@@ -4,7 +4,7 @@
  *
  * This file is part of VOLK
  *
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
 #ifndef INCLUDED_VOLK_VERSION_H

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # This file is part of VOLK.
 #
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-License-Identifier: LGPL-3.0-or-later
 #
 
 ########################################################################

--- a/lib/constants.c.in
+++ b/lib/constants.c.in
@@ -4,7 +4,7 @@
  *
  * This file is part of VOLK
  *
- * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
 #if HAVE_CONFIG_H

--- a/python/volk_modtool/CMakeLists.txt
+++ b/python/volk_modtool/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # This file is part of VOLK
 #
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-License-Identifier: LGPL-3.0-or-later
 #
 
 ########################################################################


### PR DESCRIPTION
Some files still carried GPL identifiers. These were identified and updated. Thus, all files should carry the LGPL identifier now.

Files with incorrect identifiers were found with:
`grep -irnI --exclude-dir={build,.git,cpu_features} GPL . | grep -v LGPL`

Fixes #613