### PR TITLE
Add missing volk_16_byteswap_u_orc to puppet

### DIFF
--- a/kernels/volk/volk_16u_byteswappuppet_16u.h
+++ b/kernels/volk/volk_16u_byteswappuppet_16u.h
@@ -92,4 +92,14 @@ static inline void volk_16u_byteswappuppet_16u_a_avx2(uint16_t* output,
 }
 #endif
 
+#ifdef LV_HAVE_ORC
+static inline void volk_16u_byteswappuppet_16u_u_orc(uint16_t* output,
+                                                     uint16_t* intsToSwap,
+                                                     unsigned int num_points)
+{
+    volk_16u_byteswap_u_orc((uint16_t*)intsToSwap, num_points);
+    memcpy((void*)output, (void*)intsToSwap, num_points * sizeof(uint16_t));
+}
+#endif /* LV_HAVE_ORC */
+
 #endif


### PR DESCRIPTION
`volk_16u_byteswap_u_orc` is not tested or profiled, because it does not have a wrapper in `volk_16u_byteswappuppet_16u`. Here I've added the missing wrapper.

The `volk_16u_byteswap_u_orc` protokernel seems to work fine, and has perforance comparable to the others:

```
$ apps/volk_profile -n -R byteswappuppet_16u
Warning: this IS a dry-run. Config will not be written!
RUN_VOLK_TESTS: volk_16u_byteswappuppet_16u(131071,1987)
generic completed in 54.6349 ms
u_sse2 completed in 41.4502 ms
a_sse2 completed in 40.915 ms
u_avx2 completed in 28.288 ms
a_avx2 completed in 28.9922 ms
u_orc completed in 32.8863 ms
Best aligned arch: u_avx2
Best unaligned arch: u_avx2
```