### PR TITLE
Fix buffer overflow in volk_32fc_x2_square_dist_32f_a_sse3

### DIFF
--- a/kernels/volk/volk_32fc_x2_square_dist_32f.h
+++ b/kernels/volk/volk_32fc_x2_square_dist_32f.h
@@ -181,40 +181,24 @@ static inline void volk_32fc_x2_square_dist_32f_a_sse3(float* target,
 
     xmm1 = _mm_setzero_ps();
     xmm1 = _mm_loadl_pi(xmm1, (__m64*)src0);
-    xmm2 = _mm_load_ps((float*)&points[0]);
     xmm1 = _mm_movelh_ps(xmm1, xmm1);
-    xmm3 = _mm_load_ps((float*)&points[2]);
 
-    for (; i < bound - 1; ++i) {
+    for (; i < bound; ++i) {
+        xmm2 = _mm_load_ps((float*)&points[0]);
         xmm4 = _mm_sub_ps(xmm1, xmm2);
+        xmm3 = _mm_load_ps((float*)&points[2]);
         xmm5 = _mm_sub_ps(xmm1, xmm3);
-        points += 4;
+
         xmm6 = _mm_mul_ps(xmm4, xmm4);
         xmm7 = _mm_mul_ps(xmm5, xmm5);
 
-        xmm2 = _mm_load_ps((float*)&points[0]);
-
         xmm4 = _mm_hadd_ps(xmm6, xmm7);
-
-        xmm3 = _mm_load_ps((float*)&points[2]);
 
         _mm_store_ps(target, xmm4);
 
+        points += 4;
         target += 4;
     }
-
-    xmm4 = _mm_sub_ps(xmm1, xmm2);
-    xmm5 = _mm_sub_ps(xmm1, xmm3);
-
-    points += 4;
-    xmm6 = _mm_mul_ps(xmm4, xmm4);
-    xmm7 = _mm_mul_ps(xmm5, xmm5);
-
-    xmm4 = _mm_hadd_ps(xmm6, xmm7);
-
-    _mm_store_ps(target, xmm4);
-
-    target += 4;
 
     if (num_bytes >> 4 & 1) {
 


### PR DESCRIPTION
When the vector length is less than 4, `volk_32fc_x2_square_dist_32f_a_sse3` performs an out-of-bounds read. Its main loop is set up to fetch data one iteration ahead, but the edge case is not considered and the last iteration is executed unconditionally.

I tried removing the pre-fetch logic like in #565, but performance was reduced. So I added an `if` statement around the last iteration instead.

Valgrind report:
```
==649543== Invalid read of size 16
==649543==    at 0x4B371B1: _mm_load_ps (xmmintrin.h:927)
==649543==    by 0x4B371B1: volk_32fc_x2_square_dist_32f_a_sse3 (volk_32fc_x2_square_dist_32f.h:221)
==649543==    by 0x48D982F: volk_32fc_x2_square_dist_32f_manual (volk.c:9276)
==649543==    by 0x12ADE2: run_cast_test3(void (*)(void*, void*, void*, unsigned int, char const*), std::vector<void*, std::allocator<void*> >&, unsigned int, unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (qa_utils.cc:279)
==649543==    by 0x128765: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, float, std::complex<float>, unsigned int, unsigned int, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, bool) (qa_utils.cc:672)
==649543==    by 0x127809: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, volk_test_params_t, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (qa_utils.cc:507)
==649543==    by 0x11E0DD: main (volk_profile.cc:139)
==649543==  Address 0x5401d00 is 0 bytes after a block of size 32 alloc'd
==649543==    at 0x484E120: memalign (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==649543==    by 0x48BF2C9: volk_malloc (volk_malloc.c:71)
==649543==    by 0x12B2FA: volk_qa_aligned_mem_pool::get_new(unsigned long) (qa_utils.cc:484)
==649543==    by 0x127F8D: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, float, std::complex<float>, unsigned int, unsigned int, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, bool) (qa_utils.cc:602)
==649543==    by 0x127809: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, volk_test_params_t, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (qa_utils.cc:507)
==649543==    by 0x11E0DD: main (volk_profile.cc:139)
==649543== 
==649543== Invalid read of size 4
==649543==    at 0x4B372AD: volk_32fc_x2_square_dist_32f_a_sse3 (volk_32fc_x2_square_dist_32f.h:236)
==649543==    by 0x48D982F: volk_32fc_x2_square_dist_32f_manual (volk.c:9276)
==649543==    by 0x12ADE2: run_cast_test3(void (*)(void*, void*, void*, unsigned int, char const*), std::vector<void*, std::allocator<void*> >&, unsigned int, unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (qa_utils.cc:279)
==649543==    by 0x128765: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, float, std::complex<float>, unsigned int, unsigned int, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, bool) (qa_utils.cc:672)
==649543==    by 0x127809: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, volk_test_params_t, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (qa_utils.cc:507)
==649543==    by 0x11E0DD: main (volk_profile.cc:139)
==649543==  Address 0x5401d10 is 16 bytes after a block of size 32 alloc'd
==649543==    at 0x484E120: memalign (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==649543==    by 0x48BF2C9: volk_malloc (volk_malloc.c:71)
==649543==    by 0x12B2FA: volk_qa_aligned_mem_pool::get_new(unsigned long) (qa_utils.cc:484)
==649543==    by 0x127F8D: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, float, std::complex<float>, unsigned int, unsigned int, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, bool) (qa_utils.cc:602)
==649543==    by 0x127809: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, volk_test_params_t, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (qa_utils.cc:507)
==649543==    by 0x11E0DD: main (volk_profile.cc:139)
==649543== 
==649543== Invalid read of size 4
==649543==    at 0x4B372B8: volk_32fc_x2_square_dist_32f_a_sse3 (volk_32fc_x2_square_dist_32f.h:236)
==649543==    by 0x48D982F: volk_32fc_x2_square_dist_32f_manual (volk.c:9276)
==649543==    by 0x12ADE2: run_cast_test3(void (*)(void*, void*, void*, unsigned int, char const*), std::vector<void*, std::allocator<void*> >&, unsigned int, unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (qa_utils.cc:279)
==649543==    by 0x128765: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, float, std::complex<float>, unsigned int, unsigned int, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, bool) (qa_utils.cc:672)
==649543==    by 0x127809: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, volk_test_params_t, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (qa_utils.cc:507)
==649543==    by 0x11E0DD: main (volk_profile.cc:139)
==649543==  Address 0x5401d14 is 20 bytes after a block of size 32 alloc'd
==649543==    at 0x484E120: memalign (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==649543==    by 0x48BF2C9: volk_malloc (volk_malloc.c:71)
==649543==    by 0x12B2FA: volk_qa_aligned_mem_pool::get_new(unsigned long) (qa_utils.cc:484)
==649543==    by 0x127F8D: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, float, std::complex<float>, unsigned int, unsigned int, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, bool) (qa_utils.cc:602)
==649543==    by 0x127809: run_volk_tests(volk_func_desc, void (*)(), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, volk_test_params_t, std::vector<volk_test_results_t, std::allocator<volk_test_results_t> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (qa_utils.cc:507)
==649543==    by 0x11E0DD: main (volk_profile.cc:139)
==649543== 
```