### PR TITLE
ci: Fix obsolete MacOS Intel CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -227,7 +227,7 @@ jobs:
   build-macos:
     strategy:
       matrix:
-        os: [macos-13, macos-latest]
+        os: [macos-15-intel, macos-latest]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
GH migrates to MacOS 15 for Intel CPUs. In turn, this will be the last Intel MacOS release. Afterwards, we'll probably drop support for these then old platforms.