### PR TITLE
Feature: Add Environment Variable Kernel Override

### DIFF
--- a/lib/volk_rank_archs.c
+++ b/lib/volk_rank_archs.c
@@ -56,6 +56,13 @@ int volk_rank_archs(const char* kern_name,    // name of the kernel to rank
         return volk_get_index(impl_names, n_impls, "generic");
     }
 
+    // If we've defined the kernel name as an environment variable, always return
+    // the 'overridden' kernel. Used for manually overring config kernels at runtime.
+    char *override_env = getenv(kern_name);
+    if (override_env) {
+        return volk_get_index(impl_names, n_impls, override_env);
+    }
+
     // now look for the function name in the prefs list
     for (i = 0; i < n_arch_prefs; i++) {
         if (!strncmp(kern_name,

--- a/lib/volk_rank_archs.c
+++ b/lib/volk_rank_archs.c
@@ -58,7 +58,7 @@ int volk_rank_archs(const char* kern_name,    // name of the kernel to rank
 
     // If we've defined the kernel name as an environment variable, always return
     // the 'overridden' kernel. Used for manually overring config kernels at runtime.
-    char *override_env = getenv(kern_name);
+    char* override_env = getenv(kern_name);
     if (override_env) {
         return volk_get_index(impl_names, n_impls, override_env);
     }


### PR DESCRIPTION
Tiny PR to add environment variable based overriding of configured kernel for debugging & run-time fixing of broken kernels without having to entirely disable volk using VOLK_GENERIC=1

Closes: #785 