### PR TITLE
Fix flaky fm_detect test

### DIFF
--- a/kernels/volk/volk_32f_x2_fm_detectpuppet_32f.h
+++ b/kernels/volk/volk_32f_x2_fm_detectpuppet_32f.h
@@ -20,7 +20,7 @@ static inline void volk_32f_x2_fm_detectpuppet_32f_a_avx(float* outputVector,
                                                          float* saveValue,
                                                          unsigned int num_points)
 {
-    const float bound = 1.0f;
+    const float bound = 2.0f;
 
     volk_32f_s32f_32f_fm_detect_32f_a_avx(
         outputVector, inputVector, bound, saveValue, num_points);
@@ -35,7 +35,7 @@ static inline void volk_32f_x2_fm_detectpuppet_32f_a_sse(float* outputVector,
                                                          float* saveValue,
                                                          unsigned int num_points)
 {
-    const float bound = 1.0f;
+    const float bound = 2.0f;
 
     volk_32f_s32f_32f_fm_detect_32f_a_sse(
         outputVector, inputVector, bound, saveValue, num_points);
@@ -49,7 +49,7 @@ static inline void volk_32f_x2_fm_detectpuppet_32f_generic(float* outputVector,
                                                            float* saveValue,
                                                            unsigned int num_points)
 {
-    const float bound = 1.0f;
+    const float bound = 2.0f;
 
     volk_32f_s32f_32f_fm_detect_32f_generic(
         outputVector, inputVector, bound, saveValue, num_points);
@@ -73,7 +73,7 @@ static inline void volk_32f_x2_fm_detectpuppet_32f_u_avx(float* outputVector,
                                                          float* saveValue,
                                                          unsigned int num_points)
 {
-    const float bound = 1.0f;
+    const float bound = 2.0f;
 
     volk_32f_s32f_32f_fm_detect_32f_u_avx(
         outputVector, inputVector, bound, saveValue, num_points);

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -64,8 +64,9 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
                       test_params_rotator))
     QA(VOLK_INIT_PUPP(
         volk_8u_conv_k7_r2puppet_8u, volk_8u_x4_conv_k7_r2_8u, test_params.make_tol(0)))
-    QA(VOLK_INIT_PUPP(
-        volk_32f_x2_fm_detectpuppet_32f, volk_32f_s32f_32f_fm_detect_32f, test_params))
+    QA(VOLK_INIT_PUPP(volk_32f_x2_fm_detectpuppet_32f,
+                      volk_32f_s32f_32f_fm_detect_32f,
+                      test_params.make_absolute(1e-6)))
     QA(VOLK_INIT_TEST(volk_16ic_s32f_deinterleave_real_32f, test_params))
     QA(VOLK_INIT_TEST(volk_16ic_deinterleave_real_8i, test_params))
     QA(VOLK_INIT_TEST(volk_16ic_deinterleave_16i_x2, test_params))


### PR DESCRIPTION
`volk_32fc_s32f_magnitude_16i` fails in [i386 Debian CI](https://buildd.debian.org/status/fetch.php?pkg=volk&arch=i386&ver=3.1.0-1&stamp=1701982056&raw=0) and locally:

```
68: offset 763 in1: 0.0534787 in2: 0.0534787 tolerance was: 1e-06
68: offset 4405 in1: -0.0228593 in2: -0.0228593 tolerance was: 1e-06
68: offset 6398 in1: -0.0512945 in2: -0.0512946 tolerance was: 1e-06
68: offset 8635 in1: -0.0217852 in2: -0.0217853 tolerance was: 1e-06
68: offset 9565 in1: 0.0521163 in2: 0.0521164 tolerance was: 1e-06
68: offset 10353 in1: 0.0130416 in2: 0.0130415 tolerance was: 1e-06
68: offset 14364 in1: -0.0432156 in2: -0.0432155 tolerance was: 1e-06
68: offset 17398 in1: 0.0538341 in2: 0.0538342 tolerance was: 1e-06
68: offset 17866 in1: 0.0584753 in2: 0.0584753 tolerance was: 1e-06
68: offset 25493 in1: 0.0356272 in2: 0.0356271 tolerance was: 1e-06
68: volk_32f_x2_fm_detectpuppet_32f: fail on arch a_avx
68: offset 763 in1: 0.0534787 in2: 0.0534787 tolerance was: 1e-06
68: offset 4405 in1: -0.0228593 in2: -0.0228593 tolerance was: 1e-06
68: offset 6398 in1: -0.0512945 in2: -0.0512946 tolerance was: 1e-06
68: offset 8635 in1: -0.0217852 in2: -0.0217853 tolerance was: 1e-06
68: offset 9565 in1: 0.0521163 in2: 0.0521164 tolerance was: 1e-06
68: offset 10353 in1: 0.0130416 in2: 0.0130415 tolerance was: 1e-06
68: offset 14364 in1: -0.0432156 in2: -0.0432155 tolerance was: 1e-06
68: offset 17398 in1: 0.0538341 in2: 0.0538342 tolerance was: 1e-06
68: offset 17866 in1: 0.0584753 in2: 0.0584753 tolerance was: 1e-06
68: offset 25493 in1: 0.0356272 in2: 0.0356271 tolerance was: 1e-06
68: volk_32f_x2_fm_detectpuppet_32f: fail on arch a_sse
68: offset 763 in1: 0.0534787 in2: 0.0534787 tolerance was: 1e-06
68: offset 4405 in1: -0.0228593 in2: -0.0228593 tolerance was: 1e-06
68: offset 6398 in1: -0.0512945 in2: -0.0512946 tolerance was: 1e-06
68: offset 8635 in1: -0.0217852 in2: -0.0217853 tolerance was: 1e-06
68: offset 9565 in1: 0.0521163 in2: 0.0521164 tolerance was: 1e-06
68: offset 10353 in1: 0.0130416 in2: 0.0130415 tolerance was: 1e-06
68: offset 14364 in1: -0.0432156 in2: -0.0432155 tolerance was: 1e-06
68: offset 17398 in1: 0.0538341 in2: 0.0538342 tolerance was: 1e-06
68: offset 17866 in1: 0.0584753 in2: 0.0584753 tolerance was: 1e-06
68: offset 25493 in1: 0.0356272 in2: 0.0356271 tolerance was: 1e-06
68: volk_32f_x2_fm_detectpuppet_32f: fail on arch u_avx
```

There are two bugs:

1. The test uses a relative tolerance, but the outputs are differences of two potentially large values. If the difference happens to be near zero, the test fails.
1. If the difference between two inputs happens to be close to `bound` or `-bound` (both of which represent a phase difference of 180 degrees), then a small floating point error can flip the sign of the output value, causing the test to fail.

To fix the first problem, I've switched the test to an absolute tolerance, and to fix the second I've increased the bound to 2.0. After these changes, the test passes reliably on i386.