### PR TITLE
Fix register size warnings in reverse kernel

### DIFF
--- a/kernels/volk/volk_32u_reverse_32u.h
+++ b/kernels/volk/volk_32u_reverse_32u.h
@@ -363,10 +363,20 @@ volk_32u_reverse_32u_neonv8(uint32_t* out, const uint32_t* in, unsigned int num_
     }
 }
 
-#else
+#endif /* LV_HAVE_NEONV8 */
+
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
 
+#if defined(__aarch64__)
+#define DO_RBIT                             \
+    __VOLK_ASM("rbit %w[result], %w[value]" \
+               : [result] "=r"(*out_ptr)    \
+               : [value] "r"(*in_ptr)       \
+               :);                          \
+    in_ptr++;                               \
+    out_ptr++;
+#else
 #define DO_RBIT                           \
     __VOLK_ASM("rbit %[result], %[value]" \
                : [result] "=r"(*out_ptr)  \
@@ -374,6 +384,7 @@ volk_32u_reverse_32u_neonv8(uint32_t* out, const uint32_t* in, unsigned int num_
                :);                        \
     in_ptr++;                             \
     out_ptr++;
+#endif
 
 static inline void
 volk_32u_reverse_32u_arm(uint32_t* out, const uint32_t* in, unsigned int num_points)
@@ -401,7 +412,6 @@ volk_32u_reverse_32u_arm(uint32_t* out, const uint32_t* in, unsigned int num_poi
 }
 #undef DO_RBIT
 #endif /* LV_HAVE_NEON */
-#endif /* LV_HAVE_NEONV8 */
 
 
 #endif /* INCLUDED_volk_32u_reverse_32u_u_H */


### PR DESCRIPTION
When building VOLK on 64-bit ARM, many compiler warnings are printed because the register size of the `rbit` instruction is incorrect. To fix that, I've added an aarch64 version of the `DO_RBIT` macro which includes the `w` template modifier to select 32-bit registers.

Also, it appears the `arm` version of the reverse kernel was inaccessible (on both 32-bit and 64-bit ARM) because `volk_kernel_defs.py` does not understand nested `#ifdef LV_HAVE_*`. I separated the `#ifdef`s and now the `arm` version of the kernel runs on both 32-bit and 64-bit ARM.