### PR TITLE
Optimize asin acos

### DIFF
--- a/include/volk/volk_avx2_fma_intrinsics.h
+++ b/include/volk/volk_avx2_fma_intrinsics.h
@@ -47,4 +47,27 @@ static inline __m256 _mm256_arctan_poly_avx2_fma(const __m256 x)
     return arctan;
 }
 
+/*
+ * Approximate arcsin(x) via polynomial expansion
+ * P(u) such that asin(x) = x * P(x^2) on |x| <= 0.5
+ *
+ * Maximum relative error ~1.5e-6
+ * Polynomial evaluated via Horner's method
+ */
+static inline __m256 _mm256_arcsin_poly_avx2_fma(const __m256 x)
+{
+    const __m256 c0 = _mm256_set1_ps(0x1.ffffcep-1f);
+    const __m256 c1 = _mm256_set1_ps(0x1.55b648p-3f);
+    const __m256 c2 = _mm256_set1_ps(0x1.24d192p-4f);
+    const __m256 c3 = _mm256_set1_ps(0x1.0a788p-4f);
+
+    const __m256 u = _mm256_mul_ps(x, x);
+    __m256 p = c3;
+    p = _mm256_fmadd_ps(u, p, c2);
+    p = _mm256_fmadd_ps(u, p, c1);
+    p = _mm256_fmadd_ps(u, p, c0);
+
+    return _mm256_mul_ps(x, p);
+}
+
 #endif /* INCLUDE_VOLK_VOLK_AVX2_FMA_INTRINSICS_H_ */

--- a/include/volk/volk_avx512_intrinsics.h
+++ b/include/volk/volk_avx512_intrinsics.h
@@ -69,6 +69,29 @@ static inline __m512 _mm512_arctan_poly_avx512(const __m512 x)
 }
 
 ////////////////////////////////////////////////////////////////////////
+// Approximate arcsin(x) via polynomial expansion
+// P(u) such that asin(x) = x * P(x^2) on |x| <= 0.5
+// Maximum relative error ~1.5e-6
+// Polynomial evaluated via Horner's method
+// Requires AVX512F
+////////////////////////////////////////////////////////////////////////
+static inline __m512 _mm512_arcsin_poly_avx512(const __m512 x)
+{
+    const __m512 c0 = _mm512_set1_ps(0x1.ffffcep-1f);
+    const __m512 c1 = _mm512_set1_ps(0x1.55b648p-3f);
+    const __m512 c2 = _mm512_set1_ps(0x1.24d192p-4f);
+    const __m512 c3 = _mm512_set1_ps(0x1.0a788p-4f);
+
+    const __m512 u = _mm512_mul_ps(x, x);
+    __m512 p = c3;
+    p = _mm512_fmadd_ps(u, p, c2);
+    p = _mm512_fmadd_ps(u, p, c1);
+    p = _mm512_fmadd_ps(u, p, c0);
+
+    return _mm512_mul_ps(x, p);
+}
+
+////////////////////////////////////////////////////////////////////////
 // Complex multiply: (a+bi) * (c+di) = (ac-bd) + i(ad+bc)
 // Requires AVX512F
 ////////////////////////////////////////////////////////////////////////

--- a/include/volk/volk_avx_intrinsics.h
+++ b/include/volk/volk_avx_intrinsics.h
@@ -54,6 +54,32 @@ static inline __m256 _mm256_arctan_poly_avx(const __m256 x)
     return arctan;
 }
 
+/*
+ * Approximate arcsin(x) via polynomial expansion
+ * P(u) such that asin(x) = x * P(x^2) on |x| <= 0.5
+ *
+ * Maximum relative error ~1.5e-6
+ * Polynomial evaluated via Horner's method
+ */
+static inline __m256 _mm256_arcsin_poly_avx(const __m256 x)
+{
+    const __m256 c0 = _mm256_set1_ps(0x1.ffffcep-1f);
+    const __m256 c1 = _mm256_set1_ps(0x1.55b648p-3f);
+    const __m256 c2 = _mm256_set1_ps(0x1.24d192p-4f);
+    const __m256 c3 = _mm256_set1_ps(0x1.0a788p-4f);
+
+    const __m256 u = _mm256_mul_ps(x, x);
+    __m256 p = c3;
+    p = _mm256_mul_ps(u, p);
+    p = _mm256_add_ps(p, c2);
+    p = _mm256_mul_ps(u, p);
+    p = _mm256_add_ps(p, c1);
+    p = _mm256_mul_ps(u, p);
+    p = _mm256_add_ps(p, c0);
+
+    return _mm256_mul_ps(x, p);
+}
+
 static inline __m256 _mm256_complexmul_ps(__m256 x, __m256 y)
 {
     __m256 yl, yh, tmp1, tmp2;

--- a/include/volk/volk_neon_intrinsics.h
+++ b/include/volk/volk_neon_intrinsics.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2015 Free Software Foundation, Inc.
+ * Copyright 2025 Magnus Lundmark <magnuslundmark@gmail.com>
  *
  * This file is part of VOLK
  *
@@ -89,6 +90,14 @@ static inline float32x4_t _vinvsqrtq_f32(float32x4_t x)
         vrsqrtsq_f32(vmulq_f32(x, sqrt_reciprocal), sqrt_reciprocal), sqrt_reciprocal);
 
     return sqrt_reciprocal;
+}
+
+/* Approximate square root for ARMv7 NEON (no vsqrtq_f32)
+ * Uses recip(rsqrt(x)) = 1/(1/sqrt(x)) = sqrt(x)
+ * Note: Low precision, use vsqrtq_f32 on ARMv8 */
+static inline float32x4_t _vsqrtq_f32(float32x4_t x)
+{
+    return vrecpeq_f32(vrsqrteq_f32(x));
 }
 
 /* Inverse */

--- a/include/volk/volk_sse_intrinsics.h
+++ b/include/volk/volk_sse_intrinsics.h
@@ -54,6 +54,32 @@ static inline __m128 _mm_arctan_poly_sse(const __m128 x)
     return arctan;
 }
 
