### PR TITLE
macos: Fix CI dependency error

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -254,7 +254,7 @@ jobs:
       with:
         submodules: 'recursive'
     - name: dependencies
-      run: pip3 install mako
+      run: pip3 install --break-system-packages mako && brew install orc
     - name: configure
       run: mkdir build && cd build && cmake -DBUILD_EXECUTABLE=ON ..
     - name: build


### PR DESCRIPTION
The following error popped up during our CI builds on MacOS:
```shell
$ pip3 install mako
  shell: /bin/bash -e {0}
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try brew install
    xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-brew-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip.

    If you wish to install a non-brew packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```
[PEP668](https://peps.python.org/pep-0668/) tries to help people to prevent dependency issues on their systems.
We can be pretty sure that our controlled CI environment is not affected by this issue. Thus, we can use `--break-system-packages` and install system-wide.

We introduced the FlyCI runner in #752 to enable CI runs on MacOS/ARM. This PR fixes a Python dependency install issue. Further, it installs liborc via `brew install orc` to test and install ORC kernels. 