### PR TITLE
flyci: Test CI service with M2 instance

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -241,7 +241,11 @@ jobs:
 
   build-macos:
 
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        os: [macos-latest, flyci-macos-large-latest-m2]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3.1.0


### PR DESCRIPTION
Assuming their app has access to our git repo etc. This might be a viable option for the time being to get some more stability into the Apple Silicon support effort. It worked on my personal account:
https://github.com/jdemel/volk/actions/runs/7717048987/job/21035255427