### PR TITLE
Add 32f_s32f_multiply_32f RISC-V manually optimized assembly

### DIFF
--- a/gen/archs.xml
+++ b/gen/archs.xml
@@ -1,4 +1,9 @@
-<!-- archs appear in order of significance for blind, de-facto version ordering -->
+<!--
+Archs appear in order of significance for blind, de-facto version ordering.
+
+In other words when available, an arch further down will be used. "generic" is
+at the top, as a last resort.
+-->
 <grammar>
 
 <arch name="generic"> <!-- name is required-->
@@ -171,6 +176,9 @@
     <flag compiler="clang">-mavx512cd</flag>
     <flag compiler="msvc">/arch:AVX512CD</flag>
     <alignment>64</alignment>
+</arch>
+
+<arch name="riscv64">
 </arch>
 
 </grammar>

--- a/gen/machines.xml
+++ b/gen/machines.xml
@@ -29,6 +29,10 @@
 <archs>generic 32|64| mmx| sse sse2 sse3 ssse3 orc|</archs>
 </machine>
 
+<machine name="sifive_u74">
+<archs>generic riscv64 orc|</archs>
+</machine>
+
 <machine name="sse4_a">
 <archs>generic 32|64| mmx| sse sse2 sse3 sse4_a popcount orc|</archs>
 </machine>

--- a/kernels/volk/asm/riscv/volk_32f_s32f_multiply_32f_sifive_u74.s
+++ b/kernels/volk/asm/riscv/volk_32f_s32f_multiply_32f_sifive_u74.s
@@ -1,0 +1,82 @@
+        .text
+        .align 2
+        .type volk_32f_s32f_multiply_32f_sifive_u74, @function
+        .global volk_32f_s32f_multiply_32f_sifive_u74
+
+volk_32f_s32f_multiply_32f_sifive_u74:
+        # Input:
+        # a0  out
+        # a1  in
+        # fa0 scalar
+        # a2  size
+
+        # Main loop in 8x unrolled.
+
+        # Split counter into main and final loop.
+        # a5  main loop counter
+        # a2  closing loop counter
+        srli    a5,a2,3
+        andi    a2,a2,7
+        slli    a5,a5,5
+        beqz    a5,.dolastloop
+        add     a5,a0,a5
+
+        .align 2
+.loop:
+        flw     fa1,0(a1)
+        addi    a0,a0,32      # increment output (free, running on pipeline A)
+
+        flw     fa2,4(a1)
+        flw     fa3,8(a1)
+        flw     fa4,12(a1)
+        flw     fa5,16(a1)
+        flw     fa6,20(a1)
+        flw     fa7,24(a1)
+        flw     ft8,28(a1)
+        addi    a1,a1,32      # increment input (free, running on pipeline A)
+
+        fmul.s  fa1,fa1,fa0
+        fmul.s  fa2,fa2,fa0
+        fmul.s  fa3,fa3,fa0
+        fmul.s  fa4,fa4,fa0
+        fmul.s  fa5,fa5,fa0
+        fmul.s  fa6,fa6,fa0
+        fmul.s  fa7,fa7,fa0
+        fmul.s  ft8,ft8,fa0
+
+        fsw     fa1,-32(a0)
+        fsw     fa2,-28(a0)
+        fsw     fa3,-24(a0)
+        fsw     fa4,-20(a0)
+        fsw     fa5,-16(a0)
+        fsw     fa6,-12(a0)
+        fsw     fa7,-8(a0)
+        fsw     ft8,-4(a0)
+
+        bne    a5,a0,.loop
+
+        .align 2
+.dolastloop:
+        # TODO: is branch assumed to be taken or not?
+        beqz    a2,.done
+
+        # Everything below is less optimized. In theory we could split
+        # this into more partial unrolled loops, but it's at most 7
+        # iterations, so not clear that it's worth it.
+
+        # make a2 a pointer to the last entry.
+        slli    a2,a2,2
+        add     a2,a0,a2   # Stall!
+
+        .align 2
+.lastloop:
+        flw     fa5,0(a1)     # Latency: 2
+        addi    a0,a0,4       # Increment out
+        fmul.s  fa5,fa5,fa0   # Stalled for a cycle or two. Latency: 5
+        addi    a1,a1,4       # Increment in
+        fsw     fa5,-4(a0)    # Stalled for a couple of cycles waiting for mul.
+        bne     a2,a0,.lastloop
+
+	.align 2
+.done:
+        ret

--- a/kernels/volk/volk_32f_s32f_multiply_32f.h
+++ b/kernels/volk/volk_32f_s32f_multiply_32f.h
@@ -128,8 +128,14 @@ static inline void volk_32f_s32f_multiply_32f_u_avx(float* cVector,
 }
 #endif /* LV_HAVE_AVX */
 
-#ifdef LV_HAVE_GENERIC
+#ifdef LV_HAVE_RISCV64
+extern void volk_32f_s32f_multiply_32f_sifive_u74(float* cVector,
+                                                  const float* aVector,
+                                                  const float scalar,
+                                                  unsigned int num_points);
+#endif /* LV_HAVE_RISCV64 */
 
+#ifdef LV_HAVE_GENERIC
 static inline void volk_32f_s32f_multiply_32f_generic(float* cVector,
                                                       const float* aVector,
                                                       const float scalar,

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -264,6 +264,19 @@ if(NOT CROSSCOMPILE_MULTILIB AND CPU_IS_x86)
 
 endif()
 
+if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^riscv64$")
+  message("---- Adding RISC-V ASM files")
+  message("DEBUG: looking for ASM files in ${CMAKE_SOURCE_DIR}/kernels/volk/asm/riscv")
+  include_directories(${CMAKE_SOURCE_DIR}/kernels/volk/asm/riscv)
+  file(GLOB asm_files ${CMAKE_SOURCE_DIR}/kernels/volk/asm/riscv/*.s)
+  foreach(asm_file ${asm_files})
+    list(APPEND volk_sources ${asm_file})
+    message(STATUS "Adding source file: ${asm_file}")
+  endforeach(asm_file)
+else()
+  OVERRULE_ARCH(riscv64 "machine is not riscv64")
+endif()
+
 ########################################################################
 # done overrules! print the result
 ########################################################################


### PR DESCRIPTION
I don't know volk wants hand optimized assembly when there's no SIMD or vector instructions used, but a <strike>35% gain is a 35% gain</strike>56% gain is a 56% gain, right?