### PR TITLE
Decrease the range for signed 16-bit integer testing

### DIFF
--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -84,7 +84,7 @@ void load_random_data(void* data, volk_type_t type, unsigned int n)
             break;
         case 2:
             if (type.is_signed) {
-                std::uniform_int_distribution<int16_t> uniform_dist(-7, 7);
+                std::uniform_int_distribution<int16_t> uniform_dist(-6, 6);
                 for (unsigned int i = 0; i < n; i++)
                     ((int16_t*)data)[i] = uniform_dist(rnd_engine);
             } else {


### PR DESCRIPTION
Mitigates #676.

The `qa_volk_16ic_x2_dot_prod_16ic` test is now the most frequent source of CI failures which does not already have an open pull request. The `volk_16ic_x2_dot_prod_16ic` kernel was added in #77, and because it does not handle integer overflow consistently, the test suite was modified at that time to limit signed 16-bit integer testing to the range -7 .. +7. Unfortunately, this is not sufficient to prevent overflows in the `qa_volk_16ic_x2_dot_prod_16ic`.

It would be quite a bit of work to rewrite the `volk_16ic_x2_dot_prod_16ic` kernel to have consistent overflow handling between the protokernels, so I'm proposing to decrease the signed integer range slightly (to -6 .. +6). This does not remove test failures entirely, but reduces the failure rate by about 50x.