### PR TITLE
Add gtest suite for volk_32fc_s32fc_x2_rotator2_32fc

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -563,9 +563,7 @@ endif()
 target_compile_features(volk_obj PUBLIC c_std_17)
 
 #Configure object target properties
-if(NOT MSVC)
-    set_target_properties(volk_obj PROPERTIES COMPILE_FLAGS "-fPIC")
-endif()
+set_target_properties(volk_obj PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # Disable complex math NaN/INFO range checking for performance
 include(CheckCCompilerFlag)

--- a/tests/test_volk_32fc_s32fc_x2_rotator2_32fc.cc
+++ b/tests/test_volk_32fc_s32fc_x2_rotator2_32fc.cc
@@ -1,0 +1,151 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2025 Johannes Demel
+ *
+ * This file is part of VOLK
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#include "volk_test.h"
+#include <fmt/chrono.h>
+#include <fmt/core.h>
+#include <fmt/ranges.h>
+#include <gtest/gtest.h>
+#include <volk/volk.h>
+#include <volk/volk_alloc.hh>
+#include <chrono>
+
+class volk_32fc_s32fc_x2_rotator2_32fc_test : public VolkTest
+{
+protected:
+    void SetUp() override
+    {
+        initialize_test(GetParam());
+        initialize_data(vector_length);
+    }
+
+    void initialize_data(const size_t length)
+    {
+        // Be stricter for smaller vectors. Error accumulate slowly!
+        if (length < 16) {
+            absolute_error = 10.e-7;
+        } else if (length < 128) {
+            absolute_error = 10.e-6;
+        } else if (length < 65536) {
+            absolute_error = 10.e-5;
+        } else {
+            absolute_error = 10.e-3;
+        }
+
+        vector_length = length;
+        input = volk::vector<lv_32fc_t>(length);
+        result = volk::vector<lv_32fc_t>(length);
+        result_magnitude = volk::vector<float>(length);
+
+        const float initial_phase = initial_phase_steps * increment;
+        phase_increment = std::polar(1.0f, increment);
+        phase = std::polar(1.0f, initial_phase);
+
+        for (size_t i = 0; i < length; ++i) {
+            input[i] =
+                std::complex<float>(2.0f * std::cos(2.0f * M_PI * i / length),
+                                    2.0f * std::sin(0.3f + 2.0f * M_PI * i / length));
+        }
+
+        // Calculate expected results
+        expected = volk::vector<lv_32fc_t>(length);
+        for (size_t i = 0; i < length; ++i) {
+            expected[i] =
+                input[i] *
+                std::polar(1.0f, initial_phase + static_cast<float>(i) * increment);
+        }
+
+        expected_magnitude = volk::vector<float>(length);
+        for (size_t i = 0; i < length; ++i) {
+            expected_magnitude[i] = std::abs(input[i]);
+        }
+
+        // This is a hacky solution to have unaligned tests.
+        ua_result = result;
+        ua_result.at(0) = expected.at(0);
+    }
+
+    void execute_aligned(const std::string impl_name)
+    {
+        volk_32fc_s32fc_x2_rotator2_32fc_manual(result.data(),
+                                                input.data(),
+                                                &phase_increment,
+                                                &phase,
+                                                vector_length,
+                                                impl_name.c_str());
+
+        for (size_t i = 0; i < vector_length; ++i) {
+            result_magnitude[i] = std::abs(result[i]);
+        }
+        EXPECT_TRUE(AreFloatingPointArraysEqualWithAbsoluteError(
+            expected_magnitude, result_magnitude, absolute_magnitue_error));
+        EXPECT_TRUE(AreComplexFloatingPointArraysEqualWithAbsoluteError(
+            expected, result, absolute_error));
+    }
+
+    void execute_unaligned(const std::string impl_name)
+    {
+        lv_32fc_t unaligned_phase =
+            std::polar(1.0f, (initial_phase_steps + 1.0f) * increment);
+        volk_32fc_s32fc_x2_rotator2_32fc_manual(ua_result.data() + 1,
+                                                input.data() + 1,
+                                                &phase_increment,
+                                                &unaligned_phase,
+                                                vector_length - 1,
+                                                impl_name.c_str());
+        for (size_t i = 0; i < vector_length; ++i) {
+            result_magnitude[i] = std::abs(ua_result[i]);
+        }
+        result_magnitude[0] = expected_magnitude[0];
+
+        EXPECT_TRUE(AreFloatingPointArraysEqualWithAbsoluteError(
+            expected_magnitude, result_magnitude, absolute_magnitue_error));
+        EXPECT_TRUE(AreComplexFloatingPointArraysEqualWithAbsoluteError(
+            expected, ua_result, absolute_error));
+    }
+
+    static constexpr float increment = 0.07f;
+    static constexpr float initial_phase_steps = 0.0f;
+    static constexpr float absolute_magnitue_error = 1.0e-4;
+    float absolute_error{};
+    volk::vector<lv_32fc_t> input;
+    volk::vector<lv_32fc_t> result;
+    lv_32fc_t phase_increment;
+    lv_32fc_t phase;
+    volk::vector<lv_32fc_t> expected;
+    volk::vector<float> expected_magnitude;
+    volk::vector<lv_32fc_t> ua_result;
+    volk::vector<float> result_magnitude;
+};
+
+TEST_P(volk_32fc_s32fc_x2_rotator2_32fc_test, run)
+{
+    fmt::print("test {} implementation: {:>12}, size={} ...",
+               is_aligned_implementation ? "aligned" : "unaligned",
+               implementation_name,
+               vector_length);
+    auto start = std::chrono::steady_clock::now();
+
+    if (is_aligned_implementation) {
+        execute_aligned(implementation_name);
+    } else {
+        execute_unaligned(implementation_name);
+    }
+
+    std::chrono::duration<double> elapsed = std::chrono::steady_clock::now() - start;
+    fmt::print("\tduration={}\n", elapsed);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    volk_32fc_s32fc_x2_rotator2_32fc,
+    volk_32fc_s32fc_x2_rotator2_32fc_test,
+    testing::Combine(testing::ValuesIn(get_kernel_implementation_name_list(
+                         volk_32fc_s32fc_x2_rotator2_32fc_get_func_desc())),
+                     testing::ValuesIn(default_vector_sizes)),
+    generate_volk_test_name());

--- a/tests/volk_test.h
+++ b/tests/volk_test.h
@@ -70,9 +70,83 @@ template <class T>
         auto actual_real = ::testing::internal::FloatingPoint(actual[index].real());
         auto actual_imag = ::testing::internal::FloatingPoint(actual[index].imag());
         if (not expected_real.AlmostEquals(actual_real) or
-            not expected_imag.AlmostEquals(actual_imag))
+            not expected_imag.AlmostEquals(actual_imag)) {
+            if (errorsFound == 0) {
+                result << "Differences found:";
+            }
+            if (errorsFound < 3) {
+                result << separator << expected[index] << " != " << actual[index] << " @ "
+                       << index;
+                separator = ",\n";
+            }
+            errorsFound++;
+        }
+    }
+    if (errorsFound > 0) {
+        result << separator << errorsFound << " differences in total";
+        return result;
+    }
+    return ::testing::AssertionSuccess();
+}
 
