### PR TITLE
Add length checks to puppets

### DIFF
--- a/kernels/volk/volk_32f_8u_polarbutterflypuppet_32f.h
+++ b/kernels/volk/volk_32f_8u_polarbutterflypuppet_32f.h
@@ -81,6 +81,10 @@ static inline void volk_32f_8u_polarbutterflypuppet_32f_generic(float* llrs,
                                                                 unsigned char* u,
                                                                 const int elements)
 {
+    if (elements < 2) {
+        return;
+    }
+
     unsigned int frame_size = maximum_frame_size(elements);
     unsigned int frame_exp = log2_of_power_of_2(frame_size);
 
@@ -104,6 +108,10 @@ static inline void volk_32f_8u_polarbutterflypuppet_32f_u_avx(float* llrs,
                                                               unsigned char* u,
                                                               const int elements)
 {
+    if (elements < 2) {
+        return;
+    }
+
     unsigned int frame_size = maximum_frame_size(elements);
     unsigned int frame_exp = log2_of_power_of_2(frame_size);
 
@@ -127,6 +135,10 @@ static inline void volk_32f_8u_polarbutterflypuppet_32f_u_avx2(float* llrs,
                                                                unsigned char* u,
                                                                const int elements)
 {
+    if (elements < 2) {
+        return;
+    }
+
     unsigned int frame_size = maximum_frame_size(elements);
     unsigned int frame_exp = log2_of_power_of_2(frame_size);
 

--- a/kernels/volk/volk_8u_x3_encodepolarpuppet_8u.h
+++ b/kernels/volk/volk_8u_x3_encodepolarpuppet_8u.h
@@ -48,6 +48,10 @@ volk_8u_x3_encodepolarpuppet_8u_generic(unsigned char* frame,
                                         const unsigned char* info_bits,
                                         unsigned int frame_size)
 {
+    if (frame_size < 1) {
+        return;
+    }
+
     frame_size = next_lower_power_of_two(frame_size);
     unsigned char* temp = (unsigned char*)volk_malloc(sizeof(unsigned char) * frame_size,
                                                       volk_get_alignment());
@@ -67,6 +71,10 @@ volk_8u_x3_encodepolarpuppet_8u_u_ssse3(unsigned char* frame,
                                         const unsigned char* info_bits,
                                         unsigned int frame_size)
 {
+    if (frame_size < 1) {
+        return;
+    }
+
     frame_size = next_lower_power_of_two(frame_size);
     unsigned char* temp = (unsigned char*)volk_malloc(sizeof(unsigned char) * frame_size,
                                                       volk_get_alignment());
@@ -85,6 +93,10 @@ volk_8u_x3_encodepolarpuppet_8u_u_avx2(unsigned char* frame,
                                        const unsigned char* info_bits,
                                        unsigned int frame_size)
 {
+    if (frame_size < 1) {
+        return;
+    }
+
     frame_size = next_lower_power_of_two(frame_size);
     unsigned char* temp = (unsigned char*)volk_malloc(sizeof(unsigned char) * frame_size,
                                                       volk_get_alignment());
@@ -108,6 +120,10 @@ volk_8u_x3_encodepolarpuppet_8u_a_ssse3(unsigned char* frame,
                                         const unsigned char* info_bits,
                                         unsigned int frame_size)
 {
+    if (frame_size < 1) {
+        return;
+    }
+
     frame_size = next_lower_power_of_two(frame_size);
     unsigned char* temp = (unsigned char*)volk_malloc(sizeof(unsigned char) * frame_size,
                                                       volk_get_alignment());
@@ -126,6 +142,10 @@ volk_8u_x3_encodepolarpuppet_8u_a_avx2(unsigned char* frame,
                                        const unsigned char* info_bits,
                                        unsigned int frame_size)
 {
+    if (frame_size < 1) {
+        return;
+    }
+
     frame_size = next_lower_power_of_two(frame_size);
     unsigned char* temp = (unsigned char*)volk_malloc(sizeof(unsigned char) * frame_size,
                                                       volk_get_alignment());

--- a/lib/volk_malloc.c
+++ b/lib/volk_malloc.c
@@ -38,7 +38,7 @@
 void* volk_malloc(size_t size, size_t alignment)
 {
     if ((size == 0) || (alignment == 0)) {
-        fprintf(stderr, "VOLK: Error allocating memory: either size or alignment is 0");
+        fprintf(stderr, "VOLK: Error allocating memory: either size or alignment is 0\n");
         return NULL;
     }
     // Tweak size to satisfy ASAN (the GCC address sanitizer).


### PR DESCRIPTION
Almost all kernels are now testable all the way down to vector length zero, with a couple exceptions which I've fixed here:

* `volk_32f_8u_polarbutterflypuppet_32f` fails below length 2 due to division by zero in `maximum_frame_size`
* `volk_8u_x3_encodepolarpuppet_8u` generates an error message below length 1 (`VOLK: Error allocating memory: either size or alignment is 0`)

I've added length checks to both, which should open the door to testing kernels over a wide range of vector lengths.

I also too the opportunity to add a missing carriage return to the allocation error message; it's the only such message that lacks a carriage return.