### PR TITLE
Fix undefined behaviour in volk_32u_reverse_32u

### DIFF
--- a/kernels/volk/volk_32u_reverse_32u.h
+++ b/kernels/volk/volk_32u_reverse_32u.h
@@ -206,7 +206,7 @@ volk_32u_reverse_32u_lut(uint32_t* out, const uint32_t* in, unsigned int num_poi
     uint32_t* out_ptr = out;
     unsigned int number = 0;
     for (; number < num_points; ++number) {
-        *out_ptr = (BitReverseTable256[*in_ptr & 0xff] << 24) |
+        *out_ptr = ((uint32_t)BitReverseTable256[*in_ptr & 0xff] << 24) |
                    (BitReverseTable256[(*in_ptr >> 8) & 0xff] << 16) |
                    (BitReverseTable256[(*in_ptr >> 16) & 0xff] << 8) |
                    (BitReverseTable256[(*in_ptr >> 24) & 0xff]);
@@ -354,7 +354,7 @@ volk_32u_reverse_32u_neonv8(uint32_t* out, const uint32_t* in, unsigned int num_
     }
     number = quarterPoints * 4;
     for (; number < num_points; ++number) {
-        *out_ptr = (BitReverseTable256[*in_ptr & 0xff] << 24) |
+        *out_ptr = ((uint32_t)BitReverseTable256[*in_ptr & 0xff] << 24) |
                    (BitReverseTable256[(*in_ptr >> 8) & 0xff] << 16) |
                    (BitReverseTable256[(*in_ptr >> 16) & 0xff] << 8) |
                    (BitReverseTable256[(*in_ptr >> 24) & 0xff]);


### PR DESCRIPTION
Undefined Behaviour Sanitizer (UBSAN, `-fsanitize=undefined`) reports two instances of overflowing left shifts in volk_32u_reverse_32u.

In both cases, an `unsigned char` is promoted to `int` and then left-shifted by 24 bits, but `int` is not large enough to hold the result. I've added an explicit cast to `uint32_t`, which resolves the Undefined Behaviour warnings.