### PR TITLE
new kernels for atan2

### DIFF
--- a/include/volk/volk_avx2_intrinsics.h
+++ b/include/volk/volk_avx2_intrinsics.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2015 Free Software Foundation, Inc.
+ * Copyright 2023 Magnus Lundmark <magnuslundmark@gmail.com>
  *
  * This file is part of VOLK
  *
@@ -16,6 +17,20 @@
 #define INCLUDE_VOLK_VOLK_AVX2_INTRINSICS_H_
 #include "volk/volk_avx_intrinsics.h"
 #include <immintrin.h>
+
+static inline __m256 _mm256_real(const __m256 z1, const __m256 z2)
+{
+    const __m256i permute_mask = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
+    __m256 r = _mm256_shuffle_ps(z1, z2, _MM_SHUFFLE(2, 0, 2, 0));
+    return _mm256_permutevar8x32_ps(r, permute_mask);
+}
+
+static inline __m256 _mm256_imag(const __m256 z1, const __m256 z2)
+{
+    const __m256i permute_mask = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
+    __m256 i = _mm256_shuffle_ps(z1, z2, _MM_SHUFFLE(3, 1, 3, 1));
+    return _mm256_permutevar8x32_ps(i, permute_mask);
+}
 
 static inline __m256 _mm256_polar_sign_mask_avx2(__m128i fbits)
 {

--- a/include/volk/volk_common.h
+++ b/include/volk/volk_common.h
@@ -225,13 +225,14 @@ static inline float volk_atan2(const float y, const float x)
      * atan2(y, x) =  |  arctan(y / x)  - PI   if x < 0 and y <  0
      *                |  sign(y) * PI / 2      if x = 0
      *                \  undefined             if x = 0 and y = 0
-     * atan2f(0.f, 0.f) shall return 0.f
+     * atan2f(0.f,  0.f) shall return  0.f
+     * atan2f(0.f, -0.f) shall return -0.f
      */
     const float pi = 0x1.921fb6p1f;
     const float pi_2 = 0x1.921fb6p0f;
 
-    if (x == 0.f) {
-        return (y == 0.f) ? copysignf(0.f, y) : copysignf(pi_2, y);
+    if (fabs(x) == 0.f) {
+        return (fabs(y) == 0.f) ? copysignf(0.f, y) : copysignf(pi_2, y);
     }
     const int swap = fabs(x) < fabs(y);
     const float input = swap ? (x / y) : (y / x);

--- a/include/volk/volk_common.h
+++ b/include/volk/volk_common.h
@@ -206,12 +206,12 @@ static inline float volk_arctan(const float x)
     /*
      *  arctan(x) + arctan(1 / x) == sign(x) * pi / 2
      */
-    const float pi_over_2 = 0x1.921fb6p0f;
+    const float pi_2 = 0x1.921fb6p0f;
 
     if (fabs(x) < 1.f) {
         return volk_arctan_poly(x);
     } else {
-        return copysignf(pi_over_2, x) - volk_arctan_poly(1.f / x);
+        return copysignf(pi_2, x) - volk_arctan_poly(1.f / x);
     }
 }
 ////////////////////////////////////////////////////////////////////////

--- a/kernels/volk/volk_32fc_s32f_atan2_32f.h
+++ b/kernels/volk/volk_32fc_s32f_atan2_32f.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2012, 2014 Free Software Foundation, Inc.
+ * Copyright 2023 Magnus Lundmark <magnuslundmark@gmail.com>
  *
  * This file is part of VOLK
  *
@@ -57,136 +58,12 @@
  * \endcode
  */
 
-
 #ifndef INCLUDED_volk_32fc_s32f_atan2_32f_a_H
 #define INCLUDED_volk_32fc_s32f_atan2_32f_a_H
 
-#include <inttypes.h>
 #include <math.h>
-#include <stdio.h>
-
-#ifdef LV_HAVE_SSE4_1
-#include <smmintrin.h>
-
-#ifdef LV_HAVE_LIB_SIMDMATH
-#include <simdmath.h>
-#endif /* LV_HAVE_LIB_SIMDMATH */
-
-static inline void volk_32fc_s32f_atan2_32f_a_sse4_1(float* outputVector,
-                                                     const lv_32fc_t* complexVector,
-                                                     const float normalizeFactor,
-                                                     unsigned int num_points)
-{
-    const float* complexVectorPtr = (float*)complexVector;
-    float* outPtr = outputVector;
-
-    unsigned int number = 0;
-    const float invNormalizeFactor = 1.0 / normalizeFactor;
-
-#ifdef LV_HAVE_LIB_SIMDMATH
-    const unsigned int quarterPoints = num_points / 4;
-    __m128 testVector = _mm_set_ps1(2 * M_PI);
-    __m128 correctVector = _mm_set_ps1(M_PI);
-    __m128 vNormalizeFactor = _mm_set_ps1(invNormalizeFactor);
-    __m128 phase;
-    __m128 complex1, complex2, iValue, qValue;
-    __m128 keepMask;
-
-    for (; number < quarterPoints; number++) {
-        // Load IQ data:
-        complex1 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-        complex2 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-        // Deinterleave IQ data:
-        iValue = _mm_shuffle_ps(complex1, complex2, _MM_SHUFFLE(2, 0, 2, 0));
-        qValue = _mm_shuffle_ps(complex1, complex2, _MM_SHUFFLE(3, 1, 3, 1));
-        // Arctan to get phase:
-        phase = atan2f4(qValue, iValue);
-        // When Q = 0 and I < 0, atan2f4 sucks and returns 2pi vice pi.
-        // Compare to 2pi:
-        keepMask = _mm_cmpneq_ps(phase, testVector);
-        phase = _mm_blendv_ps(correctVector, phase, keepMask);
-        // done with above correction.
-        phase = _mm_mul_ps(phase, vNormalizeFactor);
-        _mm_store_ps((float*)outPtr, phase);
-        outPtr += 4;
-    }
-    number = quarterPoints * 4;
-#endif /* LV_HAVE_LIB_SIMDMATH */
-
-    for (; number < num_points; number++) {
-        const float real = *complexVectorPtr++;
-        const float imag = *complexVectorPtr++;
-        *outPtr++ = atan2f(imag, real) * invNormalizeFactor;
-    }
-}
-#endif /* LV_HAVE_SSE4_1 */
-
-
-#ifdef LV_HAVE_SSE
-#include <xmmintrin.h>
-
-#ifdef LV_HAVE_LIB_SIMDMATH
-#include <simdmath.h>
-#endif /* LV_HAVE_LIB_SIMDMATH */
-
-static inline void volk_32fc_s32f_atan2_32f_a_sse(float* outputVector,
-                                                  const lv_32fc_t* complexVector,
-                                                  const float normalizeFactor,
-                                                  unsigned int num_points)
-{
-    const float* complexVectorPtr = (float*)complexVector;
-    float* outPtr = outputVector;
-
-    unsigned int number = 0;
-    const float invNormalizeFactor = 1.0 / normalizeFactor;
-
-#ifdef LV_HAVE_LIB_SIMDMATH
-    const unsigned int quarterPoints = num_points / 4;
-    __m128 testVector = _mm_set_ps1(2 * M_PI);
-    __m128 correctVector = _mm_set_ps1(M_PI);
-    __m128 vNormalizeFactor = _mm_set_ps1(invNormalizeFactor);
-    __m128 phase;
-    __m128 complex1, complex2, iValue, qValue;
-    __m128 mask;
-    __m128 keepMask;
-
-    for (; number < quarterPoints; number++) {
-        // Load IQ data:
-        complex1 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-        complex2 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-        // Deinterleave IQ data:
-        iValue = _mm_shuffle_ps(complex1, complex2, _MM_SHUFFLE(2, 0, 2, 0));
-        qValue = _mm_shuffle_ps(complex1, complex2, _MM_SHUFFLE(3, 1, 3, 1));
-        // Arctan to get phase:
-        phase = atan2f4(qValue, iValue);
-        // When Q = 0 and I < 0, atan2f4 sucks and returns 2pi vice pi.
-        // Compare to 2pi:
-        keepMask = _mm_cmpneq_ps(phase, testVector);
-        phase = _mm_and_ps(phase, keepMask);
-        mask = _mm_andnot_ps(keepMask, correctVector);
-        phase = _mm_or_ps(phase, mask);
-        // done with above correction.
-        phase = _mm_mul_ps(phase, vNormalizeFactor);
-        _mm_store_ps((float*)outPtr, phase);
-        outPtr += 4;
-    }
-    number = quarterPoints * 4;
-#endif /* LV_HAVE_LIB_SIMDMATH */
-
-    for (; number < num_points; number++) {
-        const float real = *complexVectorPtr++;
-        const float imag = *complexVectorPtr++;
-        *outPtr++ = atan2f(imag, real) * invNormalizeFactor;
-    }
-}
-#endif /* LV_HAVE_SSE */
 
 #ifdef LV_HAVE_GENERIC
-
 static inline void volk_32fc_s32f_atan2_32f_generic(float* outputVector,
                                                     const lv_32fc_t* inputVector,
                                                     const float normalizeFactor,
@@ -194,9 +71,9 @@ static inline void volk_32fc_s32f_atan2_32f_generic(float* outputVector,
 {
     float* outPtr = outputVector;
     const float* inPtr = (float*)inputVector;
-    const float invNormalizeFactor = 1.0 / normalizeFactor;
-    unsigned int number;
-    for (number = 0; number < num_points; number++) {
+    const float invNormalizeFactor = 1.f / normalizeFactor;
+    unsigned int number = 0;
+    for (; number < num_points; number++) {
         const float real = *inPtr++;
         const float imag = *inPtr++;
         *outPtr++ = atan2f(imag, real) * invNormalizeFactor;
@@ -204,5 +81,255 @@ static inline void volk_32fc_s32f_atan2_32f_generic(float* outputVector,
 }
 #endif /* LV_HAVE_GENERIC */
 
+#ifdef LV_HAVE_GENERIC
+#include <volk/volk_common.h>
+static inline void volk_32fc_s32f_atan2_32f_polynomial(float* outputVector,
+                                                       const lv_32fc_t* inputVector,
+                                                       const float normalizeFactor,
+                                                       unsigned int num_points)
+{
+    float* outPtr = outputVector;
+    const float* inPtr = (float*)inputVector;
+    const float invNormalizeFactor = 1.f / normalizeFactor;
+    unsigned int number = 0;
+    for (; number < num_points; number++) {
+        const float x = *inPtr++;
+        const float y = *inPtr++;
+        *outPtr++ = volk_atan2(y, x) * invNormalizeFactor;
+    }
+}
+#endif /* LV_HAVE_GENERIC */
 
+#if LV_HAVE_AVX2 && LV_HAVE_FMA
+#include <immintrin.h>
+#include <volk/volk_avx2_fma_intrinsics.h>
+static inline void volk_32fc_s32f_atan2_32f_a_avx2_fma(float* outputVector,
+                                                       const lv_32fc_t* complexVector,
+                                                       const float normalizeFactor,
+                                                       unsigned int num_points)
+{
+    const float* in = (float*)complexVector;
+    float* out = (float*)outputVector;
+
+    const float invNormalizeFactor = 1.f / normalizeFactor;
+    const __m256 vinvNormalizeFactor = _mm256_set1_ps(invNormalizeFactor);
+    const __m256 pi = _mm256_set1_ps(0x1.921fb6p1f);
+    const __m256 pi_2 = _mm256_set1_ps(0x1.921fb6p0f);
+    const __m256 abs_mask = _mm256_castsi256_ps(_mm256_set1_epi32(0x7FFFFFFF));
+    const __m256 sign_mask = _mm256_castsi256_ps(_mm256_set1_epi32(0x80000000));
+
+    unsigned int number = 0;
+    unsigned int eighth_points = num_points / 8;
+    for (; number < eighth_points; number++) {
+        __m256 z1 = _mm256_load_ps(in);
+        in += 8;
+        __m256 z2 = _mm256_load_ps(in);
+        in += 8;
+
+        __m256 x = _mm256_real(z1, z2);
+        __m256 y = _mm256_imag(z1, z2);
+
+        __m256 swap_mask = _mm256_cmp_ps(
+            _mm256_and_ps(y, abs_mask), _mm256_and_ps(x, abs_mask), _CMP_GT_OS);
+        __m256 input = _mm256_div_ps(_mm256_blendv_ps(y, x, swap_mask),
+                                     _mm256_blendv_ps(x, y, swap_mask));
+        __m256 result = _m256_arctan_poly_avx2_fma(input);
+
+        input =
+            _mm256_sub_ps(_mm256_or_ps(pi_2, _mm256_and_ps(input, sign_mask)), result);
+        result = _mm256_blendv_ps(result, input, swap_mask);
+
+        __m256 x_sign_mask =
+            _mm256_castsi256_ps(_mm256_srai_epi32(_mm256_castps_si256(x), 31));
+
+        result = _mm256_add_ps(
+            _mm256_and_ps(_mm256_xor_ps(pi, _mm256_and_ps(sign_mask, y)), x_sign_mask),
+            result);
+        result = _mm256_mul_ps(result, vinvNormalizeFactor);
+
+        _mm256_store_ps(out, result);
+        out += 8;
+    }
+
+    number = eighth_points * 8;
+    volk_32fc_s32f_atan2_32f_polynomial(
+        out, (lv_32fc_t*)in, normalizeFactor, num_points - number);
+}
+#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA for aligned */
+
+#if LV_HAVE_AVX2
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+static inline void volk_32fc_s32f_atan2_32f_a_avx2(float* outputVector,
+                                                   const lv_32fc_t* complexVector,
+                                                   const float normalizeFactor,
+                                                   unsigned int num_points)
+{
+    const float* in = (float*)complexVector;
+    float* out = (float*)outputVector;
+
+    const float invNormalizeFactor = 1.f / normalizeFactor;
+    const __m256 vinvNormalizeFactor = _mm256_set1_ps(invNormalizeFactor);
+    const __m256 pi = _mm256_set1_ps(0x1.921fb6p1f);
+    const __m256 pi_2 = _mm256_set1_ps(0x1.921fb6p0f);
+    const __m256 abs_mask = _mm256_castsi256_ps(_mm256_set1_epi32(0x7FFFFFFF));
+    const __m256 sign_mask = _mm256_castsi256_ps(_mm256_set1_epi32(0x80000000));
+
+    unsigned int number = 0;
+    unsigned int eighth_points = num_points / 8;
+    for (; number < eighth_points; number++) {
+        __m256 z1 = _mm256_load_ps(in);
+        in += 8;
+        __m256 z2 = _mm256_load_ps(in);
+        in += 8;
+
+        __m256 x = _mm256_real(z1, z2);
+        __m256 y = _mm256_imag(z1, z2);
+
+        __m256 swap_mask = _mm256_cmp_ps(
+            _mm256_and_ps(y, abs_mask), _mm256_and_ps(x, abs_mask), _CMP_GT_OS);
+        __m256 input = _mm256_div_ps(_mm256_blendv_ps(y, x, swap_mask),
+                                     _mm256_blendv_ps(x, y, swap_mask));
+        __m256 result = _m256_arctan_poly_avx(input);
+
+        input =
+            _mm256_sub_ps(_mm256_or_ps(pi_2, _mm256_and_ps(input, sign_mask)), result);
+        result = _mm256_blendv_ps(result, input, swap_mask);
+
+        __m256 x_sign_mask =
+            _mm256_castsi256_ps(_mm256_srai_epi32(_mm256_castps_si256(x), 31));
+
+        result = _mm256_add_ps(
+            _mm256_and_ps(_mm256_xor_ps(pi, _mm256_and_ps(sign_mask, y)), x_sign_mask),
+            result);
+        result = _mm256_mul_ps(result, vinvNormalizeFactor);
+
+        _mm256_store_ps(out, result);
+        out += 8;
+    }
+
+    number = eighth_points * 8;
+    volk_32fc_s32f_atan2_32f_polynomial(
+        out, (lv_32fc_t*)in, normalizeFactor, num_points - number);
+}
+#endif /* LV_HAVE_AVX2 for aligned */
 #endif /* INCLUDED_volk_32fc_s32f_atan2_32f_a_H */
+
+#ifndef INCLUDED_volk_32fc_s32f_atan2_32f_u_H
+#define INCLUDED_volk_32fc_s32f_atan2_32f_u_H
+
+#if LV_HAVE_AVX2 && LV_HAVE_FMA
+#include <immintrin.h>
+#include <volk/volk_avx2_fma_intrinsics.h>
+static inline void volk_32fc_s32f_atan2_32f_u_avx2_fma(float* outputVector,
+                                                       const lv_32fc_t* complexVector,
+                                                       const float normalizeFactor,
+                                                       unsigned int num_points)
+{
+    const float* in = (float*)complexVector;
+    float* out = (float*)outputVector;
+
+    const float invNormalizeFactor = 1.f / normalizeFactor;
+    const __m256 vinvNormalizeFactor = _mm256_set1_ps(invNormalizeFactor);
+    const __m256 pi = _mm256_set1_ps(0x1.921fb6p1f);
+    const __m256 pi_2 = _mm256_set1_ps(0x1.921fb6p0f);
+    const __m256 abs_mask = _mm256_castsi256_ps(_mm256_set1_epi32(0x7FFFFFFF));
+    const __m256 sign_mask = _mm256_castsi256_ps(_mm256_set1_epi32(0x80000000));
+
+    unsigned int number = 0;
+    unsigned int eighth_points = num_points / 8;
+    for (; number < eighth_points; number++) {
+        __m256 z1 = _mm256_loadu_ps(in);
+        in += 8;
+        __m256 z2 = _mm256_loadu_ps(in);
+        in += 8;
+
+        __m256 x = _mm256_real(z1, z2);
+        __m256 y = _mm256_imag(z1, z2);
+
+        __m256 swap_mask = _mm256_cmp_ps(
+            _mm256_and_ps(y, abs_mask), _mm256_and_ps(x, abs_mask), _CMP_GT_OS);
+        __m256 input = _mm256_div_ps(_mm256_blendv_ps(y, x, swap_mask),
+                                     _mm256_blendv_ps(x, y, swap_mask));
+        __m256 result = _m256_arctan_poly_avx2_fma(input);
+
+        input =
+            _mm256_sub_ps(_mm256_or_ps(pi_2, _mm256_and_ps(input, sign_mask)), result);
+        result = _mm256_blendv_ps(result, input, swap_mask);
+
+        __m256 x_sign_mask =
+            _mm256_castsi256_ps(_mm256_srai_epi32(_mm256_castps_si256(x), 31));
+
+        result = _mm256_add_ps(
+            _mm256_and_ps(_mm256_xor_ps(pi, _mm256_and_ps(sign_mask, y)), x_sign_mask),
+            result);
+        result = _mm256_mul_ps(result, vinvNormalizeFactor);
+
+        _mm256_storeu_ps(out, result);
+        out += 8;
+    }
+
+    number = eighth_points * 8;
+    volk_32fc_s32f_atan2_32f_polynomial(
+        out, (lv_32fc_t*)in, normalizeFactor, num_points - number);
+}
+#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA for unaligned */
+
+#if LV_HAVE_AVX2
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+static inline void volk_32fc_s32f_atan2_32f_u_avx2(float* outputVector,
+                                                   const lv_32fc_t* complexVector,
+                                                   const float normalizeFactor,
+                                                   unsigned int num_points)
+{
+    const float* in = (float*)complexVector;
+    float* out = (float*)outputVector;
+
+    const float invNormalizeFactor = 1.f / normalizeFactor;
+    const __m256 vinvNormalizeFactor = _mm256_set1_ps(invNormalizeFactor);
+    const __m256 pi = _mm256_set1_ps(0x1.921fb6p1f);
+    const __m256 pi_2 = _mm256_set1_ps(0x1.921fb6p0f);
+    const __m256 abs_mask = _mm256_castsi256_ps(_mm256_set1_epi32(0x7FFFFFFF));
+    const __m256 sign_mask = _mm256_castsi256_ps(_mm256_set1_epi32(0x80000000));
+
+    unsigned int number = 0;
+    unsigned int eighth_points = num_points / 8;
+    for (; number < eighth_points; number++) {
+        __m256 z1 = _mm256_loadu_ps(in);
+        in += 8;
+        __m256 z2 = _mm256_loadu_ps(in);
+        in += 8;
+
+        __m256 x = _mm256_real(z1, z2);
+        __m256 y = _mm256_imag(z1, z2);
+
+        __m256 swap_mask = _mm256_cmp_ps(
+            _mm256_and_ps(y, abs_mask), _mm256_and_ps(x, abs_mask), _CMP_GT_OS);
+        __m256 input = _mm256_div_ps(_mm256_blendv_ps(y, x, swap_mask),
+                                     _mm256_blendv_ps(x, y, swap_mask));
+        __m256 result = _m256_arctan_poly_avx(input);
+
+        input =
+            _mm256_sub_ps(_mm256_or_ps(pi_2, _mm256_and_ps(input, sign_mask)), result);
+        result = _mm256_blendv_ps(result, input, swap_mask);
+
+        __m256 x_sign_mask =
+            _mm256_castsi256_ps(_mm256_srai_epi32(_mm256_castps_si256(x), 31));
+
+        result = _mm256_add_ps(
+            _mm256_and_ps(_mm256_xor_ps(pi, _mm256_and_ps(sign_mask, y)), x_sign_mask),
+            result);
+        result = _mm256_mul_ps(result, vinvNormalizeFactor);
+
+        _mm256_storeu_ps(out, result);
+        out += 8;
+    }
+
+    number = eighth_points * 8;
+    volk_32fc_s32f_atan2_32f_polynomial(
+        out, (lv_32fc_t*)in, normalizeFactor, num_points - number);
+}
+#endif /* LV_HAVE_AVX2 for unaligned */
+
+#endif /* INCLUDED_volk_32fc_s32f_atan2_32f_u_H */


### PR DESCRIPTION
New kernels for atan2 based on the recently merged arctan work. Almost 40x speedup.

With this PR:
```
$ volk_profile -R atan2

RUN_VOLK_TESTS: volk_32fc_s32f_atan2_32f(131071,1987)
generic completed in 5091.65 ms
polynomial completed in 2138.51 ms
a_avx2_fma completed in 131.781 ms
a_avx2 completed in 131.696 ms
u_avx2_fma completed in 131.963 ms
u_avx2 completed in 132.086 ms
Best aligned arch: a_avx2
Best unaligned arch: u_avx2_fma
```

Without:
```
$ volk_profile -R atan2

RUN_VOLK_TESTS: volk_32fc_s32f_atan2_32f(131071,1987)
a_sse4_1 completed in 5159.66 ms
a_sse completed in 5168.12 ms
generic completed in 5201.91 ms
Best aligned arch: a_sse4_1
Best unaligned arch: generic
```