### PR TITLE
Fix undefined behaviour in volk_8u_x4_conv_k7_r2_8u

### DIFF
--- a/kernels/volk/volk_8u_x4_conv_k7_r2_8u.h
+++ b/kernels/volk/volk_8u_x4_conv_k7_r2_8u.h
@@ -82,7 +82,8 @@ static inline void BFLY(int i,
                         decision_t* d,
                         unsigned char* Branchtab)
 {
-    int j, decision0, decision1;
+    int j;
+    unsigned int decision0, decision1;
     unsigned char metric, m0, m1, m2, m3;
 
     int NUMSTATES = 64;


### PR DESCRIPTION
Undefined Behaviour Sanitizer (enabled with `-fsanitize=undefined`) reports the following Undefined Behaviour during a `volk_profile` run:

`/home/argilo/git/volk/kernels/volk/volk_8u_x4_conv_k7_r2_8u.h:113:38: runtime error: left shift of 2 by 30 places cannot be represented in type 'int'`

This left shift results in signed integer overflow, which is Undefined Behaviour. To fix it, I changed `decision0` and `decision1` to `unsigned int`, which allows them to accommodate 32-bit positive integers without overflow. These variables never store negative numbers, so the change shouldn't break anything.