### PR TITLE
ci: Fix run-on-arch hiccup

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -115,7 +115,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
-      - uses: uraimo/run-on-arch-action@v2.7.2
+      - uses: uraimo/run-on-arch-action@v2
         name: Build in non-x86 container
         id: build
         with:


### PR DESCRIPTION
We probably need to load a newer version than what we pinned before. Let's just update and hopefully enjoy the benefits.