### PR TITLE
Fix documentation for the clamp kernel

### DIFF
--- a/docs/kernels.dox
+++ b/docs/kernels.dox
@@ -84,6 +84,7 @@
 \li \subpage volk_32f_s32f_power_32f
 \li \subpage volk_32f_s32f_s32f_mod_range_32f
 \li \subpage volk_32f_s32f_stddev_32f
+\li \subpage volk_32f_s32f_x2_clamp_32f
 \li \subpage volk_32f_s32f_x2_convert_8u
 \li \subpage volk_32f_sin_32f
 \li \subpage volk_32f_sqrt_32f

--- a/kernels/volk/volk_32f_s32f_x2_clamp_32f.h
+++ b/kernels/volk/volk_32f_s32f_x2_clamp_32f.h
@@ -8,7 +8,7 @@
  */
 
 /*!
- * \page volk_32fc_s32f_x2_clamp_32f
+ * \page volk_32f_s32f_x2_clamp_32f
  *
  * \b Overview
  *


### PR DESCRIPTION
Two bugs prevented the clamp kernel's documentation from working correctly:

* The page name was incorrect.
* It was not added as a subpage in kernels.dox.

I've fixed both issues here, and the documentation now appears in the expected place.