### PR TITLE
Fix AppVeyor git checkout

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 #
-clone_depth: 1
 image: Visual Studio 2019
 cache:
   - packages -> appveyor.yml


### PR DESCRIPTION
Fixes #710.

As [noted in AppVeyor's documentation](https://www.appveyor.com/docs/how-to/repository-shallow-clone/#setting-depth-of-git-clone-command), setting `clone_depth` to a low value can cause queued builds to fail. VOLK is not a large repository, so I think `clone_depth` can simply be removed. (A full clone on my system only takes about 200 ms longer than a shallow clone.)

For reference, the `clone_depth: 1` setting was added in the PR that introduced AppVeyor: https://github.com/gnuradio/volk/pull/91