### PR TITLE
Fix compiler warnings

### DIFF
--- a/apps/volk_option_helpers.cc
+++ b/apps/volk_option_helpers.cc
@@ -188,6 +188,7 @@ void option_list::parse(int argc, char** argv)
                     } catch (std::exception& exc) {
                         throw std::exception();
                     };
+                    break;
                 case STRING:
                     std::cout << this_option->printval << std::endl;
                     break;
@@ -225,15 +226,8 @@ void option_list::help()
             help_line += this_option->shortform + " [ " + this_option->longform + " ]";
         }
 
-        switch (help_line.size() / 8) {
-        case 0:
-            help_line += "\t";
-        case 1:
-            help_line += "\t";
-        case 2:
-            help_line += "\t";
-        case 3:
-            help_line += "\t";
+        while (help_line.size() < 32) {
+            help_line += " ";
         }
         help_line += this_option->msg;
         std::cout << help_line << std::endl;

--- a/kernels/volk/volk_32f_8u_polarbutterflypuppet_32f.h
+++ b/kernels/volk/volk_32f_8u_polarbutterflypuppet_32f.h
@@ -81,6 +81,8 @@ static inline void volk_32f_8u_polarbutterflypuppet_32f_generic(float* llrs,
                                                                 unsigned char* u,
                                                                 const int elements)
 {
+    (void)input; // suppress unused parameter warning
+
     if (elements < 2) {
         return;
     }
@@ -108,6 +110,8 @@ static inline void volk_32f_8u_polarbutterflypuppet_32f_u_avx(float* llrs,
                                                               unsigned char* u,
                                                               const int elements)
 {
+    (void)input; // suppress unused parameter warning
+
     if (elements < 2) {
         return;
     }
@@ -135,6 +139,8 @@ static inline void volk_32f_8u_polarbutterflypuppet_32f_u_avx2(float* llrs,
                                                                unsigned char* u,
                                                                const int elements)
 {
+    (void)input; // suppress unused parameter warning
+
     if (elements < 2) {
         return;
     }


### PR DESCRIPTION
When building with `-DCMAKE_BUILD_TYPE=ASAN` a number of compiler warnings are shown. I've cleaned up most of them here.