+/*
+ * Approximate arcsin(x) via polynomial expansion
+ * P(u) such that asin(x) = x * P(x^2) on |x| <= 0.5
+ *
+ * Maximum relative error ~1.5e-6
+ * Polynomial evaluated via Horner's method
+ */
+static inline __m128 _mm_arcsin_poly_sse(const __m128 x)
+{
+    const __m128 c0 = _mm_set1_ps(0x1.ffffcep-1f);
+    const __m128 c1 = _mm_set1_ps(0x1.55b648p-3f);
+    const __m128 c2 = _mm_set1_ps(0x1.24d192p-4f);
+    const __m128 c3 = _mm_set1_ps(0x1.0a788p-4f);
+
+    const __m128 u = _mm_mul_ps(x, x);
+    __m128 p = c3;
+    p = _mm_mul_ps(u, p);
+    p = _mm_add_ps(p, c2);
+    p = _mm_mul_ps(u, p);
+    p = _mm_add_ps(p, c1);
+    p = _mm_mul_ps(u, p);
+    p = _mm_add_ps(p, c0);
+
+    return _mm_mul_ps(x, p);
+}
+
 static inline __m128 _mm_magnitudesquared_ps(__m128 cplxValue1, __m128 cplxValue2)
 {
     __m128 iValue, qValue;

--- a/kernels/volk/volk_32f_acos_32f.h
+++ b/kernels/volk/volk_32f_acos_32f.h
@@ -522,7 +522,7 @@ volk_32f_acos_32f_neon(float* bVector, const float* aVector, unsigned int num_po
             vandq_u32(vreinterpretq_u32_f32(aVal), vdupq_n_u32(0x80000000));
 
         float32x4_t t = vmulq_f32(vsubq_f32(one, ax), half);
-        float32x4_t s = vsqrtq_f32(t);
+        float32x4_t s = _vsqrtq_f32(t);
 
         float32x4_t poly_small = _varcsinq_f32(ax);
         float32x4_t poly_large = _varcsinq_f32(s);

--- a/kernels/volk/volk_32f_acos_32f.h
+++ b/kernels/volk/volk_32f_acos_32f.h
@@ -13,7 +13,7 @@
  *
  * \b Overview
  *
- * Computes arccosine of the input vector and stores results in the output vector.
+ * Computes arccosine of input vector and stores results in output vector.
  *
  * <b>Dispatcher Prototype</b>
  * \code
@@ -28,8 +28,8 @@
  * \li bVector: The vector where results will be stored.
  *
  * \b Example
- * Calculate common angles around the top half of the unit circle.
  * \code
+ * Calculate common angles around the top half of the unit circle.
  *   int N = 10;
  *   unsigned int alignment = volk_get_alignment();
  *   float* in = (float*)volk_malloc(sizeof(float)*N, alignment);
@@ -58,711 +58,494 @@
 #include <inttypes.h>
 #include <math.h>
 #include <stdio.h>
-
-/* This is the number of terms of Taylor series to evaluate, increase this for more
- * accuracy*/
-#define ACOS_TERMS 2
+#include <volk/volk_common.h>
 
 #ifndef INCLUDED_volk_32f_acos_32f_a_H
 #define INCLUDED_volk_32f_acos_32f_a_H
-
-#ifdef LV_HAVE_AVX512F
-#include <immintrin.h>
-
-static inline void
-volk_32f_acos_32f_a_avx512(float* bVector, const float* aVector, unsigned int num_points)
-{
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
-
-    unsigned int number = 0;
-    unsigned int sixteenthPoints = num_points / 16;
-    int i, j;
-
-    __m512 aVal, d, pi, pio2, x, y, z, arccosine;
-    __m512 fzeroes, fones, ftwos, ffours;
-    __mmask16 condition;
-
-    pi = _mm512_set1_ps(3.14159265358979323846);
-    pio2 = _mm512_set1_ps(3.14159265358979323846 / 2);
-    fzeroes = _mm512_setzero_ps();
-    fones = _mm512_set1_ps(1.0);
-    ftwos = _mm512_set1_ps(2.0);
-    ffours = _mm512_set1_ps(4.0);
-
-    for (; number < sixteenthPoints; number++) {
-        aVal = _mm512_load_ps(aPtr);
-        d = aVal;
-        aVal = _mm512_mul_ps(_mm512_sqrt_ps(_mm512_mul_ps(_mm512_add_ps(fones, aVal),
-                                                          _mm512_sub_ps(fones, aVal))),
-                             _mm512_rcp14_ps(aVal));
-        z = aVal;
-        condition = _mm512_cmp_ps_mask(z, fzeroes, _CMP_LT_OS);
-        z = _mm512_mask_sub_ps(z, condition, z, _mm512_mul_ps(z, ftwos));
-        condition = _mm512_cmp_ps_mask(z, fones, _CMP_LT_OS);
-        x = _mm512_mask_add_ps(z, condition, z, _mm512_sub_ps(_mm512_rcp14_ps(z), z));
-
-        for (i = 0; i < 2; i++) {
-            x = _mm512_add_ps(x, _mm512_sqrt_ps(_mm512_fmadd_ps(x, x, fones)));
-        }
-        x = _mm512_rcp14_ps(x);
-        y = fzeroes;
-        for (j = ACOS_TERMS - 1; j >= 0; j--) {
-            y = _mm512_fmadd_ps(
-                y, _mm512_mul_ps(x, x), _mm512_set1_ps(pow(-1, j) / (2 * j + 1)));
-        }
-
-        y = _mm512_mul_ps(y, _mm512_mul_ps(x, ffours));
-        condition = _mm512_cmp_ps_mask(z, fones, _CMP_GT_OS);
-
-        y = _mm512_mask_add_ps(y, condition, y, _mm512_fnmadd_ps(y, ftwos, pio2));
-        arccosine = y;
-        condition = _mm512_cmp_ps_mask(aVal, fzeroes, _CMP_LT_OS);
-        arccosine = _mm512_mask_sub_ps(
-            arccosine, condition, arccosine, _mm512_mul_ps(arccosine, ftwos));
-        condition = _mm512_cmp_ps_mask(d, fzeroes, _CMP_LT_OS);
-        arccosine = _mm512_mask_add_ps(arccosine, condition, arccosine, pi);
-
-        _mm512_store_ps(bPtr, arccosine);
-        aPtr += 16;
-        bPtr += 16;
-    }
-
-    number = sixteenthPoints * 16;
-    for (; number < num_points; number++) {
-        *bPtr++ = acos(*aPtr++);
-    }
-}
-
-#endif /* LV_HAVE_AVX512F for aligned */
-
-
-#if LV_HAVE_AVX2 && LV_HAVE_FMA
-#include <immintrin.h>
-
-static inline void volk_32f_acos_32f_a_avx2_fma(float* bVector,
-                                                const float* aVector,
-                                                unsigned int num_points)
-{
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
-
-    unsigned int number = 0;
-    unsigned int eighthPoints = num_points / 8;
-    int i, j;
-
-    __m256 aVal, d, pi, pio2, x, y, z, arccosine;
-    __m256 fzeroes, fones, ftwos, ffours, condition;
-
-    pi = _mm256_set1_ps(3.14159265358979323846);
-    pio2 = _mm256_set1_ps(3.14159265358979323846 / 2);
-    fzeroes = _mm256_setzero_ps();
-    fones = _mm256_set1_ps(1.0);
-    ftwos = _mm256_set1_ps(2.0);
-    ffours = _mm256_set1_ps(4.0);
-
-    for (; number < eighthPoints; number++) {
-        aVal = _mm256_load_ps(aPtr);
-        d = aVal;
-        aVal = _mm256_div_ps(_mm256_sqrt_ps(_mm256_mul_ps(_mm256_add_ps(fones, aVal),
-                                                          _mm256_sub_ps(fones, aVal))),
-                             aVal);
-        z = aVal;
-        condition = _mm256_cmp_ps(z, fzeroes, _CMP_LT_OS);
-        z = _mm256_sub_ps(z, _mm256_and_ps(_mm256_mul_ps(z, ftwos), condition));
-        condition = _mm256_cmp_ps(z, fones, _CMP_LT_OS);
-        x = _mm256_add_ps(z,
-                          _mm256_and_ps(_mm256_sub_ps(_mm256_rcp_ps(z), z), condition));
-
-        for (i = 0; i < 2; i++) {
-            x = _mm256_add_ps(x, _mm256_sqrt_ps(_mm256_fmadd_ps(x, x, fones)));
-        }
-        x = _mm256_rcp_ps(x);
-        y = fzeroes;
-        for (j = ACOS_TERMS - 1; j >= 0; j--) {
-            y = _mm256_fmadd_ps(
-                y, _mm256_mul_ps(x, x), _mm256_set1_ps(pow(-1, j) / (2 * j + 1)));
-        }
-
-        y = _mm256_mul_ps(y, _mm256_mul_ps(x, ffours));
-        condition = _mm256_cmp_ps(z, fones, _CMP_GT_OS);
-
-        y = _mm256_add_ps(y, _mm256_and_ps(_mm256_fnmadd_ps(y, ftwos, pio2), condition));
-        arccosine = y;
-        condition = _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS);
-        arccosine = _mm256_sub_ps(
-            arccosine, _mm256_and_ps(_mm256_mul_ps(arccosine, ftwos), condition));
-        condition = _mm256_cmp_ps(d, fzeroes, _CMP_LT_OS);
-        arccosine = _mm256_add_ps(arccosine, _mm256_and_ps(pi, condition));
-
-        _mm256_store_ps(bPtr, arccosine);
-        aPtr += 8;
-        bPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        *bPtr++ = acos(*aPtr++);
-    }
-}
-
-#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA for aligned */
-
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-
-static inline void
-volk_32f_acos_32f_a_avx(float* bVector, const float* aVector, unsigned int num_points)
-{
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
-
-    unsigned int number = 0;
-    unsigned int eighthPoints = num_points / 8;
-    int i, j;
-
-    __m256 aVal, d, pi, pio2, x, y, z, arccosine;
-    __m256 fzeroes, fones, ftwos, ffours, condition;
-
-    pi = _mm256_set1_ps(3.14159265358979323846);
-    pio2 = _mm256_set1_ps(3.14159265358979323846 / 2);
-    fzeroes = _mm256_setzero_ps();
-    fones = _mm256_set1_ps(1.0);
-    ftwos = _mm256_set1_ps(2.0);
-    ffours = _mm256_set1_ps(4.0);
-
-    for (; number < eighthPoints; number++) {
-        aVal = _mm256_load_ps(aPtr);
-        d = aVal;
-        aVal = _mm256_div_ps(_mm256_sqrt_ps(_mm256_mul_ps(_mm256_add_ps(fones, aVal),
-                                                          _mm256_sub_ps(fones, aVal))),
-                             aVal);
-        z = aVal;
-        condition = _mm256_cmp_ps(z, fzeroes, _CMP_LT_OS);
-        z = _mm256_sub_ps(z, _mm256_and_ps(_mm256_mul_ps(z, ftwos), condition));
-        condition = _mm256_cmp_ps(z, fones, _CMP_LT_OS);
-        x = _mm256_add_ps(z,
-                          _mm256_and_ps(_mm256_sub_ps(_mm256_rcp_ps(z), z), condition));
-
-        for (i = 0; i < 2; i++) {
-            x = _mm256_add_ps(x,
-                              _mm256_sqrt_ps(_mm256_add_ps(fones, _mm256_mul_ps(x, x))));
-        }
-        x = _mm256_rcp_ps(x);
-        y = fzeroes;
-        for (j = ACOS_TERMS - 1; j >= 0; j--) {
-            y = _mm256_add_ps(_mm256_mul_ps(y, _mm256_mul_ps(x, x)),
-                              _mm256_set1_ps(pow(-1, j) / (2 * j + 1)));
-        }
-
-        y = _mm256_mul_ps(y, _mm256_mul_ps(x, ffours));
-        condition = _mm256_cmp_ps(z, fones, _CMP_GT_OS);
-
-        y = _mm256_add_ps(
-            y, _mm256_and_ps(_mm256_sub_ps(pio2, _mm256_mul_ps(y, ftwos)), condition));
-        arccosine = y;
-        condition = _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS);
-        arccosine = _mm256_sub_ps(
-            arccosine, _mm256_and_ps(_mm256_mul_ps(arccosine, ftwos), condition));
-        condition = _mm256_cmp_ps(d, fzeroes, _CMP_LT_OS);
-        arccosine = _mm256_add_ps(arccosine, _mm256_and_ps(pi, condition));
-
-        _mm256_store_ps(bPtr, arccosine);
-        aPtr += 8;
-        bPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        *bPtr++ = acos(*aPtr++);
-    }
-}
-
-#endif /* LV_HAVE_AVX2 for aligned */
-
-#ifdef LV_HAVE_SSE4_1
-#include <smmintrin.h>
-
-static inline void
-volk_32f_acos_32f_a_sse4_1(float* bVector, const float* aVector, unsigned int num_points)
-{
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
-
-    unsigned int number = 0;
-    unsigned int quarterPoints = num_points / 4;
-    int i, j;
-
-    __m128 aVal, d, pi, pio2, x, y, z, arccosine;
-    __m128 fzeroes, fones, ftwos, ffours, condition;
-
-    pi = _mm_set1_ps(3.14159265358979323846);
-    pio2 = _mm_set1_ps(3.14159265358979323846 / 2);
-    fzeroes = _mm_setzero_ps();
-    fones = _mm_set1_ps(1.0);
-    ftwos = _mm_set1_ps(2.0);
-    ffours = _mm_set1_ps(4.0);
-
-    for (; number < quarterPoints; number++) {
-        aVal = _mm_load_ps(aPtr);
-        d = aVal;
-        aVal = _mm_div_ps(
-            _mm_sqrt_ps(_mm_mul_ps(_mm_add_ps(fones, aVal), _mm_sub_ps(fones, aVal))),
-            aVal);
-        z = aVal;
-        condition = _mm_cmplt_ps(z, fzeroes);
-        z = _mm_sub_ps(z, _mm_and_ps(_mm_mul_ps(z, ftwos), condition));
-        condition = _mm_cmplt_ps(z, fones);
-        x = _mm_add_ps(z, _mm_and_ps(_mm_sub_ps(_mm_rcp_ps(z), z), condition));
-
-        for (i = 0; i < 2; i++) {
-            x = _mm_add_ps(x, _mm_sqrt_ps(_mm_add_ps(fones, _mm_mul_ps(x, x))));
-        }
-        x = _mm_rcp_ps(x);
-        y = fzeroes;
-        for (j = ACOS_TERMS - 1; j >= 0; j--) {
-            y = _mm_add_ps(_mm_mul_ps(y, _mm_mul_ps(x, x)),
-                           _mm_set1_ps(pow(-1, j) / (2 * j + 1)));
-        }
-
-        y = _mm_mul_ps(y, _mm_mul_ps(x, ffours));
-        condition = _mm_cmpgt_ps(z, fones);
-
-        y = _mm_add_ps(y, _mm_and_ps(_mm_sub_ps(pio2, _mm_mul_ps(y, ftwos)), condition));
-        arccosine = y;
-        condition = _mm_cmplt_ps(aVal, fzeroes);
-        arccosine =
-            _mm_sub_ps(arccosine, _mm_and_ps(_mm_mul_ps(arccosine, ftwos), condition));
-        condition = _mm_cmplt_ps(d, fzeroes);
-        arccosine = _mm_add_ps(arccosine, _mm_and_ps(pi, condition));
-
-        _mm_store_ps(bPtr, arccosine);
-        aPtr += 4;
-        bPtr += 4;
-    }
-
-    number = quarterPoints * 4;
-    for (; number < num_points; number++) {
-        *bPtr++ = acosf(*aPtr++);
-    }
-}
-
-#endif /* LV_HAVE_SSE4_1 for aligned */
-
-#endif /* INCLUDED_volk_32f_acos_32f_a_H */
-
-
-#ifndef INCLUDED_volk_32f_acos_32f_u_H
-#define INCLUDED_volk_32f_acos_32f_u_H
-
-#ifdef LV_HAVE_AVX512F
-#include <immintrin.h>
-
-static inline void
-volk_32f_acos_32f_u_avx512(float* bVector, const float* aVector, unsigned int num_points)
-{
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
-
-    unsigned int number = 0;
-    unsigned int sixteenthPoints = num_points / 16;
-    int i, j;
-
-    __m512 aVal, d, pi, pio2, x, y, z, arccosine;
-    __m512 fzeroes, fones, ftwos, ffours;
-    __mmask16 condition;
-
-    pi = _mm512_set1_ps(3.14159265358979323846);
-    pio2 = _mm512_set1_ps(3.14159265358979323846 / 2);
-    fzeroes = _mm512_setzero_ps();
-    fones = _mm512_set1_ps(1.0);
-    ftwos = _mm512_set1_ps(2.0);
-    ffours = _mm512_set1_ps(4.0);
-
-    for (; number < sixteenthPoints; number++) {
-        aVal = _mm512_loadu_ps(aPtr);
-        d = aVal;
-        aVal = _mm512_mul_ps(_mm512_sqrt_ps(_mm512_mul_ps(_mm512_add_ps(fones, aVal),
-                                                          _mm512_sub_ps(fones, aVal))),
-                             _mm512_rcp14_ps(aVal));
-        z = aVal;
-        condition = _mm512_cmp_ps_mask(z, fzeroes, _CMP_LT_OS);
-        z = _mm512_mask_sub_ps(z, condition, z, _mm512_mul_ps(z, ftwos));
-        condition = _mm512_cmp_ps_mask(z, fones, _CMP_LT_OS);
-        x = _mm512_mask_add_ps(z, condition, z, _mm512_sub_ps(_mm512_rcp14_ps(z), z));
-
-        for (i = 0; i < 2; i++) {
-            x = _mm512_add_ps(x, _mm512_sqrt_ps(_mm512_fmadd_ps(x, x, fones)));
-        }
-        x = _mm512_rcp14_ps(x);
-        y = fzeroes;
-        for (j = ACOS_TERMS - 1; j >= 0; j--) {
-            y = _mm512_fmadd_ps(
-                y, _mm512_mul_ps(x, x), _mm512_set1_ps(pow(-1, j) / (2 * j + 1)));
-        }
-
-        y = _mm512_mul_ps(y, _mm512_mul_ps(x, ffours));
-        condition = _mm512_cmp_ps_mask(z, fones, _CMP_GT_OS);
-
-        y = _mm512_mask_add_ps(y, condition, y, _mm512_fnmadd_ps(y, ftwos, pio2));
-        arccosine = y;
-        condition = _mm512_cmp_ps_mask(aVal, fzeroes, _CMP_LT_OS);
-        arccosine = _mm512_mask_sub_ps(
-            arccosine, condition, arccosine, _mm512_mul_ps(arccosine, ftwos));
-        condition = _mm512_cmp_ps_mask(d, fzeroes, _CMP_LT_OS);
-        arccosine = _mm512_mask_add_ps(arccosine, condition, arccosine, pi);
-
-        _mm512_storeu_ps(bPtr, arccosine);
-        aPtr += 16;
-        bPtr += 16;
-    }
-
-    number = sixteenthPoints * 16;
-    for (; number < num_points; number++) {
-        *bPtr++ = acos(*aPtr++);
-    }
-}
-
-#endif /* LV_HAVE_AVX512F for unaligned */
-
-
-#if LV_HAVE_AVX2 && LV_HAVE_FMA
-#include <immintrin.h>
-
-static inline void volk_32f_acos_32f_u_avx2_fma(float* bVector,
-                                                const float* aVector,
-                                                unsigned int num_points)
-{
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
-
-    unsigned int number = 0;
-    unsigned int eighthPoints = num_points / 8;
-    int i, j;
-
-    __m256 aVal, d, pi, pio2, x, y, z, arccosine;
-    __m256 fzeroes, fones, ftwos, ffours, condition;
-
-    pi = _mm256_set1_ps(3.14159265358979323846);
-    pio2 = _mm256_set1_ps(3.14159265358979323846 / 2);
-    fzeroes = _mm256_setzero_ps();
-    fones = _mm256_set1_ps(1.0);
-    ftwos = _mm256_set1_ps(2.0);
-    ffours = _mm256_set1_ps(4.0);
-
-    for (; number < eighthPoints; number++) {
-        aVal = _mm256_loadu_ps(aPtr);
-        d = aVal;
-        aVal = _mm256_div_ps(_mm256_sqrt_ps(_mm256_mul_ps(_mm256_add_ps(fones, aVal),
-                                                          _mm256_sub_ps(fones, aVal))),
-                             aVal);
-        z = aVal;
-        condition = _mm256_cmp_ps(z, fzeroes, _CMP_LT_OS);
-        z = _mm256_sub_ps(z, _mm256_and_ps(_mm256_mul_ps(z, ftwos), condition));
-        condition = _mm256_cmp_ps(z, fones, _CMP_LT_OS);
-        x = _mm256_add_ps(z,
-                          _mm256_and_ps(_mm256_sub_ps(_mm256_rcp_ps(z), z), condition));
-
-        for (i = 0; i < 2; i++) {
-            x = _mm256_add_ps(x, _mm256_sqrt_ps(_mm256_fmadd_ps(x, x, fones)));
-        }
-        x = _mm256_rcp_ps(x);
-        y = fzeroes;
-        for (j = ACOS_TERMS - 1; j >= 0; j--) {
-            y = _mm256_fmadd_ps(
-                y, _mm256_mul_ps(x, x), _mm256_set1_ps(pow(-1, j) / (2 * j + 1)));
-        }
-
-        y = _mm256_mul_ps(y, _mm256_mul_ps(x, ffours));
-        condition = _mm256_cmp_ps(z, fones, _CMP_GT_OS);
-
-        y = _mm256_add_ps(y, _mm256_and_ps(_mm256_fnmadd_ps(y, ftwos, pio2), condition));
-        arccosine = y;
-        condition = _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS);
-        arccosine = _mm256_sub_ps(
-            arccosine, _mm256_and_ps(_mm256_mul_ps(arccosine, ftwos), condition));
-        condition = _mm256_cmp_ps(d, fzeroes, _CMP_LT_OS);
-        arccosine = _mm256_add_ps(arccosine, _mm256_and_ps(pi, condition));
-
-        _mm256_storeu_ps(bPtr, arccosine);
-        aPtr += 8;
-        bPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        *bPtr++ = acos(*aPtr++);
-    }
-}
-
-#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA for unaligned */
-
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-
-static inline void
-volk_32f_acos_32f_u_avx(float* bVector, const float* aVector, unsigned int num_points)
-{
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
-
-    unsigned int number = 0;
-    unsigned int eighthPoints = num_points / 8;
-    int i, j;
-
-    __m256 aVal, d, pi, pio2, x, y, z, arccosine;
-    __m256 fzeroes, fones, ftwos, ffours, condition;
-
-    pi = _mm256_set1_ps(3.14159265358979323846);
-    pio2 = _mm256_set1_ps(3.14159265358979323846 / 2);
-    fzeroes = _mm256_setzero_ps();
-    fones = _mm256_set1_ps(1.0);
-    ftwos = _mm256_set1_ps(2.0);
-    ffours = _mm256_set1_ps(4.0);
-
-    for (; number < eighthPoints; number++) {
-        aVal = _mm256_loadu_ps(aPtr);
-        d = aVal;
-        aVal = _mm256_div_ps(_mm256_sqrt_ps(_mm256_mul_ps(_mm256_add_ps(fones, aVal),
-                                                          _mm256_sub_ps(fones, aVal))),
-                             aVal);
-        z = aVal;
-        condition = _mm256_cmp_ps(z, fzeroes, _CMP_LT_OS);
-        z = _mm256_sub_ps(z, _mm256_and_ps(_mm256_mul_ps(z, ftwos), condition));
-        condition = _mm256_cmp_ps(z, fones, _CMP_LT_OS);
-        x = _mm256_add_ps(z,
-                          _mm256_and_ps(_mm256_sub_ps(_mm256_rcp_ps(z), z), condition));
-
-        for (i = 0; i < 2; i++) {
-            x = _mm256_add_ps(x,
-                              _mm256_sqrt_ps(_mm256_add_ps(fones, _mm256_mul_ps(x, x))));
-        }
-        x = _mm256_rcp_ps(x);
-        y = fzeroes;
-        for (j = ACOS_TERMS - 1; j >= 0; j--) {
-            y = _mm256_add_ps(_mm256_mul_ps(y, _mm256_mul_ps(x, x)),
-                              _mm256_set1_ps(pow(-1, j) / (2 * j + 1)));
-        }
-
-        y = _mm256_mul_ps(y, _mm256_mul_ps(x, ffours));
-        condition = _mm256_cmp_ps(z, fones, _CMP_GT_OS);
-
-        y = _mm256_add_ps(
-            y, _mm256_and_ps(_mm256_sub_ps(pio2, _mm256_mul_ps(y, ftwos)), condition));
-        arccosine = y;
-        condition = _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS);
-        arccosine = _mm256_sub_ps(
-            arccosine, _mm256_and_ps(_mm256_mul_ps(arccosine, ftwos), condition));
-        condition = _mm256_cmp_ps(d, fzeroes, _CMP_LT_OS);
-        arccosine = _mm256_add_ps(arccosine, _mm256_and_ps(pi, condition));
-
-        _mm256_storeu_ps(bPtr, arccosine);
-        aPtr += 8;
-        bPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        *bPtr++ = acos(*aPtr++);
-    }
-}
-
-#endif /* LV_HAVE_AVX2 for unaligned */
-
-#ifdef LV_HAVE_SSE4_1
-#include <smmintrin.h>
-
-static inline void
-volk_32f_acos_32f_u_sse4_1(float* bVector, const float* aVector, unsigned int num_points)
-{
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
-
-    unsigned int number = 0;
-    unsigned int quarterPoints = num_points / 4;
-    int i, j;
-
-    __m128 aVal, d, pi, pio2, x, y, z, arccosine;
-    __m128 fzeroes, fones, ftwos, ffours, condition;
-
-    pi = _mm_set1_ps(3.14159265358979323846);
-    pio2 = _mm_set1_ps(3.14159265358979323846 / 2);
-    fzeroes = _mm_setzero_ps();
-    fones = _mm_set1_ps(1.0);
-    ftwos = _mm_set1_ps(2.0);
-    ffours = _mm_set1_ps(4.0);
-
-    for (; number < quarterPoints; number++) {
-        aVal = _mm_loadu_ps(aPtr);
-        d = aVal;
-        aVal = _mm_div_ps(
-            _mm_sqrt_ps(_mm_mul_ps(_mm_add_ps(fones, aVal), _mm_sub_ps(fones, aVal))),
-            aVal);
-        z = aVal;
-        condition = _mm_cmplt_ps(z, fzeroes);
-        z = _mm_sub_ps(z, _mm_and_ps(_mm_mul_ps(z, ftwos), condition));
-        condition = _mm_cmplt_ps(z, fones);
-        x = _mm_add_ps(z, _mm_and_ps(_mm_sub_ps(_mm_rcp_ps(z), z), condition));
-
-        for (i = 0; i < 2; i++) {
-            x = _mm_add_ps(x, _mm_sqrt_ps(_mm_add_ps(fones, _mm_mul_ps(x, x))));
-        }
-        x = _mm_rcp_ps(x);
-        y = fzeroes;
-
-        for (j = ACOS_TERMS - 1; j >= 0; j--) {
-            y = _mm_add_ps(_mm_mul_ps(y, _mm_mul_ps(x, x)),
-                           _mm_set1_ps(pow(-1, j) / (2 * j + 1)));
-        }
-
-        y = _mm_mul_ps(y, _mm_mul_ps(x, ffours));
-        condition = _mm_cmpgt_ps(z, fones);
-
-        y = _mm_add_ps(y, _mm_and_ps(_mm_sub_ps(pio2, _mm_mul_ps(y, ftwos)), condition));
-        arccosine = y;
-        condition = _mm_cmplt_ps(aVal, fzeroes);
-        arccosine =
-            _mm_sub_ps(arccosine, _mm_and_ps(_mm_mul_ps(arccosine, ftwos), condition));
-        condition = _mm_cmplt_ps(d, fzeroes);
-        arccosine = _mm_add_ps(arccosine, _mm_and_ps(pi, condition));
-
-        _mm_storeu_ps(bPtr, arccosine);
-        aPtr += 4;
-        bPtr += 4;
-    }
-
-    number = quarterPoints * 4;
-    for (; number < num_points; number++) {
-        *bPtr++ = acosf(*aPtr++);
-    }
-}
-
-#endif /* LV_HAVE_SSE4_1 for aligned */
 
 #ifdef LV_HAVE_GENERIC
 
 static inline void
 volk_32f_acos_32f_generic(float* bVector, const float* aVector, unsigned int num_points)
 {
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
-    unsigned int number = 0;
-
-    for (number = 0; number < num_points; number++) {
-        *bPtr++ = acosf(*aPtr++);
+    for (unsigned int i = 0; i < num_points; i++) {
+        bVector[i] = volk_arccos(aVector[i]);
     }
 }
+
 #endif /* LV_HAVE_GENERIC */
 
-#ifdef LV_HAVE_NEON
-#include <arm_neon.h>
+#ifdef LV_HAVE_SSE4_1
+#include <smmintrin.h>
+#include <volk/volk_sse_intrinsics.h>
 
 static inline void
-volk_32f_acos_32f_neon(float* bVector, const float* aVector, unsigned int num_points)
+volk_32f_acos_32f_a_sse4_1(float* bVector, const float* aVector, unsigned int num_points)
 {
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
+    const __m128 pi_2 = _mm_set1_ps(0x1.921fb6p0f);
+    const __m128 half = _mm_set1_ps(0.5f);
+    const __m128 one = _mm_set1_ps(1.0f);
+    const __m128 two = _mm_set1_ps(2.0f);
+    const __m128 sign_mask = _mm_set1_ps(-0.0f);
 
     unsigned int number = 0;
-    unsigned int quarterPoints = num_points / 4;
-    int i, j;
-
-    float32x4_t aVal, d, x, y, z, arccosine;
-    uint32x4_t condition;
-    const float32x4_t fzeroes = vdupq_n_f32(0.0f);
-    const float32x4_t fones = vdupq_n_f32(1.0f);
-    const float32x4_t ftwos = vdupq_n_f32(2.0f);
-    const float32x4_t ffours = vdupq_n_f32(4.0f);
-    const float32x4_t pi = vdupq_n_f32(3.14159265358979323846f);
-    const float32x4_t pio2 = vdupq_n_f32(3.14159265358979323846f / 2.0f);
+    const unsigned int quarterPoints = num_points / 4;
 
     for (; number < quarterPoints; number++) {
-        aVal = vld1q_f32(aPtr);
-        d = aVal;
+        __m128 aVal = _mm_load_ps(aVector);
 
-        // Compute sqrt((1+x)*(1-x)) / x using reciprocal estimate
-        // For |x| > 1, this produces NaN (matching generic behavior)
-        float32x4_t one_plus = vaddq_f32(fones, aVal);
-        float32x4_t one_minus = vsubq_f32(fones, aVal);
-        float32x4_t sqrt_arg = vmulq_f32(one_plus, one_minus);
+        // acos(x) = pi/2 - asin(x)
+        // Get absolute value and sign
+        __m128 sign = _mm_and_ps(aVal, sign_mask);
+        __m128 ax = _mm_andnot_ps(sign_mask, aVal);
 
-        // Newton-Raphson sqrt approximation
-        float32x4_t sqrt_est = vrsqrteq_f32(sqrt_arg);
-        sqrt_est =
-            vmulq_f32(sqrt_est, vrsqrtsq_f32(vmulq_f32(sqrt_arg, sqrt_est), sqrt_est));
-        float32x4_t sqrt_val = vmulq_f32(sqrt_arg, sqrt_est);
+        // Two-range asin computation
+        __m128 t = _mm_mul_ps(_mm_sub_ps(one, ax), half);
+        __m128 s = _mm_sqrt_ps(t);
 
-        // Reciprocal of aVal
-        float32x4_t recip = vrecpeq_f32(aVal);
-        recip = vmulq_f32(recip, vrecpsq_f32(aVal, recip));
-        float32x4_t tanVal = vmulq_f32(sqrt_val, recip);
+        __m128 poly_small = _mm_arcsin_poly_sse(ax);
+        __m128 poly_large = _mm_arcsin_poly_sse(s);
 
-        z = tanVal;
-        // z = abs(z) - conditionally negate if z < 0
-        condition = vcltq_f32(z, fzeroes);
-        z = vbslq_f32(condition, vnegq_f32(z), z);
+        __m128 asin_large = _mm_sub_ps(pi_2, _mm_mul_ps(two, poly_large));
 
-        // x = 1/z if z < 1, else x = z (matching SSE logic)
-        condition = vcltq_f32(z, fones);
-        float32x4_t z_recip = vrecpeq_f32(z);
-        z_recip = vmulq_f32(z_recip, vrecpsq_f32(z, z_recip));
-        x = vbslq_f32(condition, z_recip, z);
+        __m128 mask = _mm_cmpgt_ps(ax, half);
+        __m128 asin_result = _mm_blendv_ps(poly_small, asin_large, mask);
 
-        // Two iterations: x = x + sqrt(1 + x*x)
-        // Note: For very large x (approaching infinity), the NR rsqrt iteration produces
-        // NaN due to inf*0 in vrsqrtsq. Use approximation sqrt(1+x²) ≈ x for large x.
-        const float32x4_t large_threshold = vdupq_n_f32(1e10f);
-        for (i = 0; i < 2; i++) {
-            float32x4_t xx = vmulq_f32(x, x);
-            float32x4_t sum = vaddq_f32(fones, xx);
-            uint32x4_t is_large = vcgtq_f32(x, large_threshold);
-            float32x4_t sqrt_sum_est = vrsqrteq_f32(sum);
-            sqrt_sum_est = vmulq_f32(
-                sqrt_sum_est, vrsqrtsq_f32(vmulq_f32(sum, sqrt_sum_est), sqrt_sum_est));
-            float32x4_t sqrt_sum = vmulq_f32(sum, sqrt_sum_est);
-            sqrt_sum = vbslq_f32(is_large, x, sqrt_sum);
-            x = vaddq_f32(x, sqrt_sum);
-        }
+        // Apply sign to get asin(x)
+        asin_result = _mm_or_ps(asin_result, sign);
 
-        // x = 1/x
-        float32x4_t x_recip = vrecpeq_f32(x);
-        x_recip = vmulq_f32(x_recip, vrecpsq_f32(x, x_recip));
-        x = x_recip;
+        // acos(x) = pi/2 - asin(x)
+        __m128 result = _mm_sub_ps(pi_2, asin_result);
 
-        // Taylor series: y = sum of (-1)^j / (2j+1) * x^(2j)
-        y = fzeroes;
-        for (j = ACOS_TERMS - 1; j >= 0; j--) {
-            float coeff = (j % 2 == 0) ? 1.0f / (2 * j + 1) : -1.0f / (2 * j + 1);
-            y = vaddq_f32(vmulq_f32(y, vmulq_f32(x, x)), vdupq_n_f32(coeff));
-        }
+        _mm_store_ps(bVector, result);
 
-        y = vmulq_f32(y, vmulq_f32(x, ffours));
-
-        // Adjust if z > 1: y = y + (pio2 - 2*y)
-        condition = vcgtq_f32(z, fones);
-        float32x4_t y_adj = vsubq_f32(pio2, vmulq_f32(y, ftwos));
-        y = vbslq_f32(condition, vaddq_f32(y, y_adj), y);
-
-        arccosine = y;
-
-        // If tanVal < 0, arccosine = -arccosine
-        condition = vcltq_f32(tanVal, fzeroes);
-        arccosine = vbslq_f32(condition, vnegq_f32(arccosine), arccosine);
-
-        // If d < 0, arccosine += pi
-        condition = vcltq_f32(d, fzeroes);
-        arccosine = vbslq_f32(condition, vaddq_f32(arccosine, pi), arccosine);
-
-        vst1q_f32(bPtr, arccosine);
-        aPtr += 4;
-        bPtr += 4;
+        aVector += 4;
+        bVector += 4;
     }
 
     number = quarterPoints * 4;
     for (; number < num_points; number++) {
-        *bPtr++ = acosf(*aPtr++);
+        *bVector++ = volk_arccos(*aVector++);
+    }
+}
+
+#endif /* LV_HAVE_SSE4_1 */
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
+static inline void
+volk_32f_acos_32f_a_avx(float* bVector, const float* aVector, unsigned int num_points)
+{
+    const __m256 pi_2 = _mm256_set1_ps(0x1.921fb6p0f);
+    const __m256 half = _mm256_set1_ps(0.5f);
+    const __m256 one = _mm256_set1_ps(1.0f);
+    const __m256 two = _mm256_set1_ps(2.0f);
+    const __m256 sign_mask = _mm256_set1_ps(-0.0f);
+
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    for (; number < eighthPoints; number++) {
+        __m256 aVal = _mm256_load_ps(aVector);
+
+        __m256 sign = _mm256_and_ps(aVal, sign_mask);
+        __m256 ax = _mm256_andnot_ps(sign_mask, aVal);
+
+        __m256 t = _mm256_mul_ps(_mm256_sub_ps(one, ax), half);
+        __m256 s = _mm256_sqrt_ps(t);
+
+        __m256 poly_small = _mm256_arcsin_poly_avx(ax);
+        __m256 poly_large = _mm256_arcsin_poly_avx(s);
+
+        __m256 asin_large = _mm256_sub_ps(pi_2, _mm256_mul_ps(two, poly_large));
+
+        __m256 mask = _mm256_cmp_ps(ax, half, _CMP_GT_OS);
+        __m256 asin_result = _mm256_blendv_ps(poly_small, asin_large, mask);
+
+        asin_result = _mm256_or_ps(asin_result, sign);
+
+        __m256 result = _mm256_sub_ps(pi_2, asin_result);
+
+        _mm256_store_ps(bVector, result);
+
+        aVector += 8;
+        bVector += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *bVector++ = volk_arccos(*aVector++);
+    }
+}
+
+#endif /* LV_HAVE_AVX */
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+#include <volk/volk_avx2_fma_intrinsics.h>
+
+static inline void volk_32f_acos_32f_a_avx2_fma(float* bVector,
+                                                const float* aVector,
+                                                unsigned int num_points)
+{
+    const __m256 pi_2 = _mm256_set1_ps(0x1.921fb6p0f);
+    const __m256 half = _mm256_set1_ps(0.5f);
+    const __m256 one = _mm256_set1_ps(1.0f);
+    const __m256 two = _mm256_set1_ps(2.0f);
+    const __m256 sign_mask = _mm256_set1_ps(-0.0f);
+
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    for (; number < eighthPoints; number++) {
+        __m256 aVal = _mm256_load_ps(aVector);
+
+        __m256 sign = _mm256_and_ps(aVal, sign_mask);
+        __m256 ax = _mm256_andnot_ps(sign_mask, aVal);
+
+        __m256 t = _mm256_mul_ps(_mm256_sub_ps(one, ax), half);
+        __m256 s = _mm256_sqrt_ps(t);
+
+        __m256 poly_small = _mm256_arcsin_poly_avx2_fma(ax);
+        __m256 poly_large = _mm256_arcsin_poly_avx2_fma(s);
+
+        __m256 asin_large = _mm256_fnmadd_ps(two, poly_large, pi_2);
+
+        __m256 mask = _mm256_cmp_ps(ax, half, _CMP_GT_OS);
+        __m256 asin_result = _mm256_blendv_ps(poly_small, asin_large, mask);
+
+        asin_result = _mm256_or_ps(asin_result, sign);
+
+        __m256 result = _mm256_sub_ps(pi_2, asin_result);
+
+        _mm256_store_ps(bVector, result);
+
+        aVector += 8;
+        bVector += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *bVector++ = volk_arccos(*aVector++);
+    }
+}
+
+#endif /* LV_HAVE_AVX2 */
+
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+#include <volk/volk_avx512_intrinsics.h>
+
+static inline void
+volk_32f_acos_32f_a_avx512(float* bVector, const float* aVector, unsigned int num_points)
+{
+    const __m512 pi_2 = _mm512_set1_ps(0x1.921fb6p0f);
+    const __m512 half = _mm512_set1_ps(0.5f);
+    const __m512 one = _mm512_set1_ps(1.0f);
+    const __m512 two = _mm512_set1_ps(2.0f);
+    const __m512i sign_mask = _mm512_set1_epi32(0x80000000);
+
+    unsigned int number = 0;
+    const unsigned int sixteenthPoints = num_points / 16;
+
+    for (; number < sixteenthPoints; number++) {
+        __m512 aVal = _mm512_load_ps(aVector);
+
+        __m512i aVal_i = _mm512_castps_si512(aVal);
+        __m512i sign = _mm512_and_epi32(aVal_i, sign_mask);
+        __m512 ax = _mm512_castsi512_ps(_mm512_andnot_epi32(sign_mask, aVal_i));
+
+        __m512 t = _mm512_mul_ps(_mm512_sub_ps(one, ax), half);
+        __m512 s = _mm512_sqrt_ps(t);
+
+        __m512 poly_small = _mm512_arcsin_poly_avx512(ax);
+        __m512 poly_large = _mm512_arcsin_poly_avx512(s);
+
+        __m512 asin_large = _mm512_fnmadd_ps(two, poly_large, pi_2);
+
+        __mmask16 mask = _mm512_cmp_ps_mask(ax, half, _CMP_GT_OS);
+        __m512 asin_result = _mm512_mask_blend_ps(mask, poly_small, asin_large);
+
+        asin_result =
+            _mm512_castsi512_ps(_mm512_or_epi32(_mm512_castps_si512(asin_result), sign));
+
+        __m512 result = _mm512_sub_ps(pi_2, asin_result);
+
+        _mm512_store_ps(bVector, result);
+
+        aVector += 16;
+        bVector += 16;
+    }
+
+    number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        *bVector++ = volk_arccos(*aVector++);
+    }
+}
+
+#endif /* LV_HAVE_AVX512F */
+
+#endif /* INCLUDED_volk_32f_acos_32f_a_H */
+
+#ifndef INCLUDED_volk_32f_acos_32f_u_H
+#define INCLUDED_volk_32f_acos_32f_u_H
+
+#ifdef LV_HAVE_SSE4_1
+#include <smmintrin.h>
+#include <volk/volk_sse_intrinsics.h>
+
+static inline void
+volk_32f_acos_32f_u_sse4_1(float* bVector, const float* aVector, unsigned int num_points)
+{
+    const __m128 pi_2 = _mm_set1_ps(0x1.921fb6p0f);
+    const __m128 half = _mm_set1_ps(0.5f);
+    const __m128 one = _mm_set1_ps(1.0f);
+    const __m128 two = _mm_set1_ps(2.0f);
+    const __m128 sign_mask = _mm_set1_ps(-0.0f);
+
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    for (; number < quarterPoints; number++) {
+        __m128 aVal = _mm_loadu_ps(aVector);
+
+        __m128 sign = _mm_and_ps(aVal, sign_mask);
+        __m128 ax = _mm_andnot_ps(sign_mask, aVal);
+
+        __m128 t = _mm_mul_ps(_mm_sub_ps(one, ax), half);
+        __m128 s = _mm_sqrt_ps(t);
+
+        __m128 poly_small = _mm_arcsin_poly_sse(ax);
+        __m128 poly_large = _mm_arcsin_poly_sse(s);
+
+        __m128 asin_large = _mm_sub_ps(pi_2, _mm_mul_ps(two, poly_large));
+
+        __m128 mask = _mm_cmpgt_ps(ax, half);
+        __m128 asin_result = _mm_blendv_ps(poly_small, asin_large, mask);
+
+        asin_result = _mm_or_ps(asin_result, sign);
+
+        __m128 result = _mm_sub_ps(pi_2, asin_result);
+
+        _mm_storeu_ps(bVector, result);
+
+        aVector += 4;
+        bVector += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        *bVector++ = volk_arccos(*aVector++);
+    }
+}
+
+#endif /* LV_HAVE_SSE4_1 */
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
+static inline void
+volk_32f_acos_32f_u_avx(float* bVector, const float* aVector, unsigned int num_points)
+{
+    const __m256 pi_2 = _mm256_set1_ps(0x1.921fb6p0f);
+    const __m256 half = _mm256_set1_ps(0.5f);
+    const __m256 one = _mm256_set1_ps(1.0f);
+    const __m256 two = _mm256_set1_ps(2.0f);
+    const __m256 sign_mask = _mm256_set1_ps(-0.0f);
+
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    for (; number < eighthPoints; number++) {
+        __m256 aVal = _mm256_loadu_ps(aVector);
+
+        __m256 sign = _mm256_and_ps(aVal, sign_mask);
+        __m256 ax = _mm256_andnot_ps(sign_mask, aVal);
+
+        __m256 t = _mm256_mul_ps(_mm256_sub_ps(one, ax), half);
+        __m256 s = _mm256_sqrt_ps(t);
+
+        __m256 poly_small = _mm256_arcsin_poly_avx(ax);
+        __m256 poly_large = _mm256_arcsin_poly_avx(s);
+
+        __m256 asin_large = _mm256_sub_ps(pi_2, _mm256_mul_ps(two, poly_large));
+
+        __m256 mask = _mm256_cmp_ps(ax, half, _CMP_GT_OS);
+        __m256 asin_result = _mm256_blendv_ps(poly_small, asin_large, mask);
+
+        asin_result = _mm256_or_ps(asin_result, sign);
+
+        __m256 result = _mm256_sub_ps(pi_2, asin_result);
+
+        _mm256_storeu_ps(bVector, result);
+
+        aVector += 8;
+        bVector += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *bVector++ = volk_arccos(*aVector++);
+    }
+}
+
+#endif /* LV_HAVE_AVX */
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+#include <volk/volk_avx2_fma_intrinsics.h>
+
+static inline void volk_32f_acos_32f_u_avx2_fma(float* bVector,
+                                                const float* aVector,
+                                                unsigned int num_points)
+{
+    const __m256 pi_2 = _mm256_set1_ps(0x1.921fb6p0f);
+    const __m256 half = _mm256_set1_ps(0.5f);
+    const __m256 one = _mm256_set1_ps(1.0f);
+    const __m256 two = _mm256_set1_ps(2.0f);
+    const __m256 sign_mask = _mm256_set1_ps(-0.0f);
+
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    for (; number < eighthPoints; number++) {
+        __m256 aVal = _mm256_loadu_ps(aVector);
+
+        __m256 sign = _mm256_and_ps(aVal, sign_mask);
+        __m256 ax = _mm256_andnot_ps(sign_mask, aVal);
+
+        __m256 t = _mm256_mul_ps(_mm256_sub_ps(one, ax), half);
+        __m256 s = _mm256_sqrt_ps(t);
+
+        __m256 poly_small = _mm256_arcsin_poly_avx2_fma(ax);
+        __m256 poly_large = _mm256_arcsin_poly_avx2_fma(s);
+
+        __m256 asin_large = _mm256_fnmadd_ps(two, poly_large, pi_2);
+
+        __m256 mask = _mm256_cmp_ps(ax, half, _CMP_GT_OS);
+        __m256 asin_result = _mm256_blendv_ps(poly_small, asin_large, mask);
+
+        asin_result = _mm256_or_ps(asin_result, sign);
+
+        __m256 result = _mm256_sub_ps(pi_2, asin_result);
+
+        _mm256_storeu_ps(bVector, result);
+
+        aVector += 8;
+        bVector += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *bVector++ = volk_arccos(*aVector++);
+    }
+}
+
+#endif /* LV_HAVE_AVX2 */
+
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+#include <volk/volk_avx512_intrinsics.h>
+
+static inline void
+volk_32f_acos_32f_u_avx512(float* bVector, const float* aVector, unsigned int num_points)
+{
+    const __m512 pi_2 = _mm512_set1_ps(0x1.921fb6p0f);
+    const __m512 half = _mm512_set1_ps(0.5f);
+    const __m512 one = _mm512_set1_ps(1.0f);
+    const __m512 two = _mm512_set1_ps(2.0f);
+    const __m512i sign_mask = _mm512_set1_epi32(0x80000000);
+
+    unsigned int number = 0;
+    const unsigned int sixteenthPoints = num_points / 16;
+
+    for (; number < sixteenthPoints; number++) {
+        __m512 aVal = _mm512_loadu_ps(aVector);
+
+        __m512i aVal_i = _mm512_castps_si512(aVal);
+        __m512i sign = _mm512_and_epi32(aVal_i, sign_mask);
+        __m512 ax = _mm512_castsi512_ps(_mm512_andnot_epi32(sign_mask, aVal_i));
+
+        __m512 t = _mm512_mul_ps(_mm512_sub_ps(one, ax), half);
+        __m512 s = _mm512_sqrt_ps(t);
+
+        __m512 poly_small = _mm512_arcsin_poly_avx512(ax);
+        __m512 poly_large = _mm512_arcsin_poly_avx512(s);
+
+        __m512 asin_large = _mm512_fnmadd_ps(two, poly_large, pi_2);
+
+        __mmask16 mask = _mm512_cmp_ps_mask(ax, half, _CMP_GT_OS);
+        __m512 asin_result = _mm512_mask_blend_ps(mask, poly_small, asin_large);
+
+        asin_result =
+            _mm512_castsi512_ps(_mm512_or_epi32(_mm512_castps_si512(asin_result), sign));
+
+        __m512 result = _mm512_sub_ps(pi_2, asin_result);
+
+        _mm512_storeu_ps(bVector, result);
+
+        aVector += 16;
+        bVector += 16;
+    }
+
+    number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        *bVector++ = volk_arccos(*aVector++);
+    }
+}
+
+#endif /* LV_HAVE_AVX512F */
+
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+#include <volk/volk_neon_intrinsics.h>
+
+static inline void
+volk_32f_acos_32f_neon(float* bVector, const float* aVector, unsigned int num_points)
+{
+    const float32x4_t pi_2 = vdupq_n_f32(0x1.921fb6p0f);
+    const float32x4_t half = vdupq_n_f32(0.5f);
+    const float32x4_t one = vdupq_n_f32(1.0f);
+    const float32x4_t two = vdupq_n_f32(2.0f);
+
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    for (; number < quarterPoints; number++) {
+        float32x4_t aVal = vld1q_f32(aVector);
+
+        float32x4_t ax = vabsq_f32(aVal);
+        uint32x4_t sign_bits =
+            vandq_u32(vreinterpretq_u32_f32(aVal), vdupq_n_u32(0x80000000));
+
+        float32x4_t t = vmulq_f32(vsubq_f32(one, ax), half);
+        float32x4_t s = vsqrtq_f32(t);
+
+        float32x4_t poly_small = _varcsinq_f32(ax);
+        float32x4_t poly_large = _varcsinq_f32(s);
+
+        float32x4_t asin_large = vmlsq_f32(pi_2, two, poly_large);
+
+        uint32x4_t mask = vcgtq_f32(ax, half);
+        float32x4_t asin_result = vbslq_f32(mask, asin_large, poly_small);
+
+        asin_result = vreinterpretq_f32_u32(
+            vorrq_u32(vreinterpretq_u32_f32(asin_result), sign_bits));
+
+        float32x4_t result = vsubq_f32(pi_2, asin_result);
+
+        vst1q_f32(bVector, result);
+
+        aVector += 4;
+        bVector += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        *bVector++ = volk_arccos(*aVector++);
     }
 }
 
