### PR TITLE
Avoid integer overflow in volk_8ic_x2_multiply_conjugate_16ic corner case

### DIFF
--- a/kernels/volk/volk_8ic_x2_multiply_conjugate_16ic.h
+++ b/kernels/volk/volk_8ic_x2_multiply_conjugate_16ic.h
@@ -11,6 +11,7 @@
 #define INCLUDED_volk_8ic_x2_multiply_conjugate_16ic_a_H
 
 #include <inttypes.h>
+#include <limits.h>
 #include <stdio.h>
 #include <volk/volk_complex.h>
 
@@ -81,7 +82,7 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_a_avx2(lv_16sc_t* cVector
         lv_32fc_t bVal = lv_cmake(bReal, -bImag);
         lv_32fc_t temp = aVal * bVal;
 
-        *c16Ptr++ = (int16_t)lv_creal(temp);
+        *c16Ptr++ = (int16_t)(lv_creal(temp) > SHRT_MAX ? SHRT_MAX : lv_creal(temp));
         *c16Ptr++ = (int16_t)lv_cimag(temp);
     }
 }
@@ -152,7 +153,7 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_a_sse4_1(lv_16sc_t* cVect
         lv_32fc_t bVal = lv_cmake(bReal, -bImag);
         lv_32fc_t temp = aVal * bVal;
 
-        *c16Ptr++ = (int16_t)lv_creal(temp);
+        *c16Ptr++ = (int16_t)(lv_creal(temp) > SHRT_MAX ? SHRT_MAX : lv_creal(temp));
         *c16Ptr++ = (int16_t)lv_cimag(temp);
     }
 }
@@ -185,7 +186,7 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_generic(lv_16sc_t* cVecto
         lv_32fc_t bVal = lv_cmake(bReal, -bImag);
         lv_32fc_t temp = aVal * bVal;
 
-        *c16Ptr++ = (int16_t)lv_creal(temp);
+        *c16Ptr++ = (int16_t)(lv_creal(temp) > SHRT_MAX ? SHRT_MAX : lv_creal(temp));
         *c16Ptr++ = (int16_t)lv_cimag(temp);
     }
 }
@@ -267,7 +268,7 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_u_avx2(lv_16sc_t* cVector
         lv_32fc_t bVal = lv_cmake(bReal, -bImag);
         lv_32fc_t temp = aVal * bVal;
 
-        *c16Ptr++ = (int16_t)lv_creal(temp);
+        *c16Ptr++ = (int16_t)(lv_creal(temp) > SHRT_MAX ? SHRT_MAX : lv_creal(temp));
         *c16Ptr++ = (int16_t)lv_cimag(temp);
     }
 }


### PR DESCRIPTION
While looking for flaky tests with `ctest --repeat until-fail:<n>`, the `qa_volk_8ic_x2_multiply_conjugate_16ic` test turned out to be flaky. Failures are rare, but can be induced with the following change to the test framework:

```diff
diff --git a/lib/qa_utils.cc b/lib/qa_utils.cc
index 4be7b8a..21a1e34 100644
--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -99,7 +99,7 @@ void load_random_data(void* data, volk_type_t type, unsigned int n)
             if (type.is_signed) {
                 std::uniform_int_distribution<int16_t> uniform_dist(
                     std::numeric_limits<int8_t>::min(),
-                    std::numeric_limits<int8_t>::max());
+                    -127);
                 for (unsigned int i = 0; i < n; i++)
                     ((int8_t*)data)[i] = uniform_dist(rnd_engine);
             } else {
```

The root cause is that the corner case `aVector[i] = -128-128j`, `bVector[i] = -128-128j` produces an output of `32768+0j`, and the real part is too large to fit in a signed 16-bit integer. The SIMD protokernels use saturation arithmetic (producing `32767+0j`, while the generic protokernel (and tail processing in the other protokernels) overflows and produces `-32768+0j`. To fix the problem, I've switched to saturation arithmetic everywhere, which seems more appropriate for a DSP context, and avoids Undefined Behaviour.

Only the real part of the result needs to be clamped, because the imaginary part cannot overflow.