### PR TITLE
Align types in ORC function signatures

### DIFF
--- a/kernels/volk/asm/orc/volk_16ic_deinterleave_16i_x2_a_orc_impl.orc
+++ b/kernels/volk/asm/orc/volk_16ic_deinterleave_16i_x2_a_orc_impl.orc
@@ -1,5 +1,5 @@
 .function volk_16ic_deinterleave_16i_x2_a_orc_impl
-.dest 2 idst
-.dest 2 qdst
-.source 4 src
+.dest 2 idst int16_t
+.dest 2 qdst int16_t
+.source 4 src lv_16sc_t
 splitlw qdst, idst, src

--- a/kernels/volk/asm/orc/volk_16ic_deinterleave_real_8i_a_orc_impl.orc
+++ b/kernels/volk/asm/orc/volk_16ic_deinterleave_real_8i_a_orc_impl.orc
@@ -1,6 +1,6 @@
 .function volk_16ic_deinterleave_real_8i_a_orc_impl
-.dest 1 dst
-.source 4 src
+.dest 1 dst int8_t
+.source 4 src lv_16sc_t
 .temp 2 iw
 select0lw iw, src
 convhwb dst, iw

--- a/kernels/volk/asm/orc/volk_16ic_s32f_deinterleave_32f_x2_a_orc_impl.orc
+++ b/kernels/volk/asm/orc/volk_16ic_s32f_deinterleave_32f_x2_a_orc_impl.orc
@@ -1,7 +1,7 @@
 .function volk_16ic_s32f_deinterleave_32f_x2_a_orc_impl
-.dest 4 idst
-.dest 4 qdst
-.source 4 src
+.dest 4 idst float
+.dest 4 qdst float
+.source 4 src lv_16sc_t
 .floatparam 4 scalar
 .temp 8 iql
 .temp 8 iqf

--- a/kernels/volk/asm/orc/volk_16u_byteswap_a_orc_impl.orc
+++ b/kernels/volk/asm/orc/volk_16u_byteswap_a_orc_impl.orc
@@ -1,3 +1,3 @@
 .function volk_16u_byteswap_a_orc_impl
-.dest 2 dst
+.dest 2 dst uint16_t
 swapw dst, dst

--- a/kernels/volk/asm/orc/volk_32f_s32f_add_32f_a_orc_impl.orc
+++ b/kernels/volk/asm/orc/volk_32f_s32f_add_32f_a_orc_impl.orc
@@ -1,5 +1,5 @@
 .function volk_32f_s32f_add_32f_a_orc_impl
-.dest 4 dst
-.source 4 src1
+.dest 4 dst float
+.source 4 src1 float
 .floatparam 4 scalar
 addf dst, src1, scalar

--- a/kernels/volk/asm/orc/volk_32f_s32f_multiply_32f_a_orc_impl.orc
+++ b/kernels/volk/asm/orc/volk_32f_s32f_multiply_32f_a_orc_impl.orc
@@ -1,5 +1,5 @@
 .function volk_32f_s32f_multiply_32f_a_orc_impl
-.dest 4 dst
-.source 4 src1
+.dest 4 dst float
+.source 4 src1 float
 .floatparam 4 scalar
 mulf dst, src1, scalar

--- a/kernels/volk/asm/orc/volk_32f_s32f_normalize_a_orc_impl.orc
+++ b/kernels/volk/asm/orc/volk_32f_s32f_normalize_a_orc_impl.orc
@@ -1,5 +1,5 @@
 .function volk_32f_s32f_normalize_a_orc_impl
-.source 4 src1
+.source 4 src1 float
 .floatparam 4 invscalar
-.dest 4 dst
+.dest 4 dst float
 mulf dst, src1, invscalar

--- a/kernels/volk/asm/orc/volk_32f_x2_add_32f_a_orc_impl.orc
+++ b/kernels/volk/asm/orc/volk_32f_x2_add_32f_a_orc_impl.orc
@@ -1,5 +1,5 @@
 .function volk_32f_x2_add_32f_a_orc_impl
-.dest 4 dst
-.source 4 src1
-.source 4 src2
+.dest 4 dst float
+.source 4 src1 float
+.source 4 src2 float
 addf dst, src1, src2

--- a/kernels/volk/asm/orc/volk_32f_x2_divide_32f_a_orc_impl.orc
+++ b/kernels/volk/asm/orc/volk_32f_x2_divide_32f_a_orc_impl.orc
@@ -1,5 +1,5 @@
 .function volk_32f_x2_divide_32f_a_orc_impl