@@ -770,159 +553,54 @@ volk_32f_acos_32f_neon(float* bVector, const float* aVector, unsigned int num_po
 
 #ifdef LV_HAVE_NEONV8
 #include <arm_neon.h>
+#include <volk/volk_neon_intrinsics.h>
 
 static inline void
 volk_32f_acos_32f_neonv8(float* bVector, const float* aVector, unsigned int num_points)
 {
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
+    const float32x4_t pi_2 = vdupq_n_f32(0x1.921fb6p0f);
+    const float32x4_t half = vdupq_n_f32(0.5f);
+    const float32x4_t one = vdupq_n_f32(1.0f);
+    const float32x4_t two = vdupq_n_f32(2.0f);
 
     unsigned int number = 0;
-    unsigned int quarterPoints = num_points / 4;
-    int i, j;
-
-    float32x4_t aVal, d, x, y, z, arccosine;
-    const float32x4_t fzeroes = vdupq_n_f32(0.0f);
-    const float32x4_t fones = vdupq_n_f32(1.0f);
-    const float32x4_t ftwos = vdupq_n_f32(2.0f);
-    const float32x4_t ffours = vdupq_n_f32(4.0f);
-    const float32x4_t pi = vdupq_n_f32(3.14159265358979323846f);
-    const float32x4_t pio2 = vdupq_n_f32(3.14159265358979323846f / 2.0f);
+    const unsigned int quarterPoints = num_points / 4;
 
     for (; number < quarterPoints; number++) {
-        aVal = vld1q_f32(aPtr);
-        d = aVal;
+        float32x4_t aVal = vld1q_f32(aVector);
 
-        // Compute sqrt((1+x)*(1-x)) / x
-        // For |x| > 1, this produces NaN (matching generic behavior)
-        float32x4_t one_plus = vaddq_f32(fones, aVal);
-        float32x4_t one_minus = vsubq_f32(fones, aVal);
-        float32x4_t sqrt_val = vsqrtq_f32(vmulq_f32(one_plus, one_minus));
+        float32x4_t ax = vabsq_f32(aVal);
+        uint32x4_t sign_bits =
+            vandq_u32(vreinterpretq_u32_f32(aVal), vdupq_n_u32(0x80000000));
 
-        float32x4_t tanVal = vdivq_f32(sqrt_val, aVal);
+        float32x4_t t = vmulq_f32(vsubq_f32(one, ax), half);
+        float32x4_t s = vsqrtq_f32(t);
 
-        z = tanVal;
-        // z = abs(z)
-        z = vabsq_f32(z);
+        float32x4_t poly_small = _varcsinq_f32_neonv8(ax);
+        float32x4_t poly_large = _varcsinq_f32_neonv8(s);
 
-        // x = 1/z if z < 1, else x = z (matching SSE logic)
-        uint32x4_t z_lt_one = vcltq_f32(z, fones);
-        float32x4_t z_recip = vdivq_f32(fones, z);
-        x = vbslq_f32(z_lt_one, z_recip, z);
+        float32x4_t asin_large = vfmsq_f32(pi_2, two, poly_large);
 
-        // Two iterations: x = x + sqrt(1 + x*x)
-        for (i = 0; i < 2; i++) {
-            x = vaddq_f32(x, vsqrtq_f32(vfmaq_f32(fones, x, x)));
-        }
+        uint32x4_t mask = vcgtq_f32(ax, half);
+        float32x4_t asin_result = vbslq_f32(mask, asin_large, poly_small);
 
-        // x = 1/x
-        x = vdivq_f32(fones, x);
+        asin_result = vreinterpretq_f32_u32(
+            vorrq_u32(vreinterpretq_u32_f32(asin_result), sign_bits));
 
-        // Taylor series
-        y = fzeroes;
-        for (j = ACOS_TERMS - 1; j >= 0; j--) {
-            float coeff = (j % 2 == 0) ? 1.0f / (2 * j + 1) : -1.0f / (2 * j + 1);
-            y = vfmaq_f32(vdupq_n_f32(coeff), y, vmulq_f32(x, x));
-        }
+        float32x4_t result = vsubq_f32(pi_2, asin_result);
 
-        y = vmulq_f32(y, vmulq_f32(x, ffours));
+        vst1q_f32(bVector, result);
 
-        // Adjust if z > 1: y = y + (pio2 - 2*y)
-        uint32x4_t z_gt_one = vcgtq_f32(z, fones);
-        float32x4_t y_adj = vfmsq_f32(pio2, y, ftwos);
-        y = vbslq_f32(z_gt_one, vaddq_f32(y, y_adj), y);
-
-        arccosine = y;
-
-        // If tanVal < 0, arccosine = -arccosine
-        uint32x4_t tanVal_neg = vcltq_f32(tanVal, fzeroes);
-        arccosine = vbslq_f32(tanVal_neg, vnegq_f32(arccosine), arccosine);
-
-        // If d < 0, arccosine += pi
-        uint32x4_t d_neg = vcltq_f32(d, fzeroes);
-        arccosine = vbslq_f32(d_neg, vaddq_f32(arccosine, pi), arccosine);
-
-        vst1q_f32(bPtr, arccosine);
-        aPtr += 4;
-        bPtr += 4;
+        aVector += 4;
+        bVector += 4;
     }
 
     number = quarterPoints * 4;
     for (; number < num_points; number++) {
-        *bPtr++ = acosf(*aPtr++);
+        *bVector++ = volk_arccos(*aVector++);
     }
 }
 
 #endif /* LV_HAVE_NEONV8 */
-
-#ifdef LV_HAVE_RVV
-#include <riscv_vector.h>
-#include <volk/volk_rvv_intrinsics.h>
-
-static inline void
-volk_32f_acos_32f_rvv(float* bVector, const float* aVector, unsigned int num_points)
-{
-    size_t vlmax = __riscv_vsetvlmax_e32m2();
-
-    const vfloat32m2_t cpi = __riscv_vfmv_v_f_f32m2(3.1415927f, vlmax);
-    const vfloat32m2_t cpio2 = __riscv_vfmv_v_f_f32m2(1.5707964f, vlmax);
-    const vfloat32m2_t cf1 = __riscv_vfmv_v_f_f32m2(1.0f, vlmax);
-    const vfloat32m2_t cf2 = __riscv_vfmv_v_f_f32m2(2.0f, vlmax);
-    const vfloat32m2_t cf4 = __riscv_vfmv_v_f_f32m2(4.0f, vlmax);
-
-#if ACOS_TERMS == 2
-    const vfloat32m2_t cfm1o3 = __riscv_vfmv_v_f_f32m2(-1 / 3.0f, vlmax);
-#elif ACOS_TERMS == 3
-    const vfloat32m2_t cf1o5 = __riscv_vfmv_v_f_f32m2(1 / 5.0f, vlmax);
-#elif ACOS_TERMS == 4
-    const vfloat32m2_t cfm1o7 = __riscv_vfmv_v_f_f32m2(-1 / 7.0f, vlmax);
-#endif
-
-    size_t n = num_points;
-    for (size_t vl; n > 0; n -= vl, aVector += vl, bVector += vl) {
-        vl = __riscv_vsetvl_e32m2(n);
-        vfloat32m2_t v = __riscv_vle32_v_f32m2(aVector, vl);
-        // Compute 1 - v^2 = (1+v)*(1-v) for better numerical stability
-        vfloat32m2_t one_minus_v_sq =
-            __riscv_vfmul(__riscv_vfadd(cf1, v, vl), __riscv_vfsub(cf1, v, vl), vl);
-        vfloat32m2_t a = __riscv_vfdiv(__riscv_vfsqrt(one_minus_v_sq, vl), v, vl);
-        vfloat32m2_t z = __riscv_vfabs(a, vl);
-        vfloat32m2_t x = __riscv_vfdiv_mu(__riscv_vmflt(z, cf1, vl), z, cf1, z, vl);
-        x = __riscv_vfadd(x, __riscv_vfsqrt(__riscv_vfmadd(x, x, cf1, vl), vl), vl);
-        x = __riscv_vfadd(x, __riscv_vfsqrt(__riscv_vfmadd(x, x, cf1, vl), vl), vl);
-        x = __riscv_vfdiv(cf1, x, vl);
-        vfloat32m2_t xx = __riscv_vfmul(x, x, vl);
-
-#if ACOS_TERMS < 1
-        vfloat32m2_t y = __riscv_vfmv_v_f_f32m2(0, vl);
-#elif ACOS_TERMS == 1
-        y = __riscv_vfmadd(y, xx, cf1, vl);
-#elif ACOS_TERMS == 2
-        vfloat32m2_t y = cfm1o3;
-        y = __riscv_vfmadd(y, xx, cf1, vl);
-#elif ACOS_TERMS == 3
-        vfloat32m2_t y = cf1o5;
-        y = __riscv_vfmadd(y, xx, cfm1o3, vl);
-        y = __riscv_vfmadd(y, xx, cf1, vl);
-#elif ACOS_TERMS == 4
-        vfloat32m2_t y = cfm1o7;
-        y = __riscv_vfmadd(y, xx, cf1o5, vl);
-        y = __riscv_vfmadd(y, xx, cfm1o3, vl);
-        y = __riscv_vfmadd(y, xx, cf1, vl);
-#else
-#error "ACOS_TERMS > 4 not supported by volk_32f_acos_32f_rvv"
-#endif
-        y = __riscv_vfmul(y, __riscv_vfmul(x, cf4, vl), vl);
-        y = __riscv_vfadd_mu(
-            __riscv_vmfgt(z, cf1, vl), y, y, __riscv_vfnmsub(y, cf2, cpio2, vl), vl);
-
-        vfloat32m2_t acosine;
-        acosine = __riscv_vfneg_mu(RISCV_VMFLTZ(32m2, a, vl), y, y, vl);
-        acosine = __riscv_vfadd_mu(RISCV_VMFLTZ(32m2, v, vl), acosine, acosine, cpi, vl);
-
-        __riscv_vse32(bVector, acosine, vl);
-    }
-}
-#endif /*LV_HAVE_RVV*/
 
 #endif /* INCLUDED_volk_32f_acos_32f_u_H */

--- a/kernels/volk/volk_32f_asin_32f.h
+++ b/kernels/volk/volk_32f_asin_32f.h
@@ -58,672 +58,502 @@
 #include <inttypes.h>
 #include <math.h>
 #include <stdio.h>
-
-/* This is the number of terms of Taylor series to evaluate, increase this for more
- * accuracy*/
-#define ASIN_TERMS 2
+#include <volk/volk_common.h>
 
 #ifndef INCLUDED_volk_32f_asin_32f_a_H
 #define INCLUDED_volk_32f_asin_32f_a_H
-
-#ifdef LV_HAVE_AVX512F
-#include <immintrin.h>
-
-static inline void
-volk_32f_asin_32f_a_avx512(float* bVector, const float* aVector, unsigned int num_points)
-{
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
-
-    unsigned int number = 0;
-    unsigned int sixteenthPoints = num_points / 16;
-    int i, j;
-
-    __m512 aVal, pio2, x, y, z, arcsine;
-    __m512 fzeroes, fones, ftwos, ffours;
-    __mmask16 condition;
-
-    pio2 = _mm512_set1_ps(3.14159265358979323846 / 2);
-    fzeroes = _mm512_setzero_ps();
-    fones = _mm512_set1_ps(1.0);
-    ftwos = _mm512_set1_ps(2.0);
-    ffours = _mm512_set1_ps(4.0);
-
-    for (; number < sixteenthPoints; number++) {
-        aVal = _mm512_load_ps(aPtr);
-        aVal =
-            _mm512_mul_ps(aVal,
-                          _mm512_rsqrt14_ps(_mm512_mul_ps(_mm512_add_ps(fones, aVal),
-                                                          _mm512_sub_ps(fones, aVal))));
-        z = aVal;
-        condition = _mm512_cmp_ps_mask(z, fzeroes, _CMP_LT_OS);
-        z = _mm512_mask_sub_ps(z, condition, z, _mm512_mul_ps(z, ftwos));
-        condition = _mm512_cmp_ps_mask(z, fones, _CMP_LT_OS);
-        x = _mm512_mask_add_ps(z, condition, z, _mm512_sub_ps(_mm512_rcp14_ps(z), z));
-
-        for (i = 0; i < 2; i++) {
-            x = _mm512_add_ps(x, _mm512_sqrt_ps(_mm512_fmadd_ps(x, x, fones)));
-        }
-        x = _mm512_rcp14_ps(x);
-        y = fzeroes;
-        for (j = ASIN_TERMS - 1; j >= 0; j--) {
-            y = _mm512_fmadd_ps(
-                y, _mm512_mul_ps(x, x), _mm512_set1_ps(pow(-1, j) / (2 * j + 1)));
-        }
-
-        y = _mm512_mul_ps(y, _mm512_mul_ps(x, ffours));
-        condition = _mm512_cmp_ps_mask(z, fones, _CMP_GT_OS);
-
-        y = _mm512_mask_add_ps(y, condition, y, _mm512_fnmadd_ps(y, ftwos, pio2));
-        arcsine = y;
-        condition = _mm512_cmp_ps_mask(aVal, fzeroes, _CMP_LT_OS);
-        arcsine = _mm512_mask_sub_ps(
-            arcsine, condition, arcsine, _mm512_mul_ps(arcsine, ftwos));
-
-        _mm512_store_ps(bPtr, arcsine);
-        aPtr += 16;
-        bPtr += 16;
-    }
-
-    number = sixteenthPoints * 16;
-    for (; number < num_points; number++) {
-        *bPtr++ = asin(*aPtr++);
-    }
-}
-
-#endif /* LV_HAVE_AVX512F for aligned */
-
-
-#if LV_HAVE_AVX2 && LV_HAVE_FMA
-#include <immintrin.h>
-
-static inline void volk_32f_asin_32f_a_avx2_fma(float* bVector,
-                                                const float* aVector,
-                                                unsigned int num_points)
-{
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
-
-    unsigned int number = 0;
-    unsigned int eighthPoints = num_points / 8;
-    int i, j;
-
-    __m256 aVal, pio2, x, y, z, arcsine;
-    __m256 fzeroes, fones, ftwos, ffours, condition;
-
-    pio2 = _mm256_set1_ps(3.14159265358979323846 / 2);
-    fzeroes = _mm256_setzero_ps();
-    fones = _mm256_set1_ps(1.0);
-    ftwos = _mm256_set1_ps(2.0);
-    ffours = _mm256_set1_ps(4.0);
-
-    for (; number < eighthPoints; number++) {
-        aVal = _mm256_load_ps(aPtr);
-        aVal = _mm256_div_ps(aVal,
-                             _mm256_sqrt_ps(_mm256_mul_ps(_mm256_add_ps(fones, aVal),
-                                                          _mm256_sub_ps(fones, aVal))));
-        z = aVal;
-        condition = _mm256_cmp_ps(z, fzeroes, _CMP_LT_OS);
-        z = _mm256_sub_ps(z, _mm256_and_ps(_mm256_mul_ps(z, ftwos), condition));
-        condition = _mm256_cmp_ps(z, fones, _CMP_LT_OS);
-        x = _mm256_add_ps(z,
-                          _mm256_and_ps(_mm256_sub_ps(_mm256_rcp_ps(z), z), condition));
-
-        for (i = 0; i < 2; i++) {
-            x = _mm256_add_ps(x, _mm256_sqrt_ps(_mm256_fmadd_ps(x, x, fones)));
-        }
-        x = _mm256_rcp_ps(x);
-        y = fzeroes;
-        for (j = ASIN_TERMS - 1; j >= 0; j--) {
-            y = _mm256_fmadd_ps(
-                y, _mm256_mul_ps(x, x), _mm256_set1_ps(pow(-1, j) / (2 * j + 1)));
-        }
-
-        y = _mm256_mul_ps(y, _mm256_mul_ps(x, ffours));
-        condition = _mm256_cmp_ps(z, fones, _CMP_GT_OS);
-
-        y = _mm256_add_ps(y, _mm256_and_ps(_mm256_fnmadd_ps(y, ftwos, pio2), condition));
-        arcsine = y;
-        condition = _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS);
-        arcsine = _mm256_sub_ps(arcsine,
-                                _mm256_and_ps(_mm256_mul_ps(arcsine, ftwos), condition));
-
-        _mm256_store_ps(bPtr, arcsine);
-        aPtr += 8;
-        bPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        *bPtr++ = asin(*aPtr++);
-    }
-}
-
-#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA for aligned */
-
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-
-static inline void
-volk_32f_asin_32f_a_avx(float* bVector, const float* aVector, unsigned int num_points)
-{
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
-
-    unsigned int number = 0;
-    unsigned int eighthPoints = num_points / 8;
-    int i, j;
-
-    __m256 aVal, pio2, x, y, z, arcsine;
-    __m256 fzeroes, fones, ftwos, ffours, condition;
-
-    pio2 = _mm256_set1_ps(3.14159265358979323846 / 2);
-    fzeroes = _mm256_setzero_ps();
-    fones = _mm256_set1_ps(1.0);
-    ftwos = _mm256_set1_ps(2.0);
-    ffours = _mm256_set1_ps(4.0);
-
-    for (; number < eighthPoints; number++) {
-        aVal = _mm256_load_ps(aPtr);
-        aVal = _mm256_div_ps(aVal,
-                             _mm256_sqrt_ps(_mm256_mul_ps(_mm256_add_ps(fones, aVal),
-                                                          _mm256_sub_ps(fones, aVal))));
-        z = aVal;
-        condition = _mm256_cmp_ps(z, fzeroes, _CMP_LT_OS);
-        z = _mm256_sub_ps(z, _mm256_and_ps(_mm256_mul_ps(z, ftwos), condition));
-        condition = _mm256_cmp_ps(z, fones, _CMP_LT_OS);
-        x = _mm256_add_ps(z,
-                          _mm256_and_ps(_mm256_sub_ps(_mm256_rcp_ps(z), z), condition));
-
-        for (i = 0; i < 2; i++) {
-            x = _mm256_add_ps(x,
-                              _mm256_sqrt_ps(_mm256_add_ps(fones, _mm256_mul_ps(x, x))));
-        }
-        x = _mm256_rcp_ps(x);
-        y = fzeroes;
-        for (j = ASIN_TERMS - 1; j >= 0; j--) {
-            y = _mm256_add_ps(_mm256_mul_ps(y, _mm256_mul_ps(x, x)),
-                              _mm256_set1_ps(pow(-1, j) / (2 * j + 1)));
-        }
-
-        y = _mm256_mul_ps(y, _mm256_mul_ps(x, ffours));
-        condition = _mm256_cmp_ps(z, fones, _CMP_GT_OS);
-
-        y = _mm256_add_ps(
-            y, _mm256_and_ps(_mm256_sub_ps(pio2, _mm256_mul_ps(y, ftwos)), condition));
-        arcsine = y;
-        condition = _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS);
-        arcsine = _mm256_sub_ps(arcsine,
-                                _mm256_and_ps(_mm256_mul_ps(arcsine, ftwos), condition));
-
-        _mm256_store_ps(bPtr, arcsine);
-        aPtr += 8;
-        bPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        *bPtr++ = asin(*aPtr++);
-    }
-}
-
-#endif /* LV_HAVE_AVX for aligned */
-
-#ifdef LV_HAVE_SSE4_1
-#include <smmintrin.h>
-
-static inline void
-volk_32f_asin_32f_a_sse4_1(float* bVector, const float* aVector, unsigned int num_points)
-{
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
-
-    unsigned int number = 0;
-    unsigned int quarterPoints = num_points / 4;
-    int i, j;
-
-    __m128 aVal, pio2, x, y, z, arcsine;
-    __m128 fzeroes, fones, ftwos, ffours, condition;
-
-    pio2 = _mm_set1_ps(3.14159265358979323846 / 2);
-    fzeroes = _mm_setzero_ps();
-    fones = _mm_set1_ps(1.0);
-    ftwos = _mm_set1_ps(2.0);
-    ffours = _mm_set1_ps(4.0);
-
-    for (; number < quarterPoints; number++) {
-        aVal = _mm_load_ps(aPtr);
-        aVal = _mm_div_ps(
-            aVal,
-            _mm_sqrt_ps(_mm_mul_ps(_mm_add_ps(fones, aVal), _mm_sub_ps(fones, aVal))));
-        z = aVal;
-        condition = _mm_cmplt_ps(z, fzeroes);
-        z = _mm_sub_ps(z, _mm_and_ps(_mm_mul_ps(z, ftwos), condition));
-        condition = _mm_cmplt_ps(z, fones);
-        x = _mm_add_ps(z, _mm_and_ps(_mm_sub_ps(_mm_rcp_ps(z), z), condition));
-
-        for (i = 0; i < 2; i++) {
-            x = _mm_add_ps(x, _mm_sqrt_ps(_mm_add_ps(fones, _mm_mul_ps(x, x))));
-        }
-        x = _mm_rcp_ps(x);
-        y = fzeroes;
-        for (j = ASIN_TERMS - 1; j >= 0; j--) {
-            y = _mm_add_ps(_mm_mul_ps(y, _mm_mul_ps(x, x)),
-                           _mm_set1_ps(pow(-1, j) / (2 * j + 1)));
-        }
-
-        y = _mm_mul_ps(y, _mm_mul_ps(x, ffours));
-        condition = _mm_cmpgt_ps(z, fones);
-
-        y = _mm_add_ps(y, _mm_and_ps(_mm_sub_ps(pio2, _mm_mul_ps(y, ftwos)), condition));
-        arcsine = y;
-        condition = _mm_cmplt_ps(aVal, fzeroes);
-        arcsine = _mm_sub_ps(arcsine, _mm_and_ps(_mm_mul_ps(arcsine, ftwos), condition));
-
-        _mm_store_ps(bPtr, arcsine);
-        aPtr += 4;
-        bPtr += 4;
-    }
-
-    number = quarterPoints * 4;
-    for (; number < num_points; number++) {
-        *bPtr++ = asinf(*aPtr++);
-    }
-}
-
-#endif /* LV_HAVE_SSE4_1 for aligned */
-
-#endif /* INCLUDED_volk_32f_asin_32f_a_H */
-
-#ifndef INCLUDED_volk_32f_asin_32f_u_H
-#define INCLUDED_volk_32f_asin_32f_u_H
-
-#ifdef LV_HAVE_AVX512F
-#include <immintrin.h>
-
-static inline void
-volk_32f_asin_32f_u_avx512(float* bVector, const float* aVector, unsigned int num_points)
-{
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
-
-    unsigned int number = 0;
-    unsigned int sixteenthPoints = num_points / 16;
-    int i, j;
-
-    __m512 aVal, pio2, x, y, z, arcsine;
-    __m512 fzeroes, fones, ftwos, ffours;
-    __mmask16 condition;
-
-    pio2 = _mm512_set1_ps(3.14159265358979323846 / 2);
-    fzeroes = _mm512_setzero_ps();
-    fones = _mm512_set1_ps(1.0);
-    ftwos = _mm512_set1_ps(2.0);
-    ffours = _mm512_set1_ps(4.0);
-
-    for (; number < sixteenthPoints; number++) {
-        aVal = _mm512_loadu_ps(aPtr);
-        aVal =
-            _mm512_mul_ps(aVal,
-                          _mm512_rsqrt14_ps(_mm512_mul_ps(_mm512_add_ps(fones, aVal),
-                                                          _mm512_sub_ps(fones, aVal))));
-        z = aVal;
-        condition = _mm512_cmp_ps_mask(z, fzeroes, _CMP_LT_OS);
-        z = _mm512_mask_sub_ps(z, condition, z, _mm512_mul_ps(z, ftwos));
-        condition = _mm512_cmp_ps_mask(z, fones, _CMP_LT_OS);
-        x = _mm512_mask_add_ps(z, condition, z, _mm512_sub_ps(_mm512_rcp14_ps(z), z));
-
-        for (i = 0; i < 2; i++) {
-            x = _mm512_add_ps(x, _mm512_sqrt_ps(_mm512_fmadd_ps(x, x, fones)));
-        }
-        x = _mm512_rcp14_ps(x);
-        y = fzeroes;
-        for (j = ASIN_TERMS - 1; j >= 0; j--) {
-            y = _mm512_fmadd_ps(
-                y, _mm512_mul_ps(x, x), _mm512_set1_ps(pow(-1, j) / (2 * j + 1)));
-        }
-
-        y = _mm512_mul_ps(y, _mm512_mul_ps(x, ffours));
-        condition = _mm512_cmp_ps_mask(z, fones, _CMP_GT_OS);
-
-        y = _mm512_mask_add_ps(y, condition, y, _mm512_fnmadd_ps(y, ftwos, pio2));
-        arcsine = y;
-        condition = _mm512_cmp_ps_mask(aVal, fzeroes, _CMP_LT_OS);
-        arcsine = _mm512_mask_sub_ps(
-            arcsine, condition, arcsine, _mm512_mul_ps(arcsine, ftwos));
-
-        _mm512_storeu_ps(bPtr, arcsine);
-        aPtr += 16;
-        bPtr += 16;
-    }
-
-    number = sixteenthPoints * 16;
-    for (; number < num_points; number++) {
-        *bPtr++ = asin(*aPtr++);
-    }
-}
-
-#endif /* LV_HAVE_AVX512F for unaligned */
-
-
-#if LV_HAVE_AVX2 && LV_HAVE_FMA
-#include <immintrin.h>
-
-static inline void volk_32f_asin_32f_u_avx2_fma(float* bVector,
-                                                const float* aVector,
-                                                unsigned int num_points)
-{
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
-
-    unsigned int number = 0;
-    unsigned int eighthPoints = num_points / 8;
-    int i, j;
-
-    __m256 aVal, pio2, x, y, z, arcsine;
-    __m256 fzeroes, fones, ftwos, ffours, condition;
-
-    pio2 = _mm256_set1_ps(3.14159265358979323846 / 2);
-    fzeroes = _mm256_setzero_ps();
-    fones = _mm256_set1_ps(1.0);
-    ftwos = _mm256_set1_ps(2.0);
-    ffours = _mm256_set1_ps(4.0);
-
-    for (; number < eighthPoints; number++) {
-        aVal = _mm256_loadu_ps(aPtr);
-        aVal = _mm256_div_ps(aVal,
-                             _mm256_sqrt_ps(_mm256_mul_ps(_mm256_add_ps(fones, aVal),
-                                                          _mm256_sub_ps(fones, aVal))));
-        z = aVal;
-        condition = _mm256_cmp_ps(z, fzeroes, _CMP_LT_OS);
-        z = _mm256_sub_ps(z, _mm256_and_ps(_mm256_mul_ps(z, ftwos), condition));
-        condition = _mm256_cmp_ps(z, fones, _CMP_LT_OS);
-        x = _mm256_add_ps(z,
-                          _mm256_and_ps(_mm256_sub_ps(_mm256_rcp_ps(z), z), condition));
-
-        for (i = 0; i < 2; i++) {
-            x = _mm256_add_ps(x, _mm256_sqrt_ps(_mm256_fmadd_ps(x, x, fones)));
-        }
-        x = _mm256_rcp_ps(x);
-        y = fzeroes;
-        for (j = ASIN_TERMS - 1; j >= 0; j--) {
-            y = _mm256_fmadd_ps(
-                y, _mm256_mul_ps(x, x), _mm256_set1_ps(pow(-1, j) / (2 * j + 1)));
-        }
-
-        y = _mm256_mul_ps(y, _mm256_mul_ps(x, ffours));
-        condition = _mm256_cmp_ps(z, fones, _CMP_GT_OS);
-
-        y = _mm256_add_ps(y, _mm256_and_ps(_mm256_fnmadd_ps(y, ftwos, pio2), condition));
-        arcsine = y;
-        condition = _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS);
-        arcsine = _mm256_sub_ps(arcsine,
-                                _mm256_and_ps(_mm256_mul_ps(arcsine, ftwos), condition));
-
-        _mm256_storeu_ps(bPtr, arcsine);
-        aPtr += 8;
-        bPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        *bPtr++ = asin(*aPtr++);
-    }
-}
-
-#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA for unaligned */
-
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-
-static inline void
-volk_32f_asin_32f_u_avx(float* bVector, const float* aVector, unsigned int num_points)
-{
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
-
-    unsigned int number = 0;
-    unsigned int eighthPoints = num_points / 8;
-    int i, j;
-
-    __m256 aVal, pio2, x, y, z, arcsine;
-    __m256 fzeroes, fones, ftwos, ffours, condition;
-
-    pio2 = _mm256_set1_ps(3.14159265358979323846 / 2);
-    fzeroes = _mm256_setzero_ps();
-    fones = _mm256_set1_ps(1.0);
-    ftwos = _mm256_set1_ps(2.0);
-    ffours = _mm256_set1_ps(4.0);
-
-    for (; number < eighthPoints; number++) {
-        aVal = _mm256_loadu_ps(aPtr);
-        aVal = _mm256_div_ps(aVal,
-                             _mm256_sqrt_ps(_mm256_mul_ps(_mm256_add_ps(fones, aVal),
-                                                          _mm256_sub_ps(fones, aVal))));
-        z = aVal;
-        condition = _mm256_cmp_ps(z, fzeroes, _CMP_LT_OS);
-        z = _mm256_sub_ps(z, _mm256_and_ps(_mm256_mul_ps(z, ftwos), condition));
-        condition = _mm256_cmp_ps(z, fones, _CMP_LT_OS);
-        x = _mm256_add_ps(z,
-                          _mm256_and_ps(_mm256_sub_ps(_mm256_rcp_ps(z), z), condition));
-
-        for (i = 0; i < 2; i++) {
-            x = _mm256_add_ps(x,
-                              _mm256_sqrt_ps(_mm256_add_ps(fones, _mm256_mul_ps(x, x))));
-        }
-        x = _mm256_rcp_ps(x);
-        y = fzeroes;
-        for (j = ASIN_TERMS - 1; j >= 0; j--) {
-            y = _mm256_add_ps(_mm256_mul_ps(y, _mm256_mul_ps(x, x)),
-                              _mm256_set1_ps(pow(-1, j) / (2 * j + 1)));
-        }
-
-        y = _mm256_mul_ps(y, _mm256_mul_ps(x, ffours));
-        condition = _mm256_cmp_ps(z, fones, _CMP_GT_OS);
-
-        y = _mm256_add_ps(
-            y, _mm256_and_ps(_mm256_sub_ps(pio2, _mm256_mul_ps(y, ftwos)), condition));
-        arcsine = y;
-        condition = _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS);
-        arcsine = _mm256_sub_ps(arcsine,
-                                _mm256_and_ps(_mm256_mul_ps(arcsine, ftwos), condition));
-
-        _mm256_storeu_ps(bPtr, arcsine);
-        aPtr += 8;
-        bPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        *bPtr++ = asin(*aPtr++);
-    }
-}
-
-#endif /* LV_HAVE_AVX for unaligned */
-
-
-#ifdef LV_HAVE_SSE4_1
-#include <smmintrin.h>
-
-static inline void
-volk_32f_asin_32f_u_sse4_1(float* bVector, const float* aVector, unsigned int num_points)
-{
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
-
-    unsigned int number = 0;
-    unsigned int quarterPoints = num_points / 4;
-    int i, j;
-
-    __m128 aVal, pio2, x, y, z, arcsine;
-    __m128 fzeroes, fones, ftwos, ffours, condition;
-
-    pio2 = _mm_set1_ps(3.14159265358979323846 / 2);
-    fzeroes = _mm_setzero_ps();
-    fones = _mm_set1_ps(1.0);
-    ftwos = _mm_set1_ps(2.0);
-    ffours = _mm_set1_ps(4.0);
-
-    for (; number < quarterPoints; number++) {
-        aVal = _mm_loadu_ps(aPtr);
-        aVal = _mm_div_ps(
-            aVal,
-            _mm_sqrt_ps(_mm_mul_ps(_mm_add_ps(fones, aVal), _mm_sub_ps(fones, aVal))));
-        z = aVal;
-        condition = _mm_cmplt_ps(z, fzeroes);
-        z = _mm_sub_ps(z, _mm_and_ps(_mm_mul_ps(z, ftwos), condition));
-        condition = _mm_cmplt_ps(z, fones);
-        x = _mm_add_ps(z, _mm_and_ps(_mm_sub_ps(_mm_rcp_ps(z), z), condition));
-
-        for (i = 0; i < 2; i++) {
-            x = _mm_add_ps(x, _mm_sqrt_ps(_mm_add_ps(fones, _mm_mul_ps(x, x))));
-        }
-        x = _mm_rcp_ps(x);
-        y = fzeroes;
-        for (j = ASIN_TERMS - 1; j >= 0; j--) {
-            y = _mm_add_ps(_mm_mul_ps(y, _mm_mul_ps(x, x)),
-                           _mm_set1_ps(pow(-1, j) / (2 * j + 1)));
-        }
-
-        y = _mm_mul_ps(y, _mm_mul_ps(x, ffours));
-        condition = _mm_cmpgt_ps(z, fones);
-
-        y = _mm_add_ps(y, _mm_and_ps(_mm_sub_ps(pio2, _mm_mul_ps(y, ftwos)), condition));
-        arcsine = y;
-        condition = _mm_cmplt_ps(aVal, fzeroes);
-        arcsine = _mm_sub_ps(arcsine, _mm_and_ps(_mm_mul_ps(arcsine, ftwos), condition));
-
-        _mm_storeu_ps(bPtr, arcsine);
-        aPtr += 4;
-        bPtr += 4;
-    }
-
-    number = quarterPoints * 4;
-    for (; number < num_points; number++) {
-        *bPtr++ = asinf(*aPtr++);
-    }
-}
-
-#endif /* LV_HAVE_SSE4_1 for unaligned */
 
 #ifdef LV_HAVE_GENERIC
 
 static inline void
 volk_32f_asin_32f_generic(float* bVector, const float* aVector, unsigned int num_points)
 {
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
-    unsigned int number = 0;
-
-    for (number = 0; number < num_points; number++) {
-        *bPtr++ = asinf(*aPtr++);
+    for (unsigned int i = 0; i < num_points; i++) {
+        bVector[i] = volk_arcsin(aVector[i]);
     }
 }
+
 #endif /* LV_HAVE_GENERIC */
 
-#ifdef LV_HAVE_NEON
-#include <arm_neon.h>
+#ifdef LV_HAVE_SSE4_1
+#include <smmintrin.h>
+#include <volk/volk_sse_intrinsics.h>
 
 static inline void
-volk_32f_asin_32f_neon(float* bVector, const float* aVector, unsigned int num_points)
+volk_32f_asin_32f_a_sse4_1(float* bVector, const float* aVector, unsigned int num_points)
 {
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
+    const __m128 pi_2 = _mm_set1_ps(0x1.921fb6p0f);
+    const __m128 half = _mm_set1_ps(0.5f);
+    const __m128 one = _mm_set1_ps(1.0f);
+    const __m128 two = _mm_set1_ps(2.0f);
+    const __m128 sign_mask = _mm_set1_ps(-0.0f);
 
     unsigned int number = 0;
-    unsigned int quarterPoints = num_points / 4;
-    int i, j;
-
-    float32x4_t aVal, x, y, z, arcsine;
-    uint32x4_t condition;
-    const float32x4_t fzeroes = vdupq_n_f32(0.0f);
-    const float32x4_t fones = vdupq_n_f32(1.0f);
-    const float32x4_t ftwos = vdupq_n_f32(2.0f);
-    const float32x4_t ffours = vdupq_n_f32(4.0f);
-    const float32x4_t pio2 = vdupq_n_f32(3.14159265358979323846f / 2.0f);
+    const unsigned int quarterPoints = num_points / 4;
 
     for (; number < quarterPoints; number++) {
-        aVal = vld1q_f32(aPtr);
+        __m128 aVal = _mm_load_ps(aVector);
 
-        // Compute x / sqrt((1+x)*(1-x)) using reciprocal estimate
-        // For |x| > 1, this produces NaN (matching generic behavior)
-        float32x4_t one_plus = vaddq_f32(fones, aVal);
-        float32x4_t one_minus = vsubq_f32(fones, aVal);
-        float32x4_t sqrt_arg = vmulq_f32(one_plus, one_minus);
+        // Get absolute value and sign
+        __m128 sign = _mm_and_ps(aVal, sign_mask);
+        __m128 ax = _mm_andnot_ps(sign_mask, aVal);
 
-        // Newton-Raphson sqrt approximation
-        float32x4_t sqrt_est = vrsqrteq_f32(sqrt_arg);
-        sqrt_est =
-            vmulq_f32(sqrt_est, vrsqrtsq_f32(vmulq_f32(sqrt_arg, sqrt_est), sqrt_est));
-        float32x4_t sqrt_val = vmulq_f32(sqrt_arg, sqrt_est);
+        // Two-range computation
+        // Small: result = arcsin_poly(x)
+        // Large: result = pi/2 - 2*arcsin_poly(sqrt((1-|x|)/2))
 
-        // Reciprocal of sqrt_val
-        float32x4_t recip = vrecpeq_f32(sqrt_val);
-        recip = vmulq_f32(recip, vrecpsq_f32(sqrt_val, recip));
-        float32x4_t tanVal = vmulq_f32(aVal, recip);
+        __m128 t = _mm_mul_ps(_mm_sub_ps(one, ax), half);
+        __m128 s = _mm_sqrt_ps(t);
 
-        z = tanVal;
-        // z = abs(z)
-        condition = vcltq_f32(z, fzeroes);
-        z = vbslq_f32(condition, vnegq_f32(z), z);
+        // Compute polynomial for both ranges
+        __m128 poly_small = _mm_arcsin_poly_sse(ax);
+        __m128 poly_large = _mm_arcsin_poly_sse(s);
 
-        // x = 1/z if z < 1, else x = z (matching SSE logic)
-        condition = vcltq_f32(z, fones);
-        float32x4_t z_recip = vrecpeq_f32(z);
-        z_recip = vmulq_f32(z_recip, vrecpsq_f32(z, z_recip));
-        x = vbslq_f32(condition, z_recip, z);
+        // Large range: pi/2 - 2*poly_large
+        __m128 result_large = _mm_sub_ps(pi_2, _mm_mul_ps(two, poly_large));
 
-        // Two iterations: x = x + sqrt(1 + x*x)
-        // Note: For very large x (approaching infinity), the NR rsqrt iteration produces
-        // NaN due to inf*0 in vrsqrtsq. Use approximation sqrt(1+x²) ≈ x for large x.
-        const float32x4_t large_threshold = vdupq_n_f32(1e10f);
-        for (i = 0; i < 2; i++) {
-            float32x4_t xx = vmulq_f32(x, x);
-            float32x4_t sum = vaddq_f32(fones, xx);
-            uint32x4_t is_large = vcgtq_f32(x, large_threshold);
-            float32x4_t sqrt_sum_est = vrsqrteq_f32(sum);
-            sqrt_sum_est = vmulq_f32(
-                sqrt_sum_est, vrsqrtsq_f32(vmulq_f32(sum, sqrt_sum_est), sqrt_sum_est));
-            float32x4_t sqrt_sum = vmulq_f32(sum, sqrt_sum_est);
-            sqrt_sum = vbslq_f32(is_large, x, sqrt_sum);
-            x = vaddq_f32(x, sqrt_sum);
-        }
+        // Blend based on |x| > 0.5
+        __m128 mask = _mm_cmpgt_ps(ax, half);
+        __m128 result = _mm_blendv_ps(poly_small, result_large, mask);
 
-        // x = 1/x
-        float32x4_t x_recip = vrecpeq_f32(x);
-        x_recip = vmulq_f32(x_recip, vrecpsq_f32(x, x_recip));
-        x = x_recip;
+        // Apply sign
+        result = _mm_or_ps(result, sign);
 
-        // Taylor series
-        y = fzeroes;
-        for (j = ASIN_TERMS - 1; j >= 0; j--) {
-            float coeff = (j % 2 == 0) ? 1.0f / (2 * j + 1) : -1.0f / (2 * j + 1);
-            y = vaddq_f32(vmulq_f32(y, vmulq_f32(x, x)), vdupq_n_f32(coeff));
-        }
+        _mm_store_ps(bVector, result);
 
-        y = vmulq_f32(y, vmulq_f32(x, ffours));
-
-        // Adjust if z > 1: y = y + (pio2 - 2*y)
-        condition = vcgtq_f32(z, fones);
-        float32x4_t y_adj = vsubq_f32(pio2, vmulq_f32(y, ftwos));
-        y = vbslq_f32(condition, vaddq_f32(y, y_adj), y);
-
-        arcsine = y;
-
-        // If tanVal < 0, arcsine = -arcsine
-        condition = vcltq_f32(tanVal, fzeroes);
-        arcsine = vbslq_f32(condition, vnegq_f32(arcsine), arcsine);
-
-        vst1q_f32(bPtr, arcsine);
-        aPtr += 4;
-        bPtr += 4;
+        aVector += 4;
+        bVector += 4;
     }
 
     number = quarterPoints * 4;
     for (; number < num_points; number++) {
-        *bPtr++ = asinf(*aPtr++);
+        *bVector++ = volk_arcsin(*aVector++);
+    }
+}
+
+#endif /* LV_HAVE_SSE4_1 */
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
+static inline void
+volk_32f_asin_32f_a_avx(float* bVector, const float* aVector, unsigned int num_points)
+{
+    const __m256 pi_2 = _mm256_set1_ps(0x1.921fb6p0f);
+    const __m256 half = _mm256_set1_ps(0.5f);
+    const __m256 one = _mm256_set1_ps(1.0f);
+    const __m256 two = _mm256_set1_ps(2.0f);
+    const __m256 sign_mask = _mm256_set1_ps(-0.0f);
+
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    for (; number < eighthPoints; number++) {
+        __m256 aVal = _mm256_load_ps(aVector);
+
+        // Get absolute value and sign
+        __m256 sign = _mm256_and_ps(aVal, sign_mask);
+        __m256 ax = _mm256_andnot_ps(sign_mask, aVal);
+
+        // Two-range computation
+        __m256 t = _mm256_mul_ps(_mm256_sub_ps(one, ax), half);
+        __m256 s = _mm256_sqrt_ps(t);
+
+        // Compute polynomial for both ranges
+        __m256 poly_small = _mm256_arcsin_poly_avx(ax);
+        __m256 poly_large = _mm256_arcsin_poly_avx(s);
+
+        // Large range: pi/2 - 2*poly_large
+        __m256 result_large = _mm256_sub_ps(pi_2, _mm256_mul_ps(two, poly_large));
+
+        // Blend based on |x| > 0.5
+        __m256 mask = _mm256_cmp_ps(ax, half, _CMP_GT_OS);
+        __m256 result = _mm256_blendv_ps(poly_small, result_large, mask);
+
+        // Apply sign
+        result = _mm256_or_ps(result, sign);
+
+        _mm256_store_ps(bVector, result);
+
+        aVector += 8;
+        bVector += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *bVector++ = volk_arcsin(*aVector++);
+    }
+}
+
+#endif /* LV_HAVE_AVX */
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+#include <volk/volk_avx2_fma_intrinsics.h>
+
+static inline void volk_32f_asin_32f_a_avx2_fma(float* bVector,
+                                                const float* aVector,
+                                                unsigned int num_points)
+{
+    const __m256 pi_2 = _mm256_set1_ps(0x1.921fb6p0f);
+    const __m256 half = _mm256_set1_ps(0.5f);
+    const __m256 one = _mm256_set1_ps(1.0f);
+    const __m256 two = _mm256_set1_ps(2.0f);
+    const __m256 sign_mask = _mm256_set1_ps(-0.0f);
+
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    for (; number < eighthPoints; number++) {
+        __m256 aVal = _mm256_load_ps(aVector);
+
+        // Get absolute value and sign
+        __m256 sign = _mm256_and_ps(aVal, sign_mask);
+        __m256 ax = _mm256_andnot_ps(sign_mask, aVal);
+
+        // Two-range computation
+        __m256 t = _mm256_mul_ps(_mm256_sub_ps(one, ax), half);
+        __m256 s = _mm256_sqrt_ps(t);
+
+        // Compute polynomial for both ranges
+        __m256 poly_small = _mm256_arcsin_poly_avx2_fma(ax);
+        __m256 poly_large = _mm256_arcsin_poly_avx2_fma(s);
+
+        // Large range: pi/2 - 2*poly_large
+        __m256 result_large = _mm256_fnmadd_ps(two, poly_large, pi_2);
+
+        // Blend based on |x| > 0.5
+        __m256 mask = _mm256_cmp_ps(ax, half, _CMP_GT_OS);
+        __m256 result = _mm256_blendv_ps(poly_small, result_large, mask);
+
+        // Apply sign
+        result = _mm256_or_ps(result, sign);
+
+        _mm256_store_ps(bVector, result);
+
+        aVector += 8;
+        bVector += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *bVector++ = volk_arcsin(*aVector++);
+    }
+}
+
+#endif /* LV_HAVE_AVX2 */
+
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+#include <volk/volk_avx512_intrinsics.h>
+
+static inline void
+volk_32f_asin_32f_a_avx512(float* bVector, const float* aVector, unsigned int num_points)
+{
+    const __m512 pi_2 = _mm512_set1_ps(0x1.921fb6p0f);
+    const __m512 half = _mm512_set1_ps(0.5f);
+    const __m512 one = _mm512_set1_ps(1.0f);
+    const __m512 two = _mm512_set1_ps(2.0f);
+    const __m512i sign_mask = _mm512_set1_epi32(0x80000000);
+
+    unsigned int number = 0;
+    const unsigned int sixteenthPoints = num_points / 16;
+
+    for (; number < sixteenthPoints; number++) {
+        __m512 aVal = _mm512_load_ps(aVector);
+
+        // Get absolute value and sign using integer ops (AVX512F compatible)
+        __m512i aVal_i = _mm512_castps_si512(aVal);
+        __m512i sign = _mm512_and_epi32(aVal_i, sign_mask);
+        __m512 ax = _mm512_castsi512_ps(_mm512_andnot_epi32(sign_mask, aVal_i));
+
+        // Two-range computation
+        __m512 t = _mm512_mul_ps(_mm512_sub_ps(one, ax), half);
+        __m512 s = _mm512_sqrt_ps(t);
+
+        // Compute polynomial for both ranges
+        __m512 poly_small = _mm512_arcsin_poly_avx512(ax);
+        __m512 poly_large = _mm512_arcsin_poly_avx512(s);
+
+        // Large range: pi/2 - 2*poly_large
+        __m512 result_large = _mm512_fnmadd_ps(two, poly_large, pi_2);
+
+        // Blend based on |x| > 0.5
+        __mmask16 mask = _mm512_cmp_ps_mask(ax, half, _CMP_GT_OS);
+        __m512 result = _mm512_mask_blend_ps(mask, poly_small, result_large);
+
+        // Apply sign
+        result = _mm512_castsi512_ps(_mm512_or_epi32(_mm512_castps_si512(result), sign));
+
+        _mm512_store_ps(bVector, result);
+
+        aVector += 16;
+        bVector += 16;
+    }
+
+    number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        *bVector++ = volk_arcsin(*aVector++);
+    }
+}
+
+#endif /* LV_HAVE_AVX512F */
+
+#endif /* INCLUDED_volk_32f_asin_32f_a_H */
+
+#ifndef INCLUDED_volk_32f_asin_32f_u_H
+#define INCLUDED_volk_32f_asin_32f_u_H
+
+#ifdef LV_HAVE_SSE4_1
+#include <smmintrin.h>
+#include <volk/volk_sse_intrinsics.h>
+
+static inline void
+volk_32f_asin_32f_u_sse4_1(float* bVector, const float* aVector, unsigned int num_points)
+{
+    const __m128 pi_2 = _mm_set1_ps(0x1.921fb6p0f);
+    const __m128 half = _mm_set1_ps(0.5f);
+    const __m128 one = _mm_set1_ps(1.0f);
+    const __m128 two = _mm_set1_ps(2.0f);
+    const __m128 sign_mask = _mm_set1_ps(-0.0f);
+
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    for (; number < quarterPoints; number++) {
+        __m128 aVal = _mm_loadu_ps(aVector);
+
+        __m128 sign = _mm_and_ps(aVal, sign_mask);
+        __m128 ax = _mm_andnot_ps(sign_mask, aVal);
+
+        __m128 t = _mm_mul_ps(_mm_sub_ps(one, ax), half);
+        __m128 s = _mm_sqrt_ps(t);
+
+        __m128 poly_small = _mm_arcsin_poly_sse(ax);
+        __m128 poly_large = _mm_arcsin_poly_sse(s);
+
+        __m128 result_large = _mm_sub_ps(pi_2, _mm_mul_ps(two, poly_large));
+
+        __m128 mask = _mm_cmpgt_ps(ax, half);
+        __m128 result = _mm_blendv_ps(poly_small, result_large, mask);
+
+        result = _mm_or_ps(result, sign);
+
+        _mm_storeu_ps(bVector, result);
+
+        aVector += 4;
+        bVector += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        *bVector++ = volk_arcsin(*aVector++);
+    }
+}
+
+#endif /* LV_HAVE_SSE4_1 */
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
+static inline void
+volk_32f_asin_32f_u_avx(float* bVector, const float* aVector, unsigned int num_points)
+{
+    const __m256 pi_2 = _mm256_set1_ps(0x1.921fb6p0f);
+    const __m256 half = _mm256_set1_ps(0.5f);
+    const __m256 one = _mm256_set1_ps(1.0f);
+    const __m256 two = _mm256_set1_ps(2.0f);
+    const __m256 sign_mask = _mm256_set1_ps(-0.0f);
+
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    for (; number < eighthPoints; number++) {
+        __m256 aVal = _mm256_loadu_ps(aVector);
+
+        __m256 sign = _mm256_and_ps(aVal, sign_mask);
+        __m256 ax = _mm256_andnot_ps(sign_mask, aVal);
+
+        __m256 t = _mm256_mul_ps(_mm256_sub_ps(one, ax), half);
+        __m256 s = _mm256_sqrt_ps(t);
+
+        __m256 poly_small = _mm256_arcsin_poly_avx(ax);
+        __m256 poly_large = _mm256_arcsin_poly_avx(s);
+
+        __m256 result_large = _mm256_sub_ps(pi_2, _mm256_mul_ps(two, poly_large));
+
+        __m256 mask = _mm256_cmp_ps(ax, half, _CMP_GT_OS);
+        __m256 result = _mm256_blendv_ps(poly_small, result_large, mask);
+
+        result = _mm256_or_ps(result, sign);
+
+        _mm256_storeu_ps(bVector, result);
+
+        aVector += 8;
+        bVector += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *bVector++ = volk_arcsin(*aVector++);
+    }
+}
+
+#endif /* LV_HAVE_AVX */
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+#include <volk/volk_avx2_fma_intrinsics.h>
+
+static inline void volk_32f_asin_32f_u_avx2_fma(float* bVector,
+                                                const float* aVector,
+                                                unsigned int num_points)
+{
+    const __m256 pi_2 = _mm256_set1_ps(0x1.921fb6p0f);
+    const __m256 half = _mm256_set1_ps(0.5f);
+    const __m256 one = _mm256_set1_ps(1.0f);
+    const __m256 two = _mm256_set1_ps(2.0f);
+    const __m256 sign_mask = _mm256_set1_ps(-0.0f);
+
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    for (; number < eighthPoints; number++) {
+        __m256 aVal = _mm256_loadu_ps(aVector);
+
+        __m256 sign = _mm256_and_ps(aVal, sign_mask);
+        __m256 ax = _mm256_andnot_ps(sign_mask, aVal);
+
+        __m256 t = _mm256_mul_ps(_mm256_sub_ps(one, ax), half);
+        __m256 s = _mm256_sqrt_ps(t);
+
+        __m256 poly_small = _mm256_arcsin_poly_avx2_fma(ax);
+        __m256 poly_large = _mm256_arcsin_poly_avx2_fma(s);
+
+        __m256 result_large = _mm256_fnmadd_ps(two, poly_large, pi_2);
+
+        __m256 mask = _mm256_cmp_ps(ax, half, _CMP_GT_OS);
+        __m256 result = _mm256_blendv_ps(poly_small, result_large, mask);
+
+        result = _mm256_or_ps(result, sign);
+
+        _mm256_storeu_ps(bVector, result);
+
+        aVector += 8;
+        bVector += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *bVector++ = volk_arcsin(*aVector++);
+    }
+}
+
+#endif /* LV_HAVE_AVX2 */
+
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+#include <volk/volk_avx512_intrinsics.h>
+
+static inline void
+volk_32f_asin_32f_u_avx512(float* bVector, const float* aVector, unsigned int num_points)
+{
+    const __m512 pi_2 = _mm512_set1_ps(0x1.921fb6p0f);
+    const __m512 half = _mm512_set1_ps(0.5f);
+    const __m512 one = _mm512_set1_ps(1.0f);
+    const __m512 two = _mm512_set1_ps(2.0f);
+    const __m512i sign_mask = _mm512_set1_epi32(0x80000000);
+
+    unsigned int number = 0;
+    const unsigned int sixteenthPoints = num_points / 16;
+
+    for (; number < sixteenthPoints; number++) {
+        __m512 aVal = _mm512_loadu_ps(aVector);
+
+        __m512i aVal_i = _mm512_castps_si512(aVal);
+        __m512i sign = _mm512_and_epi32(aVal_i, sign_mask);
+        __m512 ax = _mm512_castsi512_ps(_mm512_andnot_epi32(sign_mask, aVal_i));
+
+        __m512 t = _mm512_mul_ps(_mm512_sub_ps(one, ax), half);
+        __m512 s = _mm512_sqrt_ps(t);
+
+        __m512 poly_small = _mm512_arcsin_poly_avx512(ax);
+        __m512 poly_large = _mm512_arcsin_poly_avx512(s);
+
+        __m512 result_large = _mm512_fnmadd_ps(two, poly_large, pi_2);
+
+        __mmask16 mask = _mm512_cmp_ps_mask(ax, half, _CMP_GT_OS);
+        __m512 result = _mm512_mask_blend_ps(mask, poly_small, result_large);
+
+        result = _mm512_castsi512_ps(_mm512_or_epi32(_mm512_castps_si512(result), sign));
+
+        _mm512_storeu_ps(bVector, result);
+
+        aVector += 16;
+        bVector += 16;
+    }
+
+    number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        *bVector++ = volk_arcsin(*aVector++);
+    }
+}
+
+#endif /* LV_HAVE_AVX512F */
+
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+#include <volk/volk_neon_intrinsics.h>
+
+static inline void
+volk_32f_asin_32f_neon(float* bVector, const float* aVector, unsigned int num_points)
+{
+    const float32x4_t pi_2 = vdupq_n_f32(0x1.921fb6p0f);
+    const float32x4_t half = vdupq_n_f32(0.5f);
+    const float32x4_t one = vdupq_n_f32(1.0f);
+    const float32x4_t two = vdupq_n_f32(2.0f);
+
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    for (; number < quarterPoints; number++) {
+        float32x4_t aVal = vld1q_f32(aVector);
+
+        // Get absolute value and sign
+        float32x4_t ax = vabsq_f32(aVal);
+        uint32x4_t sign_bits =
+            vandq_u32(vreinterpretq_u32_f32(aVal), vdupq_n_u32(0x80000000));
+
+        // Two-range computation
+        float32x4_t t = vmulq_f32(vsubq_f32(one, ax), half);
+        float32x4_t s = vsqrtq_f32(t);
+
+        // Compute polynomial for both ranges
+        float32x4_t poly_small = _varcsinq_f32(ax);
+        float32x4_t poly_large = _varcsinq_f32(s);
+
+        // Large range: pi/2 - 2*poly_large
+        float32x4_t result_large = vmlsq_f32(pi_2, two, poly_large);
+
+        // Blend based on |x| > 0.5
+        uint32x4_t mask = vcgtq_f32(ax, half);
+        float32x4_t result = vbslq_f32(mask, result_large, poly_small);
+
+        // Apply sign
+        result =
+            vreinterpretq_f32_u32(vorrq_u32(vreinterpretq_u32_f32(result), sign_bits));
+
+        vst1q_f32(bVector, result);
+
+        aVector += 4;
+        bVector += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        *bVector++ = volk_arcsin(*aVector++);
     }
 }
 
