### PR TITLE
Disable ORC kernels that are broken on ARM

### DIFF
--- a/kernels/volk/volk_32f_sqrt_32f.h
+++ b/kernels/volk/volk_32f_sqrt_32f.h
@@ -168,6 +168,7 @@ volk_32f_sqrt_32f_generic(float* cVector, const float* aVector, unsigned int num
 
 
 #ifdef LV_HAVE_ORC
+#ifndef LV_HAVE_NEON /* ORC sqrtf instruction is broken */
 
 extern void volk_32f_sqrt_32f_a_orc_impl(float*, const float*, unsigned int);
 
@@ -177,6 +178,7 @@ volk_32f_sqrt_32f_u_orc(float* cVector, const float* aVector, unsigned int num_p
     volk_32f_sqrt_32f_a_orc_impl(cVector, aVector, num_points);
 }
 
+#endif /* LV_HAVE_NEON */
 #endif /* LV_HAVE_ORC */
 
 #endif /* INCLUDED_volk_32f_sqrt_32f_a_H */

--- a/kernels/volk/volk_32fc_magnitude_32f.h
+++ b/kernels/volk/volk_32fc_magnitude_32f.h
@@ -440,6 +440,7 @@ static inline void volk_32fc_magnitude_32f_neon_fancy_sweet(
 
 
 #ifdef LV_HAVE_ORC
+#ifndef LV_HAVE_NEON /* ORC sqrtf instruction is broken */
 
 extern void volk_32fc_magnitude_32f_a_orc_impl(float* magnitudeVector,
                                                const lv_32fc_t* complexVector,
@@ -451,6 +452,7 @@ static inline void volk_32fc_magnitude_32f_u_orc(float* magnitudeVector,
 {
     volk_32fc_magnitude_32f_a_orc_impl(magnitudeVector, complexVector, num_points);
 }
+#endif /* LV_HAVE_NEON */
 #endif /* LV_HAVE_ORC */
 
 


### PR DESCRIPTION
Fixes #622.

Both `volk_32f_sqrt_32f_a_orc_impl` and `volk_32fc_magnitude_32f_a_orc_impl` use the ORC `sqrtf` instruction, which is broken on ARM (`sqrt(0) = NaN`):

https://gitlab.freedesktop.org/gstreamer/orc/-/blob/72b4699314e0a6eeeb29cea33d0410612c80f533/orc-test/orctest.c#L587-591

Here I've disabled the broken kernels on ARM.