### PR TITLE
fprintf: Remove fprintf statements from volk_malloc

### DIFF
--- a/lib/volk_malloc.c
+++ b/lib/volk_malloc.c
@@ -38,7 +38,6 @@
 void* volk_malloc(size_t size, size_t alignment)
 {
     if ((size == 0) || (alignment == 0)) {
-        fprintf(stderr, "VOLK: Error allocating memory: either size or alignment is 0\n");
         return NULL;
     }
     // Tweak size to satisfy ASAN (the GCC address sanitizer).
@@ -59,21 +58,12 @@ void* volk_malloc(size_t size, size_t alignment)
     int err = posix_memalign(&ptr, alignment, size);
     if (err != 0) {
         ptr = NULL;
-        fprintf(stderr,
-                "VOLK: Error allocating memory "
-                "(posix_memalign: error %d: %s)\n",
-                err,
-                strerror(err));
     }
 #elif defined(_MSC_VER) || defined(__MINGW32__)
     void* ptr = _aligned_malloc(size, alignment);
 #else
     void* ptr = aligned_alloc(alignment, size);
 #endif
-    if (ptr == NULL) {
-        fprintf(stderr,
-                "VOLK: Error allocating memory (aligned_alloc/_aligned_malloc)\n");
-    }
     return ptr;
 }
 


### PR DESCRIPTION
As per issue description, this may fail and is communicated the C way via a `NULL` pointer. As with similar routines, a user must check the return value. We shouldn't clutter stderr.

Fixes #666 

[Given the number of the issue, I need to point out that there is a great song about it by Iron Maiden](https://www.youtube.com/watch?v=_WCCVqkTI9Q)