@@ -731,151 +561,52 @@ volk_32f_asin_32f_neon(float* bVector, const float* aVector, unsigned int num_po
 
 #ifdef LV_HAVE_NEONV8
 #include <arm_neon.h>
+#include <volk/volk_neon_intrinsics.h>
 
 static inline void
 volk_32f_asin_32f_neonv8(float* bVector, const float* aVector, unsigned int num_points)
 {
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
+    const float32x4_t pi_2 = vdupq_n_f32(0x1.921fb6p0f);
+    const float32x4_t half = vdupq_n_f32(0.5f);
+    const float32x4_t one = vdupq_n_f32(1.0f);
+    const float32x4_t two = vdupq_n_f32(2.0f);
 
     unsigned int number = 0;
-    unsigned int quarterPoints = num_points / 4;
-    int i, j;
-
-    float32x4_t aVal, x, y, z, arcsine;
-    const float32x4_t fzeroes = vdupq_n_f32(0.0f);
-    const float32x4_t fones = vdupq_n_f32(1.0f);
-    const float32x4_t ftwos = vdupq_n_f32(2.0f);
-    const float32x4_t ffours = vdupq_n_f32(4.0f);
-    const float32x4_t pio2 = vdupq_n_f32(3.14159265358979323846f / 2.0f);
+    const unsigned int quarterPoints = num_points / 4;
 
     for (; number < quarterPoints; number++) {
-        aVal = vld1q_f32(aPtr);
+        float32x4_t aVal = vld1q_f32(aVector);
 
-        // Compute x / sqrt((1+x)*(1-x))
-        // For |x| > 1, this produces NaN (matching generic behavior)
-        float32x4_t one_plus = vaddq_f32(fones, aVal);
-        float32x4_t one_minus = vsubq_f32(fones, aVal);
-        float32x4_t sqrt_val = vsqrtq_f32(vmulq_f32(one_plus, one_minus));
-        float32x4_t tanVal = vdivq_f32(aVal, sqrt_val);
+        float32x4_t ax = vabsq_f32(aVal);
+        uint32x4_t sign_bits =
+            vandq_u32(vreinterpretq_u32_f32(aVal), vdupq_n_u32(0x80000000));
 
-        z = tanVal;
-        // z = abs(z)
-        z = vabsq_f32(z);
+        float32x4_t t = vmulq_f32(vsubq_f32(one, ax), half);
+        float32x4_t s = vsqrtq_f32(t);
 
-        // x = 1/z if z < 1, else x = z (matching SSE logic)
-        uint32x4_t z_lt_one = vcltq_f32(z, fones);
-        float32x4_t z_recip = vdivq_f32(fones, z);
-        x = vbslq_f32(z_lt_one, z_recip, z);
+        float32x4_t poly_small = _varcsinq_f32_neonv8(ax);
+        float32x4_t poly_large = _varcsinq_f32_neonv8(s);
 
-        // Two iterations: x = x + sqrt(1 + x*x)
-        for (i = 0; i < 2; i++) {
-            x = vaddq_f32(x, vsqrtq_f32(vfmaq_f32(fones, x, x)));
-        }
+        float32x4_t result_large = vfmsq_f32(pi_2, two, poly_large);
 
-        // x = 1/x
-        x = vdivq_f32(fones, x);
+        uint32x4_t mask = vcgtq_f32(ax, half);
+        float32x4_t result = vbslq_f32(mask, result_large, poly_small);
 
-        // Taylor series
-        y = fzeroes;
-        for (j = ASIN_TERMS - 1; j >= 0; j--) {
-            float coeff = (j % 2 == 0) ? 1.0f / (2 * j + 1) : -1.0f / (2 * j + 1);
-            y = vfmaq_f32(vdupq_n_f32(coeff), y, vmulq_f32(x, x));
-        }
+        result =
+            vreinterpretq_f32_u32(vorrq_u32(vreinterpretq_u32_f32(result), sign_bits));
 
-        y = vmulq_f32(y, vmulq_f32(x, ffours));
+        vst1q_f32(bVector, result);
 
-        // Adjust if z > 1: y = y + (pio2 - 2*y)
-        uint32x4_t z_gt_one = vcgtq_f32(z, fones);
-        float32x4_t y_adj = vfmsq_f32(pio2, y, ftwos);
-        y = vbslq_f32(z_gt_one, vaddq_f32(y, y_adj), y);
-
-        arcsine = y;
-
-        // If tanVal < 0, arcsine = -arcsine
-        uint32x4_t tanVal_neg = vcltq_f32(tanVal, fzeroes);
-        arcsine = vbslq_f32(tanVal_neg, vnegq_f32(arcsine), arcsine);
-
-        vst1q_f32(bPtr, arcsine);
-        aPtr += 4;
-        bPtr += 4;
+        aVector += 4;
+        bVector += 4;
     }
 
     number = quarterPoints * 4;
     for (; number < num_points; number++) {
-        *bPtr++ = asinf(*aPtr++);
+        *bVector++ = volk_arcsin(*aVector++);
     }
 }
 
 #endif /* LV_HAVE_NEONV8 */
-
-#ifdef LV_HAVE_RVV
-#include <riscv_vector.h>
-#include <volk/volk_rvv_intrinsics.h>
-
-static inline void
-volk_32f_asin_32f_rvv(float* bVector, const float* aVector, unsigned int num_points)
-{
-    size_t vlmax = __riscv_vsetvlmax_e32m2();
-
-    const vfloat32m2_t cpio2 = __riscv_vfmv_v_f_f32m2(1.5707964f, vlmax);
-    const vfloat32m2_t cf1 = __riscv_vfmv_v_f_f32m2(1.0f, vlmax);
-    const vfloat32m2_t cf2 = __riscv_vfmv_v_f_f32m2(2.0f, vlmax);
-    const vfloat32m2_t cf4 = __riscv_vfmv_v_f_f32m2(4.0f, vlmax);
-
-#if ASIN_TERMS == 2
-    const vfloat32m2_t cfm1o3 = __riscv_vfmv_v_f_f32m2(-1 / 3.0f, vlmax);
-#elif ASIN_TERMS == 3
-    const vfloat32m2_t cf1o5 = __riscv_vfmv_v_f_f32m2(1 / 5.0f, vlmax);
-#elif ASIN_TERMS == 4
-    const vfloat32m2_t cfm1o7 = __riscv_vfmv_v_f_f32m2(-1 / 7.0f, vlmax);
-#endif
-
-    size_t n = num_points;
-    for (size_t vl; n > 0; n -= vl, aVector += vl, bVector += vl) {
-        vl = __riscv_vsetvl_e32m2(n);
-        vfloat32m2_t v = __riscv_vle32_v_f32m2(aVector, vl);
-        // Compute 1 - v^2 = (1+v)*(1-v) for better numerical stability
-        // For asin: a = v / sqrt(1 - v^2)  (inverse of acos)
-        vfloat32m2_t one_minus_v_sq =
-            __riscv_vfmul(__riscv_vfadd(cf1, v, vl), __riscv_vfsub(cf1, v, vl), vl);
-        vfloat32m2_t a = __riscv_vfdiv(v, __riscv_vfsqrt(one_minus_v_sq, vl), vl);
-        vfloat32m2_t z = __riscv_vfabs(a, vl);
-        vfloat32m2_t x = __riscv_vfdiv_mu(__riscv_vmflt(z, cf1, vl), z, cf1, z, vl);
-        x = __riscv_vfadd(x, __riscv_vfsqrt(__riscv_vfmadd(x, x, cf1, vl), vl), vl);
-        x = __riscv_vfadd(x, __riscv_vfsqrt(__riscv_vfmadd(x, x, cf1, vl), vl), vl);
-        x = __riscv_vfdiv(cf1, x, vl);
-        vfloat32m2_t xx = __riscv_vfmul(x, x, vl);
-
-#if ASIN_TERMS < 1
-        vfloat32m2_t y = __riscv_vfmv_v_f_f32m2(0, vl);
-#elif ASIN_TERMS == 1
-        y = __riscv_vfmadd(y, xx, cf1, vl);
-#elif ASIN_TERMS == 2
-        vfloat32m2_t y = cfm1o3;
-        y = __riscv_vfmadd(y, xx, cf1, vl);
-#elif ASIN_TERMS == 3
-        vfloat32m2_t y = cf1o5;
-        y = __riscv_vfmadd(y, xx, cfm1o3, vl);
-        y = __riscv_vfmadd(y, xx, cf1, vl);
-#elif ASIN_TERMS == 4
-        vfloat32m2_t y = cfm1o7;
-        y = __riscv_vfmadd(y, xx, cf1o5, vl);
-        y = __riscv_vfmadd(y, xx, cfm1o3, vl);
-        y = __riscv_vfmadd(y, xx, cf1, vl);
-#else
-#error "ASIN_TERMS > 4 not supported by volk_32f_asin_32f_rvv"
-#endif
-        y = __riscv_vfmul(y, __riscv_vfmul(x, cf4, vl), vl);
-        y = __riscv_vfadd_mu(
-            __riscv_vmfgt(z, cf1, vl), y, y, __riscv_vfnmsub(y, cf2, cpio2, vl), vl);
-
-        vfloat32m2_t asine;
-        asine = __riscv_vfneg_mu(RISCV_VMFLTZ(32m2, a, vl), y, y, vl);
-
-        __riscv_vse32(bVector, asine, vl);
-    }
-}
-#endif /*LV_HAVE_RVV*/
 
 #endif /* INCLUDED_volk_32f_asin_32f_u_H */

--- a/kernels/volk/volk_32f_asin_32f.h
+++ b/kernels/volk/volk_32f_asin_32f.h
@@ -528,7 +528,7 @@ volk_32f_asin_32f_neon(float* bVector, const float* aVector, unsigned int num_po
 
         // Two-range computation
         float32x4_t t = vmulq_f32(vsubq_f32(one, ax), half);
-        float32x4_t s = vsqrtq_f32(t);
+        float32x4_t s = _vsqrtq_f32(t);
 
         // Compute polynomial for both ranges
         float32x4_t poly_small = _varcsinq_f32(ax);

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -129,8 +129,21 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
                                             -1.0f });
     QA(VOLK_INIT_TEST(volk_32f_atan_32f, test_params_atan))
 
