### PR TITLE
Use cpu_features on RISC-V platforms

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -114,7 +114,7 @@ jobs:
           submodules: 'recursive'
       - uses: uraimo/run-on-arch-action@v2.5.0
         name: Build in non-x86 container
-        continue-on-error: ${{ contains(fromJson('["ppc64le", "s390x", "riscv64"]'), matrix.arch) || contains(fromJson('["clang-14"]'), matrix.compiler.name) }}
+        continue-on-error: ${{ contains(fromJson('["ppc64le", "s390x"]'), matrix.arch) || contains(fromJson('["clang-14"]'), matrix.compiler.name) }}
         id: build
         with:
           arch: ${{ matrix.arch }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ endif(MSVC)
 
 # cpu_features - sensible defaults, user settable option
 if(CMAKE_SYSTEM_PROCESSOR MATCHES
-    "(^mips)|(^arm)|(^aarch64)|(x86_64)|(AMD64|amd64)|(^i.86$)|(^powerpc)|(^ppc)")
+    "(^mips)|(^arm)|(^aarch64)|(x86_64)|(AMD64|amd64)|(^i.86$)|(^powerpc)|(^ppc)|(^riscv)")
   option(VOLK_CPU_FEATURES "Volk uses cpu_features" ON)
 else()
   option(VOLK_CPU_FEATURES "Volk uses cpu_features" OFF)

--- a/tmpl/volk_cpu.tmpl.c
+++ b/tmpl/volk_cpu.tmpl.c
@@ -25,6 +25,8 @@
 #include "cpuinfo_mips.h"
 #elif defined(CPU_FEATURES_ARCH_PPC)
 #include "cpuinfo_ppc.h"
+#elif defined(CPU_FEATURES_ARCH_RISCV)
+#include "cpuinfo_riscv.h"
 #endif
 
 // This is required for MSVC
@@ -46,6 +48,10 @@ static int i_can_has_${arch.name} (void) {
         %elif "mips" in arch.name:
 #if defined(CPU_FEATURES_ARCH_MIPS)
     if (GetMipsInfo().features.${check} == 0){ return 0; }
+#endif
+        %elif "riscv" in arch.name:
+#if defined(CPU_FEATURES_ARCH_RISCV)
+    if (GetRiscvInfo().features.${check} == 0){ return 0; }
 #endif
         %else:
 #if defined(CPU_FEATURES_ARCH_X86)


### PR DESCRIPTION
This patch updates VOLK to use cpu_features on RISC-V platforms.
You will need to update the submodule pointer cpu_features first, because RISC-V support has ony recently been added to cpu_features.