### PR TITLE
actions: Update GH Actions checkout

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3.0.0
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
 

--- a/.github/workflows/check-pr-formatting.yml
+++ b/.github/workflows/check-pr-formatting.yml
@@ -23,9 +23,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: gnuradio/clang-format-lint-action@v0.5-4
       with:
         source: '.'
         exclude: './tmpl,./include/volk/sse2neon.h'
         extensions: 'c,cc,cpp,cxx,h,hh'
+

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.compiler.distro }}
 
     steps:
-    - uses: actions/checkout@v3.1.0
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: Install dependencies
@@ -110,7 +110,7 @@ jobs:
             compiler: { name: g++-12, cc: gcc-12, cxx: g++-12 }
 
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       - uses: uraimo/run-on-arch-action@v2.5.0
@@ -169,7 +169,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3.1.0
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: dependencies
@@ -194,7 +194,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3.1.0
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: dependencies
@@ -244,7 +244,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3.1.0
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: dependencies


### PR DESCRIPTION
This should remove a warning where GH constantly reports that we should switch to a later actions/checkout version to ensure we use Node.js20 instead of 16 underneath.