### PR TITLE
Prefer NEON kernels over ORC

### DIFF
--- a/gen/archs.xml
+++ b/gen/archs.xml
@@ -19,29 +19,6 @@ at the top, as a last resort.
   <flag compiler="clang">-mfloat-abi=hard</flag>
 </arch>
 
-<arch name="neon">
-  <flag compiler="gnu">-funsafe-math-optimizations</flag>
-  <flag compiler="clang">-funsafe-math-optimizations</flag>
-  <alignment>16</alignment>
-  <check name="neon"></check>
-</arch>
-
-<arch name="neonv7">
-  <flag compiler="gnu">-mfpu=neon</flag>
-  <flag compiler="gnu">-funsafe-math-optimizations</flag>
-  <flag compiler="clang">-mfpu=neon</flag>
-  <flag compiler="clang">-funsafe-math-optimizations</flag>
-  <alignment>16</alignment>
-  <check name="neon"></check>
-</arch>
-
-<arch name="neonv8">
-  <flag compiler="gnu">-funsafe-math-optimizations</flag>
-  <flag compiler="clang">-funsafe-math-optimizations</flag>
-  <alignment>16</alignment>
-  <check name="neon"></check>
-</arch>
-
 <arch name="32">
   <flag compiler="gnu">-m32</flag>
   <flag compiler="clang">-m32</flag>
@@ -103,6 +80,29 @@ at the top, as a last resort.
 
 <!-- it's here for overrule stuff. -->
 <arch name="norc">
+</arch>
+
+<arch name="neon">
+  <flag compiler="gnu">-funsafe-math-optimizations</flag>
+  <flag compiler="clang">-funsafe-math-optimizations</flag>
+  <alignment>16</alignment>
+  <check name="neon"></check>
+</arch>
+
+<arch name="neonv7">
+  <flag compiler="gnu">-mfpu=neon</flag>
+  <flag compiler="gnu">-funsafe-math-optimizations</flag>
+  <flag compiler="clang">-mfpu=neon</flag>
+  <flag compiler="clang">-funsafe-math-optimizations</flag>
+  <alignment>16</alignment>
+  <check name="neon"></check>
+</arch>
+
+<arch name="neonv8">
+  <flag compiler="gnu">-funsafe-math-optimizations</flag>
+  <flag compiler="clang">-funsafe-math-optimizations</flag>
+  <alignment>16</alignment>
+  <check name="neon"></check>
 </arch>
 
 <arch name="sse3">


### PR DESCRIPTION
Currently ORC appears below NEON in `archs.xml`, which means that ORC kernels will be preferred if `volk_profile` has not been executed to profile the kernels. As noted in https://github.com/gnuradio/volk/pull/639#issuecomment-1759754136, in most cases NEON kernels outperform ORC kernels (sometimes by a significant margin), so I think it makes sense to move NEON below ORC. This will also have the side benefit of mostly resolving #622, because the ORC kernels that are broken on ARM (`volk_32f_sqrt_32f_a_orc_impl` and `volk_32fc_magnitude_32f_a_orc_impl`) will no longer be selected by default, and are unlikely to be selected by `volk_profile` as they are significantly slower than their NEON counterparts.