-.dest 4 dst
-.source 4 src1
-.source 4 src2
+.dest 4 dst float
+.source 4 src1 float
+.source 4 src2 float
 divf dst, src1, src2

--- a/kernels/volk/asm/orc/volk_32f_x2_max_32f_a_orc_impl.orc
+++ b/kernels/volk/asm/orc/volk_32f_x2_max_32f_a_orc_impl.orc
@@ -1,5 +1,5 @@
 .function volk_32f_x2_max_32f_a_orc_impl
-.dest 4 dst
-.source 4 src1
-.source 4 src2
+.dest 4 dst float
+.source 4 src1 float
+.source 4 src2 float
 maxf dst, src1, src2

--- a/kernels/volk/asm/orc/volk_32f_x2_min_32f_a_orc_impl.orc
+++ b/kernels/volk/asm/orc/volk_32f_x2_min_32f_a_orc_impl.orc
@@ -1,5 +1,5 @@
 .function volk_32f_x2_min_32f_a_orc_impl
-.dest 4 dst
-.source 4 src1
-.source 4 src2
+.dest 4 dst float
+.source 4 src1 float
+.source 4 src2 float
 minf dst, src1, src2

--- a/kernels/volk/asm/orc/volk_32f_x2_multiply_32f_a_orc_impl.orc
+++ b/kernels/volk/asm/orc/volk_32f_x2_multiply_32f_a_orc_impl.orc
@@ -1,5 +1,5 @@
 .function volk_32f_x2_multiply_32f_a_orc_impl
-.dest 4 dst
-.source 4 src1
-.source 4 src2
+.dest 4 dst float
+.source 4 src1 float
+.source 4 src2 float
 mulf dst, src1, src2

--- a/kernels/volk/asm/orc/volk_32f_x2_subtract_32f_a_orc_impl.orc
+++ b/kernels/volk/asm/orc/volk_32f_x2_subtract_32f_a_orc_impl.orc
@@ -1,5 +1,5 @@
 .function volk_32f_x2_subtract_32f_a_orc_impl
-.dest 4 dst
-.source 4 src1
-.source 4 src2
+.dest 4 dst float
+.source 4 src1 float
+.source 4 src2 float
 subf dst, src1, src2

--- a/kernels/volk/asm/orc/volk_32fc_32f_multiply_32fc_a_orc_impl.orc
+++ b/kernels/volk/asm/orc/volk_32fc_32f_multiply_32fc_a_orc_impl.orc
@@ -1,7 +1,7 @@
 .function volk_32fc_32f_multiply_32fc_a_orc_impl
-.source 8 src1
-.source 4 src2
-.dest 8 dst
+.source 8 src1 lv_32fc_t
+.source 4 src2 float
+.dest 8 dst lv_32fc_t
 .temp 8 tmp
 mergelq tmp, src2, src2
 x2 mulf dst, src1, tmp

--- a/kernels/volk/asm/orc/volk_32fc_x2_multiply_32fc_a_orc_impl.orc
+++ b/kernels/volk/asm/orc/volk_32fc_x2_multiply_32fc_a_orc_impl.orc
@@ -1,7 +1,7 @@
 .function volk_32fc_x2_multiply_32fc_a_orc_impl
-.source 8 src1
-.source 8 src2
-.dest 8 dst
+.source 8 src1 lv_32fc_t
+.source 8 src2 lv_32fc_t
+.dest 8 dst lv_32fc_t
 .temp 8 iqprod
 .temp 4 real
 .temp 4 imag

--- a/kernels/volk/asm/orc/volk_32i_x2_and_32i_a_orc_impl.orc
+++ b/kernels/volk/asm/orc/volk_32i_x2_and_32i_a_orc_impl.orc
@@ -1,5 +1,5 @@
 .function volk_32i_x2_and_32i_a_orc_impl
-.dest 4 dst
-.source 4 src1
-.source 4 src2
+.dest 4 dst int32_t
+.source 4 src1 int32_t
+.source 4 src2 int32_t
 andl dst, src1, src2

--- a/kernels/volk/asm/orc/volk_32i_x2_or_32i_a_orc_impl.orc
+++ b/kernels/volk/asm/orc/volk_32i_x2_or_32i_a_orc_impl.orc
@@ -1,5 +1,5 @@
 .function volk_32i_x2_or_32i_a_orc_impl
-.dest 4 dst
-.source 4 src1
-.source 4 src2
+.dest 4 dst int32_t
+.source 4 src1 int32_t
+.source 4 src2 int32_t
 orl dst, src1, src2

