### PR TITLE
Fix flaky qa_volk_32f_s32f_convertpuppet_8u

### DIFF
--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -174,8 +174,9 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     QA(VOLK_INIT_PUPP(volk_32fc_s32f_power_spectral_densitypuppet_32f,
                       volk_32fc_s32f_x2_power_spectral_density_32f,
                       test_params))
-    QA(VOLK_INIT_PUPP(
-        volk_32f_s32f_convertpuppet_8u, volk_32f_s32f_x2_convert_8u, test_params))
+    QA(VOLK_INIT_PUPP(volk_32f_s32f_convertpuppet_8u,
+                      volk_32f_s32f_x2_convert_8u,
+                      test_params.make_tol(1)))
     // no one uses these, so don't test them
     // VOLK_PROFILE(volk_16i_x5_add_quad_16i_x4, 1e-4, 2046, 10000, &results,
     // benchmark_mode, kernel_regex); VOLK_PROFILE(volk_16i_branch_4_state_8, 1e-4, 2046,


### PR DESCRIPTION
Fixes #646.

Floating point values are rounded slightly differently depending on the order of operations, so some tolerance is needed.

As suggested in https://github.com/gnuradio/volk/pull/617#issuecomment-1398566328, we can increase the tolerance to 1. I don't see a better way to do it within the current test framework.