### PR TITLE
Add length checks to volk_8u_x2_encodeframepolar_8u

### DIFF
--- a/kernels/volk/volk_32f_8u_polarbutterfly_32f.h
+++ b/kernels/volk/volk_32f_8u_polarbutterfly_32f.h
@@ -232,11 +232,7 @@ static inline void volk_32f_8u_polarbutterfly_32f_u_avx(float* llrs,
         unsigned char* u_temp = u + 2 * frame_size;
         memcpy(u_temp, u + u_num - stage_size, sizeof(unsigned char) * stage_size);
 
-        if (stage_size > 15) {
-            volk_8u_x2_encodeframepolar_8u_u_ssse3(u_target, u_temp, stage_size);
-        } else {
-            volk_8u_x2_encodeframepolar_8u_generic(u_target, u_temp, stage_size);
-        }
+        volk_8u_x2_encodeframepolar_8u_u_ssse3(u_target, u_temp, stage_size);
 
         src_llr_ptr = llrs + (max_stage_depth + 1) * frame_size + row - stage_size;
         dst_llr_ptr = llrs + max_stage_depth * frame_size + row;
@@ -331,11 +327,7 @@ static inline void volk_32f_8u_polarbutterfly_32f_u_avx2(float* llrs,
         unsigned char* u_temp = u + 2 * frame_size;
         memcpy(u_temp, u + u_num - stage_size, sizeof(unsigned char) * stage_size);
 
-        if (stage_size > 15) {
-            volk_8u_x2_encodeframepolar_8u_u_ssse3(u_target, u_temp, stage_size);
-        } else {
-            volk_8u_x2_encodeframepolar_8u_generic(u_target, u_temp, stage_size);
-        }
+        volk_8u_x2_encodeframepolar_8u_u_avx2(u_target, u_temp, stage_size);
 
         src_llr_ptr = llrs + (max_stage_depth + 1) * frame_size + row - stage_size;
         dst_llr_ptr = llrs + max_stage_depth * frame_size + row;

--- a/kernels/volk/volk_8u_x2_encodeframepolar_8u.h
+++ b/kernels/volk/volk_8u_x2_encodeframepolar_8u.h
@@ -77,6 +77,11 @@ static inline void volk_8u_x2_encodeframepolar_8u_u_ssse3(unsigned char* frame,
                                                           unsigned char* temp,
                                                           unsigned int frame_size)
 {
+    if (frame_size < 16) {
+        volk_8u_x2_encodeframepolar_8u_generic(frame, temp, frame_size);
+        return;
+    }
+
     const unsigned int po2 = log2_of_power_of_2(frame_size);
 
     unsigned int stage = po2;
@@ -256,6 +261,11 @@ static inline void volk_8u_x2_encodeframepolar_8u_u_avx2(unsigned char* frame,
                                                          unsigned char* temp,
                                                          unsigned int frame_size)
 {
+    if (frame_size < 32) {
+        volk_8u_x2_encodeframepolar_8u_generic(frame, temp, frame_size);
+        return;
+    }
+
     const unsigned int po2 = log2_of_power_of_2(frame_size);
 
     unsigned int stage = po2;
@@ -612,6 +622,11 @@ static inline void volk_8u_x2_encodeframepolar_8u_a_ssse3(unsigned char* frame,
                                                           unsigned char* temp,
                                                           unsigned int frame_size)
 {
+    if (frame_size < 16) {
+        volk_8u_x2_encodeframepolar_8u_generic(frame, temp, frame_size);
+        return;
+    }
+
     const unsigned int po2 = log2_of_power_of_2(frame_size);
 
     unsigned int stage = po2;
@@ -790,6 +805,11 @@ static inline void volk_8u_x2_encodeframepolar_8u_a_avx2(unsigned char* frame,
                                                          unsigned char* temp,
                                                          unsigned int frame_size)
 {
+    if (frame_size < 32) {
+        volk_8u_x2_encodeframepolar_8u_generic(frame, temp, frame_size);
+        return;
+    }
+
     const unsigned int po2 = log2_of_power_of_2(frame_size);
 
     unsigned int stage = po2;


### PR DESCRIPTION
Fixes #414.

The various `volk_8u_x2_encodeframepolar_8u` implementations have warnings about the input size:

https://github.com/gnuradio/volk/blob/a26a1b808ddd75baeebe660e324f23c36dec6416/kernels/volk/volk_8u_x2_encodeframepolar_8u.h#L157-L158

https://github.com/gnuradio/volk/blob/a26a1b808ddd75baeebe660e324f23c36dec6416/kernels/volk/volk_8u_x2_encodeframepolar_8u.h#L430-L431

https://github.com/gnuradio/volk/blob/a26a1b808ddd75baeebe660e324f23c36dec6416/kernels/volk/volk_8u_x2_encodeframepolar_8u.h#L692-L693

https://github.com/gnuradio/volk/blob/a26a1b808ddd75baeebe660e324f23c36dec6416/kernels/volk/volk_8u_x2_encodeframepolar_8u.h#L964-L965

So let's heed those warnings by falling back to the generic implementation if the input size is too small.

Doing so also removes the need for extra size checks in `volk_32f_8u_polarbutterfly_32f.h`.

After this change, all failures disappear. I tested with the following:

```
for i in {1..64}; do apps/volk_profile -n -i 1 -v $i -R encodepolar | grep fail; done
```

I also verified that all valgrind warnings disappear after these changes. I tested with:

```
for i in {1..64}; do valgrind apps/volk_profile -n -i 1 -v $i -R encodepolar | grep fail; done
```