--- a/kernels/volk/asm/orc/volk_8i_convert_16i_a_orc_impl.orc
+++ b/kernels/volk/asm/orc/volk_8i_convert_16i_a_orc_impl.orc
@@ -1,6 +1,6 @@
 .function volk_8i_convert_16i_a_orc_impl
-.source 1 src
-.dest 2 dst
+.source 1 src int8_t
+.dest 2 dst int16_t
 .temp 2 tmp
 convsbw tmp, src
 shlw dst, tmp, 8

--- a/kernels/volk/asm/orc/volk_8i_s32f_convert_32f_a_orc_impl.orc
+++ b/kernels/volk/asm/orc/volk_8i_s32f_convert_32f_a_orc_impl.orc
@@ -1,6 +1,6 @@
 .function volk_8i_s32f_convert_32f_a_orc_impl
-.source 1 src
-.dest 4 dst
+.source 1 src uint8_t
+.dest 4 dst float
 .floatparam 4 scalar
 .temp 4 flsrc
 .temp 4 lsrc

--- a/kernels/volk/volk_16ic_deinterleave_16i_x2.h
+++ b/kernels/volk/volk_16ic_deinterleave_16i_x2.h
@@ -274,7 +274,7 @@ static inline void volk_16ic_deinterleave_16i_x2_generic(int16_t* iBuffer,
 extern void volk_16ic_deinterleave_16i_x2_a_orc_impl(int16_t* iBuffer,
                                                      int16_t* qBuffer,
                                                      const lv_16sc_t* complexVector,
-                                                     unsigned int num_points);
+                                                     int num_points);
 static inline void volk_16ic_deinterleave_16i_x2_u_orc(int16_t* iBuffer,
                                                        int16_t* qBuffer,
                                                        const lv_16sc_t* complexVector,

--- a/kernels/volk/volk_16ic_deinterleave_real_8i.h
+++ b/kernels/volk/volk_16ic_deinterleave_real_8i.h
@@ -275,7 +275,7 @@ static inline void volk_16ic_deinterleave_real_8i_neon(int8_t* iBuffer,
 
 extern void volk_16ic_deinterleave_real_8i_a_orc_impl(int8_t* iBuffer,
                                                       const lv_16sc_t* complexVector,
-                                                      unsigned int num_points);
+                                                      int num_points);
 
 static inline void volk_16ic_deinterleave_real_8i_u_orc(int8_t* iBuffer,
                                                         const lv_16sc_t* complexVector,

--- a/kernels/volk/volk_16ic_s32f_deinterleave_32f_x2.h
+++ b/kernels/volk/volk_16ic_s32f_deinterleave_32f_x2.h
@@ -240,7 +240,7 @@ extern void volk_16ic_s32f_deinterleave_32f_x2_a_orc_impl(float* iBuffer,
                                                           float* qBuffer,
                                                           const lv_16sc_t* complexVector,
                                                           const float scalar,
-                                                          unsigned int num_points);
+                                                          int num_points);
 
 static inline void
 volk_16ic_s32f_deinterleave_32f_x2_u_orc(float* iBuffer,

--- a/kernels/volk/volk_16u_byteswap.h
+++ b/kernels/volk/volk_16u_byteswap.h
@@ -273,7 +273,7 @@ static inline void volk_16u_byteswap_neon_table(uint16_t* intsToSwap,
 
 #ifdef LV_HAVE_ORC
 
-extern void volk_16u_byteswap_a_orc_impl(uint16_t* intsToSwap, unsigned int num_points);
+extern void volk_16u_byteswap_a_orc_impl(uint16_t* intsToSwap, int num_points);
 static inline void volk_16u_byteswap_u_orc(uint16_t* intsToSwap, unsigned int num_points)
 {
     volk_16u_byteswap_a_orc_impl(intsToSwap, num_points);

--- a/kernels/volk/volk_32f_s32f_add_32f.h
+++ b/kernels/volk/volk_32f_s32f_add_32f.h
@@ -247,7 +247,7 @@ static inline void volk_32f_s32f_add_32f_a_avx(float* cVector,
 extern void volk_32f_s32f_add_32f_a_orc_impl(float* dst,
                                              const float* src,
                                              const float scalar,
-                                             unsigned int num_points);
+                                             int num_points);
 
 static inline void volk_32f_s32f_add_32f_u_orc(float* cVector,
                                                const float* aVector,

--- a/kernels/volk/volk_32f_s32f_multiply_32f.h
+++ b/kernels/volk/volk_32f_s32f_multiply_32f.h
@@ -245,7 +245,7 @@ static inline void volk_32f_s32f_multiply_32f_u_neon(float* cVector,
 extern void volk_32f_s32f_multiply_32f_a_orc_impl(float* dst,
                                                   const float* src,
                                                   const float scalar,
-                                                  unsigned int num_points);
+                                                  int num_points);
 
 static inline void volk_32f_s32f_multiply_32f_u_orc(float* cVector,
                                                     const float* aVector,

--- a/kernels/volk/volk_32f_s32f_normalize.h
+++ b/kernels/volk/volk_32f_s32f_normalize.h
@@ -151,7 +151,7 @@ static inline void volk_32f_s32f_normalize_generic(float* vecBuffer,
 extern void volk_32f_s32f_normalize_a_orc_impl(float* dst,
                                                float* src,
                                                const float scalar,
-                                               unsigned int num_points);
+                                               int num_points);
 static inline void volk_32f_s32f_normalize_u_orc(float* vecBuffer,
                                                  const float scalar,
                                                  unsigned int num_points)

--- a/kernels/volk/volk_32f_x2_add_32f.h
+++ b/kernels/volk/volk_32f_x2_add_32f.h
@@ -379,7 +379,7 @@ extern void volk_32f_x2_add_32f_a_neonpipeline(float* cVector,
 extern void volk_32f_x2_add_32f_a_orc_impl(float* cVector,
                                            const float* aVector,
                                            const float* bVector,
-                                           unsigned int num_points);
+                                           int num_points);
 
 static inline void volk_32f_x2_add_32f_u_orc(float* cVector,
                                              const float* aVector,

--- a/kernels/volk/volk_32f_x2_divide_32f.h
+++ b/kernels/volk/volk_32f_x2_divide_32f.h
@@ -253,7 +253,7 @@ static inline void volk_32f_x2_divide_32f_generic(float* cVector,
 extern void volk_32f_x2_divide_32f_a_orc_impl(float* cVector,
                                               const float* aVector,
                                               const float* bVector,
-                                              unsigned int num_points);
+                                              int num_points);
 
 static inline void volk_32f_x2_divide_32f_u_orc(float* cVector,
                                                 const float* aVector,

--- a/kernels/volk/volk_32f_x2_max_32f.h
+++ b/kernels/volk/volk_32f_x2_max_32f.h
@@ -233,7 +233,7 @@ static inline void volk_32f_x2_max_32f_generic(float* cVector,
 extern void volk_32f_x2_max_32f_a_orc_impl(float* cVector,
                                            const float* aVector,
                                            const float* bVector,
-                                           unsigned int num_points);
+                                           int num_points);
 
 static inline void volk_32f_x2_max_32f_u_orc(float* cVector,
                                              const float* aVector,

--- a/kernels/volk/volk_32f_x2_min_32f.h
+++ b/kernels/volk/volk_32f_x2_min_32f.h
@@ -162,7 +162,7 @@ static inline void volk_32f_x2_min_32f_generic(float* cVector,
 extern void volk_32f_x2_min_32f_a_orc_impl(float* cVector,
                                            const float* aVector,
                                            const float* bVector,
-                                           unsigned int num_points);
+                                           int num_points);
 
 static inline void volk_32f_x2_min_32f_u_orc(float* cVector,
                                              const float* aVector,

--- a/kernels/volk/volk_32f_x2_multiply_32f.h
+++ b/kernels/volk/volk_32f_x2_multiply_32f.h
@@ -345,7 +345,7 @@ static inline void volk_32f_x2_multiply_32f_neon(float* cVector,
 extern void volk_32f_x2_multiply_32f_a_orc_impl(float* cVector,
                                                 const float* aVector,
                                                 const float* bVector,
-                                                unsigned int num_points);
+                                                int num_points);
 
 static inline void volk_32f_x2_multiply_32f_u_orc(float* cVector,
                                                   const float* aVector,

--- a/kernels/volk/volk_32f_x2_subtract_32f.h
+++ b/kernels/volk/volk_32f_x2_subtract_32f.h
@@ -194,7 +194,7 @@ static inline void volk_32f_x2_subtract_32f_neon(float* cVector,
 extern void volk_32f_x2_subtract_32f_a_orc_impl(float* cVector,
                                                 const float* aVector,
                                                 const float* bVector,
-                                                unsigned int num_points);
+                                                int num_points);
 
 static inline void volk_32f_x2_subtract_32f_u_orc(float* cVector,
                                                   const float* aVector,

--- a/kernels/volk/volk_32fc_32f_multiply_32fc.h
+++ b/kernels/volk/volk_32fc_32f_multiply_32fc.h
@@ -212,7 +212,7 @@ static inline void volk_32fc_32f_multiply_32fc_neon(lv_32fc_t* cVector,
 extern void volk_32fc_32f_multiply_32fc_a_orc_impl(lv_32fc_t* cVector,
                                                    const lv_32fc_t* aVector,
                                                    const float* bVector,
-                                                   unsigned int num_points);
+                                                   int num_points);
 
 static inline void volk_32fc_32f_multiply_32fc_u_orc(lv_32fc_t* cVector,
                                                      const lv_32fc_t* aVector,

--- a/kernels/volk/volk_32fc_x2_multiply_32fc.h
+++ b/kernels/volk/volk_32fc_x2_multiply_32fc.h
@@ -448,7 +448,7 @@ extern void volk_32fc_x2_multiply_32fc_a_neonasm(lv_32fc_t* cVector,
 extern void volk_32fc_x2_multiply_32fc_a_orc_impl(lv_32fc_t* cVector,
                                                   const lv_32fc_t* aVector,
                                                   const lv_32fc_t* bVector,
-                                                  unsigned int num_points);
+                                                  int num_points);
 
 static inline void volk_32fc_x2_multiply_32fc_u_orc(lv_32fc_t* cVector,
                                                     const lv_32fc_t* aVector,

--- a/kernels/volk/volk_32i_x2_and_32i.h
+++ b/kernels/volk/volk_32i_x2_and_32i.h
@@ -241,7 +241,7 @@ static inline void volk_32i_x2_and_32i_generic(int32_t* cVector,
 extern void volk_32i_x2_and_32i_a_orc_impl(int32_t* cVector,
                                            const int32_t* aVector,
                                            const int32_t* bVector,
-                                           unsigned int num_points);
+                                           int num_points);
 
 static inline void volk_32i_x2_and_32i_u_orc(int32_t* cVector,
                                              const int32_t* aVector,

--- a/kernels/volk/volk_32i_x2_or_32i.h
+++ b/kernels/volk/volk_32i_x2_or_32i.h
@@ -240,7 +240,7 @@ static inline void volk_32i_x2_or_32i_generic(int32_t* cVector,
 extern void volk_32i_x2_or_32i_a_orc_impl(int32_t* cVector,
                                           const int32_t* aVector,
                                           const int32_t* bVector,
-                                          unsigned int num_points);
+                                          int num_points);
 
 static inline void volk_32i_x2_or_32i_u_orc(int32_t* cVector,
                                             const int32_t* aVector,

--- a/kernels/volk/volk_8i_convert_16i.h
+++ b/kernels/volk/volk_8i_convert_16i.h
@@ -256,7 +256,7 @@ static inline void volk_8i_convert_16i_neon(int16_t* outputVector,
 #ifdef LV_HAVE_ORC
 extern void volk_8i_convert_16i_a_orc_impl(int16_t* outputVector,
                                            const int8_t* inputVector,
-                                           unsigned int num_points);
+                                           int num_points);
 
 static inline void volk_8i_convert_16i_u_orc(int16_t* outputVector,
                                              const int8_t* inputVector,

--- a/kernels/volk/volk_8i_s32f_convert_32f.h
+++ b/kernels/volk/volk_8i_s32f_convert_32f.h
@@ -338,7 +338,7 @@ static inline void volk_8i_s32f_convert_32f_neon(float* outputVector,
 extern void volk_8i_s32f_convert_32f_a_orc_impl(float* outputVector,
                                                 const int8_t* inputVector,
                                                 const float scalar,
-                                                unsigned int num_points);
+                                                int num_points);
 
 static inline void volk_8i_s32f_convert_32f_u_orc(float* outputVector,
                                                   const int8_t* inputVector,

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -449,7 +449,7 @@ if(ORC_FOUND)
 
         #create a rule to generate the source and add to the list of sources
         add_custom_command(
-            COMMAND ${ORCC_EXECUTABLE} --include math.h --implementation -o ${orcc_gen} ${orc_file}
+            COMMAND ${ORCC_EXECUTABLE} --include math.h --implementation --include volk/volk_complex.h -o ${orcc_gen} ${orc_file}
             DEPENDS ${orc_file} OUTPUT ${orcc_gen}
         )
         list(APPEND volk_sources ${orcc_gen})


### PR DESCRIPTION
Fixes #739.

ORC programs did not specify types for their `.source` and `.dest` arrays, so default types were used in the generated C function signatures. These often differed from VOLK's function signatures.

Also, ORC uses `int` for its length input, while VOLK used `unsigned int` in its function signatures.

Here I've fixed both problems, after which compilation with `-flto -Werror=lto-type-mismatch` succeeds.