### PR TITLE
docs: Fix upload to webserver

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -22,8 +22,12 @@ jobs:
       run: |
         ssh-agent -a $SSH_AUTH_SOCK > /dev/null
         ssh-add - <<< "${{ secrets.SSH_KEY }}"
+        mkdir $HOME/.ssh
+        echo -n "${{ secrets.SSH_KNOWN_HOST }}" > $HOME/.ssh/known_hosts
     - name: Upload via SSH
-      run: 'tar -cz build/html/ | ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} "mkdir -p /www/$(date +%Y.%m.%d); cd /www/$(date +%Y.%m.%d); tar --strip-components=1 -xz; rm /www/live; cd /www; ln -sf $(date +%Y.%m.%d) live;"'
+      env:
+        SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      run: 'tar -cz build/html/ | ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_SERVER }} "mkdir -p /www/$(date +%Y.%m.%d); cd /www/$(date +%Y.%m.%d); tar --strip-components=1 -xz; rm /www/live; cd /www; ln -sf $(date +%Y.%m.%d) live;"'
     - uses: actions/upload-artifact@v4
       with:
         name: volk_docs

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -27,7 +27,8 @@ jobs:
     - name: Upload via SSH
       env:
         SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-      run: 'tar -cz build/html/ | ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_SERVER }} "mkdir -p /www/$(date +%Y.%m.%d); cd /www/$(date +%Y.%m.%d); tar --strip-components=1 -xz; rm /www/live; cd /www; ln -sf $(date +%Y.%m.%d) live;"'
+        TARGET_DIR: "${{ github.ref_type }}/${{ github.ref_name }}"
+      run: 'tar -cz build/html/ | ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_SERVER }} "mkdir -p /www/${{ env.TARGET_DIR }}/$(date +%Y.%m.%d); cd /www/${{ env.TARGET_DIR }}/$(date +%Y.%m.%d); tar --strip-components=2 -xz; rm /www/${{ env.TARGET_DIR }}/live; cd /www/${{ env.TARGET_DIR }}; ln -sf $(date +%Y.%m.%d) live;"'
     - uses: actions/upload-artifact@v4
       with:
         name: volk_docs


### PR DESCRIPTION
This also enables storing of different versions of the documentation in subdirectories. 

Currently they will be available in `libvolk.org/test-docs/{branch,tag}/{refname}/`. 
So, currently there is a version in www.libvolk.org/test-docs/branch/noc0lour/build-docs-ci/ from this branch. 
Whenever a new version is built it will be created in a new subdirectory (based on the current date) and the symlink is switched to it on the webserver.

I did not add a version selector to the documentation HTML (maybe someone is especially motivated to do so), so access to different branches & versions is limited to people who know. Probably we could link to the versions from the main page.