### PR TITLE
Fix variable name in dot product kernels

### DIFF
--- a/kernels/volk/volk_16i_32fc_dot_prod_32fc.h
+++ b/kernels/volk/volk_16i_32fc_dot_prod_32fc.h
@@ -145,7 +145,7 @@ static inline void volk_16i_32fc_dot_prod_32fc_u_sse(lv_32fc_t* result,
 {
 
     unsigned int number = 0;
-    const unsigned int sixteenthPoints = num_points / 8;
+    const unsigned int eighthPoints = num_points / 8;
 
     float res[2];
     float *realpt = &res[0], *imagpt = &res[1];
@@ -163,7 +163,7 @@ static inline void volk_16i_32fc_dot_prod_32fc_u_sse(lv_32fc_t* result,
     __m128 dotProdVal2 = _mm_setzero_ps();
     __m128 dotProdVal3 = _mm_setzero_ps();
 
-    for (; number < sixteenthPoints; number++) {
+    for (; number < eighthPoints; number++) {
 
         m0 = _mm_set_pi16(*(aPtr + 3), *(aPtr + 2), *(aPtr + 1), *(aPtr + 0));
         m1 = _mm_set_pi16(*(aPtr + 7), *(aPtr + 6), *(aPtr + 5), *(aPtr + 4));
@@ -212,7 +212,7 @@ static inline void volk_16i_32fc_dot_prod_32fc_u_sse(lv_32fc_t* result,
     *realpt += dotProductVector[2];
     *imagpt += dotProductVector[3];
 
-    number = sixteenthPoints * 8;
+    number = eighthPoints * 8;
     for (; number < num_points; number++) {
         *realpt += ((*aPtr) * (*bPtr++));
         *imagpt += ((*aPtr++) * (*bPtr++));
@@ -422,7 +422,7 @@ static inline void volk_16i_32fc_dot_prod_32fc_a_sse(lv_32fc_t* result,
 {
 
     unsigned int number = 0;
-    const unsigned int sixteenthPoints = num_points / 8;
+    const unsigned int eighthPoints = num_points / 8;
 
     float res[2];
     float *realpt = &res[0], *imagpt = &res[1];
@@ -440,7 +440,7 @@ static inline void volk_16i_32fc_dot_prod_32fc_a_sse(lv_32fc_t* result,
     __m128 dotProdVal2 = _mm_setzero_ps();
     __m128 dotProdVal3 = _mm_setzero_ps();
 
-    for (; number < sixteenthPoints; number++) {
+    for (; number < eighthPoints; number++) {
 
         m0 = _mm_set_pi16(*(aPtr + 3), *(aPtr + 2), *(aPtr + 1), *(aPtr + 0));
         m1 = _mm_set_pi16(*(aPtr + 7), *(aPtr + 6), *(aPtr + 5), *(aPtr + 4));
@@ -489,7 +489,7 @@ static inline void volk_16i_32fc_dot_prod_32fc_a_sse(lv_32fc_t* result,
     *realpt += dotProductVector[2];
     *imagpt += dotProductVector[3];
 
-    number = sixteenthPoints * 8;
+    number = eighthPoints * 8;
     for (; number < num_points; number++) {
         *realpt += ((*aPtr) * (*bPtr++));
         *imagpt += ((*aPtr++) * (*bPtr++));

--- a/kernels/volk/volk_32fc_32f_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_32f_dot_prod_32fc.h
@@ -267,7 +267,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_a_sse(lv_32fc_t* result,
 {
 
     unsigned int number = 0;
-    const unsigned int sixteenthPoints = num_points / 8;
+    const unsigned int eighthPoints = num_points / 8;
 
     float res[2];
     float *realpt = &res[0], *imagpt = &res[1];
@@ -284,7 +284,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_a_sse(lv_32fc_t* result,
     __m128 dotProdVal2 = _mm_setzero_ps();
     __m128 dotProdVal3 = _mm_setzero_ps();
 
-    for (; number < sixteenthPoints; number++) {
+    for (; number < eighthPoints; number++) {
 
         a0Val = _mm_load_ps(aPtr);
         a1Val = _mm_load_ps(aPtr + 4);
@@ -328,7 +328,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_a_sse(lv_32fc_t* result,
     *realpt += dotProductVector[2];
     *imagpt += dotProductVector[3];
 
-    number = sixteenthPoints * 8;
+    number = eighthPoints * 8;
     for (; number < num_points; number++) {
         *realpt += ((*aPtr++) * (*bPtr));
         *imagpt += ((*aPtr++) * (*bPtr++));
@@ -698,7 +698,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_u_sse(lv_32fc_t* result,
 {
 
     unsigned int number = 0;
-    const unsigned int sixteenthPoints = num_points / 8;
+    const unsigned int eighthPoints = num_points / 8;
 
     float res[2];
     float *realpt = &res[0], *imagpt = &res[1];
@@ -715,7 +715,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_u_sse(lv_32fc_t* result,
     __m128 dotProdVal2 = _mm_setzero_ps();
     __m128 dotProdVal3 = _mm_setzero_ps();
 
-    for (; number < sixteenthPoints; number++) {
+    for (; number < eighthPoints; number++) {
 
         a0Val = _mm_loadu_ps(aPtr);
         a1Val = _mm_loadu_ps(aPtr + 4);
@@ -759,7 +759,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_u_sse(lv_32fc_t* result,
     *realpt += dotProductVector[2];
     *imagpt += dotProductVector[3];
 
-    number = sixteenthPoints * 8;
+    number = eighthPoints * 8;
     for (; number < num_points; number++) {
         *realpt += ((*aPtr++) * (*bPtr));
         *imagpt += ((*aPtr++) * (*bPtr++));


### PR DESCRIPTION
It looks like `sixteenthPoints` was copy-pasted into the SSE kernels by mistake. They process eight points at a time, so I've renamed the variable.