### PR TITLE
Include ORC in neonv8 machine definition

### DIFF
--- a/gen/machines.xml
+++ b/gen/machines.xml
@@ -13,7 +13,7 @@
 </machine>
 
 <machine name="neonv8">
-<archs>generic neon neonv8</archs>
+<archs>generic neon neonv8 orc|</archs>
 </machine>
 
 <!-- trailing | bar means generate without either for MSVC -->


### PR DESCRIPTION
I noticed that neonv8 kernels do not run in CI, nor do they run on my Raspberry Pi if `liborc-0.4-dev` is installed. It looks like this happens because VOLK chooses the `neon_orc` machine over the ORC-less `neonv8` machine.

The `neonv8` machine is the only one in `machines.xml` that lacks `orc|`; adding this corrects the problem, and VOLK then chooses the `neonv8_orc` machine and executes neonv8 kernels.