### PR TITLE
Fix flaky mod_range test

### DIFF
--- a/kernels/volk/volk_32f_s32f_mod_rangepuppet_32f.h
+++ b/kernels/volk/volk_32f_s32f_mod_rangepuppet_32f.h
@@ -19,7 +19,7 @@ static inline void volk_32f_s32f_mod_rangepuppet_32f_generic(float* output,
                                                              unsigned int num_points)
 {
     volk_32f_s32f_s32f_mod_range_32f_generic(
-        output, input, bound - 3.141f, bound, num_points);
+        output, input, bound - 3.131f, bound, num_points);
 }
 #endif
 
@@ -31,7 +31,7 @@ static inline void volk_32f_s32f_mod_rangepuppet_32f_u_sse(float* output,
                                                            unsigned int num_points)
 {
     volk_32f_s32f_s32f_mod_range_32f_u_sse(
-        output, input, bound - 3.141f, bound, num_points);
+        output, input, bound - 3.131f, bound, num_points);
 }
 #endif
 #ifdef LV_HAVE_SSE
@@ -41,7 +41,7 @@ static inline void volk_32f_s32f_mod_rangepuppet_32f_a_sse(float* output,
                                                            unsigned int num_points)
 {
     volk_32f_s32f_s32f_mod_range_32f_a_sse(
-        output, input, bound - 3.141f, bound, num_points);
+        output, input, bound - 3.131f, bound, num_points);
 }
 #endif
 
@@ -52,7 +52,7 @@ static inline void volk_32f_s32f_mod_rangepuppet_32f_u_sse2(float* output,
                                                             unsigned int num_points)
 {
     volk_32f_s32f_s32f_mod_range_32f_u_sse2(
-        output, input, bound - 3.141f, bound, num_points);
+        output, input, bound - 3.131f, bound, num_points);
 }
 #endif
 #ifdef LV_HAVE_SSE2
@@ -62,7 +62,7 @@ static inline void volk_32f_s32f_mod_rangepuppet_32f_a_sse2(float* output,
                                                             unsigned int num_points)
 {
     volk_32f_s32f_s32f_mod_range_32f_a_sse2(
-        output, input, bound - 3.141f, bound, num_points);
+        output, input, bound - 3.131f, bound, num_points);
 }
 #endif
 
@@ -73,7 +73,7 @@ static inline void volk_32f_s32f_mod_rangepuppet_32f_u_avx(float* output,
                                                            unsigned int num_points)
 {
     volk_32f_s32f_s32f_mod_range_32f_u_avx(
-        output, input, bound - 3.141f, bound, num_points);
+        output, input, bound - 3.131f, bound, num_points);
 }
 #endif
 #ifdef LV_HAVE_AVX
@@ -83,7 +83,7 @@ static inline void volk_32f_s32f_mod_rangepuppet_32f_a_avx(float* output,
                                                            unsigned int num_points)
 {
     volk_32f_s32f_s32f_mod_range_32f_a_avx(
-        output, input, bound - 3.141f, bound, num_points);
+        output, input, bound - 3.131f, bound, num_points);
 }
 #endif
 #endif


### PR DESCRIPTION
`volk_32fc_s32f_magnitude_16i` fails in locally on i386:

```
offset 9838 in1: 323.859 in2: 327 tolerance was: 1e-06
volk_32f_s32f_mod_rangepuppet_32f: fail on arch u_sse
offset 9838 in1: 323.859 in2: 327 tolerance was: 1e-06
volk_32f_s32f_mod_rangepuppet_32f: fail on arch a_sse
offset 9838 in1: 323.859 in2: 327 tolerance was: 1e-06
volk_32f_s32f_mod_rangepuppet_32f: fail on arch u_sse2
offset 9838 in1: 323.859 in2: 327 tolerance was: 1e-06
volk_32f_s32f_mod_rangepuppet_32f: fail on arch a_sse2
offset 9838 in1: 323.859 in2: 327 tolerance was: 1e-06
volk_32f_s32f_mod_rangepuppet_32f: fail on arch u_avx
offset 9838 in1: 323.859 in2: 327 tolerance was: 1e-06
volk_32f_s32f_mod_rangepuppet_32f: fail on arch a_avx
```

This happens because the input range (-1 .. +1) maps to the output ranges (325.664 .. 327) and (323.859 .. 324.523), with a wrap-around occurring when the input is equal to 0.336. When an input close to 0.336 occurs, floating-point error could cause the output to be close to either 327 or 323.859, and the test can fail.

To avoid this situation, I've adjusted the lower bound such that the wrap-around condition is avoided. After this change, (-1 .. +1) maps to the continuous range (324.624 .. 326.624) and the test passes reliably on i386.