### PR TITLE
Fix aligned loads and stores in unaligned kernels

### DIFF
--- a/kernels/volk/volk_32f_accumulator_s32f.h
+++ b/kernels/volk/volk_32f_accumulator_s32f.h
@@ -196,7 +196,7 @@ static inline void volk_32f_accumulator_s32f_u_sse(float* result,
     __m128 aVal = _mm_setzero_ps();
 
     for (; number < quarterPoints; number++) {
-        aVal = _mm_load_ps(aPtr);
+        aVal = _mm_loadu_ps(aPtr);
         accumulator = _mm_add_ps(accumulator, aVal);
         aPtr += 4;
     }

--- a/kernels/volk/volk_32f_s32f_s32f_mod_range_32f.h
+++ b/kernels/volk/volk_32f_s32f_s32f_mod_range_32f.h
@@ -184,7 +184,7 @@ static inline void volk_32f_s32f_s32f_mod_range_32f_u_sse2(float* outputVector,
     float* outPtr = outputVector;
     const size_t quarter_points = num_points / 4;
     for (size_t counter = 0; counter < quarter_points; counter++) {
-        input = _mm_load_ps(inPtr);
+        input = _mm_loadu_ps(inPtr);
         // calculate mask: input < lower, input > upper
         is_smaller = _mm_cmplt_ps(input, lower);
         is_bigger = _mm_cmpgt_ps(input, upper);
@@ -204,7 +204,7 @@ static inline void volk_32f_s32f_s32f_mod_range_32f_u_sse2(float* outputVector,
         // scale by distance, sign
         excess = _mm_mul_ps(_mm_mul_ps(excess, adj), distance);
         output = _mm_add_ps(input, excess);
-        _mm_store_ps(outPtr, output);
+        _mm_storeu_ps(outPtr, output);
         inPtr += 4;
         outPtr += 4;
     }
@@ -281,7 +281,7 @@ static inline void volk_32f_s32f_s32f_mod_range_32f_u_sse(float* outputVector,
     float* outPtr = outputVector;
     const size_t quarter_points = num_points / 4;
     for (size_t counter = 0; counter < quarter_points; counter++) {
-        input = _mm_load_ps(inPtr);
+        input = _mm_loadu_ps(inPtr);
         // calculate mask: input < lower, input > upper
         is_smaller = _mm_cmplt_ps(input, lower);
         is_bigger = _mm_cmpgt_ps(input, upper);
@@ -302,7 +302,7 @@ static inline void volk_32f_s32f_s32f_mod_range_32f_u_sse(float* outputVector,
         // scale by distance, sign
         excess = _mm_mul_ps(_mm_mul_ps(excess, adj), distance);
         output = _mm_add_ps(input, excess);
-        _mm_store_ps(outPtr, output);
+        _mm_storeu_ps(outPtr, output);
         inPtr += 4;
         outPtr += 4;
     }

--- a/kernels/volk/volk_32fc_32f_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_32f_dot_prod_32fc.h
@@ -373,8 +373,8 @@ static inline void volk_32fc_32f_dot_prod_32fc_u_avx2_fma(lv_32fc_t* result,
         a2Val = _mm256_loadu_ps(aPtr + 16);
         a3Val = _mm256_loadu_ps(aPtr + 24);
 
-        x0Val = _mm256_load_ps(bPtr); // t0|t1|t2|t3|t4|t5|t6|t7
-        x1Val = _mm256_load_ps(bPtr + 8);
+        x0Val = _mm256_loadu_ps(bPtr); // t0|t1|t2|t3|t4|t5|t6|t7
+        x1Val = _mm256_loadu_ps(bPtr + 8);
         x0loVal = _mm256_unpacklo_ps(x0Val, x0Val); // t0|t0|t1|t1|t4|t4|t5|t5
         x0hiVal = _mm256_unpackhi_ps(x0Val, x0Val); // t2|t2|t3|t3|t6|t6|t7|t7
         x1loVal = _mm256_unpacklo_ps(x1Val, x1Val);


### PR DESCRIPTION
Various unaligned kernels (`volk_32f_accumulator_s32f_u_sse`, `volk_32f_s32f_s32f_mod_range_32f_u_sse2`, `volk_32fc_32f_dot_prod_32fc_u_avx2_fma`) load input data using aligned loads, so they fail when given unaligned input buffers. Here I've fixed that by switching them to unaligned loads.