### PR TITLE
Add length checks to conv_k7 kernels

### DIFF
--- a/kernels/volk/volk_8u_conv_k7_r2puppet_8u.h
+++ b/kernels/volk/volk_8u_conv_k7_r2puppet_8u.h
@@ -101,7 +101,9 @@ static inline void volk_8u_conv_k7_r2puppet_8u_spiral(unsigned char* syms,
                                                       unsigned char* dec,
                                                       unsigned int framebits)
 {
-
+    if (framebits < 12) {
+        return;
+    }
 
     static int once = 1;
     int d_numstates = (1 << 6);
@@ -183,7 +185,9 @@ static inline void volk_8u_conv_k7_r2puppet_8u_neonspiral(unsigned char* syms,
                                                           unsigned char* dec,
                                                           unsigned int framebits)
 {
-
+    if (framebits < 12) {
+        return;
+    }
 
     static int once = 1;
     int d_numstates = (1 << 6);
@@ -266,7 +270,9 @@ static inline void volk_8u_conv_k7_r2puppet_8u_neonspiral(unsigned char* syms,
 //                                                    unsigned char* dec,
 //                                                    unsigned int framebits)
 //{
-//
+//    if (framebits < 12) {
+//        return;
+//    }
 //
 //    static int once = 1;
 //    int d_numstates = (1 << 6);
@@ -347,7 +353,9 @@ static inline void volk_8u_conv_k7_r2puppet_8u_generic(unsigned char* syms,
                                                        unsigned char* dec,
                                                        unsigned int framebits)
 {
-
+    if (framebits < 12) {
+        return;
+    }
 
     static int once = 1;
     int d_numstates = (1 << 6);


### PR DESCRIPTION
The `volk_8u_conv_k7_r2puppet_8u` kernels require an input vector length of at least 12 = (k-1)*r; if the input is shorter than 12 then `framebits / 2 - excess` (an unsigned int) underflows and turns into a huge number, which causes a buffer overflow in `chainback_viterbi`. I think it makes sense to add a length check so that out-of-bounds memory access does not occur if the user passes in a vector that is too short.