### PR TITLE
Add .size to volk_32f_s32f_multiply_32f_sifive_u74

### DIFF
--- a/kernels/volk/asm/riscv/volk_32f_s32f_multiply_32f_sifive_u74.s
+++ b/kernels/volk/asm/riscv/volk_32f_s32f_multiply_32f_sifive_u74.s
@@ -80,3 +80,4 @@ volk_32f_s32f_multiply_32f_sifive_u74:
 	.align 2
 .done:
         ret
+	.size	volk_32f_s32f_multiply_32f_sifive_u74, .-volk_32f_s32f_multiply_32f_sifive_u74


### PR DESCRIPTION
Function size is needed for Linux uprobes, e.g. for bpftrace.