### PR TITLE
Remove volk_16u_byteswap_a_orc

### DIFF
--- a/kernels/volk/asm/orc/volk_16u_byteswap_a_orc_impl.orc
+++ b/kernels/volk/asm/orc/volk_16u_byteswap_a_orc_impl.orc
@@ -1,3 +1,0 @@
-.function volk_16u_byteswap_a_orc_impl
-.dest 2 dst uint16_t
-swapw dst, dst

--- a/kernels/volk/volk_16u_byteswap.h
+++ b/kernels/volk/volk_16u_byteswap.h
@@ -271,14 +271,5 @@ static inline void volk_16u_byteswap_neon_table(uint16_t* intsToSwap,
 }
 #endif /* LV_HAVE_NEON */
 
-#ifdef LV_HAVE_ORC
-
-extern void volk_16u_byteswap_a_orc_impl(uint16_t* intsToSwap, int num_points);
-static inline void volk_16u_byteswap_u_orc(uint16_t* intsToSwap, unsigned int num_points)
-{
-    volk_16u_byteswap_a_orc_impl(intsToSwap, num_points);
-}
-#endif /* LV_HAVE_ORC */
-
 
 #endif /* INCLUDED_volk_16u_byteswap_a_H */

--- a/kernels/volk/volk_16u_byteswappuppet_16u.h
+++ b/kernels/volk/volk_16u_byteswappuppet_16u.h
@@ -92,14 +92,4 @@ static inline void volk_16u_byteswappuppet_16u_a_avx2(uint16_t* output,
 }
 #endif
 
-#ifdef LV_HAVE_ORC
-static inline void volk_16u_byteswappuppet_16u_u_orc(uint16_t* output,
-                                                     uint16_t* intsToSwap,
-                                                     unsigned int num_points)
-{
-    volk_16u_byteswap_u_orc((uint16_t*)intsToSwap, num_points);
-    memcpy((void*)output, (void*)intsToSwap, num_points * sizeof(uint16_t));
-}
-#endif /* LV_HAVE_ORC */
-
 #endif


### PR DESCRIPTION
This protokernel was enabled in #719, but it appears to be broken on M1, so let's remove it for now.

Fixes #745.