-    QA(VOLK_INIT_TEST(volk_32f_asin_32f, test_params_inacc))
-    QA(VOLK_INIT_TEST(volk_32f_acos_32f, test_params_inacc))
+    volk_test_params_t test_params_asin(test_params);
+    test_params_asin.set_tol(1e-5);
+    test_params_asin.add_float_edge_cases({ std::nanf(""),
+                                            1.0f,
+                                            -1.0f,
+                                            0.0f,
+                                            -0.0f,
+                                            0.5f,
+                                            -0.5f,
+                                            0.99f,
+                                            -0.99f,
+                                            0.707107f,
+                                            -0.707107f });
+    QA(VOLK_INIT_TEST(volk_32f_asin_32f, test_params_asin))
+    QA(VOLK_INIT_TEST(volk_32f_acos_32f, test_params_asin))
     QA(VOLK_INIT_TEST(volk_32fc_s32f_power_32fc, test_params_power))
     QA(VOLK_INIT_TEST(volk_32f_s32f_calc_spectral_noise_floor_32f, test_params_snf))
 


### PR DESCRIPTION
tighter tolerance and better performance

```
$ volk_profile -R acos -R asin

RUN_VOLK_TESTS: volk_32f_asin_32f(131071,1987)
generic                          894.9393 ms (  2328.2 MB/s)
a_sse4_1                          95.6585 ms ( 21781.5 MB/s)
a_avx                             48.8771 ms ( 42629.1 MB/s)
a_avx2_fma                        48.5638 ms ( 42904.0 MB/s)
a_avx512                          24.4720 ms ( 85141.5 MB/s)
u_sse4_1                          96.0423 ms ( 21694.4 MB/s)
u_avx                             48.6893 ms ( 42793.5 MB/s)
u_avx2_fma                        49.1357 ms ( 42404.7 MB/s)
u_avx512                          24.3148 ms ( 85692.1 MB/s) *
Best aligned arch:                  u_avx512        (36.81x)
Best unaligned arch:                u_avx512        (36.81x)
--------------------------------------------------------------------------------

RUN_VOLK_TESTS: volk_32f_acos_32f(131071,1987)
generic                          900.7805 ms (  2313.1 MB/s)
a_sse4_1                          99.1825 ms ( 21007.6 MB/s)
a_avx                             50.4496 ms ( 41300.3 MB/s)
a_avx2_fma                        50.4888 ms ( 41268.3 MB/s)
a_avx512                          26.6562 ms ( 78165.0 MB/s)
u_sse4_1                          99.4588 ms ( 20949.2 MB/s)
u_avx                             50.4416 ms ( 41306.8 MB/s)
u_avx2_fma                        50.4510 ms ( 41299.1 MB/s)
u_avx512                          26.1615 ms ( 79643.2 MB/s) *
Best aligned arch:                  u_avx512        (34.43x)
Best unaligned arch:                u_avx512        (34.43x)
-------------------------------------------------------------------------------
```


aarch64:

```

RUN_VOLK_TESTS: volk_32f_asin_32f(131071,597)
generic                          583.3719 ms (  1073.1 MB/s)
neon                             149.8219 ms (  4178.4 MB/s)
neonv8                           127.5585 ms (  4907.7 MB/s) *
Best aligned arch:                    neonv8         (4.57x)
Best unaligned arch:                  neonv8         (4.57x)
--------------------------------------------------------------------------------

RUN_VOLK_TESTS: volk_32f_acos_32f(131071,597)
generic                          609.4464 ms (  1027.2 MB/s)
neon                             158.1575 ms (  3958.2 MB/s)
neonv8                           133.3098 ms (  4696.0 MB/s) *
Best aligned arch:                    neonv8         (4.57x)
Best unaligned arch:                  neonv8         (4.57x)
--------------------------------------------------------------------------------
```