-        {
+template <class T>
+::testing::AssertionResult AreComplexFloatingPointArraysEqualWithAbsoluteError(
+    const T& expected, const T& actual, const float absolute_error = 1.0e-7)
+{
+    ::testing::AssertionResult result = ::testing::AssertionFailure();
+    if (expected.size() != actual.size()) {
+        return result << "expected result size=" << expected.size()
+                      << " differs from actual size=" << actual.size();
+    }
+    const unsigned long length = expected.size();
+
+    int errorsFound = 0;
+    const char* separator = " ";
+    for (unsigned long index = 0; index < length; index++) {
+        auto expected_real = ::testing::internal::FloatingPoint(expected[index].real());
+        auto expected_imag = ::testing::internal::FloatingPoint(expected[index].imag());
+        auto actual_real = ::testing::internal::FloatingPoint(actual[index].real());
+        auto actual_imag = ::testing::internal::FloatingPoint(actual[index].imag());
+        if (expected_real.is_nan() or actual_real.is_nan() or expected_imag.is_nan() or
+            actual_imag.is_nan() or
+            std::abs(expected[index].real() - actual[index].real()) > absolute_error or
+            std::abs(expected[index].imag() - actual[index].imag()) > absolute_error) {
+            if (errorsFound == 0) {
+                result << "Differences found:";
+            }
+            if (errorsFound < 3) {
+                result << separator << expected[index] << " != " << actual[index] << " @ "
+                       << index;
+                separator = ",\n";
+            }
+            errorsFound++;
+        }
+    }
+    if (errorsFound > 0) {
+        result << separator << errorsFound << " differences in total";
+        return result;
+    }
+    return ::testing::AssertionSuccess();
+}
+
+template <class T>
+::testing::AssertionResult AreFloatingPointArraysEqualWithAbsoluteError(
+    const T& expected, const T& actual, const float absolute_error = 1.0e-7)
+{
+    ::testing::AssertionResult result = ::testing::AssertionFailure();
+    if (expected.size() != actual.size()) {
+        return result << "expected result size=" << expected.size()
+                      << " differs from actual size=" << actual.size();
+    }
+    const unsigned long length = expected.size();
+
+    int errorsFound = 0;
+    const char* separator = " ";
+    for (unsigned long index = 0; index < length; index++) {
+        auto expected_value = ::testing::internal::FloatingPoint(expected[index]);
+        auto actual_value = ::testing::internal::FloatingPoint(actual[index]);
+        if (expected_value.is_nan() or actual_value.is_nan() or
+            std::abs(expected[index] - actual[index]) > absolute_error) {
             if (errorsFound == 0) {
                 result << "Differences found:";
             }


### PR DESCRIPTION
We see test failures with this kernel rather frequently. Mostly due to the fact that the underlying algorithm inherently accumulates errors. This new test suite should allow for more fine grained analysis of the issue.

Compare: https://github.com/gnuradio/volk/issues/794