### PR TITLE
Neon kernels

### DIFF
--- a/kernels/volk/volk_16i_convert_8i.h
+++ b/kernels/volk/volk_16i_convert_8i.h
@@ -363,6 +363,42 @@ static inline void volk_16i_convert_8i_neon(int8_t* outputVector,
 }
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_16i_convert_8i_neonv8(int8_t* outputVector,
+                                              const int16_t* inputVector,
+                                              unsigned int num_points)
+{
+    int8_t* outputVectorPtr = outputVector;
+    const int16_t* inputVectorPtr = inputVector;
+    const unsigned int thirtysecondPoints = num_points / 32;
+
+    for (unsigned int number = 0; number < thirtysecondPoints; number++) {
+        int16x8_t in0 = vld1q_s16(inputVectorPtr);
+        int16x8_t in1 = vld1q_s16(inputVectorPtr + 8);
+        int16x8_t in2 = vld1q_s16(inputVectorPtr + 16);
+        int16x8_t in3 = vld1q_s16(inputVectorPtr + 24);
+        __VOLK_PREFETCH(inputVectorPtr + 64);
+
+        int8x8_t out0 = vshrn_n_s16(in0, 8);
+        int8x8_t out1 = vshrn_n_s16(in1, 8);
+        int8x8_t out2 = vshrn_n_s16(in2, 8);
+        int8x8_t out3 = vshrn_n_s16(in3, 8);
+
+        vst1q_s8(outputVectorPtr, vcombine_s8(out0, out1));
+        vst1q_s8(outputVectorPtr + 16, vcombine_s8(out2, out3));
+
+        inputVectorPtr += 32;
+        outputVectorPtr += 32;
+    }
+
+    for (unsigned int number = thirtysecondPoints * 32; number < num_points; number++) {
+        *outputVectorPtr++ = ((int8_t)(*inputVectorPtr++ >> 8));
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 

--- a/kernels/volk/volk_16ic_deinterleave_16i_x2.h
+++ b/kernels/volk/volk_16ic_deinterleave_16i_x2.h
@@ -269,6 +269,81 @@ static inline void volk_16ic_deinterleave_16i_x2_generic(int16_t* iBuffer,
 }
 #endif /* LV_HAVE_GENERIC */
 
+
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+
+static inline void volk_16ic_deinterleave_16i_x2_neon(int16_t* iBuffer,
+                                                      int16_t* qBuffer,
+                                                      const lv_16sc_t* complexVector,
+                                                      unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+    const int16_t* complexVectorPtr = (const int16_t*)complexVector;
+    int16_t* iBufferPtr = iBuffer;
+    int16_t* qBufferPtr = qBuffer;
+
+    int16x8x2_t complexVal;
+
+    for (; number < eighthPoints; number++) {
+        complexVal = vld2q_s16(complexVectorPtr);
+        vst1q_s16(iBufferPtr, complexVal.val[0]);
+        vst1q_s16(qBufferPtr, complexVal.val[1]);
+        complexVectorPtr += 16;
+        iBufferPtr += 8;
+        qBufferPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = *complexVectorPtr++;
+        *qBufferPtr++ = *complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_NEON */
+
+
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_16ic_deinterleave_16i_x2_neonv8(int16_t* iBuffer,
+                                                        int16_t* qBuffer,
+                                                        const lv_16sc_t* complexVector,
+                                                        unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int sixteenthPoints = num_points / 16;
+    const int16_t* complexVectorPtr = (const int16_t*)complexVector;
+    int16_t* iBufferPtr = iBuffer;
+    int16_t* qBufferPtr = qBuffer;
+
+    int16x8x2_t complexVal0, complexVal1;
+
+    for (; number < sixteenthPoints; number++) {
+        complexVal0 = vld2q_s16(complexVectorPtr);
+        complexVal1 = vld2q_s16(complexVectorPtr + 16);
+        __VOLK_PREFETCH(complexVectorPtr + 32);
+
+        vst1q_s16(iBufferPtr, complexVal0.val[0]);
+        vst1q_s16(iBufferPtr + 8, complexVal1.val[0]);
+        vst1q_s16(qBufferPtr, complexVal0.val[1]);
+        vst1q_s16(qBufferPtr + 8, complexVal1.val[1]);
+
+        complexVectorPtr += 32;
+        iBufferPtr += 16;
+        qBufferPtr += 16;
+    }
+
+    number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = *complexVectorPtr++;
+        *qBufferPtr++ = *complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
+
 #ifdef LV_HAVE_ORC
 
 extern void volk_16ic_deinterleave_16i_x2_a_orc_impl(int16_t* iBuffer,

--- a/kernels/volk/volk_16ic_deinterleave_real_16i.h
+++ b/kernels/volk/volk_16ic_deinterleave_real_16i.h
@@ -262,6 +262,71 @@ static inline void volk_16ic_deinterleave_real_16i_generic(int16_t* iBuffer,
 #endif /* LV_HAVE_GENERIC */
 
 
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+
+static inline void volk_16ic_deinterleave_real_16i_neon(int16_t* iBuffer,
+                                                        const lv_16sc_t* complexVector,
+                                                        unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+    const int16_t* complexVectorPtr = (const int16_t*)complexVector;
+    int16_t* iBufferPtr = iBuffer;
+
+    int16x8x2_t complexVal;
+
+    for (; number < eighthPoints; number++) {
+        complexVal = vld2q_s16(complexVectorPtr);
+        vst1q_s16(iBufferPtr, complexVal.val[0]);
+        complexVectorPtr += 16;
+        iBufferPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = *complexVectorPtr++;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_NEON */
+
+
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_16ic_deinterleave_real_16i_neonv8(int16_t* iBuffer,
+                                                          const lv_16sc_t* complexVector,
+                                                          unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int sixteenthPoints = num_points / 16;
+    const int16_t* complexVectorPtr = (const int16_t*)complexVector;
+    int16_t* iBufferPtr = iBuffer;
+
+    int16x8x2_t complexVal0, complexVal1;
+
+    for (; number < sixteenthPoints; number++) {
+        complexVal0 = vld2q_s16(complexVectorPtr);
+        complexVal1 = vld2q_s16(complexVectorPtr + 16);
+        __VOLK_PREFETCH(complexVectorPtr + 32);
+
+        vst1q_s16(iBufferPtr, complexVal0.val[0]);
+        vst1q_s16(iBufferPtr + 8, complexVal1.val[0]);
+
+        complexVectorPtr += 32;
+        iBufferPtr += 16;
+    }
+
+    number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = *complexVectorPtr++;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
+
 #endif /* INCLUDED_volk_16ic_deinterleave_real_16i_a_H */
 
 

--- a/kernels/volk/volk_16ic_magnitude_16i.h
+++ b/kernels/volk/volk_16ic_magnitude_16i.h
@@ -411,6 +411,60 @@ static inline void volk_16ic_magnitude_16i_neonv7(int16_t* magnitudeVector,
 }
 #endif /* LV_HAVE_NEONV7 */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_16ic_magnitude_16i_neonv8(int16_t* magnitudeVector,
+                                                  const lv_16sc_t* complexVector,
+                                                  unsigned int num_points)
+{
+    unsigned int number = 0;
+    unsigned int quarter_points = num_points / 4;
+
+    const float scalar = SHRT_MAX;
+    const float inv_scalar = 1.0f / scalar;
+
+    int16_t* magnitudeVectorPtr = magnitudeVector;
+    const lv_16sc_t* complexVectorPtr = complexVector;
+
+    float32x4_t mag_vec, mag_sq;
+    float32x4x2_t c_vec;
+
+    for (number = 0; number < quarter_points; number++) {
+        const int16x4x2_t c16_vec = vld2_s16((int16_t*)complexVectorPtr);
+        __VOLK_PREFETCH(complexVectorPtr + 4);
+        c_vec.val[0] = vcvtq_f32_s32(vmovl_s16(c16_vec.val[0]));
+        c_vec.val[1] = vcvtq_f32_s32(vmovl_s16(c16_vec.val[1]));
+        // Scale to close to 0-1
+        c_vec.val[0] = vmulq_n_f32(c_vec.val[0], inv_scalar);
+        c_vec.val[1] = vmulq_n_f32(c_vec.val[1], inv_scalar);
+        // ARMv8: Use FMA for magnitude squared and native sqrt
+        mag_sq =
+            vfmaq_f32(vmulq_f32(c_vec.val[0], c_vec.val[0]), c_vec.val[1], c_vec.val[1]);
+        mag_vec = vsqrtq_f32(mag_sq);
+        // Reconstruct
+        mag_vec = vmulq_n_f32(mag_vec, scalar);
+        // Add 0.5 for correct rounding because vcvtq_s32_f32 truncates.
+        mag_vec = vaddq_f32(mag_vec, vdupq_n_f32(0.5f));
+        const int16x4_t mag16_vec = vmovn_s32(vcvtq_s32_f32(mag_vec));
+        vst1_s16(magnitudeVectorPtr, mag16_vec);
+        // Advance pointers
+        magnitudeVectorPtr += 4;
+        complexVectorPtr += 4;
+    }
+
+    // Deal with the rest
+    for (number = quarter_points * 4; number < num_points; number++) {
+        const float real = lv_creal(*complexVectorPtr) * inv_scalar;
+        const float imag = lv_cimag(*complexVectorPtr) * inv_scalar;
+        *magnitudeVectorPtr =
+            (int16_t)rintf(sqrtf((real * real) + (imag * imag)) * scalar);
+        complexVectorPtr++;
+        magnitudeVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 

--- a/kernels/volk/volk_32f_accumulator_s32f.h
+++ b/kernels/volk/volk_32f_accumulator_s32f.h
@@ -284,6 +284,83 @@ static inline void volk_32f_accumulator_s32f_u_sse(float* result,
 }
 #endif /* LV_HAVE_SSE */
 
+
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+
+static inline void volk_32f_accumulator_s32f_neon(float* result,
+                                                  const float* inputBuffer,
+                                                  unsigned int num_points)
+{
+    float returnValue = 0;
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    const float* aPtr = inputBuffer;
+    float32x4_t accumulator = vdupq_n_f32(0.0f);
+    float32x4_t aVal;
+
+    for (; number < quarterPoints; number++) {
+        aVal = vld1q_f32(aPtr);
+        accumulator = vaddq_f32(accumulator, aVal);
+        aPtr += 4;
+    }
+
+    // Horizontal sum - manual for NEON (ARMv7 compatible)
+    float32x2_t sum_pair =
+        vadd_f32(vget_low_f32(accumulator), vget_high_f32(accumulator));
+    sum_pair = vpadd_f32(sum_pair, sum_pair);
+    returnValue = vget_lane_f32(sum_pair, 0);
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        returnValue += (*aPtr++);
+    }
+    *result = returnValue;
+}
+#endif /* LV_HAVE_NEON */
+
+
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32f_accumulator_s32f_neonv8(float* result,
+                                                    const float* inputBuffer,
+                                                    unsigned int num_points)
+{
+    float returnValue = 0;
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    const float* aPtr = inputBuffer;
+    float32x4_t accumulator0 = vdupq_n_f32(0.0f);
+    float32x4_t accumulator1 = vdupq_n_f32(0.0f);
+
+    // 2x unrolled loop for better instruction-level parallelism
+    for (; number < eighthPoints; number++) {
+        float32x4_t aVal0 = vld1q_f32(aPtr);
+        float32x4_t aVal1 = vld1q_f32(aPtr + 4);
+        __VOLK_PREFETCH(aPtr + 8);
+        accumulator0 = vaddq_f32(accumulator0, aVal0);
+        accumulator1 = vaddq_f32(accumulator1, aVal1);
+        aPtr += 8;
+    }
+
+    // Combine accumulators
+    accumulator0 = vaddq_f32(accumulator0, accumulator1);
+
+    // ARMv8 horizontal sum using vaddvq_f32
+    returnValue = vaddvq_f32(accumulator0);
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        returnValue += (*aPtr++);
+    }
+    *result = returnValue;
+}
+#endif /* LV_HAVE_NEONV8 */
+
+
 #ifdef LV_HAVE_GENERIC
 static inline void volk_32f_accumulator_s32f_generic(float* result,
                                                      const float* inputBuffer,

--- a/kernels/volk/volk_32f_acos_32f.h
+++ b/kernels/volk/volk_32f_acos_32f.h
@@ -656,6 +656,199 @@ volk_32f_acos_32f_generic(float* bVector, const float* aVector, unsigned int num
 }
 #endif /* LV_HAVE_GENERIC */
 
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+
+static inline void
+volk_32f_acos_32f_neon(float* bVector, const float* aVector, unsigned int num_points)
+{
+    float* bPtr = bVector;
+    const float* aPtr = aVector;
+
+    unsigned int number = 0;
+    unsigned int quarterPoints = num_points / 4;
+    int i, j;
+
+    float32x4_t aVal, d, x, y, z, arccosine;
+    uint32x4_t condition;
+    const float32x4_t fzeroes = vdupq_n_f32(0.0f);
+    const float32x4_t fones = vdupq_n_f32(1.0f);
+    const float32x4_t ftwos = vdupq_n_f32(2.0f);
+    const float32x4_t ffours = vdupq_n_f32(4.0f);
+    const float32x4_t pi = vdupq_n_f32(3.14159265358979323846f);
+    const float32x4_t pio2 = vdupq_n_f32(3.14159265358979323846f / 2.0f);
+
+    for (; number < quarterPoints; number++) {
+        aVal = vld1q_f32(aPtr);
+        d = aVal;
+
+        // Compute sqrt((1+x)*(1-x)) / x using reciprocal estimate
+        // For |x| > 1, this produces NaN (matching generic behavior)
+        float32x4_t one_plus = vaddq_f32(fones, aVal);
+        float32x4_t one_minus = vsubq_f32(fones, aVal);
+        float32x4_t sqrt_arg = vmulq_f32(one_plus, one_minus);
+
+        // Newton-Raphson sqrt approximation
+        float32x4_t sqrt_est = vrsqrteq_f32(sqrt_arg);
+        sqrt_est =
+            vmulq_f32(sqrt_est, vrsqrtsq_f32(vmulq_f32(sqrt_arg, sqrt_est), sqrt_est));
+        float32x4_t sqrt_val = vmulq_f32(sqrt_arg, sqrt_est);
+
+        // Reciprocal of aVal
+        float32x4_t recip = vrecpeq_f32(aVal);
+        recip = vmulq_f32(recip, vrecpsq_f32(aVal, recip));
+        float32x4_t tanVal = vmulq_f32(sqrt_val, recip);
+
+        z = tanVal;
+        // z = abs(z) - conditionally negate if z < 0
+        condition = vcltq_f32(z, fzeroes);
+        z = vbslq_f32(condition, vnegq_f32(z), z);
+
+        // x = 1/z if z < 1, else x = z (matching SSE logic)
+        condition = vcltq_f32(z, fones);
+        float32x4_t z_recip = vrecpeq_f32(z);
+        z_recip = vmulq_f32(z_recip, vrecpsq_f32(z, z_recip));
+        x = vbslq_f32(condition, z_recip, z);
+
+        // Two iterations: x = x + sqrt(1 + x*x)
+        for (i = 0; i < 2; i++) {
+            float32x4_t xx = vmulq_f32(x, x);
+            float32x4_t sum = vaddq_f32(fones, xx);
+            float32x4_t sqrt_sum_est = vrsqrteq_f32(sum);
+            sqrt_sum_est = vmulq_f32(
+                sqrt_sum_est, vrsqrtsq_f32(vmulq_f32(sum, sqrt_sum_est), sqrt_sum_est));
+            x = vaddq_f32(x, vmulq_f32(sum, sqrt_sum_est));
+        }
+
+        // x = 1/x
+        float32x4_t x_recip = vrecpeq_f32(x);
+        x_recip = vmulq_f32(x_recip, vrecpsq_f32(x, x_recip));
+        x = x_recip;
+
+        // Taylor series: y = sum of (-1)^j / (2j+1) * x^(2j)
+        y = fzeroes;
+        for (j = ACOS_TERMS - 1; j >= 0; j--) {
+            float coeff = (j % 2 == 0) ? 1.0f / (2 * j + 1) : -1.0f / (2 * j + 1);
+            y = vaddq_f32(vmulq_f32(y, vmulq_f32(x, x)), vdupq_n_f32(coeff));
+        }
+
+        y = vmulq_f32(y, vmulq_f32(x, ffours));
+
+        // Adjust if z > 1: y = y + (pio2 - 2*y)
+        condition = vcgtq_f32(z, fones);
+        float32x4_t y_adj = vsubq_f32(pio2, vmulq_f32(y, ftwos));
+        y = vbslq_f32(condition, vaddq_f32(y, y_adj), y);
+
+        arccosine = y;
+
+        // If tanVal < 0, arccosine = -arccosine
+        condition = vcltq_f32(tanVal, fzeroes);
+        arccosine = vbslq_f32(condition, vnegq_f32(arccosine), arccosine);
+
+        // If d < 0, arccosine += pi
+        condition = vcltq_f32(d, fzeroes);
+        arccosine = vbslq_f32(condition, vaddq_f32(arccosine, pi), arccosine);
+
+        vst1q_f32(bPtr, arccosine);
+        aPtr += 4;
+        bPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        *bPtr++ = acosf(*aPtr++);
+    }
+}
+
+#endif /* LV_HAVE_NEON */
+
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void
+volk_32f_acos_32f_neonv8(float* bVector, const float* aVector, unsigned int num_points)
+{
+    float* bPtr = bVector;
+    const float* aPtr = aVector;
+
+    unsigned int number = 0;
+    unsigned int quarterPoints = num_points / 4;
+    int i, j;
+
+    float32x4_t aVal, d, x, y, z, arccosine;
+    const float32x4_t fzeroes = vdupq_n_f32(0.0f);
+    const float32x4_t fones = vdupq_n_f32(1.0f);
+    const float32x4_t ftwos = vdupq_n_f32(2.0f);
+    const float32x4_t ffours = vdupq_n_f32(4.0f);
+    const float32x4_t pi = vdupq_n_f32(3.14159265358979323846f);
+    const float32x4_t pio2 = vdupq_n_f32(3.14159265358979323846f / 2.0f);
+
+    for (; number < quarterPoints; number++) {
+        aVal = vld1q_f32(aPtr);
+        d = aVal;
+
+        // Compute sqrt((1+x)*(1-x)) / x
+        // For |x| > 1, this produces NaN (matching generic behavior)
+        float32x4_t one_plus = vaddq_f32(fones, aVal);
+        float32x4_t one_minus = vsubq_f32(fones, aVal);
+        float32x4_t sqrt_val = vsqrtq_f32(vmulq_f32(one_plus, one_minus));
+
+        float32x4_t tanVal = vdivq_f32(sqrt_val, aVal);
+
+        z = tanVal;
+        // z = abs(z)
+        z = vabsq_f32(z);
+
+        // x = 1/z if z < 1, else x = z (matching SSE logic)
+        uint32x4_t z_lt_one = vcltq_f32(z, fones);
+        float32x4_t z_recip = vdivq_f32(fones, z);
+        x = vbslq_f32(z_lt_one, z_recip, z);
+
+        // Two iterations: x = x + sqrt(1 + x*x)
+        for (i = 0; i < 2; i++) {
+            x = vaddq_f32(x, vsqrtq_f32(vfmaq_f32(fones, x, x)));
+        }
+
+        // x = 1/x
+        x = vdivq_f32(fones, x);
+
+        // Taylor series
+        y = fzeroes;
+        for (j = ACOS_TERMS - 1; j >= 0; j--) {
+            float coeff = (j % 2 == 0) ? 1.0f / (2 * j + 1) : -1.0f / (2 * j + 1);
+            y = vfmaq_f32(vdupq_n_f32(coeff), y, vmulq_f32(x, x));
+        }
+
+        y = vmulq_f32(y, vmulq_f32(x, ffours));
+
+        // Adjust if z > 1: y = y + (pio2 - 2*y)
+        uint32x4_t z_gt_one = vcgtq_f32(z, fones);
+        float32x4_t y_adj = vfmsq_f32(pio2, y, ftwos);
+        y = vbslq_f32(z_gt_one, vaddq_f32(y, y_adj), y);
+
+        arccosine = y;
+
+        // If tanVal < 0, arccosine = -arccosine
+        uint32x4_t tanVal_neg = vcltq_f32(tanVal, fzeroes);
+        arccosine = vbslq_f32(tanVal_neg, vnegq_f32(arccosine), arccosine);
+
+        // If d < 0, arccosine += pi
+        uint32x4_t d_neg = vcltq_f32(d, fzeroes);
+        arccosine = vbslq_f32(d_neg, vaddq_f32(arccosine, pi), arccosine);
+
+        vst1q_f32(bPtr, arccosine);
+        aPtr += 4;
+        bPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        *bPtr++ = acosf(*aPtr++);
+    }
+}
+
+#endif /* LV_HAVE_NEONV8 */
+
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 #include <volk/volk_rvv_intrinsics.h>

--- a/kernels/volk/volk_32f_asin_32f.h
+++ b/kernels/volk/volk_32f_asin_32f.h
@@ -623,6 +623,186 @@ volk_32f_asin_32f_generic(float* bVector, const float* aVector, unsigned int num
 }
 #endif /* LV_HAVE_GENERIC */
 
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+
+static inline void
+volk_32f_asin_32f_neon(float* bVector, const float* aVector, unsigned int num_points)
+{
+    float* bPtr = bVector;
+    const float* aPtr = aVector;
+
+    unsigned int number = 0;
+    unsigned int quarterPoints = num_points / 4;
+    int i, j;
+
+    float32x4_t aVal, x, y, z, arcsine;
+    uint32x4_t condition;
+    const float32x4_t fzeroes = vdupq_n_f32(0.0f);
+    const float32x4_t fones = vdupq_n_f32(1.0f);
+    const float32x4_t ftwos = vdupq_n_f32(2.0f);
+    const float32x4_t ffours = vdupq_n_f32(4.0f);
+    const float32x4_t pio2 = vdupq_n_f32(3.14159265358979323846f / 2.0f);
+
+    for (; number < quarterPoints; number++) {
+        aVal = vld1q_f32(aPtr);
+
+        // Compute x / sqrt((1+x)*(1-x)) using reciprocal estimate
+        // For |x| > 1, this produces NaN (matching generic behavior)
+        float32x4_t one_plus = vaddq_f32(fones, aVal);
+        float32x4_t one_minus = vsubq_f32(fones, aVal);
+        float32x4_t sqrt_arg = vmulq_f32(one_plus, one_minus);
+
+        // Newton-Raphson sqrt approximation
+        float32x4_t sqrt_est = vrsqrteq_f32(sqrt_arg);
+        sqrt_est =
+            vmulq_f32(sqrt_est, vrsqrtsq_f32(vmulq_f32(sqrt_arg, sqrt_est), sqrt_est));
+        float32x4_t sqrt_val = vmulq_f32(sqrt_arg, sqrt_est);
+
+        // Reciprocal of sqrt_val
+        float32x4_t recip = vrecpeq_f32(sqrt_val);
+        recip = vmulq_f32(recip, vrecpsq_f32(sqrt_val, recip));
+        float32x4_t tanVal = vmulq_f32(aVal, recip);
+
+        z = tanVal;
+        // z = abs(z)
+        condition = vcltq_f32(z, fzeroes);
+        z = vbslq_f32(condition, vnegq_f32(z), z);
+
+        // x = 1/z if z < 1, else x = z (matching SSE logic)
+        condition = vcltq_f32(z, fones);
+        float32x4_t z_recip = vrecpeq_f32(z);
+        z_recip = vmulq_f32(z_recip, vrecpsq_f32(z, z_recip));
+        x = vbslq_f32(condition, z_recip, z);
+
+        // Two iterations: x = x + sqrt(1 + x*x)
+        for (i = 0; i < 2; i++) {
+            float32x4_t xx = vmulq_f32(x, x);
+            float32x4_t sum = vaddq_f32(fones, xx);
+            float32x4_t sqrt_sum_est = vrsqrteq_f32(sum);
+            sqrt_sum_est = vmulq_f32(
+                sqrt_sum_est, vrsqrtsq_f32(vmulq_f32(sum, sqrt_sum_est), sqrt_sum_est));
+            x = vaddq_f32(x, vmulq_f32(sum, sqrt_sum_est));
+        }
+
+        // x = 1/x
+        float32x4_t x_recip = vrecpeq_f32(x);
+        x_recip = vmulq_f32(x_recip, vrecpsq_f32(x, x_recip));
+        x = x_recip;
+
+        // Taylor series
+        y = fzeroes;
+        for (j = ASIN_TERMS - 1; j >= 0; j--) {
+            float coeff = (j % 2 == 0) ? 1.0f / (2 * j + 1) : -1.0f / (2 * j + 1);
+            y = vaddq_f32(vmulq_f32(y, vmulq_f32(x, x)), vdupq_n_f32(coeff));
+        }
+
+        y = vmulq_f32(y, vmulq_f32(x, ffours));
+
+        // Adjust if z > 1: y = y + (pio2 - 2*y)
+        condition = vcgtq_f32(z, fones);
+        float32x4_t y_adj = vsubq_f32(pio2, vmulq_f32(y, ftwos));
+        y = vbslq_f32(condition, vaddq_f32(y, y_adj), y);
+
+        arcsine = y;
+
+        // If tanVal < 0, arcsine = -arcsine
+        condition = vcltq_f32(tanVal, fzeroes);
+        arcsine = vbslq_f32(condition, vnegq_f32(arcsine), arcsine);
+
+        vst1q_f32(bPtr, arcsine);
+        aPtr += 4;
+        bPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        *bPtr++ = asinf(*aPtr++);
+    }
+}
+
+#endif /* LV_HAVE_NEON */
+
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void
+volk_32f_asin_32f_neonv8(float* bVector, const float* aVector, unsigned int num_points)
+{
+    float* bPtr = bVector;
+    const float* aPtr = aVector;
+
+    unsigned int number = 0;
+    unsigned int quarterPoints = num_points / 4;
+    int i, j;
+
+    float32x4_t aVal, x, y, z, arcsine;
+    const float32x4_t fzeroes = vdupq_n_f32(0.0f);
+    const float32x4_t fones = vdupq_n_f32(1.0f);
+    const float32x4_t ftwos = vdupq_n_f32(2.0f);
+    const float32x4_t ffours = vdupq_n_f32(4.0f);
+    const float32x4_t pio2 = vdupq_n_f32(3.14159265358979323846f / 2.0f);
+
+    for (; number < quarterPoints; number++) {
+        aVal = vld1q_f32(aPtr);
+
+        // Compute x / sqrt((1+x)*(1-x))
+        // For |x| > 1, this produces NaN (matching generic behavior)
+        float32x4_t one_plus = vaddq_f32(fones, aVal);
+        float32x4_t one_minus = vsubq_f32(fones, aVal);
+        float32x4_t sqrt_val = vsqrtq_f32(vmulq_f32(one_plus, one_minus));
+        float32x4_t tanVal = vdivq_f32(aVal, sqrt_val);
+
+        z = tanVal;
+        // z = abs(z)
+        z = vabsq_f32(z);
+
+        // x = 1/z if z < 1, else x = z (matching SSE logic)
+        uint32x4_t z_lt_one = vcltq_f32(z, fones);
+        float32x4_t z_recip = vdivq_f32(fones, z);
+        x = vbslq_f32(z_lt_one, z_recip, z);
+
+        // Two iterations: x = x + sqrt(1 + x*x)
+        for (i = 0; i < 2; i++) {
+            x = vaddq_f32(x, vsqrtq_f32(vfmaq_f32(fones, x, x)));
+        }
+
+        // x = 1/x
+        x = vdivq_f32(fones, x);
+
+        // Taylor series
+        y = fzeroes;
+        for (j = ASIN_TERMS - 1; j >= 0; j--) {
+            float coeff = (j % 2 == 0) ? 1.0f / (2 * j + 1) : -1.0f / (2 * j + 1);
+            y = vfmaq_f32(vdupq_n_f32(coeff), y, vmulq_f32(x, x));
+        }
+
+        y = vmulq_f32(y, vmulq_f32(x, ffours));
+
+        // Adjust if z > 1: y = y + (pio2 - 2*y)
+        uint32x4_t z_gt_one = vcgtq_f32(z, fones);
+        float32x4_t y_adj = vfmsq_f32(pio2, y, ftwos);
+        y = vbslq_f32(z_gt_one, vaddq_f32(y, y_adj), y);
+
+        arcsine = y;
+
+        // If tanVal < 0, arcsine = -arcsine
+        uint32x4_t tanVal_neg = vcltq_f32(tanVal, fzeroes);
+        arcsine = vbslq_f32(tanVal_neg, vnegq_f32(arcsine), arcsine);
+
+        vst1q_f32(bPtr, arcsine);
+        aPtr += 4;
+        bPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        *bPtr++ = asinf(*aPtr++);
+    }
+}
+
+#endif /* LV_HAVE_NEONV8 */
+
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 #include <volk/volk_rvv_intrinsics.h>

--- a/kernels/volk/volk_32f_asin_32f.h
+++ b/kernels/volk/volk_32f_asin_32f.h
@@ -676,13 +676,19 @@ volk_32f_asin_32f_neon(float* bVector, const float* aVector, unsigned int num_po
         x = vbslq_f32(condition, z_recip, z);
 
         // Two iterations: x = x + sqrt(1 + x*x)
+        // Note: For very large x (approaching infinity), the NR rsqrt iteration produces
+        // NaN due to inf*0 in vrsqrtsq. Use approximation sqrt(1+x²) ≈ x for large x.
+        const float32x4_t large_threshold = vdupq_n_f32(1e10f);
         for (i = 0; i < 2; i++) {
             float32x4_t xx = vmulq_f32(x, x);
             float32x4_t sum = vaddq_f32(fones, xx);
+            uint32x4_t is_large = vcgtq_f32(x, large_threshold);
             float32x4_t sqrt_sum_est = vrsqrteq_f32(sum);
             sqrt_sum_est = vmulq_f32(
                 sqrt_sum_est, vrsqrtsq_f32(vmulq_f32(sum, sqrt_sum_est), sqrt_sum_est));
-            x = vaddq_f32(x, vmulq_f32(sum, sqrt_sum_est));
+            float32x4_t sqrt_sum = vmulq_f32(sum, sqrt_sum_est);
+            sqrt_sum = vbslq_f32(is_large, x, sqrt_sum);
+            x = vaddq_f32(x, sqrt_sum);
         }
 
         // x = 1/x

--- a/kernels/volk/volk_32f_convert_64f.h
+++ b/kernels/volk/volk_32f_convert_64f.h
@@ -230,6 +230,45 @@ static inline void volk_32f_convert_64f_a_sse2(double* outputVector,
 }
 #endif /* LV_HAVE_SSE2 */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32f_convert_64f_neonv8(double* outputVector,
+                                               const float* inputVector,
+                                               unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighth_points = num_points / 8;
+
+    const float* inputPtr = inputVector;
+    double* outputPtr = outputVector;
+
+    for (; number < eighth_points; number++) {
+        float32x4_t in0 = vld1q_f32(inputPtr);
+        float32x4_t in1 = vld1q_f32(inputPtr + 4);
+        __VOLK_PREFETCH(inputPtr + 8);
+
+        float64x2_t out0 = vcvt_f64_f32(vget_low_f32(in0));
+        float64x2_t out1 = vcvt_f64_f32(vget_high_f32(in0));
+        float64x2_t out2 = vcvt_f64_f32(vget_low_f32(in1));
+        float64x2_t out3 = vcvt_f64_f32(vget_high_f32(in1));
+
+        vst1q_f64(outputPtr, out0);
+        vst1q_f64(outputPtr + 2, out1);
+        vst1q_f64(outputPtr + 4, out2);
+        vst1q_f64(outputPtr + 6, out3);
+
+        inputPtr += 8;
+        outputPtr += 8;
+    }
+
+    number = eighth_points * 8;
+    for (; number < num_points; number++) {
+        *outputPtr++ = (double)(*inputPtr++);
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 

--- a/kernels/volk/volk_32f_index_max_32u.h
+++ b/kernels/volk/volk_32f_index_max_32u.h
@@ -319,6 +319,71 @@ volk_32f_index_max_32u_neon(uint32_t* target, const float* src0, uint32_t num_po
 #endif /*LV_HAVE_NEON*/
 
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void
+volk_32f_index_max_32u_neonv8(uint32_t* target, const float* src0, uint32_t num_points)
+{
+    if (num_points > 0) {
+        uint32_t number = 0;
+        const uint32_t quarterPoints = num_points / 4;
+
+        float* inputPtr = (float*)src0;
+        float32x4_t indexIncrementValues = vdupq_n_f32(4);
+        __VOLK_ATTR_ALIGNED(16)
+        float currentIndexes_float[4] = { -4.0f, -3.0f, -2.0f, -1.0f };
+        float32x4_t currentIndexes = vld1q_f32(currentIndexes_float);
+
+        float max = src0[0];
+        float index = 0;
+        float32x4_t maxValues = vdupq_n_f32(max);
+        uint32x4_t maxValuesIndex = vmovq_n_u32(0);
+        uint32x4_t compareResults;
+        uint32x4_t currentIndexes_u;
+        float32x4_t currentValues;
+
+        __VOLK_ATTR_ALIGNED(16) float maxValuesBuffer[4];
+        __VOLK_ATTR_ALIGNED(16) float maxIndexesBuffer[4];
+
+        for (; number < quarterPoints; number++) {
+            currentValues = vld1q_f32(inputPtr);
+            __VOLK_PREFETCH(inputPtr + 4);
+            inputPtr += 4;
+            currentIndexes = vaddq_f32(currentIndexes, indexIncrementValues);
+            currentIndexes_u = vcvtq_u32_f32(currentIndexes);
+            compareResults = vcleq_f32(currentValues, maxValues);
+            maxValuesIndex = vorrq_u32(vandq_u32(compareResults, maxValuesIndex),
+                                       vbicq_u32(currentIndexes_u, compareResults));
+            maxValues = vmaxq_f32(currentValues, maxValues);
+        }
+
+        // Calculate the largest value from the remaining 4 points
+        vst1q_f32(maxValuesBuffer, maxValues);
+        vst1q_f32(maxIndexesBuffer, vcvtq_f32_u32(maxValuesIndex));
+        for (number = 0; number < 4; number++) {
+            if (maxValuesBuffer[number] > max) {
+                index = maxIndexesBuffer[number];
+                max = maxValuesBuffer[number];
+            } else if (maxValues[number] == max) {
+                if (index > maxIndexesBuffer[number])
+                    index = maxIndexesBuffer[number];
+            }
+        }
+
+        number = quarterPoints * 4;
+        for (; number < num_points; number++) {
+            if (src0[number] > max) {
+                index = number;
+                max = src0[number];
+            }
+        }
+        target[0] = (uint32_t)index;
+    }
+}
+#endif /*LV_HAVE_NEONV8*/
+
+
 #ifdef LV_HAVE_GENERIC
 
 static inline void

--- a/kernels/volk/volk_32f_index_min_16u.h
+++ b/kernels/volk/volk_32f_index_min_16u.h
@@ -346,6 +346,67 @@ volk_32f_index_min_16u_u_avx(uint16_t* target, const float* source, uint32_t num
 
 #endif /*LV_HAVE_AVX*/
 
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+#include <float.h>
+
+static inline void
+volk_32f_index_min_16u_neon(uint16_t* target, const float* source, uint32_t num_points)
+{
+    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
+
+    uint32_t number = 0;
+    const uint32_t quarterPoints = num_points / 4;
+
+    const float* inputPtr = source;
+
+    float32x4_t indexIncrementValues = vdupq_n_f32(4.0f);
+    float32x4_t currentIndexes = { 0.0f, 1.0f, 2.0f, 3.0f };
+
+    float min = source[0];
+    float index = 0;
+    float32x4_t minValues = vdupq_n_f32(min);
+    float32x4_t minValuesIndex = vdupq_n_f32(0.0f);
+
+    for (; number < quarterPoints; number++) {
+        float32x4_t currentValues = vld1q_f32(inputPtr);
+        inputPtr += 4;
+
+        uint32x4_t compareResults = vcltq_f32(currentValues, minValues);
+
+        minValuesIndex = vbslq_f32(compareResults, currentIndexes, minValuesIndex);
+        minValues = vminq_f32(currentValues, minValues);
+
+        currentIndexes = vaddq_f32(currentIndexes, indexIncrementValues);
+    }
+
+    __VOLK_ATTR_ALIGNED(16) float minValuesBuffer[4];
+    __VOLK_ATTR_ALIGNED(16) float minIndexesBuffer[4];
+
+    vst1q_f32(minValuesBuffer, minValues);
+    vst1q_f32(minIndexesBuffer, minValuesIndex);
+
+    for (number = 0; number < 4; number++) {
+        if (minValuesBuffer[number] < min) {
+            index = minIndexesBuffer[number];
+            min = minValuesBuffer[number];
+        } else if (minValuesBuffer[number] == min) {
+            if (index > minIndexesBuffer[number])
+                index = minIndexesBuffer[number];
+        }
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        if (source[number] < min) {
+            index = (float)number;
+            min = source[number];
+        }
+    }
+    target[0] = (uint16_t)index;
+}
+#endif /* LV_HAVE_NEON */
+
 #ifdef LV_HAVE_RVV
 #include <float.h>
 #include <riscv_vector.h>

--- a/kernels/volk/volk_32f_invsqrt_32f.h
+++ b/kernels/volk/volk_32f_invsqrt_32f.h
@@ -163,6 +163,34 @@ volk_32f_invsqrt_32f_neon(float* cVector, const float* aVector, unsigned int num
 }
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void
+volk_32f_invsqrt_32f_neonv8(float* cVector, const float* aVector, unsigned int num_points)
+{
+    unsigned int number;
+    const unsigned int quarter_points = num_points / 4;
+
+    float* cPtr = cVector;
+    const float* aPtr = aVector;
+    const float32x4_t fones = vdupq_n_f32(1.0f);
+
+    for (number = 0; number < quarter_points; ++number) {
+        float32x4_t a_val = vld1q_f32(aPtr);
+        // Use native sqrt and division for accurate result
+        float32x4_t c_val = vdivq_f32(fones, vsqrtq_f32(a_val));
+        vst1q_f32(cPtr, c_val);
+        aPtr += 4;
+        cPtr += 4;
+    }
+
+    for (number = quarter_points * 4; number < num_points; number++) {
+        *cPtr++ = Q_rsqrt(*aPtr++);
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 
 #ifdef LV_HAVE_GENERIC
 

--- a/kernels/volk/volk_32f_reciprocal_32f.h
+++ b/kernels/volk/volk_32f_reciprocal_32f.h
@@ -198,6 +198,36 @@ volk_32f_reciprocal_32f_u_avx512(float* out, const float* in, unsigned int num_p
 }
 #endif /* LV_HAVE_AVX512F */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void
+volk_32f_reciprocal_32f_neonv8(float* out, const float* in, unsigned int num_points)
+{
+    const unsigned int eighth_points = num_points / 8;
+    float32x4_t vOne = vdupq_n_f32(1.0f);
+
+    for (unsigned int number = 0; number < eighth_points; number++) {
+        float32x4_t x0 = vld1q_f32(in);
+        float32x4_t x1 = vld1q_f32(in + 4);
+        __VOLK_PREFETCH(in + 8);
+        in += 8;
+
+        float32x4_t r0 = vdivq_f32(vOne, x0);
+        float32x4_t r1 = vdivq_f32(vOne, x1);
+
+        vst1q_f32(out, r0);
+        vst1q_f32(out + 4, r1);
+        out += 8;
+    }
+
+    const unsigned int done = eighth_points * 8;
+    for (unsigned int i = done; i < num_points; i++) {
+        *out++ = 1.0f / *in++;
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 

--- a/kernels/volk/volk_32f_s32f_add_32f.h
+++ b/kernels/volk/volk_32f_s32f_add_32f.h
@@ -171,6 +171,38 @@ static inline void volk_32f_s32f_add_32f_u_neon(float* cVector,
 }
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32f_s32f_add_32f_neonv8(float* cVector,
+                                                const float* aVector,
+                                                const float scalar,
+                                                unsigned int num_points)
+{
+    const unsigned int eighthPoints = num_points / 8;
+
+    const float* aPtr = aVector;
+    float* cPtr = cVector;
+    const float32x4_t scalarVec = vdupq_n_f32(scalar);
+
+    for (unsigned int number = 0; number < eighthPoints; number++) {
+        float32x4_t a0 = vld1q_f32(aPtr);
+        float32x4_t a1 = vld1q_f32(aPtr + 4);
+        __VOLK_PREFETCH(aPtr + 16);
+
+        vst1q_f32(cPtr, vaddq_f32(a0, scalarVec));
+        vst1q_f32(cPtr + 4, vaddq_f32(a1, scalarVec));
+
+        aPtr += 8;
+        cPtr += 8;
+    }
+
+    for (unsigned int number = eighthPoints * 8; number < num_points; number++) {
+        *cPtr++ = (*aPtr++) + scalar;
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 
 #endif /* INCLUDED_volk_32f_s32f_add_32f_u_H */
 

--- a/kernels/volk/volk_32f_s32f_clamppuppet_32f.h
+++ b/kernels/volk/volk_32f_s32f_clamppuppet_32f.h
@@ -62,6 +62,26 @@ static inline void volk_32f_s32f_clamppuppet_32f_u_sse4_1(float* out,
 }
 #endif
 
+#ifdef LV_HAVE_NEON
+static inline void volk_32f_s32f_clamppuppet_32f_neon(float* out,
+                                                      const float* in,
+                                                      const float min,
+                                                      unsigned int num_points)
+{
+    volk_32f_s32f_x2_clamp_32f_neon(out, in, min, -min, num_points);
+}
+#endif
+
+#ifdef LV_HAVE_NEONV8
+static inline void volk_32f_s32f_clamppuppet_32f_neonv8(float* out,
+                                                        const float* in,
+                                                        const float min,
+                                                        unsigned int num_points)
+{
+    volk_32f_s32f_x2_clamp_32f_neonv8(out, in, min, -min, num_points);
+}
+#endif
+
 #ifdef LV_HAVE_RVV
 static inline void volk_32f_s32f_clamppuppet_32f_rvv(float* out,
                                                      const float* in,

--- a/kernels/volk/volk_32f_s32f_convert_16i.h
+++ b/kernels/volk/volk_32f_s32f_convert_16i.h
@@ -658,6 +658,138 @@ static inline void volk_32f_s32f_convert_16i_a_sse(int16_t* outputVector,
 }
 #endif /* LV_HAVE_SSE */
 
+
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+
+static inline void volk_32f_s32f_convert_16i_neon(int16_t* outputVector,
+                                                  const float* inputVector,
+                                                  const float scalar,
+                                                  unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    const float* inputVectorPtr = inputVector;
+    int16_t* outputVectorPtr = outputVector;
+
+    float min_val = SHRT_MIN;
+    float max_val = SHRT_MAX;
+    float r;
+
+    float32x4_t vScalar = vdupq_n_f32(scalar);
+    float32x4_t vmin_val = vdupq_n_f32(min_val);
+    float32x4_t vmax_val = vdupq_n_f32(max_val);
+
+    for (; number < eighthPoints; number++) {
+        float32x4_t inputVal1 = vld1q_f32(inputVectorPtr);
+        float32x4_t inputVal2 = vld1q_f32(inputVectorPtr + 4);
+        inputVectorPtr += 8;
+
+        // Scale and clip
+        float32x4_t ret1 =
+            vmaxq_f32(vminq_f32(vmulq_f32(inputVal1, vScalar), vmax_val), vmin_val);
+        float32x4_t ret2 =
+            vmaxq_f32(vminq_f32(vmulq_f32(inputVal2, vScalar), vmax_val), vmin_val);
+
+        // Convert to int32 (truncates towards zero)
+        int32x4_t intVal1 = vcvtq_s32_f32(ret1);
+        int32x4_t intVal2 = vcvtq_s32_f32(ret2);
+
+        // Narrow to int16 with saturation
+        int16x4_t narrow1 = vqmovn_s32(intVal1);
+        int16x4_t narrow2 = vqmovn_s32(intVal2);
+        int16x8_t result = vcombine_s16(narrow1, narrow2);
+
+        vst1q_s16(outputVectorPtr, result);
+        outputVectorPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        r = inputVector[number] * scalar;
+        if (r > max_val)
+            r = max_val;
+        else if (r < min_val)
+            r = min_val;
+        outputVector[number] = (int16_t)rintf(r);
+    }
+}
+#endif /* LV_HAVE_NEON */
+
+
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32f_s32f_convert_16i_neonv8(int16_t* outputVector,
+                                                    const float* inputVector,
+                                                    const float scalar,
+                                                    unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int sixteenthPoints = num_points / 16;
+
+    const float* inputVectorPtr = inputVector;
+    int16_t* outputVectorPtr = outputVector;
+
+    float min_val = SHRT_MIN;
+    float max_val = SHRT_MAX;
+    float r;
+
+    float32x4_t vScalar = vdupq_n_f32(scalar);
+    float32x4_t vmin_val = vdupq_n_f32(min_val);
+    float32x4_t vmax_val = vdupq_n_f32(max_val);
+
+    for (; number < sixteenthPoints; number++) {
+        float32x4_t inputVal0 = vld1q_f32(inputVectorPtr);
+        float32x4_t inputVal1 = vld1q_f32(inputVectorPtr + 4);
+        float32x4_t inputVal2 = vld1q_f32(inputVectorPtr + 8);
+        float32x4_t inputVal3 = vld1q_f32(inputVectorPtr + 12);
+        __VOLK_PREFETCH(inputVectorPtr + 16);
+        inputVectorPtr += 16;
+
+        // Scale and clip
+        float32x4_t ret0 =
+            vmaxq_f32(vminq_f32(vmulq_f32(inputVal0, vScalar), vmax_val), vmin_val);
+        float32x4_t ret1 =
+            vmaxq_f32(vminq_f32(vmulq_f32(inputVal1, vScalar), vmax_val), vmin_val);
+        float32x4_t ret2 =
+            vmaxq_f32(vminq_f32(vmulq_f32(inputVal2, vScalar), vmax_val), vmin_val);
+        float32x4_t ret3 =
+            vmaxq_f32(vminq_f32(vmulq_f32(inputVal3, vScalar), vmax_val), vmin_val);
+
+        // Convert to int32 using round-to-nearest (ARMv8)
+        int32x4_t intVal0 = vcvtnq_s32_f32(ret0);
+        int32x4_t intVal1 = vcvtnq_s32_f32(ret1);
+        int32x4_t intVal2 = vcvtnq_s32_f32(ret2);
+        int32x4_t intVal3 = vcvtnq_s32_f32(ret3);
+
+        // Narrow to int16 with saturation
+        int16x4_t narrow0 = vqmovn_s32(intVal0);
+        int16x4_t narrow1 = vqmovn_s32(intVal1);
+        int16x4_t narrow2 = vqmovn_s32(intVal2);
+        int16x4_t narrow3 = vqmovn_s32(intVal3);
+        int16x8_t result0 = vcombine_s16(narrow0, narrow1);
+        int16x8_t result1 = vcombine_s16(narrow2, narrow3);
+
+        vst1q_s16(outputVectorPtr, result0);
+        vst1q_s16(outputVectorPtr + 8, result1);
+        outputVectorPtr += 16;
+    }
+
+    number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        r = inputVector[number] * scalar;
+        if (r > max_val)
+            r = max_val;
+        else if (r < min_val)
+            r = min_val;
+        outputVector[number] = (int16_t)rintf(r);
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
+
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 

--- a/kernels/volk/volk_32f_s32f_convert_32i.h
+++ b/kernels/volk/volk_32f_s32f_convert_32i.h
@@ -405,6 +405,103 @@ static inline void volk_32f_s32f_convert_32i_a_sse(int32_t* outputVector,
 
 #endif /* LV_HAVE_SSE */
 
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+
+static inline void volk_32f_s32f_convert_32i_neon(int32_t* outputVector,
+                                                  const float* inputVector,
+                                                  const float scalar,
+                                                  unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarter_points = num_points / 4;
+
+    const float* inputPtr = inputVector;
+    int32_t* outputPtr = outputVector;
+
+    const float min_val = (float)INT_MIN;
+    const float max_val = (float)((uint32_t)INT_MAX + 1);
+
+    float32x4_t vScalar = vdupq_n_f32(scalar);
+    float32x4_t vmin_val = vdupq_n_f32(min_val);
+    float32x4_t vmax_val = vdupq_n_f32(max_val);
+
+    for (; number < quarter_points; number++) {
+        float32x4_t inputVal = vld1q_f32(inputPtr);
+        inputVal = vmulq_f32(inputVal, vScalar);
+        inputVal = vmaxq_f32(vminq_f32(inputVal, vmax_val), vmin_val);
+        int32x4_t intVal = vcvtq_s32_f32(inputVal);
+        vst1q_s32(outputPtr, intVal);
+        inputPtr += 4;
+        outputPtr += 4;
+    }
+
+    number = quarter_points * 4;
+    for (; number < num_points; number++) {
+        float r = *inputPtr++ * scalar;
+        if (r >= max_val)
+            *outputPtr++ = INT_MAX;
+        else if (r < min_val)
+            *outputPtr++ = INT_MIN;
+        else
+            *outputPtr++ = (int32_t)rintf(r);
+    }
+}
+#endif /* LV_HAVE_NEON */
+
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32f_s32f_convert_32i_neonv8(int32_t* outputVector,
+                                                    const float* inputVector,
+                                                    const float scalar,
+                                                    unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighth_points = num_points / 8;
+
+    const float* inputPtr = inputVector;
+    int32_t* outputPtr = outputVector;
+
+    const float min_val = (float)INT_MIN;
+    const float max_val = (float)((uint32_t)INT_MAX + 1);
+
+    float32x4_t vScalar = vdupq_n_f32(scalar);
+    float32x4_t vmin_val = vdupq_n_f32(min_val);
+    float32x4_t vmax_val = vdupq_n_f32(max_val);
+
+    for (; number < eighth_points; number++) {
+        float32x4_t inputVal0 = vld1q_f32(inputPtr);
+        float32x4_t inputVal1 = vld1q_f32(inputPtr + 4);
+        __VOLK_PREFETCH(inputPtr + 8);
+
+        inputVal0 = vmulq_f32(inputVal0, vScalar);
+        inputVal1 = vmulq_f32(inputVal1, vScalar);
+        inputVal0 = vmaxq_f32(vminq_f32(inputVal0, vmax_val), vmin_val);
+        inputVal1 = vmaxq_f32(vminq_f32(inputVal1, vmax_val), vmin_val);
+
+        int32x4_t intVal0 = vcvtnq_s32_f32(inputVal0);
+        int32x4_t intVal1 = vcvtnq_s32_f32(inputVal1);
+
+        vst1q_s32(outputPtr, intVal0);
+        vst1q_s32(outputPtr + 4, intVal1);
+        inputPtr += 8;
+        outputPtr += 8;
+    }
+
+    number = eighth_points * 8;
+    for (; number < num_points; number++) {
+        float r = *inputPtr++ * scalar;
+        if (r >= max_val)
+            *outputPtr++ = INT_MAX;
+        else if (r < min_val)
+            *outputPtr++ = INT_MIN;
+        else
+            *outputPtr++ = (int32_t)rintf(r);
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 

--- a/kernels/volk/volk_32f_s32f_multiply_32f.h
+++ b/kernels/volk/volk_32f_s32f_multiply_32f.h
@@ -239,6 +239,38 @@ static inline void volk_32f_s32f_multiply_32f_u_neon(float* cVector,
 }
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32f_s32f_multiply_32f_neonv8(float* cVector,
+                                                     const float* aVector,
+                                                     const float scalar,
+                                                     unsigned int num_points)
+{
+    const unsigned int eighthPoints = num_points / 8;
+
+    const float* aPtr = aVector;
+    float* cPtr = cVector;
+    const float32x4_t scalarVec = vdupq_n_f32(scalar);
+
+    for (unsigned int number = 0; number < eighthPoints; number++) {
+        float32x4_t a0 = vld1q_f32(aPtr);
+        float32x4_t a1 = vld1q_f32(aPtr + 4);
+        __VOLK_PREFETCH(aPtr + 16);
+
+        vst1q_f32(cPtr, vmulq_f32(a0, scalarVec));
+        vst1q_f32(cPtr + 4, vmulq_f32(a1, scalarVec));
+
+        aPtr += 8;
+        cPtr += 8;
+    }
+
+    for (unsigned int number = eighthPoints * 8; number < num_points; number++) {
+        *cPtr++ = (*aPtr++) * scalar;
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 
 #ifdef LV_HAVE_ORC
 

--- a/kernels/volk/volk_32f_sin_32f.h
+++ b/kernels/volk/volk_32f_sin_32f.h
@@ -895,6 +895,105 @@ volk_32f_sin_32f_neon(float* bVector, const float* aVector, unsigned int num_poi
 
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+/* ARMv8 NEON with FMA: sin-only polynomial, 2x unroll for better ILP */
+static inline void
+volk_32f_sin_32f_neonv8(float* bVector, const float* aVector, unsigned int num_points)
+{
+    const float32x4_t c_minus_cephes_DP1 = vdupq_n_f32(-0.78515625f);
+    const float32x4_t c_minus_cephes_DP2 = vdupq_n_f32(-2.4187564849853515625e-4f);
+    const float32x4_t c_minus_cephes_DP3 = vdupq_n_f32(-3.77489497744594108e-8f);
+    const float32x4_t c_sincof_p0 = vdupq_n_f32(-1.9515295891e-4f);
+    const float32x4_t c_sincof_p1 = vdupq_n_f32(8.3321608736e-3f);
+    const float32x4_t c_sincof_p2 = vdupq_n_f32(-1.6666654611e-1f);
+    const float32x4_t c_coscof_p0 = vdupq_n_f32(2.443315711809948e-005f);
+    const float32x4_t c_coscof_p1 = vdupq_n_f32(-1.388731625493765e-003f);
+    const float32x4_t c_coscof_p2 = vdupq_n_f32(4.166664568298827e-002f);
+    const float32x4_t c_cephes_FOPI = vdupq_n_f32(1.27323954473516f);
+    const float32x4_t CONST_1 = vdupq_n_f32(1.f);
+    const float32x4_t CONST_1_2 = vdupq_n_f32(0.5f);
+    const float32x4_t CONST_0 = vdupq_n_f32(0.f);
+    const uint32x4_t CONST_2 = vdupq_n_u32(2);
+    const uint32x4_t CONST_4 = vdupq_n_u32(4);
+    const uint32x4_t CONST_1_U = vdupq_n_u32(1);
+    const uint32x4_t CONST_NOT1 = vdupq_n_u32(~1u);
+
+    unsigned int number = 0;
+    const unsigned int eighth_points = num_points / 8;
+
+    for (; number < eighth_points; number++) {
+        /* Load 8 floats (2 x float32x4) */
+        float32x4_t x0 = vld1q_f32(aVector);
+        float32x4_t x1 = vld1q_f32(aVector + 4);
+        aVector += 8;
+
+        /* Process first 4 */
+        uint32x4_t sign_mask0 = vcltq_f32(x0, CONST_0);
+        x0 = vabsq_f32(x0);
+        float32x4_t y0 = vmulq_f32(x0, c_cephes_FOPI);
+        uint32x4_t emm2_0 = vcvtq_u32_f32(y0);
+        emm2_0 = vandq_u32(vaddq_u32(emm2_0, CONST_1_U), CONST_NOT1);
+        y0 = vcvtq_f32_u32(emm2_0);
+        uint32x4_t poly_mask0 = vtstq_u32(emm2_0, CONST_2);
+        x0 = vfmaq_f32(x0, y0, c_minus_cephes_DP1);
+        x0 = vfmaq_f32(x0, y0, c_minus_cephes_DP2);
+        x0 = vfmaq_f32(x0, y0, c_minus_cephes_DP3);
+        sign_mask0 = veorq_u32(sign_mask0, vtstq_u32(emm2_0, CONST_4));
+        float32x4_t z0 = vmulq_f32(x0, x0);
+        float32x4_t y1_0 = vfmaq_f32(c_coscof_p1, z0, c_coscof_p0);
+        y1_0 = vfmaq_f32(c_coscof_p2, z0, y1_0);
+        y1_0 = vmulq_f32(y1_0, z0);
+        y1_0 = vmulq_f32(y1_0, z0);
+        y1_0 = vfmsq_f32(y1_0, z0, CONST_1_2);
+        y1_0 = vaddq_f32(y1_0, CONST_1);
+        float32x4_t y2_0 = vfmaq_f32(c_sincof_p1, z0, c_sincof_p0);
+        y2_0 = vfmaq_f32(c_sincof_p2, z0, y2_0);
+        y2_0 = vmulq_f32(y2_0, z0);
+        y2_0 = vfmaq_f32(x0, x0, y2_0);
+        float32x4_t ys0 = vbslq_f32(poly_mask0, y1_0, y2_0);
+        float32x4_t result0 = vbslq_f32(sign_mask0, vnegq_f32(ys0), ys0);
+
+        /* Process second 4 */
+        uint32x4_t sign_mask1 = vcltq_f32(x1, CONST_0);
+        x1 = vabsq_f32(x1);
+        float32x4_t y1 = vmulq_f32(x1, c_cephes_FOPI);
+        uint32x4_t emm2_1 = vcvtq_u32_f32(y1);
+        emm2_1 = vandq_u32(vaddq_u32(emm2_1, CONST_1_U), CONST_NOT1);
+        y1 = vcvtq_f32_u32(emm2_1);
+        uint32x4_t poly_mask1 = vtstq_u32(emm2_1, CONST_2);
+        x1 = vfmaq_f32(x1, y1, c_minus_cephes_DP1);
+        x1 = vfmaq_f32(x1, y1, c_minus_cephes_DP2);
+        x1 = vfmaq_f32(x1, y1, c_minus_cephes_DP3);
+        sign_mask1 = veorq_u32(sign_mask1, vtstq_u32(emm2_1, CONST_4));
+        float32x4_t z1 = vmulq_f32(x1, x1);
+        float32x4_t y1_1 = vfmaq_f32(c_coscof_p1, z1, c_coscof_p0);
+        y1_1 = vfmaq_f32(c_coscof_p2, z1, y1_1);
+        y1_1 = vmulq_f32(y1_1, z1);
+        y1_1 = vmulq_f32(y1_1, z1);
+        y1_1 = vfmsq_f32(y1_1, z1, CONST_1_2);
+        y1_1 = vaddq_f32(y1_1, CONST_1);
+        float32x4_t y2_1 = vfmaq_f32(c_sincof_p1, z1, c_sincof_p0);
+        y2_1 = vfmaq_f32(c_sincof_p2, z1, y2_1);
+        y2_1 = vmulq_f32(y2_1, z1);
+        y2_1 = vfmaq_f32(x1, x1, y2_1);
+        float32x4_t ys1 = vbslq_f32(poly_mask1, y1_1, y2_1);
+        float32x4_t result1 = vbslq_f32(sign_mask1, vnegq_f32(ys1), ys1);
+
+        vst1q_f32(bVector, result0);
+        vst1q_f32(bVector + 4, result1);
+        bVector += 8;
+    }
+
+    /* Handle remaining */
+    for (number = eighth_points * 8; number < num_points; number++) {
+        *bVector++ = sinf(*aVector++);
+    }
+}
+
+#endif /* LV_HAVE_NEONV8 */
+
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 

--- a/kernels/volk/volk_32f_sqrt_32f.h
+++ b/kernels/volk/volk_32f_sqrt_32f.h
@@ -228,6 +228,32 @@ volk_32f_sqrt_32f_neon(float* cVector, const float* aVector, unsigned int num_po
 
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void
+volk_32f_sqrt_32f_neonv8(float* cVector, const float* aVector, unsigned int num_points)
+{
+    float* cPtr = cVector;
+    const float* aPtr = aVector;
+    unsigned int number = 0;
+    unsigned int quarter_points = num_points / 4;
+
+    for (number = 0; number < quarter_points; number++) {
+        float32x4_t in_vec = vld1q_f32(aPtr);
+        float32x4_t out_vec = vsqrtq_f32(in_vec);
+        vst1q_f32(cPtr, out_vec);
+        aPtr += 4;
+        cPtr += 4;
+    }
+
+    for (number = quarter_points * 4; number < num_points; number++) {
+        *cPtr++ = sqrtf(*aPtr++);
+    }
+}
+
+#endif /* LV_HAVE_NEONV8 */
+
 #endif /* INCLUDED_volk_32f_sqrt_32f_a_H */
 
 #ifndef INCLUDED_volk_32f_sqrt_32f_u_H

--- a/kernels/volk/volk_32f_tan_32f.h
+++ b/kernels/volk/volk_32f_tan_32f.h
@@ -750,6 +750,34 @@ volk_32f_tan_32f_neon(float* bVector, const float* aVector, unsigned int num_poi
 }
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+#include <volk/volk_neon_intrinsics.h>
+
+static inline void
+volk_32f_tan_32f_neonv8(float* bVector, const float* aVector, unsigned int num_points)
+{
+    unsigned int number = 0;
+    unsigned int quarter_points = num_points / 4;
+    float* bVectorPtr = bVector;
+    const float* aVectorPtr = aVector;
+
+    for (number = 0; number < quarter_points; number++) {
+        float32x4_t a_vec = vld1q_f32(aVectorPtr);
+        // Use sincos, then native division for tan = sin/cos
+        const float32x4x2_t sincos = _vsincosq_f32(a_vec);
+        float32x4_t b_vec = vdivq_f32(sincos.val[0], sincos.val[1]);
+        vst1q_f32(bVectorPtr, b_vec);
+        bVectorPtr += 4;
+        aVectorPtr += 4;
+    }
+
+    for (number = quarter_points * 4; number < num_points; number++) {
+        *bVectorPtr++ = tanf(*aVectorPtr++);
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 

--- a/kernels/volk/volk_32f_x2_divide_32f.h
+++ b/kernels/volk/volk_32f_x2_divide_32f.h
@@ -228,6 +228,43 @@ static inline void volk_32f_x2_divide_32f_neon(float* cVector,
 
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32f_x2_divide_32f_neonv8(float* cVector,
+                                                 const float* aVector,
+                                                 const float* bVector,
+                                                 unsigned int num_points)
+{
+    const unsigned int eighthPoints = num_points / 8;
+
+    const float* aPtr = aVector;
+    const float* bPtr = bVector;
+    float* cPtr = cVector;
+
+    for (unsigned int number = 0; number < eighthPoints; number++) {
+        float32x4_t a0 = vld1q_f32(aPtr);
+        float32x4_t a1 = vld1q_f32(aPtr + 4);
+        float32x4_t b0 = vld1q_f32(bPtr);
+        float32x4_t b1 = vld1q_f32(bPtr + 4);
+        __VOLK_PREFETCH(aPtr + 16);
+        __VOLK_PREFETCH(bPtr + 16);
+
+        /* ARMv8 has native divide instruction */
+        vst1q_f32(cPtr, vdivq_f32(a0, b0));
+        vst1q_f32(cPtr + 4, vdivq_f32(a1, b1));
+
+        aPtr += 8;
+        bPtr += 8;
+        cPtr += 8;
+    }
+
+    for (unsigned int number = eighthPoints * 8; number < num_points; number++) {
+        *cPtr++ = (*aPtr++) / (*bPtr++);
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 
 #ifdef LV_HAVE_GENERIC
 

--- a/kernels/volk/volk_32f_x2_dot_prod_32f.h
+++ b/kernels/volk/volk_32f_x2_dot_prod_32f.h
@@ -848,92 +848,118 @@ static inline void volk_32f_x2_dot_prod_32f_a_avx512f(float* result,
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
 
-static inline void volk_32f_x2_dot_prod_32f_neonopts(float* result,
-                                                     const float* input,
-                                                     const float* taps,
-                                                     unsigned int num_points)
-{
-
-    unsigned int quarter_points = num_points / 16;
-    float dotProduct = 0;
-    const float* aPtr = input;
-    const float* bPtr = taps;
-    unsigned int number = 0;
-
-    float32x4x4_t a_val, b_val, accumulator0;
-    accumulator0.val[0] = vdupq_n_f32(0);
-    accumulator0.val[1] = vdupq_n_f32(0);
-    accumulator0.val[2] = vdupq_n_f32(0);
-    accumulator0.val[3] = vdupq_n_f32(0);
-    // factor of 4 loop unroll with independent accumulators
-    // uses 12 out of 16 neon q registers
-    for (number = 0; number < quarter_points; ++number) {
-        a_val = vld4q_f32(aPtr);
-        b_val = vld4q_f32(bPtr);
-        accumulator0.val[0] = vmlaq_f32(accumulator0.val[0], a_val.val[0], b_val.val[0]);
-        accumulator0.val[1] = vmlaq_f32(accumulator0.val[1], a_val.val[1], b_val.val[1]);
-        accumulator0.val[2] = vmlaq_f32(accumulator0.val[2], a_val.val[2], b_val.val[2]);
-        accumulator0.val[3] = vmlaq_f32(accumulator0.val[3], a_val.val[3], b_val.val[3]);
-        aPtr += 16;
-        bPtr += 16;
-    }
-    accumulator0.val[0] = vaddq_f32(accumulator0.val[0], accumulator0.val[1]);
-    accumulator0.val[2] = vaddq_f32(accumulator0.val[2], accumulator0.val[3]);
-    accumulator0.val[0] = vaddq_f32(accumulator0.val[2], accumulator0.val[0]);
-    __VOLK_ATTR_ALIGNED(32) float accumulator[4];
-    vst1q_f32(accumulator, accumulator0.val[0]);
-    dotProduct = accumulator[0] + accumulator[1] + accumulator[2] + accumulator[3];
-
-    for (number = quarter_points * 16; number < num_points; number++) {
-        dotProduct += ((*aPtr++) * (*bPtr++));
-    }
-
-    *result = dotProduct;
-}
-
-#endif
-
-
-#ifdef LV_HAVE_NEON
 static inline void volk_32f_x2_dot_prod_32f_neon(float* result,
                                                  const float* input,
                                                  const float* taps,
                                                  unsigned int num_points)
 {
-
-    unsigned int quarter_points = num_points / 8;
-    float dotProduct = 0;
+    const unsigned int sixteenthPoints = num_points / 16;
     const float* aPtr = input;
     const float* bPtr = taps;
-    unsigned int number = 0;
 
-    float32x4x2_t a_val, b_val, accumulator_val;
-    accumulator_val.val[0] = vdupq_n_f32(0);
-    accumulator_val.val[1] = vdupq_n_f32(0);
-    // factor of 2 loop unroll with independent accumulators
-    for (number = 0; number < quarter_points; ++number) {
-        a_val = vld2q_f32(aPtr);
-        b_val = vld2q_f32(bPtr);
-        accumulator_val.val[0] =
-            vmlaq_f32(accumulator_val.val[0], a_val.val[0], b_val.val[0]);
-        accumulator_val.val[1] =
-            vmlaq_f32(accumulator_val.val[1], a_val.val[1], b_val.val[1]);
-        aPtr += 8;
-        bPtr += 8;
+    // Use 4 independent accumulators for better pipelining
+    float32x4_t acc0 = vdupq_n_f32(0);
+    float32x4_t acc1 = vdupq_n_f32(0);
+    float32x4_t acc2 = vdupq_n_f32(0);
+    float32x4_t acc3 = vdupq_n_f32(0);
+
+    for (unsigned int number = 0; number < sixteenthPoints; number++) {
+        float32x4_t a0 = vld1q_f32(aPtr);
+        float32x4_t a1 = vld1q_f32(aPtr + 4);
+        float32x4_t a2 = vld1q_f32(aPtr + 8);
+        float32x4_t a3 = vld1q_f32(aPtr + 12);
+
+        float32x4_t b0 = vld1q_f32(bPtr);
+        float32x4_t b1 = vld1q_f32(bPtr + 4);
+        float32x4_t b2 = vld1q_f32(bPtr + 8);
+        float32x4_t b3 = vld1q_f32(bPtr + 12);
+
+        acc0 = vmlaq_f32(acc0, a0, b0);
+        acc1 = vmlaq_f32(acc1, a1, b1);
+        acc2 = vmlaq_f32(acc2, a2, b2);
+        acc3 = vmlaq_f32(acc3, a3, b3);
+
+        aPtr += 16;
+        bPtr += 16;
     }
-    accumulator_val.val[0] = vaddq_f32(accumulator_val.val[0], accumulator_val.val[1]);
-    __VOLK_ATTR_ALIGNED(32) float accumulator[4];
-    vst1q_f32(accumulator, accumulator_val.val[0]);
-    dotProduct = accumulator[0] + accumulator[1] + accumulator[2] + accumulator[3];
 
-    for (number = quarter_points * 8; number < num_points; number++) {
-        dotProduct += ((*aPtr++) * (*bPtr++));
+    // Combine accumulators
+    acc0 = vaddq_f32(acc0, acc1);
+    acc2 = vaddq_f32(acc2, acc3);
+    acc0 = vaddq_f32(acc0, acc2);
+
+    // Horizontal sum (ARMv7 compatible)
+    float32x2_t sum = vadd_f32(vget_low_f32(acc0), vget_high_f32(acc0));
+    sum = vpadd_f32(sum, sum);
+    float dotProduct = vget_lane_f32(sum, 0);
+
+    // Handle remainder
+    for (unsigned int number = sixteenthPoints * 16; number < num_points; number++) {
+        dotProduct += (*aPtr++) * (*bPtr++);
     }
 
     *result = dotProduct;
 }
 
 #endif /* LV_HAVE_NEON */
+
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32f_x2_dot_prod_32f_neonv8(float* result,
+                                                   const float* input,
+                                                   const float* taps,
+                                                   unsigned int num_points)
+{
+    const unsigned int sixteenthPoints = num_points / 16;
+    const float* aPtr = input;
+    const float* bPtr = taps;
+
+    /* Use 4 independent accumulators for better pipelining with FMA */
+    float32x4_t acc0 = vdupq_n_f32(0);
+    float32x4_t acc1 = vdupq_n_f32(0);
+    float32x4_t acc2 = vdupq_n_f32(0);
+    float32x4_t acc3 = vdupq_n_f32(0);
+
+    for (unsigned int number = 0; number < sixteenthPoints; number++) {
+        float32x4_t a0 = vld1q_f32(aPtr);
+        float32x4_t a1 = vld1q_f32(aPtr + 4);
+        float32x4_t a2 = vld1q_f32(aPtr + 8);
+        float32x4_t a3 = vld1q_f32(aPtr + 12);
+
+        float32x4_t b0 = vld1q_f32(bPtr);
+        float32x4_t b1 = vld1q_f32(bPtr + 4);
+        float32x4_t b2 = vld1q_f32(bPtr + 8);
+        float32x4_t b3 = vld1q_f32(bPtr + 12);
+        __VOLK_PREFETCH(aPtr + 32);
+        __VOLK_PREFETCH(bPtr + 32);
+
+        /* Use FMA for accumulate */
+        acc0 = vfmaq_f32(acc0, a0, b0);
+        acc1 = vfmaq_f32(acc1, a1, b1);
+        acc2 = vfmaq_f32(acc2, a2, b2);
+        acc3 = vfmaq_f32(acc3, a3, b3);
+
+        aPtr += 16;
+        bPtr += 16;
+    }
+
+    /* Combine accumulators */
+    acc0 = vaddq_f32(acc0, acc1);
+    acc2 = vaddq_f32(acc2, acc3);
+    acc0 = vaddq_f32(acc0, acc2);
+
+    /* Horizontal sum */
+    float dotProduct = vaddvq_f32(acc0);
+
+    /* Handle remainder */
+    for (unsigned int number = sixteenthPoints * 16; number < num_points; number++) {
+        dotProduct += (*aPtr++) * (*bPtr++);
+    }
+
+    *result = dotProduct;
+}
+#endif /* LV_HAVE_NEONV8 */
 
 #ifdef LV_HAVE_NEONV7
 extern void volk_32f_x2_dot_prod_32f_a_neonasm(float* cVector,

--- a/kernels/volk/volk_32f_x2_fm_detectpuppet_32f.h
+++ b/kernels/volk/volk_32f_x2_fm_detectpuppet_32f.h
@@ -56,6 +56,33 @@ static inline void volk_32f_x2_fm_detectpuppet_32f_generic(float* outputVector,
 }
 #endif /* LV_HAVE_GENERIC */
 
+#ifdef LV_HAVE_NEON
+
+static inline void volk_32f_x2_fm_detectpuppet_32f_neon(float* outputVector,
+                                                        const float* inputVector,
+                                                        float* saveValue,
+                                                        unsigned int num_points)
+{
+    const float bound = 2.0f;
+
+    volk_32f_s32f_32f_fm_detect_32f_neon(
+        outputVector, inputVector, bound, saveValue, num_points);
+}
+#endif /* LV_HAVE_NEON */
+
+#ifdef LV_HAVE_NEONV8
+
+static inline void volk_32f_x2_fm_detectpuppet_32f_neonv8(float* outputVector,
+                                                          const float* inputVector,
+                                                          float* saveValue,
+                                                          unsigned int num_points)
+{
+    const float bound = 2.0f;
+
+    volk_32f_s32f_32f_fm_detect_32f_neonv8(
+        outputVector, inputVector, bound, saveValue, num_points);
+}
+#endif /* LV_HAVE_NEONV8 */
 
 #endif /* INCLUDED_volk_32f_x2_fm_detectpuppet_32f_a_H */
 

--- a/kernels/volk/volk_32f_x2_interleave_32fc.h
+++ b/kernels/volk/volk_32f_x2_interleave_32fc.h
@@ -181,6 +181,44 @@ static inline void volk_32f_x2_interleave_32fc_neon(lv_32fc_t* complexVector,
 }
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32f_x2_interleave_32fc_neonv8(lv_32fc_t* complexVector,
+                                                      const float* iBuffer,
+                                                      const float* qBuffer,
+                                                      unsigned int num_points)
+{
+    const unsigned int eighthPoints = num_points / 8;
+
+    float* outPtr = (float*)complexVector;
+    const float* iPtr = iBuffer;
+    const float* qPtr = qBuffer;
+
+    for (unsigned int number = 0; number < eighthPoints; number++) {
+        float32x4x2_t cplx0, cplx1;
+        cplx0.val[0] = vld1q_f32(iPtr);
+        cplx0.val[1] = vld1q_f32(qPtr);
+        cplx1.val[0] = vld1q_f32(iPtr + 4);
+        cplx1.val[1] = vld1q_f32(qPtr + 4);
+        __VOLK_PREFETCH(iPtr + 16);
+        __VOLK_PREFETCH(qPtr + 16);
+
+        vst2q_f32(outPtr, cplx0);
+        vst2q_f32(outPtr + 8, cplx1);
+
+        iPtr += 8;
+        qPtr += 8;
+        outPtr += 16;
+    }
+
+    for (unsigned int number = eighthPoints * 8; number < num_points; number++) {
+        *outPtr++ = *iPtr++;
+        *outPtr++ = *qPtr++;
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 
 #ifdef LV_HAVE_GENERIC
 

--- a/kernels/volk/volk_32f_x2_max_32f.h
+++ b/kernels/volk/volk_32f_x2_max_32f.h
@@ -208,6 +208,44 @@ static inline void volk_32f_x2_max_32f_neon(float* cVector,
 }
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32f_x2_max_32f_neonv8(float* cVector,
+                                              const float* aVector,
+                                              const float* bVector,
+                                              unsigned int num_points)
+{
+    const unsigned int eighthPoints = num_points / 8;
+
+    const float* aPtr = aVector;
+    const float* bPtr = bVector;
+    float* cPtr = cVector;
+
+    for (unsigned int number = 0; number < eighthPoints; number++) {
+        float32x4_t a0 = vld1q_f32(aPtr);
+        float32x4_t a1 = vld1q_f32(aPtr + 4);
+        float32x4_t b0 = vld1q_f32(bPtr);
+        float32x4_t b1 = vld1q_f32(bPtr + 4);
+        __VOLK_PREFETCH(aPtr + 16);
+        __VOLK_PREFETCH(bPtr + 16);
+
+        vst1q_f32(cPtr, vmaxq_f32(a0, b0));
+        vst1q_f32(cPtr + 4, vmaxq_f32(a1, b1));
+
+        aPtr += 8;
+        bPtr += 8;
+        cPtr += 8;
+    }
+
+    for (unsigned int number = eighthPoints * 8; number < num_points; number++) {
+        const float a = *aPtr++;
+        const float b = *bPtr++;
+        *cPtr++ = (a > b ? a : b);
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 
 #ifdef LV_HAVE_GENERIC
 

--- a/kernels/volk/volk_32f_x2_min_32f.h
+++ b/kernels/volk/volk_32f_x2_min_32f.h
@@ -135,6 +135,44 @@ static inline void volk_32f_x2_min_32f_neon(float* cVector,
 }
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32f_x2_min_32f_neonv8(float* cVector,
+                                              const float* aVector,
+                                              const float* bVector,
+                                              unsigned int num_points)
+{
+    const unsigned int eighthPoints = num_points / 8;
+
+    const float* aPtr = aVector;
+    const float* bPtr = bVector;
+    float* cPtr = cVector;
+
+    for (unsigned int number = 0; number < eighthPoints; number++) {
+        float32x4_t a0 = vld1q_f32(aPtr);
+        float32x4_t a1 = vld1q_f32(aPtr + 4);
+        float32x4_t b0 = vld1q_f32(bPtr);
+        float32x4_t b1 = vld1q_f32(bPtr + 4);
+        __VOLK_PREFETCH(aPtr + 16);
+        __VOLK_PREFETCH(bPtr + 16);
+
+        vst1q_f32(cPtr, vminq_f32(a0, b0));
+        vst1q_f32(cPtr + 4, vminq_f32(a1, b1));
+
+        aPtr += 8;
+        bPtr += 8;
+        cPtr += 8;
+    }
+
+    for (unsigned int number = eighthPoints * 8; number < num_points; number++) {
+        const float a = *aPtr++;
+        const float b = *bPtr++;
+        *cPtr++ = (a < b ? a : b);
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 
 #ifdef LV_HAVE_GENERIC
 

--- a/kernels/volk/volk_32f_x2_multiply_32f.h
+++ b/kernels/volk/volk_32f_x2_multiply_32f.h
@@ -341,6 +341,56 @@ static inline void volk_32f_x2_multiply_32f_neon(float* cVector,
 #endif /* LV_HAVE_NEON */
 
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32f_x2_multiply_32f_neonv8(float* cVector,
+                                                   const float* aVector,
+                                                   const float* bVector,
+                                                   unsigned int num_points)
+{
+    unsigned int n = num_points;
+    float* c = cVector;
+    const float* a = aVector;
+    const float* b = bVector;
+
+    /* Process 8 floats per iteration (2x unroll) */
+    while (n >= 8) {
+        float32x4_t a0 = vld1q_f32(a);
+        float32x4_t a1 = vld1q_f32(a + 4);
+        float32x4_t b0 = vld1q_f32(b);
+        float32x4_t b1 = vld1q_f32(b + 4);
+        __VOLK_PREFETCH(a + 16);
+        __VOLK_PREFETCH(b + 16);
+
+        vst1q_f32(c, vmulq_f32(a0, b0));
+        vst1q_f32(c + 4, vmulq_f32(a1, b1));
+
+        a += 8;
+        b += 8;
+        c += 8;
+        n -= 8;
+    }
+
+    /* Process remaining 4 floats */
+    if (n >= 4) {
+        vst1q_f32(c, vmulq_f32(vld1q_f32(a), vld1q_f32(b)));
+        a += 4;
+        b += 4;
+        c += 4;
+        n -= 4;
+    }
+
+    /* Scalar tail */
+    while (n > 0) {
+        *c++ = *a++ * *b++;
+        n--;
+    }
+}
+
+#endif /* LV_HAVE_NEONV8 */
+
+
 #ifdef LV_HAVE_ORC
 extern void volk_32f_x2_multiply_32f_a_orc_impl(float* cVector,
                                                 const float* aVector,

--- a/kernels/volk/volk_32f_x2_powpuppet_32f.h
+++ b/kernels/volk/volk_32f_x2_powpuppet_32f.h
@@ -75,6 +75,30 @@ static inline void volk_32f_x2_powpuppet_32f_generic(float* cVector,
 }
 #endif /* LV_HAVE_GENERIC */
 
+#ifdef LV_HAVE_NEON
+static inline void volk_32f_x2_powpuppet_32f_neon(float* cVector,
+                                                  const float* bVector,
+                                                  const float* aVector,
+                                                  unsigned int num_points)
+{
+    float* aVectorPos = make_positive(aVector, num_points);
+    volk_32f_x2_pow_32f_neon(cVector, bVector, aVectorPos, num_points);
+    volk_free(aVectorPos);
+}
+#endif /* LV_HAVE_NEON */
+
+#ifdef LV_HAVE_NEONV8
+static inline void volk_32f_x2_powpuppet_32f_neonv8(float* cVector,
+                                                    const float* bVector,
+                                                    const float* aVector,
+                                                    unsigned int num_points)
+{
+    float* aVectorPos = make_positive(aVector, num_points);
+    volk_32f_x2_pow_32f_neonv8(cVector, bVector, aVectorPos, num_points);
+    volk_free(aVectorPos);
+}
+#endif /* LV_HAVE_NEONV8 */
+
 #ifdef LV_HAVE_SSE4_1
 static inline void volk_32f_x2_powpuppet_32f_u_sse4_1(float* cVector,
                                                       const float* bVector,

--- a/kernels/volk/volk_32f_x2_subtract_32f.h
+++ b/kernels/volk/volk_32f_x2_subtract_32f.h
@@ -190,6 +190,56 @@ static inline void volk_32f_x2_subtract_32f_neon(float* cVector,
 #endif /* LV_HAVE_NEON */
 
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32f_x2_subtract_32f_neonv8(float* cVector,
+                                                   const float* aVector,
+                                                   const float* bVector,
+                                                   unsigned int num_points)
+{
+    unsigned int n = num_points;
+    float* c = cVector;
+    const float* a = aVector;
+    const float* b = bVector;
+
+    /* Process 8 floats per iteration (2x unroll) */
+    while (n >= 8) {
+        float32x4_t a0 = vld1q_f32(a);
+        float32x4_t a1 = vld1q_f32(a + 4);
+        float32x4_t b0 = vld1q_f32(b);
+        float32x4_t b1 = vld1q_f32(b + 4);
+        __VOLK_PREFETCH(a + 16);
+        __VOLK_PREFETCH(b + 16);
+
+        vst1q_f32(c, vsubq_f32(a0, b0));
+        vst1q_f32(c + 4, vsubq_f32(a1, b1));
+
+        a += 8;
+        b += 8;
+        c += 8;
+        n -= 8;
+    }
+
+    /* Process remaining 4 floats */
+    if (n >= 4) {
+        vst1q_f32(c, vsubq_f32(vld1q_f32(a), vld1q_f32(b)));
+        a += 4;
+        b += 4;
+        c += 4;
+        n -= 4;
+    }
+
+    /* Scalar tail */
+    while (n > 0) {
+        *c++ = *a++ - *b++;
+        n--;
+    }
+}
+
+#endif /* LV_HAVE_NEONV8 */
+
+
 #ifdef LV_HAVE_ORC
 extern void volk_32f_x2_subtract_32f_a_orc_impl(float* cVector,
                                                 const float* aVector,

--- a/kernels/volk/volk_32fc_deinterleave_32f_x2.h
+++ b/kernels/volk/volk_32fc_deinterleave_32f_x2.h
@@ -248,6 +248,41 @@ static inline void volk_32fc_deinterleave_32f_x2_neon(float* iBuffer,
 }
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32fc_deinterleave_32f_x2_neonv8(float* iBuffer,
+                                                        float* qBuffer,
+                                                        const lv_32fc_t* complexVector,
+                                                        unsigned int num_points)
+{
+    const unsigned int eighthPoints = num_points / 8;
+    const float* complexVectorPtr = (float*)complexVector;
+    float* iBufferPtr = iBuffer;
+    float* qBufferPtr = qBuffer;
+
+    for (unsigned int number = 0; number < eighthPoints; number++) {
+        float32x4x2_t cplx0 = vld2q_f32(complexVectorPtr);
+        float32x4x2_t cplx1 = vld2q_f32(complexVectorPtr + 8);
+        __VOLK_PREFETCH(complexVectorPtr + 32);
+
+        vst1q_f32(iBufferPtr, cplx0.val[0]);
+        vst1q_f32(iBufferPtr + 4, cplx1.val[0]);
+        vst1q_f32(qBufferPtr, cplx0.val[1]);
+        vst1q_f32(qBufferPtr + 4, cplx1.val[1]);
+
+        complexVectorPtr += 16;
+        iBufferPtr += 8;
+        qBufferPtr += 8;
+    }
+
+    for (unsigned int number = eighthPoints * 8; number < num_points; number++) {
+        *iBufferPtr++ = *complexVectorPtr++;
+        *qBufferPtr++ = *complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 #endif /* INCLUDED_volk_32fc_deinterleave_32f_x2_a_H */
 
 

--- a/kernels/volk/volk_32fc_deinterleave_imag_32f.h
+++ b/kernels/volk/volk_32fc_deinterleave_imag_32f.h
@@ -165,6 +165,36 @@ static inline void volk_32fc_deinterleave_imag_32f_neon(float* qBuffer,
 }
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32fc_deinterleave_imag_32f_neonv8(float* qBuffer,
+                                                          const lv_32fc_t* complexVector,
+                                                          unsigned int num_points)
+{
+    const unsigned int eighthPoints = num_points / 8;
+    const float* complexVectorPtr = (float*)complexVector;
+    float* qBufferPtr = qBuffer;
+
+    for (unsigned int number = 0; number < eighthPoints; number++) {
+        float32x4x2_t cplx0 = vld2q_f32(complexVectorPtr);
+        float32x4x2_t cplx1 = vld2q_f32(complexVectorPtr + 8);
+        __VOLK_PREFETCH(complexVectorPtr + 32);
+
+        vst1q_f32(qBufferPtr, cplx0.val[1]);
+        vst1q_f32(qBufferPtr + 4, cplx1.val[1]);
+
+        complexVectorPtr += 16;
+        qBufferPtr += 8;
+    }
+
+    for (unsigned int number = eighthPoints * 8; number < num_points; number++) {
+        complexVectorPtr++;
+        *qBufferPtr++ = *complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 #ifdef LV_HAVE_GENERIC
 
 static inline void volk_32fc_deinterleave_imag_32f_generic(float* qBuffer,

--- a/kernels/volk/volk_32fc_deinterleave_real_32f.h
+++ b/kernels/volk/volk_32fc_deinterleave_real_32f.h
@@ -184,6 +184,36 @@ static inline void volk_32fc_deinterleave_real_32f_neon(float* iBuffer,
 }
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32fc_deinterleave_real_32f_neonv8(float* iBuffer,
+                                                          const lv_32fc_t* complexVector,
+                                                          unsigned int num_points)
+{
+    const unsigned int eighthPoints = num_points / 8;
+    const float* complexVectorPtr = (float*)complexVector;
+    float* iBufferPtr = iBuffer;
+
+    for (unsigned int number = 0; number < eighthPoints; number++) {
+        float32x4x2_t cplx0 = vld2q_f32(complexVectorPtr);
+        float32x4x2_t cplx1 = vld2q_f32(complexVectorPtr + 8);
+        __VOLK_PREFETCH(complexVectorPtr + 32);
+
+        vst1q_f32(iBufferPtr, cplx0.val[0]);
+        vst1q_f32(iBufferPtr + 4, cplx1.val[0]);
+
+        complexVectorPtr += 16;
+        iBufferPtr += 8;
+    }
+
+    for (unsigned int number = eighthPoints * 8; number < num_points; number++) {
+        *iBufferPtr++ = *complexVectorPtr++;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 #endif /* INCLUDED_volk_32fc_deinterleave_real_32f_a_H */
 
 

--- a/kernels/volk/volk_32fc_index_max_32u.h
+++ b/kernels/volk/volk_32fc_index_max_32u.h
@@ -509,6 +509,71 @@ volk_32fc_index_max_32u_neon(uint32_t* target, const lv_32fc_t* src0, uint32_t n
 
 #endif /*LV_HAVE_NEON*/
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32fc_index_max_32u_neonv8(uint32_t* target,
+                                                  const lv_32fc_t* src0,
+                                                  uint32_t num_points)
+{
+    unsigned int number = 0;
+    const uint32_t quarter_points = num_points / 4;
+    const lv_32fc_t* src0Ptr = src0;
+
+    uint32_t indices[4] = { 0, 1, 2, 3 };
+    const uint32x4_t vec_indices_incr = vdupq_n_u32(4);
+    uint32x4_t vec_indices = vld1q_u32(indices);
+    uint32x4_t vec_max_indices = vec_indices;
+
+    if (num_points) {
+        float max = FLT_MIN;
+        uint32_t index = 0;
+
+        float32x4_t vec_max = vdupq_n_f32(FLT_MIN);
+
+        for (; number < quarter_points; number++) {
+            // Load complex and compute magnitude squared using FMA
+            float32x4x2_t complex_vec = vld2q_f32((float*)src0Ptr);
+            __VOLK_PREFETCH(src0Ptr + 4);
+            const float32x4_t vec_mag2 =
+                vfmaq_f32(vmulq_f32(complex_vec.val[0], complex_vec.val[0]),
+                          complex_vec.val[1],
+                          complex_vec.val[1]);
+            src0Ptr += 4;
+            // a > b?
+            const uint32x4_t gt_mask = vcgtq_f32(vec_mag2, vec_max);
+            vec_max = vbslq_f32(gt_mask, vec_mag2, vec_max);
+            vec_max_indices = vbslq_u32(gt_mask, vec_indices, vec_max_indices);
+            vec_indices = vaddq_u32(vec_indices, vec_indices_incr);
+        }
+        uint32_t tmp_max_indices[4];
+        float tmp_max[4];
+        vst1q_u32(tmp_max_indices, vec_max_indices);
+        vst1q_f32(tmp_max, vec_max);
+
+        for (int i = 0; i < 4; i++) {
+            if (tmp_max[i] > max) {
+                max = tmp_max[i];
+                index = tmp_max_indices[i];
+            }
+        }
+
+        // Deal with the rest
+        for (number = quarter_points * 4; number < num_points; number++) {
+            const float re = lv_creal(*src0Ptr);
+            const float im = lv_cimag(*src0Ptr);
+            const float sq_dist = re * re + im * im;
+            if (sq_dist > max) {
+                max = sq_dist;
+                index = number;
+            }
+            src0Ptr++;
+        }
+        *target = index;
+    }
+}
+#endif /*LV_HAVE_NEONV8*/
+
 #ifdef LV_HAVE_RVV
 #include <float.h>
 #include <riscv_vector.h>

--- a/kernels/volk/volk_32fc_index_min_16u.h
+++ b/kernels/volk/volk_32fc_index_min_16u.h
@@ -331,6 +331,77 @@ static inline void volk_32fc_index_min_16u_generic(uint16_t* target,
 
 #endif /*LV_HAVE_GENERIC*/
 
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+#include <float.h>
+
+static inline void
+volk_32fc_index_min_16u_neon(uint16_t* target, const lv_32fc_t* src0, uint32_t num_points)
+{
+    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
+
+    uint32_t number = 0;
+    const uint32_t quarterPoints = num_points / 4;
+
+    const float* inputPtr = (const float*)src0;
+
+    float32x4_t minMagSquared = vdupq_n_f32(FLT_MAX);
+    float32x4_t minValuesIndex = vdupq_n_f32(0.0f);
+    float32x4_t currentIndexes = { 0.0f, 1.0f, 2.0f, 3.0f };
+    const float32x4_t indexIncrementValues = vdupq_n_f32(4.0f);
+
+    for (; number < quarterPoints; number++) {
+        float32x4x2_t input = vld2q_f32(inputPtr);
+        inputPtr += 8;
+
+        // Compute magnitude squared: real^2 + imag^2
+        float32x4_t magSquared = vmulq_f32(input.val[0], input.val[0]);
+        magSquared = vmlaq_f32(magSquared, input.val[1], input.val[1]);
+
+        // Compare current values with min values (less-than for min)
+        uint32x4_t compareResults = vcltq_f32(magSquared, minMagSquared);
+
+        // Select indices based on comparison
+        minValuesIndex = vbslq_f32(compareResults, currentIndexes, minValuesIndex);
+
+        // Update minimum values
+        minMagSquared = vminq_f32(magSquared, minMagSquared);
+
+        // Increment indices
+        currentIndexes = vaddq_f32(currentIndexes, indexIncrementValues);
+    }
+
+    // Find minimum across the vector
+    float minMagSquaredBuffer[4];
+    float minIndexBuffer[4];
+    vst1q_f32(minMagSquaredBuffer, minMagSquared);
+    vst1q_f32(minIndexBuffer, minValuesIndex);
+
+    float min = FLT_MAX;
+    uint32_t index = 0;
+    for (int i = 0; i < 4; i++) {
+        if (minMagSquaredBuffer[i] < min) {
+            min = minMagSquaredBuffer[i];
+            index = (uint32_t)minIndexBuffer[i];
+        }
+    }
+
+    // Handle remaining points
+    for (number = quarterPoints * 4; number < num_points; number++) {
+        float re = *inputPtr++;
+        float im = *inputPtr++;
+        float magSquared = re * re + im * im;
+        if (magSquared < min) {
+            index = number;
+            min = magSquared;
+        }
+    }
+
+    *target = index;
+}
+
+#endif /*LV_HAVE_NEON*/
+
 #endif /*INCLUDED_volk_32fc_index_min_16u_a_H*/
 
 #ifndef INCLUDED_volk_32fc_index_min_16u_u_H

--- a/kernels/volk/volk_32fc_index_min_32u.h
+++ b/kernels/volk/volk_32fc_index_min_32u.h
@@ -504,6 +504,70 @@ static inline void volk_32fc_index_min_32u_neon(uint32_t* target,
 
 #endif /*LV_HAVE_NEON*/
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32fc_index_min_32u_neonv8(uint32_t* target,
+                                                  const lv_32fc_t* source,
+                                                  uint32_t num_points)
+{
+    const uint32_t quarter_points = num_points / 4;
+    const lv_32fc_t* sourcePtr = source;
+
+    uint32_t indices[4] = { 0, 1, 2, 3 };
+    const uint32x4_t vec_indices_incr = vdupq_n_u32(4);
+    uint32x4_t vec_indices = vld1q_u32(indices);
+    uint32x4_t vec_min_indices = vec_indices;
+
+    if (num_points) {
+        float min = FLT_MAX;
+        uint32_t index = 0;
+
+        float32x4_t vec_min = vdupq_n_f32(FLT_MAX);
+
+        for (uint32_t number = 0; number < quarter_points; number++) {
+            // Load complex and compute magnitude squared using FMA
+            float32x4x2_t complex_vec = vld2q_f32((float*)sourcePtr);
+            __VOLK_PREFETCH(sourcePtr + 4);
+            const float32x4_t vec_mag2 =
+                vfmaq_f32(vmulq_f32(complex_vec.val[0], complex_vec.val[0]),
+                          complex_vec.val[1],
+                          complex_vec.val[1]);
+            sourcePtr += 4;
+            // a < b?
+            const uint32x4_t lt_mask = vcltq_f32(vec_mag2, vec_min);
+            vec_min = vbslq_f32(lt_mask, vec_mag2, vec_min);
+            vec_min_indices = vbslq_u32(lt_mask, vec_indices, vec_min_indices);
+            vec_indices = vaddq_u32(vec_indices, vec_indices_incr);
+        }
+        uint32_t tmp_min_indices[4];
+        float tmp_min[4];
+        vst1q_u32(tmp_min_indices, vec_min_indices);
+        vst1q_f32(tmp_min, vec_min);
+
+        for (int i = 0; i < 4; i++) {
+            if (tmp_min[i] < min) {
+                min = tmp_min[i];
+                index = tmp_min_indices[i];
+            }
+        }
+
+        // Deal with the rest
+        for (uint32_t number = quarter_points * 4; number < num_points; number++) {
+            const float re = lv_creal(*sourcePtr);
+            const float im = lv_cimag(*sourcePtr);
+            const float sq_dist = re * re + im * im;
+            if (sq_dist < min) {
+                min = sq_dist;
+                index = number;
+            }
+            sourcePtr++;
+        }
+        *target = index;
+    }
+}
+#endif /*LV_HAVE_NEONV8*/
+
 #ifdef LV_HAVE_RVV
 #include <float.h>
 #include <riscv_vector.h>

--- a/kernels/volk/volk_32fc_s32f_magnitude_16i.h
+++ b/kernels/volk/volk_32fc_s32f_magnitude_16i.h
@@ -302,6 +302,110 @@ static inline void volk_32fc_s32f_magnitude_16i_u_avx2(int16_t* magnitudeVector,
 }
 #endif /* LV_HAVE_AVX2 */
 
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+
+static inline void volk_32fc_s32f_magnitude_16i_neon(int16_t* magnitudeVector,
+                                                     const lv_32fc_t* complexVector,
+                                                     const float scalar,
+                                                     unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarter_points = num_points / 4;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    int16_t* magnitudeVectorPtr = magnitudeVector;
+    float32x4_t vScalar = vdupq_n_f32(scalar);
+
+    for (; number < quarter_points; number++) {
+        float32x4x2_t input = vld2q_f32(complexVectorPtr);
+        complexVectorPtr += 8;
+
+        float32x4_t realSquared = vmulq_f32(input.val[0], input.val[0]);
+        float32x4_t imagSquared = vmulq_f32(input.val[1], input.val[1]);
+        float32x4_t sumSquared = vaddq_f32(realSquared, imagSquared);
+
+        /* Use reciprocal square root estimate with Newton-Raphson refinement */
+        float32x4_t rsqrt = vrsqrteq_f32(sumSquared);
+        rsqrt = vmulq_f32(rsqrt, vrsqrtsq_f32(vmulq_f32(sumSquared, rsqrt), rsqrt));
+        rsqrt = vmulq_f32(rsqrt, vrsqrtsq_f32(vmulq_f32(sumSquared, rsqrt), rsqrt));
+        float32x4_t magnitude = vmulq_f32(sumSquared, rsqrt);
+
+        /* Handle zero case */
+        uint32x4_t zero_mask = vceqq_f32(sumSquared, vdupq_n_f32(0.0f));
+        magnitude = vbslq_f32(zero_mask, sumSquared, magnitude);
+
+        float32x4_t scaled = vmulq_f32(magnitude, vScalar);
+        int32x4_t intVal = vcvtq_s32_f32(scaled);
+        int16x4_t shortVal = vqmovn_s32(intVal);
+
+        vst1_s16(magnitudeVectorPtr, shortVal);
+        magnitudeVectorPtr += 4;
+    }
+
+    number = quarter_points * 4;
+    for (; number < num_points; number++) {
+        float real = *complexVectorPtr++;
+        float imag = *complexVectorPtr++;
+        *magnitudeVectorPtr++ =
+            (int16_t)rintf(scalar * sqrtf((real * real) + (imag * imag)));
+    }
+}
+#endif /* LV_HAVE_NEON */
+
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32fc_s32f_magnitude_16i_neonv8(int16_t* magnitudeVector,
+                                                       const lv_32fc_t* complexVector,
+                                                       const float scalar,
+                                                       unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighth_points = num_points / 8;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    int16_t* magnitudeVectorPtr = magnitudeVector;
+    float32x4_t vScalar = vdupq_n_f32(scalar);
+
+    for (; number < eighth_points; number++) {
+        float32x4x2_t input0 = vld2q_f32(complexVectorPtr);
+        float32x4x2_t input1 = vld2q_f32(complexVectorPtr + 8);
+        complexVectorPtr += 16;
+        __VOLK_PREFETCH(complexVectorPtr + 16);
+
+        float32x4_t sumSquared0 = vfmaq_f32(
+            vmulq_f32(input0.val[1], input0.val[1]), input0.val[0], input0.val[0]);
+        float32x4_t sumSquared1 = vfmaq_f32(
+            vmulq_f32(input1.val[1], input1.val[1]), input1.val[0], input1.val[0]);
+
+        float32x4_t magnitude0 = vsqrtq_f32(sumSquared0);
+        float32x4_t magnitude1 = vsqrtq_f32(sumSquared1);
+
+        float32x4_t scaled0 = vmulq_f32(magnitude0, vScalar);
+        float32x4_t scaled1 = vmulq_f32(magnitude1, vScalar);
+
+        int32x4_t intVal0 = vcvtnq_s32_f32(scaled0);
+        int32x4_t intVal1 = vcvtnq_s32_f32(scaled1);
+
+        int16x4_t shortVal0 = vqmovn_s32(intVal0);
+        int16x4_t shortVal1 = vqmovn_s32(intVal1);
+
+        vst1_s16(magnitudeVectorPtr, shortVal0);
+        vst1_s16(magnitudeVectorPtr + 4, shortVal1);
+        magnitudeVectorPtr += 8;
+    }
+
+    number = eighth_points * 8;
+    for (; number < num_points; number++) {
+        float real = *complexVectorPtr++;
+        float imag = *complexVectorPtr++;
+        *magnitudeVectorPtr++ =
+            (int16_t)rintf(scalar * sqrtf((real * real) + (imag * imag)));
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 

--- a/kernels/volk/volk_32fc_s32fc_multiply2_32fc.h
+++ b/kernels/volk/volk_32fc_s32fc_multiply2_32fc.h
@@ -383,7 +383,7 @@ static inline void volk_32fc_s32fc_multiply2_32fc_neon(lv_32fc_t* cVector,
 {
     lv_32fc_t* cPtr = cVector;
     const lv_32fc_t* aPtr = aVector;
-    unsigned int number = num_points;
+    unsigned int number = 0;
     unsigned int quarter_points = num_points / 4;
 
     float32x4x2_t a_val, scalar_val;

--- a/kernels/volk/volk_32fc_s32fc_multiply_32fc.h
+++ b/kernels/volk/volk_32fc_s32fc_multiply_32fc.h
@@ -174,4 +174,16 @@ static inline void volk_32fc_s32fc_multiply_32fc_neon(lv_32fc_t* cVector,
 }
 #endif /* LV_HAVE_NEON */
 
+
+#ifdef LV_HAVE_NEONV8
+
+static inline void volk_32fc_s32fc_multiply_32fc_neonv8(lv_32fc_t* cVector,
+                                                        const lv_32fc_t* aVector,
+                                                        const lv_32fc_t scalar,
+                                                        unsigned int num_points)
+{
+    volk_32fc_s32fc_multiply2_32fc_neonv8(cVector, aVector, &scalar, num_points);
+}
+#endif /* LV_HAVE_NEONV8 */
+
 #endif /* INCLUDED_volk_32fc_x2_multiply_32fc_a_H */

--- a/kernels/volk/volk_32fc_s32fc_rotator2puppet_32fc.h
+++ b/kernels/volk/volk_32fc_s32fc_rotator2puppet_32fc.h
@@ -55,6 +55,24 @@ static inline void volk_32fc_s32fc_rotator2puppet_32fc_neon(lv_32fc_t* outVector
 #endif /* LV_HAVE_NEON */
 
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32fc_s32fc_rotator2puppet_32fc_neonv8(lv_32fc_t* outVector,
+                                                              const lv_32fc_t* inVector,
+                                                              const lv_32fc_t* phase_inc,
+                                                              unsigned int num_points)
+{
+    lv_32fc_t phase[1] = { lv_cmake(.3f, 0.95393f) };
+    (*phase) /= hypotf(lv_creal(*phase), lv_cimag(*phase));
+    const lv_32fc_t phase_inc_n =
+        *phase_inc / hypotf(lv_creal(*phase_inc), lv_cimag(*phase_inc));
+    volk_32fc_s32fc_x2_rotator2_32fc_neonv8(
+        outVector, inVector, &phase_inc_n, phase, num_points);
+}
+#endif /* LV_HAVE_NEONV8 */
+
+
 #ifdef LV_HAVE_SSE4_1
 #include <smmintrin.h>
 

--- a/kernels/volk/volk_32fc_s32fc_x2_rotator_32fc.h
+++ b/kernels/volk/volk_32fc_s32fc_x2_rotator_32fc.h
@@ -113,6 +113,20 @@ static inline void volk_32fc_s32fc_x2_rotator_32fc_neon(lv_32fc_t* outVector,
 #endif /* LV_HAVE_NEON */
 
 
+#ifdef LV_HAVE_NEONV8
+
+static inline void volk_32fc_s32fc_x2_rotator_32fc_neonv8(lv_32fc_t* outVector,
+                                                          const lv_32fc_t* inVector,
+                                                          const lv_32fc_t phase_inc,
+                                                          lv_32fc_t* phase,
+                                                          unsigned int num_points)
+{
+    volk_32fc_s32fc_x2_rotator2_32fc_neonv8(
+        outVector, inVector, &phase_inc, phase, num_points);
+}
+#endif /* LV_HAVE_NEONV8 */
+
+
 #ifdef LV_HAVE_SSE4_1
 
 static inline void volk_32fc_s32fc_x2_rotator_32fc_a_sse4_1(lv_32fc_t* outVector,

--- a/kernels/volk/volk_32fc_x2_add_32fc.h
+++ b/kernels/volk/volk_32fc_x2_add_32fc.h
@@ -273,6 +273,42 @@ static inline void volk_32fc_x2_add_32fc_u_neon(lv_32fc_t* cVector,
 
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32fc_x2_add_32fc_neonv8(lv_32fc_t* cVector,
+                                                const lv_32fc_t* aVector,
+                                                const lv_32fc_t* bVector,
+                                                unsigned int num_points)
+{
+    const unsigned int quarterPoints = num_points / 4;
+
+    const float* aPtr = (const float*)aVector;
+    const float* bPtr = (const float*)bVector;
+    float* cPtr = (float*)cVector;
+
+    for (unsigned int number = 0; number < quarterPoints; number++) {
+        float32x4_t a0 = vld1q_f32(aPtr);
+        float32x4_t a1 = vld1q_f32(aPtr + 4);
+        float32x4_t b0 = vld1q_f32(bPtr);
+        float32x4_t b1 = vld1q_f32(bPtr + 4);
+        __VOLK_PREFETCH(aPtr + 16);
+        __VOLK_PREFETCH(bPtr + 16);
+
+        vst1q_f32(cPtr, vaddq_f32(a0, b0));
+        vst1q_f32(cPtr + 4, vaddq_f32(a1, b1));
+
+        aPtr += 8;
+        bPtr += 8;
+        cPtr += 8;
+    }
+
+    for (unsigned int number = quarterPoints * 4; number < num_points; number++) {
+        cVector[number] = aVector[number] + bVector[number];
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 

--- a/kernels/volk/volk_32fc_x2_divide_32fc.h
+++ b/kernels/volk/volk_32fc_x2_divide_32fc.h
@@ -625,6 +625,58 @@ static inline void volk_32fc_x2_divide_32fc_neon(lv_32fc_t* cVector,
 }
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32fc_x2_divide_32fc_neonv8(lv_32fc_t* cVector,
+                                                   const lv_32fc_t* aVector,
+                                                   const lv_32fc_t* bVector,
+                                                   unsigned int num_points)
+{
+    lv_32fc_t* cPtr = cVector;
+    const lv_32fc_t* aPtr = aVector;
+    const lv_32fc_t* bPtr = bVector;
+
+    float32x4x2_t aVal, bVal, cVal;
+    float32x4_t bMagSq;
+
+    const unsigned int quarterPoints = num_points / 4;
+    unsigned int number = 0;
+
+    for (; number < quarterPoints; number++) {
+        aVal = vld2q_f32((const float*)(aPtr));
+        bVal = vld2q_f32((const float*)(bPtr));
+        aPtr += 4;
+        bPtr += 4;
+        __VOLK_PREFETCH(aPtr + 4);
+        __VOLK_PREFETCH(bPtr + 4);
+
+        /* Compute |b|^2 = br^2 + bi^2 using FMA */
+        bMagSq = vfmaq_f32(vmulq_f32(bVal.val[0], bVal.val[0]), bVal.val[1], bVal.val[1]);
+
+        /* Use ARMv8 native division for 1/|b|^2 */
+        float32x4_t bMagSqInv = vdivq_f32(vdupq_n_f32(1.0f), bMagSq);
+
+        /* real = (ar*br + ai*bi) / |b|^2 */
+        cVal.val[0] =
+            vfmaq_f32(vmulq_f32(aVal.val[0], bVal.val[0]), aVal.val[1], bVal.val[1]);
+        cVal.val[0] = vmulq_f32(cVal.val[0], bMagSqInv);
+
+        /* imag = (ai*br - ar*bi) / |b|^2 */
+        cVal.val[1] =
+            vfmsq_f32(vmulq_f32(aVal.val[1], bVal.val[0]), aVal.val[0], bVal.val[1]);
+        cVal.val[1] = vmulq_f32(cVal.val[1], bMagSqInv);
+
+        vst2q_f32((float*)(cPtr), cVal);
+        cPtr += 4;
+    }
+
+    for (number = quarterPoints * 4; number < num_points; number++) {
+        *cPtr++ = (*aPtr++) / (*bPtr++);
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 

--- a/kernels/volk/volk_32fc_x2_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_x2_dot_prod_32fc.h
@@ -599,6 +599,95 @@ static inline void volk_32fc_x2_dot_prod_32fc_neon_optfmaunroll(lv_32fc_t* resul
 #endif /*LV_HAVE_NEON*/
 
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32fc_x2_dot_prod_32fc_neonv8(lv_32fc_t* result,
+                                                     const lv_32fc_t* input,
+                                                     const lv_32fc_t* taps,
+                                                     unsigned int num_points)
+{
+    unsigned int n = num_points;
+    const lv_32fc_t* a = input;
+    const lv_32fc_t* b = taps;
+
+    /* Use 4 accumulators to break data dependencies */
+    float32x4_t acc0_r = vdupq_n_f32(0);
+    float32x4_t acc0_i = vdupq_n_f32(0);
+    float32x4_t acc1_r = vdupq_n_f32(0);
+    float32x4_t acc1_i = vdupq_n_f32(0);
+
+    /* Process 8 complex numbers per iteration (2x unroll) */
+    while (n >= 8) {
+        float32x4x2_t a0 = vld2q_f32((const float*)a);
+        float32x4x2_t b0 = vld2q_f32((const float*)b);
+        float32x4x2_t a1 = vld2q_f32((const float*)(a + 4));
+        float32x4x2_t b1 = vld2q_f32((const float*)(b + 4));
+        __VOLK_PREFETCH(a + 8);
+        __VOLK_PREFETCH(b + 8);
+
+        /* Complex dot product accumulation using FMA:
+         * real += ar*br - ai*bi
+         * imag += ar*bi + ai*br
+         */
+        acc0_r = vfmaq_f32(acc0_r, a0.val[0], b0.val[0]); /* ar*br */
+        acc0_r = vfmsq_f32(acc0_r, a0.val[1], b0.val[1]); /* - ai*bi */
+        acc0_i = vfmaq_f32(acc0_i, a0.val[0], b0.val[1]); /* ar*bi */
+        acc0_i = vfmaq_f32(acc0_i, a0.val[1], b0.val[0]); /* + ai*br */
+
+        acc1_r = vfmaq_f32(acc1_r, a1.val[0], b1.val[0]);
+        acc1_r = vfmsq_f32(acc1_r, a1.val[1], b1.val[1]);
+        acc1_i = vfmaq_f32(acc1_i, a1.val[0], b1.val[1]);
+        acc1_i = vfmaq_f32(acc1_i, a1.val[1], b1.val[0]);
+
+        a += 8;
+        b += 8;
+        n -= 8;
+    }
+
+    /* Process remaining 4 */
+    if (n >= 4) {
+        float32x4x2_t a0 = vld2q_f32((const float*)a);
+        float32x4x2_t b0 = vld2q_f32((const float*)b);
+
+        acc0_r = vfmaq_f32(acc0_r, a0.val[0], b0.val[0]);
+        acc0_r = vfmsq_f32(acc0_r, a0.val[1], b0.val[1]);
+        acc0_i = vfmaq_f32(acc0_i, a0.val[0], b0.val[1]);
+        acc0_i = vfmaq_f32(acc0_i, a0.val[1], b0.val[0]);
+
+        a += 4;
+        b += 4;
+        n -= 4;
+    }
+
+    /* Combine accumulators */
+    acc0_r = vaddq_f32(acc0_r, acc1_r);
+    acc0_i = vaddq_f32(acc0_i, acc1_i);
+
+    /* Horizontal sum using pairwise add */
+    float32x2_t sum_r = vadd_f32(vget_low_f32(acc0_r), vget_high_f32(acc0_r));
+    float32x2_t sum_i = vadd_f32(vget_low_f32(acc0_i), vget_high_f32(acc0_i));
+    sum_r = vpadd_f32(sum_r, sum_r);
+    sum_i = vpadd_f32(sum_i, sum_i);
+
+    float res_r = vget_lane_f32(sum_r, 0);
+    float res_i = vget_lane_f32(sum_i, 0);
+
+    /* Scalar tail */
+    while (n > 0) {
+        res_r += lv_creal(*a) * lv_creal(*b) - lv_cimag(*a) * lv_cimag(*b);
+        res_i += lv_creal(*a) * lv_cimag(*b) + lv_cimag(*a) * lv_creal(*b);
+        a++;
+        b++;
+        n--;
+    }
+
+    *result = lv_cmake(res_r, res_i);
+}
+
+#endif /* LV_HAVE_NEONV8 */
+
+
 #ifdef LV_HAVE_AVX
 
 #include <immintrin.h>

--- a/kernels/volk/volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc.h
+++ b/kernels/volk/volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc.h
@@ -304,7 +304,7 @@ volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_neon(lv_32fc_t* cVector,
     const lv_32fc_t* bPtr = bVector;
     const lv_32fc_t* aPtr = aVector;
     lv_32fc_t* cPtr = cVector;
-    unsigned int number = num_points;
+    unsigned int number = 0;
     unsigned int quarter_points = num_points / 4;
 
     float32x4x2_t a_val, b_val, c_val, scalar_val;
@@ -355,7 +355,7 @@ volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_neonv8(lv_32fc_t* cVector,
     const lv_32fc_t* bPtr = bVector;
     const lv_32fc_t* aPtr = aVector;
     lv_32fc_t* cPtr = cVector;
-    unsigned int number = num_points;
+    unsigned int number = 0;
     unsigned int quarter_points = num_points / 4;
 
     float32x4x2_t a_val, b_val, c_val;

--- a/kernels/volk/volk_32fc_x2_s32fc_multiply_conjugate_add_32fc.h
+++ b/kernels/volk/volk_32fc_x2_s32fc_multiply_conjugate_add_32fc.h
@@ -175,4 +175,19 @@ volk_32fc_x2_s32fc_multiply_conjugate_add_32fc_neon(lv_32fc_t* cVector,
 }
 #endif /* LV_HAVE_NEON */
 
+
+#ifdef LV_HAVE_NEONV8
+
+static inline void
+volk_32fc_x2_s32fc_multiply_conjugate_add_32fc_neonv8(lv_32fc_t* cVector,
+                                                      const lv_32fc_t* aVector,
+                                                      const lv_32fc_t* bVector,
+                                                      const lv_32fc_t scalar,
+                                                      unsigned int num_points)
+{
+    volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_neonv8(
+        cVector, aVector, bVector, &scalar, num_points);
+}
+#endif /* LV_HAVE_NEONV8 */
+
 #endif /* INCLUDED_volk_32fc_x2_s32fc_multiply_conjugate_add_32fc_H */

--- a/kernels/volk/volk_32i_x2_and_32i.h
+++ b/kernels/volk/volk_32i_x2_and_32i.h
@@ -217,6 +217,42 @@ static inline void volk_32i_x2_and_32i_neon(int32_t* cVector,
 }
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32i_x2_and_32i_neonv8(int32_t* cVector,
+                                              const int32_t* aVector,
+                                              const int32_t* bVector,
+                                              unsigned int num_points)
+{
+    const unsigned int eighthPoints = num_points / 8;
+
+    const int32_t* aPtr = aVector;
+    const int32_t* bPtr = bVector;
+    int32_t* cPtr = cVector;
+
+    for (unsigned int number = 0; number < eighthPoints; number++) {
+        int32x4_t a0 = vld1q_s32(aPtr);
+        int32x4_t a1 = vld1q_s32(aPtr + 4);
+        int32x4_t b0 = vld1q_s32(bPtr);
+        int32x4_t b1 = vld1q_s32(bPtr + 4);
+        __VOLK_PREFETCH(aPtr + 16);
+        __VOLK_PREFETCH(bPtr + 16);
+
+        vst1q_s32(cPtr, vandq_s32(a0, b0));
+        vst1q_s32(cPtr + 4, vandq_s32(a1, b1));
+
+        aPtr += 8;
+        bPtr += 8;
+        cPtr += 8;
+    }
+
+    for (unsigned int number = eighthPoints * 8; number < num_points; number++) {
+        *cPtr++ = (*aPtr++) & (*bPtr++);
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 
 #ifdef LV_HAVE_GENERIC
 

--- a/kernels/volk/volk_32i_x2_or_32i.h
+++ b/kernels/volk/volk_32i_x2_or_32i.h
@@ -216,6 +216,42 @@ static inline void volk_32i_x2_or_32i_neon(int32_t* cVector,
 }
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32i_x2_or_32i_neonv8(int32_t* cVector,
+                                             const int32_t* aVector,
+                                             const int32_t* bVector,
+                                             unsigned int num_points)
+{
+    const unsigned int eighthPoints = num_points / 8;
+
+    const int32_t* aPtr = aVector;
+    const int32_t* bPtr = bVector;
+    int32_t* cPtr = cVector;
+
+    for (unsigned int number = 0; number < eighthPoints; number++) {
+        int32x4_t a0 = vld1q_s32(aPtr);
+        int32x4_t a1 = vld1q_s32(aPtr + 4);
+        int32x4_t b0 = vld1q_s32(bPtr);
+        int32x4_t b1 = vld1q_s32(bPtr + 4);
+        __VOLK_PREFETCH(aPtr + 16);
+        __VOLK_PREFETCH(bPtr + 16);
+
+        vst1q_s32(cPtr, vorrq_s32(a0, b0));
+        vst1q_s32(cPtr + 4, vorrq_s32(a1, b1));
+
+        aPtr += 8;
+        bPtr += 8;
+        cPtr += 8;
+    }
+
+    for (unsigned int number = eighthPoints * 8; number < num_points; number++) {
+        *cPtr++ = (*aPtr++) | (*bPtr++);
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 
 #ifdef LV_HAVE_GENERIC
 

--- a/kernels/volk/volk_32u_popcnt.h
+++ b/kernels/volk/volk_32u_popcnt.h
@@ -65,6 +65,25 @@ static inline void volk_32u_popcnt_generic(uint32_t* ret, const uint32_t value)
 #endif /*LV_HAVE_GENERIC*/
 
 
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+
+static inline void volk_32u_popcnt_neon(uint32_t* ret, const uint32_t value)
+{
+    // Load value into a 64-bit vector (as 8 bytes)
+    uint8x8_t input = vreinterpret_u8_u32(vdup_n_u32(value));
+    // Count bits in each byte
+    uint8x8_t counts = vcnt_u8(input);
+    // Sum across all bytes (only first 4 matter for 32-bit value)
+    // Use vpaddl to widen and add: 8x8 -> 4x16 -> 2x32 -> 1x64
+    uint16x4_t sum16 = vpaddl_u8(counts);
+    uint32x2_t sum32 = vpaddl_u16(sum16);
+    // Extract the lower 32-bit element which contains the sum of the lower 4 bytes
+    *ret = vget_lane_u32(sum32, 0);
+}
+#endif /* LV_HAVE_NEON */
+
+
 #ifdef LV_HAVE_SSE4_2
 
 #include <nmmintrin.h>

--- a/kernels/volk/volk_32u_popcntpuppet_32u.h
+++ b/kernels/volk/volk_32u_popcntpuppet_32u.h
@@ -35,6 +35,17 @@ static inline void volk_32u_popcntpuppet_32u_a_sse4_2(uint32_t* outVector,
 }
 #endif /* LV_HAVE_SSE4_2 */
 
+#ifdef LV_HAVE_NEON
+static inline void volk_32u_popcntpuppet_32u_neon(uint32_t* outVector,
+                                                  const uint32_t* inVector,
+                                                  unsigned int num_points)
+{
+    for (size_t i = 0; i < num_points; ++i) {
+        volk_32u_popcnt_neon(outVector + i, inVector[i]);
+    }
+}
+#endif /* LV_HAVE_NEON */
+
 #ifdef LV_HAVE_RVV
 static inline void volk_32u_popcntpuppet_32u_rvv(uint32_t* outVector,
                                                  const uint32_t* inVector,

--- a/kernels/volk/volk_64f_convert_32f.h
+++ b/kernels/volk/volk_64f_convert_32f.h
@@ -315,6 +315,45 @@ static inline void volk_64f_convert_32f_a_sse2(float* outputVector,
 }
 #endif /* LV_HAVE_SSE2 */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_64f_convert_32f_neonv8(float* outputVector,
+                                               const double* inputVector,
+                                               unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighth_points = num_points / 8;
+
+    const double* inputPtr = inputVector;
+    float* outputPtr = outputVector;
+
+    for (; number < eighth_points; number++) {
+        float64x2_t in0 = vld1q_f64(inputPtr);
+        float64x2_t in1 = vld1q_f64(inputPtr + 2);
+        float64x2_t in2 = vld1q_f64(inputPtr + 4);
+        float64x2_t in3 = vld1q_f64(inputPtr + 6);
+        __VOLK_PREFETCH(inputPtr + 8);
+
+        float32x2_t out0 = vcvt_f32_f64(in0);
+        float32x2_t out1 = vcvt_f32_f64(in1);
+        float32x2_t out2 = vcvt_f32_f64(in2);
+        float32x2_t out3 = vcvt_f32_f64(in3);
+
+        vst1q_f32(outputPtr, vcombine_f32(out0, out1));
+        vst1q_f32(outputPtr + 4, vcombine_f32(out2, out3));
+
+        inputPtr += 8;
+        outputPtr += 8;
+    }
+
+    number = eighth_points * 8;
+    for (; number < num_points; number++) {
+        *outputPtr++ = (float)(*inputPtr++);
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 

--- a/kernels/volk/volk_64f_x2_add_64f.h
+++ b/kernels/volk/volk_64f_x2_add_64f.h
@@ -80,6 +80,50 @@ static inline void volk_64f_x2_add_64f_generic(double* cVector,
 
 #endif /* LV_HAVE_GENERIC */
 
+
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_64f_x2_add_64f_neonv8(double* cVector,
+                                              const double* aVector,
+                                              const double* bVector,
+                                              unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarter_points = num_points / 4;
+
+    double* cPtr = cVector;
+    const double* aPtr = aVector;
+    const double* bPtr = bVector;
+
+    for (; number < quarter_points; number++) {
+        float64x2_t aVal0 = vld1q_f64(aPtr);
+        float64x2_t aVal1 = vld1q_f64(aPtr + 2);
+        float64x2_t bVal0 = vld1q_f64(bPtr);
+        float64x2_t bVal1 = vld1q_f64(bPtr + 2);
+        __VOLK_PREFETCH(aPtr + 4);
+        __VOLK_PREFETCH(bPtr + 4);
+
+        float64x2_t cVal0 = vaddq_f64(aVal0, bVal0);
+        float64x2_t cVal1 = vaddq_f64(aVal1, bVal1);
+
+        vst1q_f64(cPtr, cVal0);
+        vst1q_f64(cPtr + 2, cVal1);
+
+        aPtr += 4;
+        bPtr += 4;
+        cPtr += 4;
+    }
+
+    number = quarter_points * 4;
+    for (; number < num_points; number++) {
+        *cPtr++ = (*aPtr++) + (*bPtr++);
+    }
+}
+
+#endif /* LV_HAVE_NEONV8 */
+
+
 /*
  * Unaligned versions
  */

--- a/kernels/volk/volk_64f_x2_max_64f.h
+++ b/kernels/volk/volk_64f_x2_max_64f.h
@@ -290,6 +290,49 @@ static inline void volk_64f_x2_max_64f_u_avx(double* cVector,
 }
 #endif /* LV_HAVE_AVX */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_64f_x2_max_64f_neonv8(double* cVector,
+                                              const double* aVector,
+                                              const double* bVector,
+                                              unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarter_points = num_points / 4;
+
+    double* cPtr = cVector;
+    const double* aPtr = aVector;
+    const double* bPtr = bVector;
+
+    for (; number < quarter_points; number++) {
+        float64x2_t aVal0 = vld1q_f64(aPtr);
+        float64x2_t aVal1 = vld1q_f64(aPtr + 2);
+        float64x2_t bVal0 = vld1q_f64(bPtr);
+        float64x2_t bVal1 = vld1q_f64(bPtr + 2);
+        __VOLK_PREFETCH(aPtr + 4);
+        __VOLK_PREFETCH(bPtr + 4);
+
+        float64x2_t cVal0 = vmaxq_f64(aVal0, bVal0);
+        float64x2_t cVal1 = vmaxq_f64(aVal1, bVal1);
+
+        vst1q_f64(cPtr, cVal0);
+        vst1q_f64(cPtr + 2, cVal1);
+
+        aPtr += 4;
+        bPtr += 4;
+        cPtr += 4;
+    }
+
+    number = quarter_points * 4;
+    for (; number < num_points; number++) {
+        const double a = *aPtr++;
+        const double b = *bPtr++;
+        *cPtr++ = (a > b ? a : b);
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 

--- a/kernels/volk/volk_64f_x2_min_64f.h
+++ b/kernels/volk/volk_64f_x2_min_64f.h
@@ -290,6 +290,49 @@ static inline void volk_64f_x2_min_64f_u_avx(double* cVector,
 }
 #endif /* LV_HAVE_AVX */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_64f_x2_min_64f_neonv8(double* cVector,
+                                              const double* aVector,
+                                              const double* bVector,
+                                              unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarter_points = num_points / 4;
+
+    double* cPtr = cVector;
+    const double* aPtr = aVector;
+    const double* bPtr = bVector;
+
+    for (; number < quarter_points; number++) {
+        float64x2_t aVal0 = vld1q_f64(aPtr);
+        float64x2_t aVal1 = vld1q_f64(aPtr + 2);
+        float64x2_t bVal0 = vld1q_f64(bPtr);
+        float64x2_t bVal1 = vld1q_f64(bPtr + 2);
+        __VOLK_PREFETCH(aPtr + 4);
+        __VOLK_PREFETCH(bPtr + 4);
+
+        float64x2_t cVal0 = vminq_f64(aVal0, bVal0);
+        float64x2_t cVal1 = vminq_f64(aVal1, bVal1);
+
+        vst1q_f64(cPtr, cVal0);
+        vst1q_f64(cPtr + 2, cVal1);
+
+        aPtr += 4;
+        bPtr += 4;
+        cPtr += 4;
+    }
+
+    number = quarter_points * 4;
+    for (; number < num_points; number++) {
+        const double a = *aPtr++;
+        const double b = *bPtr++;
+        *cPtr++ = (a < b ? a : b);
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 

--- a/kernels/volk/volk_64f_x2_multiply_64f.h
+++ b/kernels/volk/volk_64f_x2_multiply_64f.h
@@ -80,6 +80,50 @@ static inline void volk_64f_x2_multiply_64f_generic(double* cVector,
 
 #endif /* LV_HAVE_GENERIC */
 
+
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_64f_x2_multiply_64f_neonv8(double* cVector,
+                                                   const double* aVector,
+                                                   const double* bVector,
+                                                   unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarter_points = num_points / 4;
+
+    double* cPtr = cVector;
+    const double* aPtr = aVector;
+    const double* bPtr = bVector;
+
+    for (; number < quarter_points; number++) {
+        float64x2_t aVal0 = vld1q_f64(aPtr);
+        float64x2_t aVal1 = vld1q_f64(aPtr + 2);
+        float64x2_t bVal0 = vld1q_f64(bPtr);
+        float64x2_t bVal1 = vld1q_f64(bPtr + 2);
+        __VOLK_PREFETCH(aPtr + 4);
+        __VOLK_PREFETCH(bPtr + 4);
+
+        float64x2_t cVal0 = vmulq_f64(aVal0, bVal0);
+        float64x2_t cVal1 = vmulq_f64(aVal1, bVal1);
+
+        vst1q_f64(cPtr, cVal0);
+        vst1q_f64(cPtr + 2, cVal1);
+
+        aPtr += 4;
+        bPtr += 4;
+        cPtr += 4;
+    }
+
+    number = quarter_points * 4;
+    for (; number < num_points; number++) {
+        *cPtr++ = (*aPtr++) * (*bPtr++);
+    }
+}
+
+#endif /* LV_HAVE_NEONV8 */
+
+
 /*
  * Unaligned versions
  */

--- a/kernels/volk/volk_64u_byteswappuppet_64u.h
+++ b/kernels/volk/volk_64u_byteswappuppet_64u.h
@@ -92,6 +92,17 @@ static inline void volk_64u_byteswappuppet_64u_a_avx2(uint64_t* output,
 }
 #endif
 
+#ifdef LV_HAVE_NEON
+static inline void volk_64u_byteswappuppet_64u_neon(uint64_t* output,
+                                                    uint64_t* intsToSwap,
+                                                    unsigned int num_points)
+{
+
+    volk_64u_byteswap_neon((uint64_t*)intsToSwap, num_points);
+    memcpy((void*)output, (void*)intsToSwap, num_points * sizeof(uint64_t));
+}
+#endif
+
 #ifdef LV_HAVE_RVV
 static inline void volk_64u_byteswappuppet_64u_rvv(uint64_t* output,
                                                    uint64_t* intsToSwap,

--- a/kernels/volk/volk_64u_popcnt.h
+++ b/kernels/volk/volk_64u_popcnt.h
@@ -116,6 +116,18 @@ static inline void volk_64u_popcnt_neon(uint64_t* ret, const uint64_t value)
 }
 #endif /*LV_HAVE_NEON*/
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_64u_popcnt_neonv8(uint64_t* ret, const uint64_t value)
+{
+    /* Same as neon, but using cleaner intrinsics available in ARMv8 */
+    uint8x8_t input_val = vreinterpret_u8_u64(vcreate_u64(value));
+    uint8x8_t count8x8_val = vcnt_u8(input_val);
+    *ret = vaddlv_u8(count8x8_val);
+}
+#endif /*LV_HAVE_NEONV8*/
+
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 

--- a/kernels/volk/volk_8i_convert_16i.h
+++ b/kernels/volk/volk_8i_convert_16i.h
@@ -316,6 +316,37 @@ static inline void volk_8i_convert_16i_neon(int16_t* outputVector,
 }
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_8i_convert_16i_neonv8(int16_t* outputVector,
+                                              const int8_t* inputVector,
+                                              unsigned int num_points)
+{
+    int16_t* outputVectorPtr = outputVector;
+    const int8_t* inputVectorPtr = inputVector;
+    const unsigned int sixteenthPoints = num_points / 16;
+
+    for (unsigned int number = 0; number < sixteenthPoints; number++) {
+        int8x16_t in = vld1q_s8(inputVectorPtr);
+        __VOLK_PREFETCH(inputVectorPtr + 32);
+
+        int16x8_t out_lo = vshll_n_s8(vget_low_s8(in), 8);
+        int16x8_t out_hi = vshll_n_s8(vget_high_s8(in), 8);
+
+        vst1q_s16(outputVectorPtr, out_lo);
+        vst1q_s16(outputVectorPtr + 8, out_hi);
+
+        inputVectorPtr += 16;
+        outputVectorPtr += 16;
+    }
+
+    for (unsigned int number = sixteenthPoints * 16; number < num_points; number++) {
+        *outputVectorPtr++ = ((int16_t)(*inputVectorPtr++)) * 256;
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 
 #ifdef LV_HAVE_ORC
 extern void volk_8i_convert_16i_a_orc_impl(int16_t* outputVector,

--- a/kernels/volk/volk_8ic_deinterleave_16i_x2.h
+++ b/kernels/volk/volk_8ic_deinterleave_16i_x2.h
@@ -393,6 +393,41 @@ static inline void volk_8ic_deinterleave_16i_x2_u_avx2(int16_t* iBuffer,
 }
 #endif /* LV_HAVE_AVX2 */
 
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+
+static inline void volk_8ic_deinterleave_16i_x2_neon(int16_t* iBuffer,
+                                                     int16_t* qBuffer,
+                                                     const lv_8sc_t* complexVector,
+                                                     unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighth_points = num_points / 8;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
+    int16_t* iBufferPtr = iBuffer;
+    int16_t* qBufferPtr = qBuffer;
+
+    for (; number < eighth_points; number++) {
+        int8x8x2_t input = vld2_s8(complexVectorPtr);
+        complexVectorPtr += 16;
+
+        int16x8_t iVal = vshll_n_s8(input.val[0], 8);
+        int16x8_t qVal = vshll_n_s8(input.val[1], 8);
+
+        vst1q_s16(iBufferPtr, iVal);
+        vst1q_s16(qBufferPtr, qVal);
+        iBufferPtr += 8;
+        qBufferPtr += 8;
+    }
+
+    number = eighth_points * 8;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = ((int16_t)*complexVectorPtr++) * 256;
+        *qBufferPtr++ = ((int16_t)*complexVectorPtr++) * 256;
+    }
+}
+#endif /* LV_HAVE_NEON */
+
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 

--- a/kernels/volk/volk_8ic_deinterleave_real_16i.h
+++ b/kernels/volk/volk_8ic_deinterleave_real_16i.h
@@ -301,6 +301,36 @@ static inline void volk_8ic_deinterleave_real_16i_u_avx2(int16_t* iBuffer,
 }
 #endif /* LV_HAVE_AVX2 */
 
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+
+static inline void volk_8ic_deinterleave_real_16i_neon(int16_t* iBuffer,
+                                                       const lv_8sc_t* complexVector,
+                                                       unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighth_points = num_points / 8;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
+    int16_t* iBufferPtr = iBuffer;
+
+    for (; number < eighth_points; number++) {
+        int8x8x2_t input = vld2_s8(complexVectorPtr);
+        complexVectorPtr += 16;
+
+        int16x8_t iVal = vshll_n_s8(input.val[0], 7);
+
+        vst1q_s16(iBufferPtr, iVal);
+        iBufferPtr += 8;
+    }
+
+    number = eighth_points * 8;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = ((int16_t)*complexVectorPtr++) * 128;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_NEON */
+
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 

--- a/kernels/volk/volk_8ic_deinterleave_real_8i.h
+++ b/kernels/volk/volk_8ic_deinterleave_real_8i.h
@@ -291,6 +291,35 @@ static inline void volk_8ic_deinterleave_real_8i_neon(int8_t* iBuffer,
 }
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_8ic_deinterleave_real_8i_neonv8(int8_t* iBuffer,
+                                                        const lv_8sc_t* complexVector,
+                                                        unsigned int num_points)
+{
+    const unsigned int thirtysecondPoints = num_points / 32;
+
+    for (unsigned int number = 0; number < thirtysecondPoints; number++) {
+        int8x16x2_t cplx0 = vld2q_s8((const int8_t*)complexVector);
+        int8x16x2_t cplx1 = vld2q_s8((const int8_t*)complexVector + 32);
+        __VOLK_PREFETCH((const int8_t*)complexVector + 64);
+
+        vst1q_s8(iBuffer, cplx0.val[0]);
+        vst1q_s8(iBuffer + 16, cplx1.val[0]);
+
+        iBuffer += 32;
+        complexVector += 32;
+    }
+
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
+    for (unsigned int number = thirtysecondPoints * 32; number < num_points; number++) {
+        *iBuffer++ = *complexVectorPtr++;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 
 #endif /* INCLUDED_VOLK_8sc_DEINTERLEAVE_REAL_8s_ALIGNED8_H */
 

--- a/kernels/volk/volk_8ic_s32f_deinterleave_32f_x2.h
+++ b/kernels/volk/volk_8ic_s32f_deinterleave_32f_x2.h
@@ -441,6 +441,63 @@ static inline void volk_8ic_s32f_deinterleave_32f_x2_u_avx2(float* iBuffer,
 }
 #endif /* LV_HAVE_AVX2 */
 
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+
+static inline void volk_8ic_s32f_deinterleave_32f_x2_neon(float* iBuffer,
+                                                          float* qBuffer,
+                                                          const lv_8sc_t* complexVector,
+                                                          const float scalar,
+                                                          unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighth_points = num_points / 8;
+
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
+    float* iBufferPtr = iBuffer;
+    float* qBufferPtr = qBuffer;
+    const float invScalar = 1.0f / scalar;
+    float32x4_t vInvScalar = vdupq_n_f32(invScalar);
+
+    for (; number < eighth_points; number++) {
+        int8x8x2_t input = vld2_s8(complexVectorPtr);
+        complexVectorPtr += 16;
+
+        int16x8_t iShort = vmovl_s8(input.val[0]);
+        int16x8_t qShort = vmovl_s8(input.val[1]);
+
+        int32x4_t iInt0 = vmovl_s16(vget_low_s16(iShort));
+        int32x4_t iInt1 = vmovl_s16(vget_high_s16(iShort));
+        int32x4_t qInt0 = vmovl_s16(vget_low_s16(qShort));
+        int32x4_t qInt1 = vmovl_s16(vget_high_s16(qShort));
+
+        float32x4_t iFloat0 = vcvtq_f32_s32(iInt0);
+        float32x4_t iFloat1 = vcvtq_f32_s32(iInt1);
+        float32x4_t qFloat0 = vcvtq_f32_s32(qInt0);
+        float32x4_t qFloat1 = vcvtq_f32_s32(qInt1);
+
+        iFloat0 = vmulq_f32(iFloat0, vInvScalar);
+        iFloat1 = vmulq_f32(iFloat1, vInvScalar);
+        qFloat0 = vmulq_f32(qFloat0, vInvScalar);
+        qFloat1 = vmulq_f32(qFloat1, vInvScalar);
+
+        vst1q_f32(iBufferPtr, iFloat0);
+        vst1q_f32(iBufferPtr + 4, iFloat1);
+        vst1q_f32(qBufferPtr, qFloat0);
+        vst1q_f32(qBufferPtr + 4, qFloat1);
+
+        iBufferPtr += 8;
+        qBufferPtr += 8;
+    }
+
+    number = eighth_points * 8;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = (float)(*complexVectorPtr++) * invScalar;
+        *qBufferPtr++ = (float)(*complexVectorPtr++) * invScalar;
+    }
+}
+#endif /* LV_HAVE_NEON */
+
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 


### PR DESCRIPTION
A lof of new neonv8 kernels:

```
  | Category     | Kernels                                                                                                            |
  |--------------|--------------------------------------------------------------------------------------------------------------------|
  | Conversions  | 16i_convert_8i, 8i_convert_16i, 32f_convert_64f, 64f_convert_32f, 16ic_convert_32fc, various s32f_convert variants |
  | Math ops     | sin, cos, tan, tanh, asin, acos, atan, atan2, exp, expfast, log2, sqrt, invsqrt, reciprocal, pow                   |
  | Complex      | magnitude, magnitude_squared, conjugate, deinterleave, interleave                                                  |
  | Arithmetic   | add, subtract, multiply, divide, max, min                                                                          |
  | Dot products | 32f_x2_dot_prod, 32fc_x2_dot_prod, conjugate_dot_prod, 16i_32fc_dot_prod                                           |
  | Rotator      | 32fc_s32fc_x2_rotator2                                                                                             |
  | FM detect    | 32f_s32f_32f_fm_detect_32f                                                                                         |
  | Index ops    | index_max, index_min (16u/32u variants)                                                                            |
  | Bit ops      | popcnt (32u, 64u), byteswap (16u, 64u)                                                                             |
  | Clamp        | 32f_s32f_x2_clamp_32f                                                                                              |
  | Accumulators | 32f_accumulator, 32fc_accumulator                                                                                  |
  | Other        | binary_slicer, normalize, mod_range, stddev, spectral_noise_floor                                                  |
```

Sample output:
```
RUN_VOLK_TESTS: volk_32f_accumulator_s32f(131071,997)
generic                           27.2899 ms ( 38309.5 MB/s)
neon                              27.3795 ms ( 38184.1 MB/s)
neonv8                            18.7945 ms ( 55626.0 MB/s) *
Best aligned arch:                    neonv8         (1.45x)
Best unaligned arch:                  neonv8         (1.45x)
--------------------------------------------------------------------------------

RUN_VOLK_TESTS: volk_32f_atan_32f(131071,997)
generic                         2195.0081 ms (   476.3 MB/s)
polynomial                       468.1448 ms (  2233.2 MB/s)
neon                             378.6153 ms (  2761.3 MB/s)
neonv8                           256.0958 ms (  4082.3 MB/s) *
Best aligned arch:                    neonv8         (8.57x)
Best unaligned arch:                  neonv8         (8.57x)
--------------------------------------------------------------------------------

RUN_VOLK_TESTS: volk_32fc_s32f_atan2_32f(131071,997)
generic                         4680.8255 ms (   335.0 MB/s)
polynomial                      2127.4419 ms (   737.1 MB/s)
neon                             682.0231 ms (  2299.3 MB/s)
neonv8                           531.9936 ms (  2947.8 MB/s) *
Best aligned arch:                    neonv8         (8.80x)
Best unaligned arch:                  neonv8         (8.80x)
--------------------------------------------------------------------------------

RUN_VOLK_TESTS: volk_32fc_accumulator_s32fc(131071,997)
generic                           54.5371 ms ( 38339.5 MB/s)
neon                              30.7164 ms ( 68071.9 MB/s)
neonv8                            29.6828 ms ( 70442.4 MB/s) *
Best aligned arch:                    neonv8         (1.84x)
Best unaligned arch:                  neonv8         (1.84x)
--------------------------------------------------------------------------------

RUN_VOLK_TESTS: volk_32u_reverse_32u(131071,397)
generic                          377.0804 ms (  1104.0 MB/s)
byte_shuffle                      91.0601 ms (  4571.7 MB/s)
lut                              104.6720 ms (  3977.2 MB/s)
2001magic                        275.5618 ms (  1510.7 MB/s)
1972magic                        666.0125 ms (   625.1 MB/s)
bintree_permute_top_down          63.5446 ms (  6551.3 MB/s)
bintree_permute_bottom_up         64.2244 ms (  6481.9 MB/s)
neonv8                            18.2431 ms ( 22819.5 MB/s) *
arm                               29.5181 ms ( 14103.1 MB/s)
Best aligned arch:                    neonv8        (20.67x)
Best unaligned arch:                  neonv8        (20.67x)
--------------------------------------------------------------------------------
```
