### PR TITLE
Fix include guards

### DIFF
--- a/kernels/volk/volk_32f_s32f_add_32f.h
+++ b/kernels/volk/volk_32f_s32f_add_32f.h
@@ -55,6 +55,9 @@
 #include <inttypes.h>
 #include <stdio.h>
 
+#ifndef INCLUDED_volk_32f_s32f_add_32f_u_H
+#define INCLUDED_volk_32f_s32f_add_32f_u_H
+
 #ifdef LV_HAVE_GENERIC
 
 static inline void volk_32f_s32f_add_32f_generic(float* cVector,
@@ -73,9 +76,6 @@ static inline void volk_32f_s32f_add_32f_generic(float* cVector,
 }
 
 #endif /* LV_HAVE_GENERIC */
-#ifndef INCLUDED_volk_32f_s32f_add_32f_u_H
-#define INCLUDED_volk_32f_s32f_add_32f_u_H
-
 #ifdef LV_HAVE_SSE
 #include <xmmintrin.h>
 

--- a/kernels/volk/volk_32fc_s32f_magnitude_16i.h
+++ b/kernels/volk/volk_32fc_s32f_magnitude_16i.h
@@ -57,8 +57,15 @@
  * \endcode
  */
 
-#ifdef LV_HAVE_GENERIC
+#ifndef INCLUDED_volk_32fc_s32f_magnitude_16i_a_H
+#define INCLUDED_volk_32fc_s32f_magnitude_16i_a_H
+
+#include <inttypes.h>
+#include <math.h>
+#include <stdio.h>
 #include <volk/volk_common.h>
+
+#ifdef LV_HAVE_GENERIC
 
 static inline void volk_32fc_s32f_magnitude_16i_generic(int16_t* magnitudeVector,
                                                         const lv_32fc_t* complexVector,
@@ -77,14 +84,6 @@ static inline void volk_32fc_s32f_magnitude_16i_generic(int16_t* magnitudeVector
     }
 }
 #endif /* LV_HAVE_GENERIC */
-
-#ifndef INCLUDED_volk_32fc_s32f_magnitude_16i_a_H
-#define INCLUDED_volk_32fc_s32f_magnitude_16i_a_H
-
-#include <inttypes.h>
-#include <math.h>
-#include <stdio.h>
-#include <volk/volk_common.h>
 
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>


### PR DESCRIPTION
The `volk_32f_s32f_add_32f_generic` and `volk_32fc_s32f_magnitude_16i_generic` kernels are defined outside their header files' include guards, which prevents `volk_kernel_defs.py` from finding them.

After moving these kernels inside the include guards, they become accessible.