### PR TITLE
cleanup: Remove unused includes

### DIFF
--- a/kernels/volk/volk_16i_x4_quad_max_star_16i.h
+++ b/kernels/volk/volk_16i_x4_quad_max_star_16i.h
@@ -47,7 +47,6 @@
 #define INCLUDED_volk_16i_x4_quad_max_star_16i_a_H
 
 #include <inttypes.h>
-#include <stdio.h>
 
 #ifdef LV_HAVE_SSE2
 

--- a/kernels/volk/volk_32fc_index_max_32u.h
+++ b/kernels/volk/volk_32fc_index_max_32u.h
@@ -58,7 +58,6 @@
 #define INCLUDED_volk_32fc_index_max_32u_a_H
 
 #include <inttypes.h>
-#include <stdio.h>
 #include <volk/volk_common.h>
 #include <volk/volk_complex.h>
 
@@ -327,7 +326,6 @@ volk_32fc_index_max_32u_generic(uint32_t* target, lv_32fc_t* src0, uint32_t num_
 #define INCLUDED_volk_32fc_index_max_32u_u_H
 
 #include <inttypes.h>
-#include <stdio.h>
 #include <volk/volk_common.h>
 #include <volk/volk_complex.h>
 

--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -21,7 +21,6 @@
 #include <cmath>    // for sqrt, fabs, abs
 #include <cstring>  // for memcpy, memset
 #include <ctime>    // for clock
-#include <fstream>  // for operator<<, basic...
 #include <iostream> // for cout, cerr
 #include <limits>   // for numeric_limits
 #include <map>      // for map, map<>::mappe...


### PR DESCRIPTION
clangd reports multiple unused includes. These should be removed to potentially reduce build times and also to minimize includes. Only including necessary includes helps to better understand the code.