### PR TITLE
Polynomial-based sin/cos/sincos kernels

### DIFF
--- a/include/volk/volk_avx2_fma_intrinsics.h
+++ b/include/volk/volk_avx2_fma_intrinsics.h
@@ -1,6 +1,6 @@
 /* -*- c++ -*- */
 /*
- * Copyright 2023 Magnus Lundmark <magnuslundmark@gmail.com>
+ * Copyright 2023 - 2025 Magnus Lundmark <magnuslundmark@gmail.com>
  *
  * This file is part of VOLK
  *
@@ -45,6 +45,48 @@ static inline __m256 _mm256_arctan_poly_avx2_fma(const __m256 x)
     arctan = _mm256_mul_ps(x, arctan);
 
     return arctan;
+}
+
+/*
+ * Approximate sin(x) via polynomial expansion
+ * on the interval [-pi/4, pi/4]
+ *
+ * Maximum absolute error ~7.3e-9
+ * sin(x) = x + x^3 * (s1 + x^2 * (s2 + x^2 * s3))
+ */
+static inline __m256 _mm256_sin_poly_avx2_fma(const __m256 x)
+{
+    const __m256 s1 = _mm256_set1_ps(-0x1.555552p-3f);
+    const __m256 s2 = _mm256_set1_ps(+0x1.110be2p-7f);
+    const __m256 s3 = _mm256_set1_ps(-0x1.9ab22ap-13f);
+
+    const __m256 x2 = _mm256_mul_ps(x, x);
+    const __m256 x3 = _mm256_mul_ps(x2, x);
+
+    __m256 poly = _mm256_fmadd_ps(x2, s3, s2);
+    poly = _mm256_fmadd_ps(x2, poly, s1);
+    return _mm256_fmadd_ps(x3, poly, x);
+}
+
+/*
+ * Approximate cos(x) via polynomial expansion
+ * on the interval [-pi/4, pi/4]
+ *
+ * Maximum absolute error ~1.1e-7
+ * cos(x) = 1 + x^2 * (c1 + x^2 * (c2 + x^2 * c3))
+ */
+static inline __m256 _mm256_cos_poly_avx2_fma(const __m256 x)
+{
+    const __m256 c1 = _mm256_set1_ps(-0x1.fffff4p-2f);
+    const __m256 c2 = _mm256_set1_ps(+0x1.554a46p-5f);
+    const __m256 c3 = _mm256_set1_ps(-0x1.661be2p-10f);
+    const __m256 one = _mm256_set1_ps(1.0f);
+
+    const __m256 x2 = _mm256_mul_ps(x, x);
+
+    __m256 poly = _mm256_fmadd_ps(x2, c3, c2);
+    poly = _mm256_fmadd_ps(x2, poly, c1);
+    return _mm256_fmadd_ps(x2, poly, one);
 }
 
 #endif /* INCLUDE_VOLK_VOLK_AVX2_FMA_INTRINSICS_H_ */

--- a/include/volk/volk_avx2_fma_intrinsics.h
+++ b/include/volk/volk_avx2_fma_intrinsics.h
@@ -48,10 +48,9 @@ static inline __m256 _mm256_arctan_poly_avx2_fma(const __m256 x)
 }
 
 /*
- * Approximate sin(x) via polynomial expansion
- * on the interval [-pi/4, pi/4]
- *
- * Maximum absolute error ~7.3e-9
+ * Minimax polynomial for sin(x) on [-pi/4, pi/4]
+ * Coefficients via Remez algorithm (Sollya)
+ * Max |error| < 7.3e-9
  * sin(x) = x + x^3 * (s1 + x^2 * (s2 + x^2 * s3))
  */
 static inline __m256 _mm256_sin_poly_avx2_fma(const __m256 x)
@@ -69,10 +68,9 @@ static inline __m256 _mm256_sin_poly_avx2_fma(const __m256 x)
 }
 
 /*
- * Approximate cos(x) via polynomial expansion
- * on the interval [-pi/4, pi/4]
- *
- * Maximum absolute error ~1.1e-7
+ * Minimax polynomial for cos(x) on [-pi/4, pi/4]
+ * Coefficients via Remez algorithm (Sollya)
+ * Max |error| < 1.1e-7
  * cos(x) = 1 + x^2 * (c1 + x^2 * (c2 + x^2 * c3))
  */
 static inline __m256 _mm256_cos_poly_avx2_fma(const __m256 x)

--- a/include/volk/volk_avx2_intrinsics.h
+++ b/include/volk/volk_avx2_intrinsics.h
@@ -345,4 +345,46 @@ static inline void vector_32fc_index_min_variant1(__m256 in0,
     *current_indices = _mm256_add_epi32(*current_indices, indices_increment);
 }
 
+/*
+ * Approximate sin(x) via polynomial expansion
+ * on the interval [-pi/4, pi/4]
+ *
+ * Maximum absolute error ~7.3e-9
+ * sin(x) = x + x^3 * (s1 + x^2 * (s2 + x^2 * s3))
+ */
+static inline __m256 _mm256_sin_poly_avx2(const __m256 x)
+{
+    const __m256 s1 = _mm256_set1_ps(-0x1.555552p-3f);
+    const __m256 s2 = _mm256_set1_ps(+0x1.110be2p-7f);
+    const __m256 s3 = _mm256_set1_ps(-0x1.9ab22ap-13f);
+
+    const __m256 x2 = _mm256_mul_ps(x, x);
+    const __m256 x3 = _mm256_mul_ps(x2, x);
+
+    __m256 poly = _mm256_add_ps(_mm256_mul_ps(x2, s3), s2);
+    poly = _mm256_add_ps(_mm256_mul_ps(x2, poly), s1);
+    return _mm256_add_ps(_mm256_mul_ps(x3, poly), x);
+}
+
+/*
+ * Approximate cos(x) via polynomial expansion
+ * on the interval [-pi/4, pi/4]
+ *
+ * Maximum absolute error ~1.1e-7
+ * cos(x) = 1 + x^2 * (c1 + x^2 * (c2 + x^2 * c3))
+ */
+static inline __m256 _mm256_cos_poly_avx2(const __m256 x)
+{
+    const __m256 c1 = _mm256_set1_ps(-0x1.fffff4p-2f);
+    const __m256 c2 = _mm256_set1_ps(+0x1.554a46p-5f);
+    const __m256 c3 = _mm256_set1_ps(-0x1.661be2p-10f);
+    const __m256 one = _mm256_set1_ps(1.0f);
+
+    const __m256 x2 = _mm256_mul_ps(x, x);
+
+    __m256 poly = _mm256_add_ps(_mm256_mul_ps(x2, c3), c2);
+    poly = _mm256_add_ps(_mm256_mul_ps(x2, poly), c1);
+    return _mm256_add_ps(_mm256_mul_ps(x2, poly), one);
+}
+
 #endif /* INCLUDE_VOLK_VOLK_AVX2_INTRINSICS_H_ */

--- a/include/volk/volk_avx512_intrinsics.h
+++ b/include/volk/volk_avx512_intrinsics.h
@@ -148,8 +148,9 @@ static inline __m512 _mm512_normalize_ps(const __m512 val)
 }
 
 ////////////////////////////////////////////////////////////////////////
-// Approximate sin(x) via polynomial expansion on the interval [-pi/4, pi/4]
-// Maximum absolute error ~7.3e-9
+// Minimax polynomial for sin(x) on [-pi/4, pi/4]
+// Coefficients via Remez algorithm (Sollya)
+// Max |error| < 7.3e-9
 // sin(x) = x + x^3 * (s1 + x^2 * (s2 + x^2 * s3))
 // Requires AVX512F
 ////////////////////////////////////////////////////////////////////////
@@ -168,8 +169,9 @@ static inline __m512 _mm512_sin_poly_avx512(const __m512 x)
 }
 
 ////////////////////////////////////////////////////////////////////////
-// Approximate cos(x) via polynomial expansion on the interval [-pi/4, pi/4]
-// Maximum absolute error ~1.1e-7
+// Minimax polynomial for cos(x) on [-pi/4, pi/4]
+// Coefficients via Remez algorithm (Sollya)
+// Max |error| < 1.1e-7
 // cos(x) = 1 + x^2 * (c1 + x^2 * (c2 + x^2 * c3))
 // Requires AVX512F
 ////////////////////////////////////////////////////////////////////////

--- a/include/volk/volk_neon_intrinsics.h
+++ b/include/volk/volk_neon_intrinsics.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2015 Free Software Foundation, Inc.
+ * Copyright 2025 Magnus Lundmark <magnuslundmark@gmail.com>
  *
  * This file is part of VOLK
  *
@@ -246,18 +247,6 @@ static inline float32x4x2_t _vsincosq_f32(float32x4_t x)
     return sincos;
 }
 
-static inline float32x4_t _vsinq_f32(float32x4_t x)
-{
-    const float32x4x2_t sincos = _vsincosq_f32(x);
-    return sincos.val[0];
-}
-
-static inline float32x4_t _vcosq_f32(float32x4_t x)
-{
-    const float32x4x2_t sincos = _vsincosq_f32(x);
-    return sincos.val[1];
-}
-
 static inline float32x4_t _vtanq_f32(float32x4_t x)
 {
     const float32x4x2_t sincos = _vsincosq_f32(x);
@@ -312,6 +301,48 @@ static inline float32x4_t _neon_accumulate_square_sum_f32(float32x4_t sq_acc,
 #endif
 }
 
+/*
+ * Approximate sin(x) via polynomial expansion
+ * on the interval [-pi/4, pi/4]
+ *
+ * Maximum absolute error ~7.3e-9
+ * sin(x) = x + x^3 * (s1 + x^2 * (s2 + x^2 * s3))
+ */
+static inline float32x4_t _vsin_poly_f32(float32x4_t x)
+{
+    const float32x4_t s1 = vdupq_n_f32(-0x1.555552p-3f);
+    const float32x4_t s2 = vdupq_n_f32(+0x1.110be2p-7f);
+    const float32x4_t s3 = vdupq_n_f32(-0x1.9ab22ap-13f);
+
+    const float32x4_t x2 = vmulq_f32(x, x);
+    const float32x4_t x3 = vmulq_f32(x2, x);
+
+    float32x4_t poly = vmlaq_f32(s2, x2, s3);
+    poly = vmlaq_f32(s1, x2, poly);
+    return vmlaq_f32(x, x3, poly);
+}
+
+/*
+ * Approximate cos(x) via polynomial expansion
+ * on the interval [-pi/4, pi/4]
+ *
+ * Maximum absolute error ~1.1e-7
+ * cos(x) = 1 + x^2 * (c1 + x^2 * (c2 + x^2 * c3))
+ */
+static inline float32x4_t _vcos_poly_f32(float32x4_t x)
+{
+    const float32x4_t c1 = vdupq_n_f32(-0x1.fffff4p-2f);
+    const float32x4_t c2 = vdupq_n_f32(+0x1.554a46p-5f);
+    const float32x4_t c3 = vdupq_n_f32(-0x1.661be2p-10f);
+    const float32x4_t one = vdupq_n_f32(1.0f);
+
+    const float32x4_t x2 = vmulq_f32(x, x);
+
+    float32x4_t poly = vmlaq_f32(c2, x2, c3);
+    poly = vmlaq_f32(c1, x2, poly);
+    return vmlaq_f32(one, x2, poly);
+}
+
 #ifdef LV_HAVE_NEONV8
 /* ARMv8 NEON FMA-based arctan polynomial for better accuracy and throughput */
 static inline float32x4_t _varctan_poly_neonv8(float32x4_t x)
@@ -335,6 +366,36 @@ static inline float32x4_t _varctan_poly_neonv8(float32x4_t x)
     result = vmulq_f32(x, result);
 
     return result;
+}
+
+/* NEONv8 FMA-based sin polynomial for interval [-pi/4, pi/4] */
+static inline float32x4_t _vsin_poly_neonv8(float32x4_t x)
+{
+    const float32x4_t s1 = vdupq_n_f32(-0x1.555552p-3f);
+    const float32x4_t s2 = vdupq_n_f32(+0x1.110be2p-7f);
+    const float32x4_t s3 = vdupq_n_f32(-0x1.9ab22ap-13f);
+
+    const float32x4_t x2 = vmulq_f32(x, x);
+    const float32x4_t x3 = vmulq_f32(x2, x);
+
+    float32x4_t poly = vfmaq_f32(s2, x2, s3);
+    poly = vfmaq_f32(s1, x2, poly);
+    return vfmaq_f32(x, x3, poly);
+}
+
+/* NEONv8 FMA-based cos polynomial for interval [-pi/4, pi/4] */
+static inline float32x4_t _vcos_poly_neonv8(float32x4_t x)
+{
+    const float32x4_t c1 = vdupq_n_f32(-0x1.fffff4p-2f);
+    const float32x4_t c2 = vdupq_n_f32(+0x1.554a46p-5f);
+    const float32x4_t c3 = vdupq_n_f32(-0x1.661be2p-10f);
+    const float32x4_t one = vdupq_n_f32(1.0f);
+
+    const float32x4_t x2 = vmulq_f32(x, x);
+
+    float32x4_t poly = vfmaq_f32(c2, x2, c3);
+    poly = vfmaq_f32(c1, x2, poly);
+    return vfmaq_f32(one, x2, poly);
 }
 #endif /* LV_HAVE_NEONV8 */
 

--- a/include/volk/volk_neon_intrinsics.h
+++ b/include/volk/volk_neon_intrinsics.h
@@ -302,10 +302,9 @@ static inline float32x4_t _neon_accumulate_square_sum_f32(float32x4_t sq_acc,
 }
 
 /*
- * Approximate sin(x) via polynomial expansion
- * on the interval [-pi/4, pi/4]
- *
- * Maximum absolute error ~7.3e-9
+ * Minimax polynomial for sin(x) on [-pi/4, pi/4]
+ * Coefficients via Remez algorithm (Sollya)
+ * Max |error| < 7.3e-9
  * sin(x) = x + x^3 * (s1 + x^2 * (s2 + x^2 * s3))
  */
 static inline float32x4_t _vsin_poly_f32(float32x4_t x)
@@ -323,10 +322,9 @@ static inline float32x4_t _vsin_poly_f32(float32x4_t x)
 }
 
 /*
- * Approximate cos(x) via polynomial expansion
- * on the interval [-pi/4, pi/4]
- *
- * Maximum absolute error ~1.1e-7
+ * Minimax polynomial for cos(x) on [-pi/4, pi/4]
+ * Coefficients via Remez algorithm (Sollya)
+ * Max |error| < 1.1e-7
  * cos(x) = 1 + x^2 * (c1 + x^2 * (c2 + x^2 * c3))
  */
 static inline float32x4_t _vcos_poly_f32(float32x4_t x)
@@ -368,7 +366,7 @@ static inline float32x4_t _varctan_poly_neonv8(float32x4_t x)
     return result;
 }
 
-/* NEONv8 FMA-based sin polynomial for interval [-pi/4, pi/4] */
+/* NEONv8 FMA sin polynomial on [-pi/4, pi/4], coeffs via Remez (Sollya) */
 static inline float32x4_t _vsin_poly_neonv8(float32x4_t x)
 {
     const float32x4_t s1 = vdupq_n_f32(-0x1.555552p-3f);
@@ -383,7 +381,7 @@ static inline float32x4_t _vsin_poly_neonv8(float32x4_t x)
     return vfmaq_f32(x, x3, poly);
 }
 
-/* NEONv8 FMA-based cos polynomial for interval [-pi/4, pi/4] */
+/* NEONv8 FMA cos polynomial on [-pi/4, pi/4], coeffs via Remez (Sollya) */
 static inline float32x4_t _vcos_poly_neonv8(float32x4_t x)
 {
     const float32x4_t c1 = vdupq_n_f32(-0x1.fffff4p-2f);

--- a/include/volk/volk_sse_intrinsics.h
+++ b/include/volk/volk_sse_intrinsics.h
@@ -94,4 +94,46 @@ static inline __m128 _mm_accumulate_square_sum_ps(
     return _mm_add_ps(sq_acc, aux);
 }
 
+/*
+ * Approximate sin(x) via polynomial expansion
+ * on the interval [-pi/4, pi/4]
+ *
+ * Maximum absolute error ~7.3e-9
+ * sin(x) = x + x^3 * (s1 + x^2 * (s2 + x^2 * s3))
+ */
+static inline __m128 _mm_sin_poly_sse(const __m128 x)
+{
+    const __m128 s1 = _mm_set1_ps(-0x1.555552p-3f);
+    const __m128 s2 = _mm_set1_ps(+0x1.110be2p-7f);
+    const __m128 s3 = _mm_set1_ps(-0x1.9ab22ap-13f);
+
+    const __m128 x2 = _mm_mul_ps(x, x);
+    const __m128 x3 = _mm_mul_ps(x2, x);
+
+    __m128 poly = _mm_add_ps(_mm_mul_ps(x2, s3), s2);
+    poly = _mm_add_ps(_mm_mul_ps(x2, poly), s1);
+    return _mm_add_ps(_mm_mul_ps(x3, poly), x);
+}
+
+/*
+ * Approximate cos(x) via polynomial expansion
+ * on the interval [-pi/4, pi/4]
+ *
+ * Maximum absolute error ~1.1e-7
+ * cos(x) = 1 + x^2 * (c1 + x^2 * (c2 + x^2 * c3))
+ */
+static inline __m128 _mm_cos_poly_sse(const __m128 x)
+{
+    const __m128 c1 = _mm_set1_ps(-0x1.fffff4p-2f);
+    const __m128 c2 = _mm_set1_ps(+0x1.554a46p-5f);
+    const __m128 c3 = _mm_set1_ps(-0x1.661be2p-10f);
+    const __m128 one = _mm_set1_ps(1.0f);
+
+    const __m128 x2 = _mm_mul_ps(x, x);
+
+    __m128 poly = _mm_add_ps(_mm_mul_ps(x2, c3), c2);
+    poly = _mm_add_ps(_mm_mul_ps(x2, poly), c1);
+    return _mm_add_ps(_mm_mul_ps(x2, poly), one);
+}
+
 #endif /* INCLUDE_VOLK_VOLK_SSE_INTRINSICS_H_ */

--- a/include/volk/volk_sse_intrinsics.h
+++ b/include/volk/volk_sse_intrinsics.h
@@ -95,10 +95,9 @@ static inline __m128 _mm_accumulate_square_sum_ps(
 }
 
 /*
- * Approximate sin(x) via polynomial expansion
- * on the interval [-pi/4, pi/4]
- *
- * Maximum absolute error ~7.3e-9
+ * Minimax polynomial for sin(x) on [-pi/4, pi/4]
+ * Coefficients via Remez algorithm (Sollya)
+ * Max |error| < 7.3e-9
  * sin(x) = x + x^3 * (s1 + x^2 * (s2 + x^2 * s3))
  */
 static inline __m128 _mm_sin_poly_sse(const __m128 x)
@@ -116,10 +115,9 @@ static inline __m128 _mm_sin_poly_sse(const __m128 x)
 }
 
 /*
- * Approximate cos(x) via polynomial expansion
- * on the interval [-pi/4, pi/4]
- *
- * Maximum absolute error ~1.1e-7
+ * Minimax polynomial for cos(x) on [-pi/4, pi/4]
+ * Coefficients via Remez algorithm (Sollya)
+ * Max |error| < 1.1e-7
  * cos(x) = 1 + x^2 * (c1 + x^2 * (c2 + x^2 * c3))
  */
 static inline __m128 _mm_cos_poly_sse(const __m128 x)

--- a/kernels/volk/volk_32f_cos_32f.h
+++ b/kernels/volk/volk_32f_cos_32f.h
@@ -79,6 +79,18 @@ volk_32f_cos_32f_generic(float* bVector, const float* aVector, unsigned int num_
 
 #endif /* LV_HAVE_GENERIC */
 
+#ifdef LV_HAVE_GENERIC
+#include <volk/volk_common.h>
+
+static inline void
+volk_32f_cos_32f_polynomial(float* bVector, const float* aVector, unsigned int num_points)
+{
+    for (unsigned int number = 0; number < num_points; number++) {
+        *bVector++ = volk_cos(*aVector++);
+    }
+}
+#endif /* LV_HAVE_GENERIC */
+
 #ifdef LV_HAVE_AVX512F
 #include <immintrin.h>
 #include <volk/volk_avx512_intrinsics.h>

--- a/kernels/volk/volk_32f_cos_32f.h
+++ b/kernels/volk/volk_32f_cos_32f.h
@@ -79,69 +79,10 @@ volk_32f_cos_32f_generic(float* bVector, const float* aVector, unsigned int num_
 
 #endif /* LV_HAVE_GENERIC */
 
-#ifdef LV_HAVE_GENERIC
-
-/*
- * For derivation see
- * Shibata, Naoki, "Efficient evaluation methods of elementary functions
- * suitable for SIMD computation," in Springer-Verlag 2010
- */
-static inline void volk_32f_cos_32f_generic_fast(float* bVector,
-                                                 const float* aVector,
-                                                 unsigned int num_points)
-{
-    float* bPtr = bVector;
-    const float* aPtr = aVector;
-
-    float m4pi = 1.273239544735162542821171882678754627704620361328125;
-    float pio4A = 0.7853981554508209228515625;
-    float pio4B = 0.794662735614792836713604629039764404296875e-8;
-    float pio4C = 0.306161699786838294306516483068750264552437361480769e-16;
-    int N = 3; // order of argument reduction
-
-    unsigned int number;
-    for (number = 0; number < num_points; number++) {
-        float s = fabs(*aPtr);
-        int q = (int)(s * m4pi);
-        int r = q + (q & 1);
-        s -= r * pio4A;
-        s -= r * pio4B;
-        s -= r * pio4C;
-
-        s = s * 0.125; // 2^-N (<--3)
-        s = s * s;
-        s = ((((s / 1814400. - 1.0 / 20160.0) * s + 1.0 / 360.0) * s - 1.0 / 12.0) * s +
-             1.0) *
-            s;
-
-        int i;
-        for (i = 0; i < N; ++i) {
-            s = (4.0 - s) * s;
-        }
-        s = s / 2.0;
-
-        float sine = sqrt((2.0 - s) * s);
-        float cosine = 1 - s;
-
-        if (((q + 1) & 2) != 0) {
-            s = cosine;
-            cosine = sine;
-            sine = s;
-        }
-        if (((q + 2) & 4) != 0) {
-            cosine = -cosine;
-        }
-        *bPtr = cosine;
-        bPtr++;
-        aPtr++;
-    }
-}
-
-#endif /* LV_HAVE_GENERIC */
-
 #ifdef LV_HAVE_AVX512F
-
 #include <immintrin.h>
+#include <volk/volk_avx512_intrinsics.h>
+
 static inline void volk_32f_cos_32f_a_avx512f(float* cosVector,
                                               const float* inVector,
                                               unsigned int num_points)
@@ -151,76 +92,52 @@ static inline void volk_32f_cos_32f_a_avx512f(float* cosVector,
 
     unsigned int number = 0;
     unsigned int sixteenPoints = num_points / 16;
-    unsigned int i = 0;
 
-    __m512 aVal, s, r, m4pi, pio4A, pio4B, pio4C, cp1, cp2, cp3, cp4, cp5, ffours, ftwos,
-        fones, sine, cosine;
-    __m512i q, zeros, ones, twos, fours;
+    // Constants for Cody-Waite argument reduction
+    // n = round(x * 2/pi), then r = x - n * pi/2
+    const __m512 two_over_pi = _mm512_set1_ps(0x1.45f306p-1f);    // 2/pi
+    const __m512 pi_over_2_hi = _mm512_set1_ps(0x1.921fb6p+0f);   // pi/2 high
+    const __m512 pi_over_2_lo = _mm512_set1_ps(-0x1.777a5cp-25f); // pi/2 low
 
-    m4pi = _mm512_set1_ps(1.273239544735162542821171882678754627704620361328125);
-    pio4A = _mm512_set1_ps(0.7853981554508209228515625);
-    pio4B = _mm512_set1_ps(0.794662735614792836713604629039764404296875e-8);
-    pio4C = _mm512_set1_ps(0.306161699786838294306516483068750264552437361480769e-16);
-    ffours = _mm512_set1_ps(4.0);
-    ftwos = _mm512_set1_ps(2.0);
-    fones = _mm512_set1_ps(1.0);
-    zeros = _mm512_setzero_epi32();
-    ones = _mm512_set1_epi32(1);
-    twos = _mm512_set1_epi32(2);
-    fours = _mm512_set1_epi32(4);
-
-    cp1 = _mm512_set1_ps(1.0);
-    cp2 = _mm512_set1_ps(0.08333333333333333);
-    cp3 = _mm512_set1_ps(0.002777777777777778);
-    cp4 = _mm512_set1_ps(4.96031746031746e-05);
-    cp5 = _mm512_set1_ps(5.511463844797178e-07);
-    __mmask16 condition1, condition2;
+    const __m512i ones = _mm512_set1_epi32(1);
+    const __m512i twos = _mm512_set1_epi32(2);
+    const __m512i sign_bit = _mm512_set1_epi32(0x80000000);
 
     for (; number < sixteenPoints; number++) {
-        aVal = _mm512_load_ps(inPtr);
-        // s = fabs(aVal)
-        s = (__m512)(_mm512_and_si512((__m512i)(aVal), _mm512_set1_epi32(0x7fffffff)));
+        __m512 x = _mm512_load_ps(inPtr);
 
-        // q = (int) (s * (4/pi)), floor(aVal / (pi/4))
-        q = _mm512_cvtps_epi32(_mm512_floor_ps(_mm512_mul_ps(s, m4pi)));
-        // r = q + q&1, q indicates quadrant, r gives
-        r = _mm512_cvtepi32_ps(_mm512_add_epi32(q, _mm512_and_si512(q, ones)));
+        // Argument reduction: n = round(x * 2/pi)
+        __m512 n_f = _mm512_roundscale_ps(_mm512_mul_ps(x, two_over_pi),
+                                          _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m512i n = _mm512_cvtps_epi32(n_f);
 
-        s = _mm512_fnmadd_ps(r, pio4A, s);
-        s = _mm512_fnmadd_ps(r, pio4B, s);
-        s = _mm512_fnmadd_ps(r, pio4C, s);
+        // r = x - n * (pi/2), using extended precision
+        __m512 r = _mm512_fnmadd_ps(n_f, pi_over_2_hi, x);
+        r = _mm512_fnmadd_ps(n_f, pi_over_2_lo, r);
 
-        s = _mm512_div_ps(
-            s,
-            _mm512_set1_ps(8.0f)); // The constant is 2^N, for 3 times argument reduction
-        s = _mm512_mul_ps(s, s);
-        // Evaluate Taylor series
-        s = _mm512_mul_ps(
-            _mm512_fmadd_ps(
-                _mm512_fmsub_ps(
-                    _mm512_fmadd_ps(_mm512_fmsub_ps(s, cp5, cp4), s, cp3), s, cp2),
-                s,
-                cp1),
-            s);
+        // Evaluate both sin and cos polynomials
+        __m512 sin_r = _mm512_sin_poly_avx512(r);
+        __m512 cos_r = _mm512_cos_poly_avx512(r);
 
-        for (i = 0; i < 3; i++) {
-            s = _mm512_mul_ps(s, _mm512_sub_ps(ffours, s));
-        }
-        s = _mm512_div_ps(s, ftwos);
+        // Reconstruct cos(x) based on quadrant (n mod 4):
+        // n&1 == 0: use cos_r, n&1 == 1: use sin_r
+        // (n+1)&2 == 0: positive, (n+1)&2 != 0: negative
+        __m512i n_and_1 = _mm512_and_si512(n, ones);
+        __m512i n_plus_1_and_2 = _mm512_and_si512(_mm512_add_epi32(n, ones), twos);
 
-        sine = _mm512_sqrt_ps(_mm512_mul_ps(_mm512_sub_ps(ftwos, s), s));
-        cosine = _mm512_sub_ps(fones, s);
+        // swap_mask: where n&1 != 0, we use sin instead of cos
+        __mmask16 swap_mask = _mm512_cmpeq_epi32_mask(n_and_1, ones);
+        __m512 result = _mm512_mask_blend_ps(swap_mask, cos_r, sin_r);
 
-        // if(((q+1)&2) != 0) { cosine=sine;}
-        condition1 = _mm512_cmpneq_epi32_mask(
-            _mm512_and_si512(_mm512_add_epi32(q, ones), twos), zeros);
+        // neg_mask: where (n+1)&2 != 0, we negate the result (use integer xor for
+        // AVX512F)
+        __mmask16 neg_mask = _mm512_cmpeq_epi32_mask(n_plus_1_and_2, twos);
+        result = _mm512_castsi512_ps(_mm512_mask_xor_epi32(_mm512_castps_si512(result),
+                                                           neg_mask,
+                                                           _mm512_castps_si512(result),
+                                                           sign_bit));
 
-        // if(((q+2)&4) != 0) { cosine = -cosine;}
-        condition2 = _mm512_cmpneq_epi32_mask(
-            _mm512_and_si512(_mm512_add_epi32(q, twos), fours), zeros);
-        cosine = _mm512_mask_blend_ps(condition1, cosine, sine);
-        cosine = _mm512_mask_mul_ps(cosine, condition2, cosine, _mm512_set1_ps(-1.f));
-        _mm512_store_ps(cosPtr, cosine);
+        _mm512_store_ps(cosPtr, result);
         inPtr += 16;
         cosPtr += 16;
     }
@@ -230,10 +147,11 @@ static inline void volk_32f_cos_32f_a_avx512f(float* cosVector,
         *cosPtr++ = cosf(*inPtr++);
     }
 }
-#endif
+#endif /* LV_HAVE_AVX512F */
 
 #if LV_HAVE_AVX2 && LV_HAVE_FMA
 #include <immintrin.h>
+#include <volk/volk_avx2_fma_intrinsics.h>
 
 static inline void
 volk_32f_cos_32f_a_avx2_fma(float* bVector, const float* aVector, unsigned int num_points)
@@ -243,102 +161,63 @@ volk_32f_cos_32f_a_avx2_fma(float* bVector, const float* aVector, unsigned int n
 
     unsigned int number = 0;
     unsigned int eighthPoints = num_points / 8;
-    unsigned int i = 0;
 
-    __m256 aVal, s, r, m4pi, pio4A, pio4B, pio4C, cp1, cp2, cp3, cp4, cp5, ffours, ftwos,
-        fones, fzeroes;
-    __m256 sine, cosine;
-    __m256i q, ones, twos, fours;
+    // Constants for Cody-Waite argument reduction
+    // n = round(x * 2/pi), then r = x - n * pi/2
+    const __m256 two_over_pi = _mm256_set1_ps(0x1.45f306p-1f);    // 2/pi
+    const __m256 pi_over_2_hi = _mm256_set1_ps(0x1.921fb6p+0f);   // pi/2 high
+    const __m256 pi_over_2_lo = _mm256_set1_ps(-0x1.777a5cp-25f); // pi/2 low
 
-    m4pi = _mm256_set1_ps(1.273239544735162542821171882678754627704620361328125);
-    pio4A = _mm256_set1_ps(0.7853981554508209228515625);
-    pio4B = _mm256_set1_ps(0.794662735614792836713604629039764404296875e-8);
-    pio4C = _mm256_set1_ps(0.306161699786838294306516483068750264552437361480769e-16);
-    ffours = _mm256_set1_ps(4.0);
-    ftwos = _mm256_set1_ps(2.0);
-    fones = _mm256_set1_ps(1.0);
-    fzeroes = _mm256_setzero_ps();
-    __m256i zeroes = _mm256_set1_epi32(0);
-    ones = _mm256_set1_epi32(1);
-    __m256i allones = _mm256_set1_epi32(0xffffffff);
-    twos = _mm256_set1_epi32(2);
-    fours = _mm256_set1_epi32(4);
-
-    cp1 = _mm256_set1_ps(1.0);
-    cp2 = _mm256_set1_ps(0.08333333333333333);
-    cp3 = _mm256_set1_ps(0.002777777777777778);
-    cp4 = _mm256_set1_ps(4.96031746031746e-05);
-    cp5 = _mm256_set1_ps(5.511463844797178e-07);
-    union bit256 condition1;
-    union bit256 condition3;
+    const __m256i ones = _mm256_set1_epi32(1);
+    const __m256i twos = _mm256_set1_epi32(2);
+    const __m256 sign_bit = _mm256_set1_ps(-0.0f);
 
     for (; number < eighthPoints; number++) {
+        __m256 x = _mm256_load_ps(aPtr);
 
-        aVal = _mm256_load_ps(aPtr);
-        // s = fabs(aVal)
-        s = _mm256_sub_ps(aVal,
-                          _mm256_and_ps(_mm256_mul_ps(aVal, ftwos),
-                                        _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS)));
-        // q = (int) (s * (4/pi)), floor(aVal / (pi/4))
-        q = _mm256_cvtps_epi32(_mm256_floor_ps(_mm256_mul_ps(s, m4pi)));
-        // r = q + q&1, q indicates quadrant, r gives
-        r = _mm256_cvtepi32_ps(_mm256_add_epi32(q, _mm256_and_si256(q, ones)));
+        // Argument reduction: n = round(x * 2/pi)
+        __m256 n_f = _mm256_round_ps(_mm256_mul_ps(x, two_over_pi),
+                                     _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m256i n = _mm256_cvtps_epi32(n_f);
 
-        s = _mm256_fnmadd_ps(r, pio4A, s);
-        s = _mm256_fnmadd_ps(r, pio4B, s);
-        s = _mm256_fnmadd_ps(r, pio4C, s);
+        // r = x - n * (pi/2), using extended precision
+        __m256 r = _mm256_fnmadd_ps(n_f, pi_over_2_hi, x);
+        r = _mm256_fnmadd_ps(n_f, pi_over_2_lo, r);
 
-        s = _mm256_div_ps(
-            s,
-            _mm256_set1_ps(8.0)); // The constant is 2^N, for 3 times argument reduction
-        s = _mm256_mul_ps(s, s);
-        // Evaluate Taylor series
-        s = _mm256_mul_ps(
-            _mm256_fmadd_ps(
-                _mm256_fmsub_ps(
-                    _mm256_fmadd_ps(_mm256_fmsub_ps(s, cp5, cp4), s, cp3), s, cp2),
-                s,
-                cp1),
-            s);
+        // Evaluate both sin and cos polynomials
+        __m256 sin_r = _mm256_sin_poly_avx2_fma(r);
+        __m256 cos_r = _mm256_cos_poly_avx2_fma(r);
 
-        for (i = 0; i < 3; i++) {
-            s = _mm256_mul_ps(s, _mm256_sub_ps(ffours, s));
-        }
-        s = _mm256_div_ps(s, ftwos);
+        // Reconstruct cos(x) based on quadrant (n mod 4):
+        // n&1 == 0: use cos_r, n&1 == 1: use sin_r
+        // (n+1)&2 == 0: positive, (n+1)&2 != 0: negative
+        __m256i n_and_1 = _mm256_and_si256(n, ones);
+        __m256i n_plus_1_and_2 = _mm256_and_si256(_mm256_add_epi32(n, ones), twos);
 
-        sine = _mm256_sqrt_ps(_mm256_mul_ps(_mm256_sub_ps(ftwos, s), s));
-        cosine = _mm256_sub_ps(fones, s);
+        // swap_mask: where n&1 != 0, we use sin instead of cos
+        __m256 swap_mask = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_and_1, ones));
+        __m256 result = _mm256_blendv_ps(cos_r, sin_r, swap_mask);
 
-        // if(((q+1)&2) != 0) { cosine=sine;}
-        condition1.int_vec =
-            _mm256_cmpeq_epi32(_mm256_and_si256(_mm256_add_epi32(q, ones), twos), zeroes);
-        condition1.int_vec = _mm256_xor_si256(allones, condition1.int_vec);
+        // neg_mask: where (n+1)&2 != 0, we negate the result
+        __m256 neg_mask = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_plus_1_and_2, twos));
+        result = _mm256_xor_ps(result, _mm256_and_ps(neg_mask, sign_bit));
 
-        // if(((q+2)&4) != 0) { cosine = -cosine;}
-        condition3.int_vec = _mm256_cmpeq_epi32(
-            _mm256_and_si256(_mm256_add_epi32(q, twos), fours), zeroes);
-        condition3.int_vec = _mm256_xor_si256(allones, condition3.int_vec);
-
-        cosine = _mm256_add_ps(
-            cosine, _mm256_and_ps(_mm256_sub_ps(sine, cosine), condition1.float_vec));
-        cosine = _mm256_sub_ps(cosine,
-                               _mm256_and_ps(_mm256_mul_ps(cosine, _mm256_set1_ps(2.0f)),
-                                             condition3.float_vec));
-        _mm256_store_ps(bPtr, cosine);
+        _mm256_store_ps(bPtr, result);
         aPtr += 8;
         bPtr += 8;
     }
 
     number = eighthPoints * 8;
     for (; number < num_points; number++) {
-        *bPtr++ = cos(*aPtr++);
+        *bPtr++ = cosf(*aPtr++);
     }
 }
 
-#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA for aligned */
+#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA */
 
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
+#include <volk/volk_avx2_intrinsics.h>
 
 static inline void
 volk_32f_cos_32f_a_avx2(float* bVector, const float* aVector, unsigned int num_points)
@@ -348,109 +227,63 @@ volk_32f_cos_32f_a_avx2(float* bVector, const float* aVector, unsigned int num_p
 
     unsigned int number = 0;
     unsigned int eighthPoints = num_points / 8;
-    unsigned int i = 0;
 
-    __m256 aVal, s, r, m4pi, pio4A, pio4B, pio4C, cp1, cp2, cp3, cp4, cp5, ffours, ftwos,
-        fones, fzeroes;
-    __m256 sine, cosine;
-    __m256i q, ones, twos, fours;
+    // Constants for Cody-Waite argument reduction
+    // n = round(x * 2/pi), then r = x - n * pi/2
+    const __m256 two_over_pi = _mm256_set1_ps(0x1.45f306p-1f);    // 2/pi
+    const __m256 pi_over_2_hi = _mm256_set1_ps(0x1.921fb6p+0f);   // pi/2 high
+    const __m256 pi_over_2_lo = _mm256_set1_ps(-0x1.777a5cp-25f); // pi/2 low
 
-    m4pi = _mm256_set1_ps(1.273239544735162542821171882678754627704620361328125);
-    pio4A = _mm256_set1_ps(0.7853981554508209228515625);
-    pio4B = _mm256_set1_ps(0.794662735614792836713604629039764404296875e-8);
-    pio4C = _mm256_set1_ps(0.306161699786838294306516483068750264552437361480769e-16);
-    ffours = _mm256_set1_ps(4.0);
-    ftwos = _mm256_set1_ps(2.0);
-    fones = _mm256_set1_ps(1.0);
-    fzeroes = _mm256_setzero_ps();
-    __m256i zeroes = _mm256_set1_epi32(0);
-    ones = _mm256_set1_epi32(1);
-    __m256i allones = _mm256_set1_epi32(0xffffffff);
-    twos = _mm256_set1_epi32(2);
-    fours = _mm256_set1_epi32(4);
-
-    cp1 = _mm256_set1_ps(1.0);
-    cp2 = _mm256_set1_ps(0.08333333333333333);
-    cp3 = _mm256_set1_ps(0.002777777777777778);
-    cp4 = _mm256_set1_ps(4.96031746031746e-05);
-    cp5 = _mm256_set1_ps(5.511463844797178e-07);
-    union bit256 condition1;
-    union bit256 condition3;
+    const __m256i ones = _mm256_set1_epi32(1);
+    const __m256i twos = _mm256_set1_epi32(2);
+    const __m256 sign_bit = _mm256_set1_ps(-0.0f);
 
     for (; number < eighthPoints; number++) {
+        __m256 x = _mm256_load_ps(aPtr);
 
-        aVal = _mm256_load_ps(aPtr);
-        // s = fabs(aVal)
-        s = _mm256_sub_ps(aVal,
-                          _mm256_and_ps(_mm256_mul_ps(aVal, ftwos),
-                                        _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS)));
-        // q = (int) (s * (4/pi)), floor(aVal / (pi/4))
-        q = _mm256_cvtps_epi32(_mm256_floor_ps(_mm256_mul_ps(s, m4pi)));
-        // r = q + q&1, q indicates quadrant, r gives
-        r = _mm256_cvtepi32_ps(_mm256_add_epi32(q, _mm256_and_si256(q, ones)));
+        // Argument reduction: n = round(x * 2/pi)
+        __m256 n_f = _mm256_round_ps(_mm256_mul_ps(x, two_over_pi),
+                                     _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m256i n = _mm256_cvtps_epi32(n_f);
 
-        s = _mm256_sub_ps(s, _mm256_mul_ps(r, pio4A));
-        s = _mm256_sub_ps(s, _mm256_mul_ps(r, pio4B));
-        s = _mm256_sub_ps(s, _mm256_mul_ps(r, pio4C));
+        // r = x - n * (pi/2), using extended precision
+        __m256 r = _mm256_sub_ps(x, _mm256_mul_ps(n_f, pi_over_2_hi));
+        r = _mm256_sub_ps(r, _mm256_mul_ps(n_f, pi_over_2_lo));
 
-        s = _mm256_div_ps(
-            s,
-            _mm256_set1_ps(8.0)); // The constant is 2^N, for 3 times argument reduction
-        s = _mm256_mul_ps(s, s);
-        // Evaluate Taylor series
-        s = _mm256_mul_ps(
-            _mm256_add_ps(
-                _mm256_mul_ps(
-                    _mm256_sub_ps(
-                        _mm256_mul_ps(
-                            _mm256_add_ps(
-                                _mm256_mul_ps(_mm256_sub_ps(_mm256_mul_ps(s, cp5), cp4),
-                                              s),
-                                cp3),
-                            s),
-                        cp2),
-                    s),
-                cp1),
-            s);
+        // Evaluate both sin and cos polynomials
+        __m256 sin_r = _mm256_sin_poly_avx2(r);
+        __m256 cos_r = _mm256_cos_poly_avx2(r);
 
-        for (i = 0; i < 3; i++) {
-            s = _mm256_mul_ps(s, _mm256_sub_ps(ffours, s));
-        }
-        s = _mm256_div_ps(s, ftwos);
+        // Reconstruct cos(x) based on quadrant (n mod 4):
+        // n&1 == 0: use cos_r, n&1 == 1: use sin_r
+        // (n+1)&2 == 0: positive, (n+1)&2 != 0: negative
+        __m256i n_and_1 = _mm256_and_si256(n, ones);
+        __m256i n_plus_1_and_2 = _mm256_and_si256(_mm256_add_epi32(n, ones), twos);
 
-        sine = _mm256_sqrt_ps(_mm256_mul_ps(_mm256_sub_ps(ftwos, s), s));
-        cosine = _mm256_sub_ps(fones, s);
+        // swap_mask: where n&1 != 0, we use sin instead of cos
+        __m256 swap_mask = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_and_1, ones));
+        __m256 result = _mm256_blendv_ps(cos_r, sin_r, swap_mask);
 
-        // if(((q+1)&2) != 0) { cosine=sine;}
-        condition1.int_vec =
-            _mm256_cmpeq_epi32(_mm256_and_si256(_mm256_add_epi32(q, ones), twos), zeroes);
-        condition1.int_vec = _mm256_xor_si256(allones, condition1.int_vec);
+        // neg_mask: where (n+1)&2 != 0, we negate the result
+        __m256 neg_mask = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_plus_1_and_2, twos));
+        result = _mm256_xor_ps(result, _mm256_and_ps(neg_mask, sign_bit));
 
-        // if(((q+2)&4) != 0) { cosine = -cosine;}
-        condition3.int_vec = _mm256_cmpeq_epi32(
-            _mm256_and_si256(_mm256_add_epi32(q, twos), fours), zeroes);
-        condition3.int_vec = _mm256_xor_si256(allones, condition3.int_vec);
-
-        cosine = _mm256_add_ps(
-            cosine, _mm256_and_ps(_mm256_sub_ps(sine, cosine), condition1.float_vec));
-        cosine = _mm256_sub_ps(cosine,
-                               _mm256_and_ps(_mm256_mul_ps(cosine, _mm256_set1_ps(2.0f)),
-                                             condition3.float_vec));
-        _mm256_store_ps(bPtr, cosine);
+        _mm256_store_ps(bPtr, result);
         aPtr += 8;
         bPtr += 8;
     }
 
     number = eighthPoints * 8;
     for (; number < num_points; number++) {
-        *bPtr++ = cos(*aPtr++);
+        *bPtr++ = cosf(*aPtr++);
     }
 }
 
-#endif /* LV_HAVE_AVX2 for aligned */
+#endif /* LV_HAVE_AVX2 */
 
 #ifdef LV_HAVE_SSE4_1
 #include <smmintrin.h>
+#include <volk/volk_sse_intrinsics.h>
 
 static inline void
 volk_32f_cos_32f_a_sse4_1(float* bVector, const float* aVector, unsigned int num_points)
@@ -460,91 +293,48 @@ volk_32f_cos_32f_a_sse4_1(float* bVector, const float* aVector, unsigned int num
 
     unsigned int number = 0;
     unsigned int quarterPoints = num_points / 4;
-    unsigned int i = 0;
 
-    __m128 aVal, s, r, m4pi, pio4A, pio4B, pio4C, cp1, cp2, cp3, cp4, cp5, ffours, ftwos,
-        fones, fzeroes;
-    __m128 sine, cosine;
-    __m128i q, ones, twos, fours;
+    // Constants for Cody-Waite argument reduction
+    // n = round(x * 2/pi), then r = x - n * pi/2
+    const __m128 two_over_pi = _mm_set1_ps(0x1.45f306p-1f);    // 2/pi
+    const __m128 pi_over_2_hi = _mm_set1_ps(0x1.921fb6p+0f);   // pi/2 high
+    const __m128 pi_over_2_lo = _mm_set1_ps(-0x1.777a5cp-25f); // pi/2 low
 
-    m4pi = _mm_set1_ps(1.273239544735162542821171882678754627704620361328125);
-    pio4A = _mm_set1_ps(0.7853981554508209228515625);
-    pio4B = _mm_set1_ps(0.794662735614792836713604629039764404296875e-8);
-    pio4C = _mm_set1_ps(0.306161699786838294306516483068750264552437361480769e-16);
-    ffours = _mm_set1_ps(4.0);
-    ftwos = _mm_set1_ps(2.0);
-    fones = _mm_set1_ps(1.0);
-    fzeroes = _mm_setzero_ps();
-    __m128i zeroes = _mm_set1_epi32(0);
-    ones = _mm_set1_epi32(1);
-    __m128i allones = _mm_set1_epi32(0xffffffff);
-    twos = _mm_set1_epi32(2);
-    fours = _mm_set1_epi32(4);
-
-    cp1 = _mm_set1_ps(1.0);
-    cp2 = _mm_set1_ps(0.08333333333333333);
-    cp3 = _mm_set1_ps(0.002777777777777778);
-    cp4 = _mm_set1_ps(4.96031746031746e-05);
-    cp5 = _mm_set1_ps(5.511463844797178e-07);
-    union bit128 condition1;
-    union bit128 condition3;
+    const __m128i ones = _mm_set1_epi32(1);
+    const __m128i twos = _mm_set1_epi32(2);
+    const __m128 sign_bit = _mm_set1_ps(-0.0f);
 
     for (; number < quarterPoints; number++) {
+        __m128 x = _mm_load_ps(aPtr);
 
-        aVal = _mm_load_ps(aPtr);
-        // s = fabs(aVal)
-        s = _mm_sub_ps(aVal,
-                       _mm_and_ps(_mm_mul_ps(aVal, ftwos), _mm_cmplt_ps(aVal, fzeroes)));
-        // q = (int) (s * (4/pi)), floor(aVal / (pi/4))
-        q = _mm_cvtps_epi32(_mm_floor_ps(_mm_mul_ps(s, m4pi)));
-        // r = q + q&1, q indicates quadrant, r gives
-        r = _mm_cvtepi32_ps(_mm_add_epi32(q, _mm_and_si128(q, ones)));
+        // Argument reduction: n = round(x * 2/pi)
+        __m128 n_f = _mm_round_ps(_mm_mul_ps(x, two_over_pi),
+                                  _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m128i n = _mm_cvtps_epi32(n_f);
 
-        s = _mm_sub_ps(s, _mm_mul_ps(r, pio4A));
-        s = _mm_sub_ps(s, _mm_mul_ps(r, pio4B));
-        s = _mm_sub_ps(s, _mm_mul_ps(r, pio4C));
+        // r = x - n * (pi/2), using extended precision
+        __m128 r = _mm_sub_ps(x, _mm_mul_ps(n_f, pi_over_2_hi));
+        r = _mm_sub_ps(r, _mm_mul_ps(n_f, pi_over_2_lo));
 
-        s = _mm_div_ps(
-            s, _mm_set1_ps(8.0)); // The constant is 2^N, for 3 times argument reduction
-        s = _mm_mul_ps(s, s);
-        // Evaluate Taylor series
-        s = _mm_mul_ps(
-            _mm_add_ps(
-                _mm_mul_ps(
-                    _mm_sub_ps(
-                        _mm_mul_ps(
-                            _mm_add_ps(_mm_mul_ps(_mm_sub_ps(_mm_mul_ps(s, cp5), cp4), s),
-                                       cp3),
-                            s),
-                        cp2),
-                    s),
-                cp1),
-            s);
+        // Evaluate both sin and cos polynomials
+        __m128 sin_r = _mm_sin_poly_sse(r);
+        __m128 cos_r = _mm_cos_poly_sse(r);
 
-        for (i = 0; i < 3; i++) {
-            s = _mm_mul_ps(s, _mm_sub_ps(ffours, s));
-        }
-        s = _mm_div_ps(s, ftwos);
+        // Reconstruct cos(x) based on quadrant (n mod 4):
+        // n&1 == 0: use cos_r, n&1 == 1: use sin_r
+        // (n+1)&2 == 0: positive, (n+1)&2 != 0: negative
+        __m128i n_and_1 = _mm_and_si128(n, ones);
+        __m128i n_plus_1_and_2 = _mm_and_si128(_mm_add_epi32(n, ones), twos);
 
-        sine = _mm_sqrt_ps(_mm_mul_ps(_mm_sub_ps(ftwos, s), s));
-        cosine = _mm_sub_ps(fones, s);
+        // swap_mask: where n&1 != 0, we use sin instead of cos
+        __m128 swap_mask = _mm_castsi128_ps(_mm_cmpeq_epi32(n_and_1, ones));
+        __m128 result = _mm_blendv_ps(cos_r, sin_r, swap_mask);
 
-        // if(((q+1)&2) != 0) { cosine=sine;}
-        condition1.int_vec =
-            _mm_cmpeq_epi32(_mm_and_si128(_mm_add_epi32(q, ones), twos), zeroes);
-        condition1.int_vec = _mm_xor_si128(allones, condition1.int_vec);
+        // neg_mask: where (n+1)&2 != 0, we negate the result
+        __m128 neg_mask = _mm_castsi128_ps(_mm_cmpeq_epi32(n_plus_1_and_2, twos));
+        result = _mm_xor_ps(result, _mm_and_ps(neg_mask, sign_bit));
 
-        // if(((q+2)&4) != 0) { cosine = -cosine;}
-        condition3.int_vec =
-            _mm_cmpeq_epi32(_mm_and_si128(_mm_add_epi32(q, twos), fours), zeroes);
-        condition3.int_vec = _mm_xor_si128(allones, condition3.int_vec);
-
-        cosine = _mm_add_ps(cosine,
-                            _mm_and_ps(_mm_sub_ps(sine, cosine), condition1.float_vec));
-        cosine = _mm_sub_ps(
-            cosine,
-            _mm_and_ps(_mm_mul_ps(cosine, _mm_set1_ps(2.0f)), condition3.float_vec));
-        _mm_store_ps(bPtr, cosine);
+        _mm_store_ps(bPtr, result);
         aPtr += 4;
         bPtr += 4;
     }
@@ -555,7 +345,7 @@ volk_32f_cos_32f_a_sse4_1(float* bVector, const float* aVector, unsigned int num
     }
 }
 
-#endif /* LV_HAVE_SSE4_1 for aligned */
+#endif /* LV_HAVE_SSE4_1 */
 
 #endif /* INCLUDED_volk_32f_cos_32f_a_H */
 
@@ -564,8 +354,9 @@ volk_32f_cos_32f_a_sse4_1(float* bVector, const float* aVector, unsigned int num
 #define INCLUDED_volk_32f_cos_32f_u_H
 
 #ifdef LV_HAVE_AVX512F
-
 #include <immintrin.h>
+#include <volk/volk_avx512_intrinsics.h>
+
 static inline void volk_32f_cos_32f_u_avx512f(float* cosVector,
                                               const float* inVector,
                                               unsigned int num_points)
@@ -575,76 +366,52 @@ static inline void volk_32f_cos_32f_u_avx512f(float* cosVector,
 
     unsigned int number = 0;
     unsigned int sixteenPoints = num_points / 16;
-    unsigned int i = 0;
 
-    __m512 aVal, s, r, m4pi, pio4A, pio4B, pio4C, cp1, cp2, cp3, cp4, cp5, ffours, ftwos,
-        fones, sine, cosine;
-    __m512i q, zeros, ones, twos, fours;
+    // Constants for Cody-Waite argument reduction
+    // n = round(x * 2/pi), then r = x - n * pi/2
+    const __m512 two_over_pi = _mm512_set1_ps(0x1.45f306p-1f);    // 2/pi
+    const __m512 pi_over_2_hi = _mm512_set1_ps(0x1.921fb6p+0f);   // pi/2 high
+    const __m512 pi_over_2_lo = _mm512_set1_ps(-0x1.777a5cp-25f); // pi/2 low
 
-    m4pi = _mm512_set1_ps(1.273239544735162542821171882678754627704620361328125);
-    pio4A = _mm512_set1_ps(0.7853981554508209228515625);
-    pio4B = _mm512_set1_ps(0.794662735614792836713604629039764404296875e-8);
-    pio4C = _mm512_set1_ps(0.306161699786838294306516483068750264552437361480769e-16);
-    ffours = _mm512_set1_ps(4.0);
-    ftwos = _mm512_set1_ps(2.0);
-    fones = _mm512_set1_ps(1.0);
-    zeros = _mm512_setzero_epi32();
-    ones = _mm512_set1_epi32(1);
-    twos = _mm512_set1_epi32(2);
-    fours = _mm512_set1_epi32(4);
+    const __m512i ones = _mm512_set1_epi32(1);
+    const __m512i twos = _mm512_set1_epi32(2);
+    const __m512i sign_bit = _mm512_set1_epi32(0x80000000);
 
-    cp1 = _mm512_set1_ps(1.0);
-    cp2 = _mm512_set1_ps(0.08333333333333333);
-    cp3 = _mm512_set1_ps(0.002777777777777778);
-    cp4 = _mm512_set1_ps(4.96031746031746e-05);
-    cp5 = _mm512_set1_ps(5.511463844797178e-07);
-    __mmask16 condition1, condition2;
     for (; number < sixteenPoints; number++) {
-        aVal = _mm512_loadu_ps(inPtr);
-        // s = fabs(aVal)
-        s = (__m512)(_mm512_and_si512((__m512i)(aVal), _mm512_set1_epi32(0x7fffffff)));
+        __m512 x = _mm512_loadu_ps(inPtr);
 
-        // q = (int) (s * (4/pi)), floor(aVal / (pi/4))
-        q = _mm512_cvtps_epi32(_mm512_floor_ps(_mm512_mul_ps(s, m4pi)));
-        // r = q + q&1, q indicates quadrant, r gives
-        r = _mm512_cvtepi32_ps(_mm512_add_epi32(q, _mm512_and_si512(q, ones)));
+        // Argument reduction: n = round(x * 2/pi)
+        __m512 n_f = _mm512_roundscale_ps(_mm512_mul_ps(x, two_over_pi),
+                                          _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m512i n = _mm512_cvtps_epi32(n_f);
 
-        s = _mm512_fnmadd_ps(r, pio4A, s);
-        s = _mm512_fnmadd_ps(r, pio4B, s);
-        s = _mm512_fnmadd_ps(r, pio4C, s);
+        // r = x - n * (pi/2), using extended precision
+        __m512 r = _mm512_fnmadd_ps(n_f, pi_over_2_hi, x);
+        r = _mm512_fnmadd_ps(n_f, pi_over_2_lo, r);
 
-        s = _mm512_div_ps(
-            s,
-            _mm512_set1_ps(8.0f)); // The constant is 2^N, for 3 times argument reduction
-        s = _mm512_mul_ps(s, s);
-        // Evaluate Taylor series
-        s = _mm512_mul_ps(
-            _mm512_fmadd_ps(
-                _mm512_fmsub_ps(
-                    _mm512_fmadd_ps(_mm512_fmsub_ps(s, cp5, cp4), s, cp3), s, cp2),
-                s,
-                cp1),
-            s);
+        // Evaluate both sin and cos polynomials
+        __m512 sin_r = _mm512_sin_poly_avx512(r);
+        __m512 cos_r = _mm512_cos_poly_avx512(r);
 
-        for (i = 0; i < 3; i++) {
-            s = _mm512_mul_ps(s, _mm512_sub_ps(ffours, s));
-        }
-        s = _mm512_div_ps(s, ftwos);
+        // Reconstruct cos(x) based on quadrant (n mod 4):
+        // n&1 == 0: use cos_r, n&1 == 1: use sin_r
+        // (n+1)&2 == 0: positive, (n+1)&2 != 0: negative
+        __m512i n_and_1 = _mm512_and_si512(n, ones);
+        __m512i n_plus_1_and_2 = _mm512_and_si512(_mm512_add_epi32(n, ones), twos);
 
-        sine = _mm512_sqrt_ps(_mm512_mul_ps(_mm512_sub_ps(ftwos, s), s));
-        cosine = _mm512_sub_ps(fones, s);
+        // swap_mask: where n&1 != 0, we use sin instead of cos
+        __mmask16 swap_mask = _mm512_cmpeq_epi32_mask(n_and_1, ones);
+        __m512 result = _mm512_mask_blend_ps(swap_mask, cos_r, sin_r);
 
-        // if(((q+1)&2) != 0) { cosine=sine;}
-        condition1 = _mm512_cmpneq_epi32_mask(
-            _mm512_and_si512(_mm512_add_epi32(q, ones), twos), zeros);
+        // neg_mask: where (n+1)&2 != 0, we negate the result (use integer xor for
+        // AVX512F)
+        __mmask16 neg_mask = _mm512_cmpeq_epi32_mask(n_plus_1_and_2, twos);
+        result = _mm512_castsi512_ps(_mm512_mask_xor_epi32(_mm512_castps_si512(result),
+                                                           neg_mask,
+                                                           _mm512_castps_si512(result),
+                                                           sign_bit));
 
-        // if(((q+2)&4) != 0) { cosine = -cosine;}
-        condition2 = _mm512_cmpneq_epi32_mask(
-            _mm512_and_si512(_mm512_add_epi32(q, twos), fours), zeros);
-
-        cosine = _mm512_mask_blend_ps(condition1, cosine, sine);
-        cosine = _mm512_mask_mul_ps(cosine, condition2, cosine, _mm512_set1_ps(-1.f));
-        _mm512_storeu_ps(cosPtr, cosine);
+        _mm512_storeu_ps(cosPtr, result);
         inPtr += 16;
         cosPtr += 16;
     }
@@ -654,10 +421,11 @@ static inline void volk_32f_cos_32f_u_avx512f(float* cosVector,
         *cosPtr++ = cosf(*inPtr++);
     }
 }
-#endif
+#endif /* LV_HAVE_AVX512F */
 
 #if LV_HAVE_AVX2 && LV_HAVE_FMA
 #include <immintrin.h>
+#include <volk/volk_avx2_fma_intrinsics.h>
 
 static inline void
 volk_32f_cos_32f_u_avx2_fma(float* bVector, const float* aVector, unsigned int num_points)
@@ -667,102 +435,63 @@ volk_32f_cos_32f_u_avx2_fma(float* bVector, const float* aVector, unsigned int n
 
     unsigned int number = 0;
     unsigned int eighthPoints = num_points / 8;
-    unsigned int i = 0;
 
-    __m256 aVal, s, r, m4pi, pio4A, pio4B, pio4C, cp1, cp2, cp3, cp4, cp5, ffours, ftwos,
-        fones, fzeroes;
-    __m256 sine, cosine;
-    __m256i q, ones, twos, fours;
+    // Constants for Cody-Waite argument reduction
+    // n = round(x * 2/pi), then r = x - n * pi/2
+    const __m256 two_over_pi = _mm256_set1_ps(0x1.45f306p-1f);    // 2/pi
+    const __m256 pi_over_2_hi = _mm256_set1_ps(0x1.921fb6p+0f);   // pi/2 high
+    const __m256 pi_over_2_lo = _mm256_set1_ps(-0x1.777a5cp-25f); // pi/2 low
 
-    m4pi = _mm256_set1_ps(1.273239544735162542821171882678754627704620361328125);
-    pio4A = _mm256_set1_ps(0.7853981554508209228515625);
-    pio4B = _mm256_set1_ps(0.794662735614792836713604629039764404296875e-8);
-    pio4C = _mm256_set1_ps(0.306161699786838294306516483068750264552437361480769e-16);
-    ffours = _mm256_set1_ps(4.0);
-    ftwos = _mm256_set1_ps(2.0);
-    fones = _mm256_set1_ps(1.0);
-    fzeroes = _mm256_setzero_ps();
-    __m256i zeroes = _mm256_set1_epi32(0);
-    ones = _mm256_set1_epi32(1);
-    __m256i allones = _mm256_set1_epi32(0xffffffff);
-    twos = _mm256_set1_epi32(2);
-    fours = _mm256_set1_epi32(4);
-
-    cp1 = _mm256_set1_ps(1.0);
-    cp2 = _mm256_set1_ps(0.08333333333333333);
-    cp3 = _mm256_set1_ps(0.002777777777777778);
-    cp4 = _mm256_set1_ps(4.96031746031746e-05);
-    cp5 = _mm256_set1_ps(5.511463844797178e-07);
-    union bit256 condition1;
-    union bit256 condition3;
+    const __m256i ones = _mm256_set1_epi32(1);
+    const __m256i twos = _mm256_set1_epi32(2);
+    const __m256 sign_bit = _mm256_set1_ps(-0.0f);
 
     for (; number < eighthPoints; number++) {
+        __m256 x = _mm256_loadu_ps(aPtr);
 
-        aVal = _mm256_loadu_ps(aPtr);
-        // s = fabs(aVal)
-        s = _mm256_sub_ps(aVal,
-                          _mm256_and_ps(_mm256_mul_ps(aVal, ftwos),
-                                        _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS)));
-        // q = (int) (s * (4/pi)), floor(aVal / (pi/4))
-        q = _mm256_cvtps_epi32(_mm256_floor_ps(_mm256_mul_ps(s, m4pi)));
-        // r = q + q&1, q indicates quadrant, r gives
-        r = _mm256_cvtepi32_ps(_mm256_add_epi32(q, _mm256_and_si256(q, ones)));
+        // Argument reduction: n = round(x * 2/pi)
+        __m256 n_f = _mm256_round_ps(_mm256_mul_ps(x, two_over_pi),
+                                     _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m256i n = _mm256_cvtps_epi32(n_f);
 
-        s = _mm256_fnmadd_ps(r, pio4A, s);
-        s = _mm256_fnmadd_ps(r, pio4B, s);
-        s = _mm256_fnmadd_ps(r, pio4C, s);
+        // r = x - n * (pi/2), using extended precision
+        __m256 r = _mm256_fnmadd_ps(n_f, pi_over_2_hi, x);
+        r = _mm256_fnmadd_ps(n_f, pi_over_2_lo, r);
 
-        s = _mm256_div_ps(
-            s,
-            _mm256_set1_ps(8.0)); // The constant is 2^N, for 3 times argument reduction
-        s = _mm256_mul_ps(s, s);
-        // Evaluate Taylor series
-        s = _mm256_mul_ps(
-            _mm256_fmadd_ps(
-                _mm256_fmsub_ps(
-                    _mm256_fmadd_ps(_mm256_fmsub_ps(s, cp5, cp4), s, cp3), s, cp2),
-                s,
-                cp1),
-            s);
+        // Evaluate both sin and cos polynomials
+        __m256 sin_r = _mm256_sin_poly_avx2_fma(r);
+        __m256 cos_r = _mm256_cos_poly_avx2_fma(r);
 
-        for (i = 0; i < 3; i++) {
-            s = _mm256_mul_ps(s, _mm256_sub_ps(ffours, s));
-        }
-        s = _mm256_div_ps(s, ftwos);
+        // Reconstruct cos(x) based on quadrant (n mod 4):
+        // n&1 == 0: use cos_r, n&1 == 1: use sin_r
+        // (n+1)&2 == 0: positive, (n+1)&2 != 0: negative
+        __m256i n_and_1 = _mm256_and_si256(n, ones);
+        __m256i n_plus_1_and_2 = _mm256_and_si256(_mm256_add_epi32(n, ones), twos);
 
-        sine = _mm256_sqrt_ps(_mm256_mul_ps(_mm256_sub_ps(ftwos, s), s));
-        cosine = _mm256_sub_ps(fones, s);
+        // swap_mask: where n&1 != 0, we use sin instead of cos
+        __m256 swap_mask = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_and_1, ones));
+        __m256 result = _mm256_blendv_ps(cos_r, sin_r, swap_mask);
 
-        // if(((q+1)&2) != 0) { cosine=sine;}
-        condition1.int_vec =
-            _mm256_cmpeq_epi32(_mm256_and_si256(_mm256_add_epi32(q, ones), twos), zeroes);
-        condition1.int_vec = _mm256_xor_si256(allones, condition1.int_vec);
+        // neg_mask: where (n+1)&2 != 0, we negate the result
+        __m256 neg_mask = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_plus_1_and_2, twos));
+        result = _mm256_xor_ps(result, _mm256_and_ps(neg_mask, sign_bit));
 
-        // if(((q+2)&4) != 0) { cosine = -cosine;}
-        condition3.int_vec = _mm256_cmpeq_epi32(
-            _mm256_and_si256(_mm256_add_epi32(q, twos), fours), zeroes);
-        condition3.int_vec = _mm256_xor_si256(allones, condition3.int_vec);
-
-        cosine = _mm256_add_ps(
-            cosine, _mm256_and_ps(_mm256_sub_ps(sine, cosine), condition1.float_vec));
-        cosine = _mm256_sub_ps(cosine,
-                               _mm256_and_ps(_mm256_mul_ps(cosine, _mm256_set1_ps(2.0f)),
-                                             condition3.float_vec));
-        _mm256_storeu_ps(bPtr, cosine);
+        _mm256_storeu_ps(bPtr, result);
         aPtr += 8;
         bPtr += 8;
     }
 
     number = eighthPoints * 8;
     for (; number < num_points; number++) {
-        *bPtr++ = cos(*aPtr++);
+        *bPtr++ = cosf(*aPtr++);
     }
 }
 
-#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA for unaligned */
+#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA */
 
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
+#include <volk/volk_avx2_intrinsics.h>
 
 static inline void
 volk_32f_cos_32f_u_avx2(float* bVector, const float* aVector, unsigned int num_points)
@@ -772,109 +501,63 @@ volk_32f_cos_32f_u_avx2(float* bVector, const float* aVector, unsigned int num_p
 
     unsigned int number = 0;
     unsigned int eighthPoints = num_points / 8;
-    unsigned int i = 0;
 
-    __m256 aVal, s, r, m4pi, pio4A, pio4B, pio4C, cp1, cp2, cp3, cp4, cp5, ffours, ftwos,
-        fones, fzeroes;
-    __m256 sine, cosine;
-    __m256i q, ones, twos, fours;
+    // Constants for Cody-Waite argument reduction
+    // n = round(x * 2/pi), then r = x - n * pi/2
+    const __m256 two_over_pi = _mm256_set1_ps(0x1.45f306p-1f);    // 2/pi
+    const __m256 pi_over_2_hi = _mm256_set1_ps(0x1.921fb6p+0f);   // pi/2 high
+    const __m256 pi_over_2_lo = _mm256_set1_ps(-0x1.777a5cp-25f); // pi/2 low
 
-    m4pi = _mm256_set1_ps(1.273239544735162542821171882678754627704620361328125);
-    pio4A = _mm256_set1_ps(0.7853981554508209228515625);
-    pio4B = _mm256_set1_ps(0.794662735614792836713604629039764404296875e-8);
-    pio4C = _mm256_set1_ps(0.306161699786838294306516483068750264552437361480769e-16);
-    ffours = _mm256_set1_ps(4.0);
-    ftwos = _mm256_set1_ps(2.0);
-    fones = _mm256_set1_ps(1.0);
-    fzeroes = _mm256_setzero_ps();
-    __m256i zeroes = _mm256_set1_epi32(0);
-    ones = _mm256_set1_epi32(1);
-    __m256i allones = _mm256_set1_epi32(0xffffffff);
-    twos = _mm256_set1_epi32(2);
-    fours = _mm256_set1_epi32(4);
-
-    cp1 = _mm256_set1_ps(1.0);
-    cp2 = _mm256_set1_ps(0.08333333333333333);
-    cp3 = _mm256_set1_ps(0.002777777777777778);
-    cp4 = _mm256_set1_ps(4.96031746031746e-05);
-    cp5 = _mm256_set1_ps(5.511463844797178e-07);
-    union bit256 condition1;
-    union bit256 condition3;
+    const __m256i ones = _mm256_set1_epi32(1);
+    const __m256i twos = _mm256_set1_epi32(2);
+    const __m256 sign_bit = _mm256_set1_ps(-0.0f);
 
     for (; number < eighthPoints; number++) {
+        __m256 x = _mm256_loadu_ps(aPtr);
 
-        aVal = _mm256_loadu_ps(aPtr);
-        // s = fabs(aVal)
-        s = _mm256_sub_ps(aVal,
-                          _mm256_and_ps(_mm256_mul_ps(aVal, ftwos),
-                                        _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS)));
-        // q = (int) (s * (4/pi)), floor(aVal / (pi/4))
-        q = _mm256_cvtps_epi32(_mm256_floor_ps(_mm256_mul_ps(s, m4pi)));
-        // r = q + q&1, q indicates quadrant, r gives
-        r = _mm256_cvtepi32_ps(_mm256_add_epi32(q, _mm256_and_si256(q, ones)));
+        // Argument reduction: n = round(x * 2/pi)
+        __m256 n_f = _mm256_round_ps(_mm256_mul_ps(x, two_over_pi),
+                                     _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m256i n = _mm256_cvtps_epi32(n_f);
 
-        s = _mm256_sub_ps(s, _mm256_mul_ps(r, pio4A));
-        s = _mm256_sub_ps(s, _mm256_mul_ps(r, pio4B));
-        s = _mm256_sub_ps(s, _mm256_mul_ps(r, pio4C));
+        // r = x - n * (pi/2), using extended precision
+        __m256 r = _mm256_sub_ps(x, _mm256_mul_ps(n_f, pi_over_2_hi));
+        r = _mm256_sub_ps(r, _mm256_mul_ps(n_f, pi_over_2_lo));
 
-        s = _mm256_div_ps(
-            s,
-            _mm256_set1_ps(8.0)); // The constant is 2^N, for 3 times argument reduction
-        s = _mm256_mul_ps(s, s);
-        // Evaluate Taylor series
-        s = _mm256_mul_ps(
-            _mm256_add_ps(
-                _mm256_mul_ps(
-                    _mm256_sub_ps(
-                        _mm256_mul_ps(
-                            _mm256_add_ps(
-                                _mm256_mul_ps(_mm256_sub_ps(_mm256_mul_ps(s, cp5), cp4),
-                                              s),
-                                cp3),
-                            s),
-                        cp2),
-                    s),
-                cp1),
-            s);
+        // Evaluate both sin and cos polynomials
+        __m256 sin_r = _mm256_sin_poly_avx2(r);
+        __m256 cos_r = _mm256_cos_poly_avx2(r);
 
-        for (i = 0; i < 3; i++) {
-            s = _mm256_mul_ps(s, _mm256_sub_ps(ffours, s));
-        }
-        s = _mm256_div_ps(s, ftwos);
+        // Reconstruct cos(x) based on quadrant (n mod 4):
+        // n&1 == 0: use cos_r, n&1 == 1: use sin_r
+        // (n+1)&2 == 0: positive, (n+1)&2 != 0: negative
+        __m256i n_and_1 = _mm256_and_si256(n, ones);
+        __m256i n_plus_1_and_2 = _mm256_and_si256(_mm256_add_epi32(n, ones), twos);
 
-        sine = _mm256_sqrt_ps(_mm256_mul_ps(_mm256_sub_ps(ftwos, s), s));
-        cosine = _mm256_sub_ps(fones, s);
+        // swap_mask: where n&1 != 0, we use sin instead of cos
+        __m256 swap_mask = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_and_1, ones));
+        __m256 result = _mm256_blendv_ps(cos_r, sin_r, swap_mask);
 
-        // if(((q+1)&2) != 0) { cosine=sine;}
-        condition1.int_vec =
-            _mm256_cmpeq_epi32(_mm256_and_si256(_mm256_add_epi32(q, ones), twos), zeroes);
-        condition1.int_vec = _mm256_xor_si256(allones, condition1.int_vec);
+        // neg_mask: where (n+1)&2 != 0, we negate the result
+        __m256 neg_mask = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_plus_1_and_2, twos));
+        result = _mm256_xor_ps(result, _mm256_and_ps(neg_mask, sign_bit));
 
-        // if(((q+2)&4) != 0) { cosine = -cosine;}
-        condition3.int_vec = _mm256_cmpeq_epi32(
-            _mm256_and_si256(_mm256_add_epi32(q, twos), fours), zeroes);
-        condition3.int_vec = _mm256_xor_si256(allones, condition3.int_vec);
-
-        cosine = _mm256_add_ps(
-            cosine, _mm256_and_ps(_mm256_sub_ps(sine, cosine), condition1.float_vec));
-        cosine = _mm256_sub_ps(cosine,
-                               _mm256_and_ps(_mm256_mul_ps(cosine, _mm256_set1_ps(2.0f)),
-                                             condition3.float_vec));
-        _mm256_storeu_ps(bPtr, cosine);
+        _mm256_storeu_ps(bPtr, result);
         aPtr += 8;
         bPtr += 8;
     }
 
     number = eighthPoints * 8;
     for (; number < num_points; number++) {
-        *bPtr++ = cos(*aPtr++);
+        *bPtr++ = cosf(*aPtr++);
     }
 }
 
-#endif /* LV_HAVE_AVX2 for unaligned */
+#endif /* LV_HAVE_AVX2 */
 
 #ifdef LV_HAVE_SSE4_1
 #include <smmintrin.h>
+#include <volk/volk_sse_intrinsics.h>
 
 static inline void
 volk_32f_cos_32f_u_sse4_1(float* bVector, const float* aVector, unsigned int num_points)
@@ -884,75 +567,48 @@ volk_32f_cos_32f_u_sse4_1(float* bVector, const float* aVector, unsigned int num
 
     unsigned int number = 0;
     unsigned int quarterPoints = num_points / 4;
-    unsigned int i = 0;
 
-    __m128 aVal, s, m4pi, pio4A, pio4B, cp1, cp2, cp3, cp4, cp5, ffours, ftwos, fones,
-        fzeroes;
-    __m128 sine, cosine, condition1, condition3;
-    __m128i q, r, ones, twos, fours;
+    // Constants for Cody-Waite argument reduction
+    // n = round(x * 2/pi), then r = x - n * pi/2
+    const __m128 two_over_pi = _mm_set1_ps(0x1.45f306p-1f);    // 2/pi
+    const __m128 pi_over_2_hi = _mm_set1_ps(0x1.921fb6p+0f);   // pi/2 high
+    const __m128 pi_over_2_lo = _mm_set1_ps(-0x1.777a5cp-25f); // pi/2 low
 
-    m4pi = _mm_set1_ps(1.273239545);
-    pio4A = _mm_set1_ps(0.78515625);
-    pio4B = _mm_set1_ps(0.241876e-3);
-    ffours = _mm_set1_ps(4.0);
-    ftwos = _mm_set1_ps(2.0);
-    fones = _mm_set1_ps(1.0);
-    fzeroes = _mm_setzero_ps();
-    ones = _mm_set1_epi32(1);
-    twos = _mm_set1_epi32(2);
-    fours = _mm_set1_epi32(4);
-
-    cp1 = _mm_set1_ps(1.0);
-    cp2 = _mm_set1_ps(0.83333333e-1);
-    cp3 = _mm_set1_ps(0.2777778e-2);
-    cp4 = _mm_set1_ps(0.49603e-4);
-    cp5 = _mm_set1_ps(0.551e-6);
+    const __m128i ones = _mm_set1_epi32(1);
+    const __m128i twos = _mm_set1_epi32(2);
+    const __m128 sign_bit = _mm_set1_ps(-0.0f);
 
     for (; number < quarterPoints; number++) {
-        aVal = _mm_loadu_ps(aPtr);
-        s = _mm_sub_ps(aVal,
-                       _mm_and_ps(_mm_mul_ps(aVal, ftwos), _mm_cmplt_ps(aVal, fzeroes)));
-        q = _mm_cvtps_epi32(_mm_floor_ps(_mm_mul_ps(s, m4pi)));
-        r = _mm_add_epi32(q, _mm_and_si128(q, ones));
+        __m128 x = _mm_loadu_ps(aPtr);
 
-        s = _mm_sub_ps(s, _mm_mul_ps(_mm_cvtepi32_ps(r), pio4A));
-        s = _mm_sub_ps(s, _mm_mul_ps(_mm_cvtepi32_ps(r), pio4B));
+        // Argument reduction: n = round(x * 2/pi)
+        __m128 n_f = _mm_round_ps(_mm_mul_ps(x, two_over_pi),
+                                  _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m128i n = _mm_cvtps_epi32(n_f);
 
-        s = _mm_div_ps(
-            s, _mm_set1_ps(8.0)); // The constant is 2^N, for 3 times argument reduction
-        s = _mm_mul_ps(s, s);
-        // Evaluate Taylor series
-        s = _mm_mul_ps(
-            _mm_add_ps(
-                _mm_mul_ps(
-                    _mm_sub_ps(
-                        _mm_mul_ps(
-                            _mm_add_ps(_mm_mul_ps(_mm_sub_ps(_mm_mul_ps(s, cp5), cp4), s),
-                                       cp3),
-                            s),
-                        cp2),
-                    s),
-                cp1),
-            s);
+        // r = x - n * (pi/2), using extended precision
+        __m128 r = _mm_sub_ps(x, _mm_mul_ps(n_f, pi_over_2_hi));
+        r = _mm_sub_ps(r, _mm_mul_ps(n_f, pi_over_2_lo));
 
-        for (i = 0; i < 3; i++) {
-            s = _mm_mul_ps(s, _mm_sub_ps(ffours, s));
-        }
-        s = _mm_div_ps(s, ftwos);
+        // Evaluate both sin and cos polynomials
+        __m128 sin_r = _mm_sin_poly_sse(r);
+        __m128 cos_r = _mm_cos_poly_sse(r);
 
-        sine = _mm_sqrt_ps(_mm_mul_ps(_mm_sub_ps(ftwos, s), s));
-        cosine = _mm_sub_ps(fones, s);
+        // Reconstruct cos(x) based on quadrant (n mod 4):
+        // n&1 == 0: use cos_r, n&1 == 1: use sin_r
+        // (n+1)&2 == 0: positive, (n+1)&2 != 0: negative
+        __m128i n_and_1 = _mm_and_si128(n, ones);
+        __m128i n_plus_1_and_2 = _mm_and_si128(_mm_add_epi32(n, ones), twos);
 
-        condition1 = _mm_cmpneq_ps(
-            _mm_cvtepi32_ps(_mm_and_si128(_mm_add_epi32(q, ones), twos)), fzeroes);
+        // swap_mask: where n&1 != 0, we use sin instead of cos
+        __m128 swap_mask = _mm_castsi128_ps(_mm_cmpeq_epi32(n_and_1, ones));
+        __m128 result = _mm_blendv_ps(cos_r, sin_r, swap_mask);
 
-        condition3 = _mm_cmpneq_ps(
-            _mm_cvtepi32_ps(_mm_and_si128(_mm_add_epi32(q, twos), fours)), fzeroes);
+        // neg_mask: where (n+1)&2 != 0, we negate the result
+        __m128 neg_mask = _mm_castsi128_ps(_mm_cmpeq_epi32(n_plus_1_and_2, twos));
+        result = _mm_xor_ps(result, _mm_and_ps(neg_mask, sign_bit));
 
-        cosine = _mm_add_ps(cosine, _mm_and_ps(_mm_sub_ps(sine, cosine), condition1));
-        cosine = _mm_sub_ps(
-            cosine, _mm_and_ps(_mm_mul_ps(cosine, _mm_set1_ps(2.0f)), condition3));
-        _mm_storeu_ps(bPtr, cosine);
+        _mm_storeu_ps(bPtr, result);
         aPtr += 4;
         bPtr += 4;
     }
@@ -963,152 +619,135 @@ volk_32f_cos_32f_u_sse4_1(float* bVector, const float* aVector, unsigned int num
     }
 }
 
-#endif /* LV_HAVE_SSE4_1 for unaligned */
+#endif /* LV_HAVE_SSE4_1 */
 
 
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
 #include <volk/volk_neon_intrinsics.h>
 
+/* NEON polynomial-based cos using Cody-Waite argument reduction */
 static inline void
 volk_32f_cos_32f_neon(float* bVector, const float* aVector, unsigned int num_points)
 {
+    // Cody-Waite argument reduction: n = round(x * 2/pi), r = x - n * pi/2
+    const float32x4_t two_over_pi = vdupq_n_f32(0x1.45f306p-1f);    // 2/pi
+    const float32x4_t pi_over_2_hi = vdupq_n_f32(0x1.921fb6p+0f);   // pi/2 high
+    const float32x4_t pi_over_2_lo = vdupq_n_f32(-0x1.777a5cp-25f); // pi/2 low
+
+    const int32x4_t ones = vdupq_n_s32(1);
+    const int32x4_t twos = vdupq_n_s32(2);
+    const float32x4_t sign_bit = vdupq_n_f32(-0.0f);
+    const float32x4_t half = vdupq_n_f32(0.5f);
+    const float32x4_t neg_half = vdupq_n_f32(-0.5f);
+    const float32x4_t fzeroes = vdupq_n_f32(0.0f);
+
     unsigned int number = 0;
-    unsigned int quarter_points = num_points / 4;
-    float* bVectorPtr = bVector;
-    const float* aVectorPtr = aVector;
+    const unsigned int quarterPoints = num_points / 4;
 
-    float32x4_t b_vec;
-    float32x4_t a_vec;
+    for (; number < quarterPoints; number++) {
+        float32x4_t x = vld1q_f32(aVector);
+        aVector += 4;
 
-    for (number = 0; number < quarter_points; number++) {
-        a_vec = vld1q_f32(aVectorPtr);
-        // Prefetch next one, speeds things up
-        __VOLK_PREFETCH(aVectorPtr + 4);
-        b_vec = _vcosq_f32(a_vec);
-        vst1q_f32(bVectorPtr, b_vec);
-        // move pointers ahead
-        bVectorPtr += 4;
-        aVectorPtr += 4;
+        // n = round(x * 2/pi) - emulate round-to-nearest for ARMv7
+        float32x4_t scaled = vmulq_f32(x, two_over_pi);
+        uint32x4_t is_neg = vcltq_f32(scaled, fzeroes);
+        float32x4_t adj = vbslq_f32(is_neg, neg_half, half);
+        float32x4_t n_f = vcvtq_f32_s32(vcvtq_s32_f32(vaddq_f32(scaled, adj)));
+        int32x4_t n = vcvtq_s32_f32(n_f);
+
+        // r = x - n * (pi/2) using extended precision
+        float32x4_t r = vmlsq_f32(x, n_f, pi_over_2_hi);
+        r = vmlsq_f32(r, n_f, pi_over_2_lo);
+
+        // Evaluate sin and cos polynomials
+        float32x4_t sin_r = _vsin_poly_f32(r);
+        float32x4_t cos_r = _vcos_poly_f32(r);
+
+        // Quadrant-based reconstruction for cos:
+        // n&1 == 0: use cos_r, n&1 == 1: use sin_r
+        // (n+1)&2 == 0: positive, (n+1)&2 == 2: negative
+        int32x4_t n_and_1 = vandq_s32(n, ones);
+        int32x4_t n_plus_1_and_2 = vandq_s32(vaddq_s32(n, ones), twos);
+
+        uint32x4_t swap_mask = vceqq_s32(n_and_1, ones);
+        float32x4_t result = vbslq_f32(swap_mask, sin_r, cos_r);
+
+        uint32x4_t neg_mask = vceqq_s32(n_plus_1_and_2, twos);
+        result = vreinterpretq_f32_u32(
+            veorq_u32(vreinterpretq_u32_f32(result),
+                      vandq_u32(neg_mask, vreinterpretq_u32_f32(sign_bit))));
+
+        vst1q_f32(bVector, result);
+        bVector += 4;
     }
 
-    // Deal with the rest
-    for (number = quarter_points * 4; number < num_points; number++) {
-        *bVectorPtr++ = cosf(*aVectorPtr++);
+    for (number = quarterPoints * 4; number < num_points; number++) {
+        *bVector++ = cosf(*aVector++);
     }
 }
-
 #endif /* LV_HAVE_NEON */
-
 
 #ifdef LV_HAVE_NEONV8
 #include <arm_neon.h>
+#include <volk/volk_neon_intrinsics.h>
 
-/* ARMv8 NEON with FMA: cos polynomial, 2x unroll for better ILP */
+/* NEONv8 polynomial-based cos using Cody-Waite argument reduction with FMA */
 static inline void
 volk_32f_cos_32f_neonv8(float* bVector, const float* aVector, unsigned int num_points)
 {
-    const float32x4_t c_minus_cephes_DP1 = vdupq_n_f32(-0.78515625f);
-    const float32x4_t c_minus_cephes_DP2 = vdupq_n_f32(-2.4187564849853515625e-4f);
-    const float32x4_t c_minus_cephes_DP3 = vdupq_n_f32(-3.77489497744594108e-8f);
-    const float32x4_t c_sincof_p0 = vdupq_n_f32(-1.9515295891e-4f);
-    const float32x4_t c_sincof_p1 = vdupq_n_f32(8.3321608736e-3f);
-    const float32x4_t c_sincof_p2 = vdupq_n_f32(-1.6666654611e-1f);
-    const float32x4_t c_coscof_p0 = vdupq_n_f32(2.443315711809948e-005f);
-    const float32x4_t c_coscof_p1 = vdupq_n_f32(-1.388731625493765e-003f);
-    const float32x4_t c_coscof_p2 = vdupq_n_f32(4.166664568298827e-002f);
-    const float32x4_t c_cephes_FOPI = vdupq_n_f32(1.27323954473516f);
-    const float32x4_t CONST_1 = vdupq_n_f32(1.f);
-    const float32x4_t CONST_1_2 = vdupq_n_f32(0.5f);
-    const uint32x4_t CONST_2 = vdupq_n_u32(2);
-    const uint32x4_t CONST_4 = vdupq_n_u32(4);
-    const uint32x4_t CONST_1_U = vdupq_n_u32(1);
-    const uint32x4_t CONST_NOT1 = vdupq_n_u32(~1u);
+    // Cody-Waite argument reduction: n = round(x * 2/pi), r = x - n * pi/2
+    const float32x4_t two_over_pi = vdupq_n_f32(0x1.45f306p-1f);    // 2/pi
+    const float32x4_t pi_over_2_hi = vdupq_n_f32(0x1.921fb6p+0f);   // pi/2 high
+    const float32x4_t pi_over_2_lo = vdupq_n_f32(-0x1.777a5cp-25f); // pi/2 low
+
+    const int32x4_t ones = vdupq_n_s32(1);
+    const int32x4_t twos = vdupq_n_s32(2);
+    const float32x4_t sign_bit = vdupq_n_f32(-0.0f);
 
     unsigned int number = 0;
-    const unsigned int eighth_points = num_points / 8;
+    const unsigned int quarterPoints = num_points / 4;
 
-    for (; number < eighth_points; number++) {
-        /* Load 8 floats (2 x float32x4) */
-        float32x4_t x0 = vld1q_f32(aVector);
-        float32x4_t x1 = vld1q_f32(aVector + 4);
-        aVector += 8;
+    for (; number < quarterPoints; number++) {
+        float32x4_t x = vld1q_f32(aVector);
+        aVector += 4;
 
-        /* Process first 4 - cos is even function, take absolute value */
-        x0 = vabsq_f32(x0);
-        float32x4_t y0 = vmulq_f32(x0, c_cephes_FOPI);
-        uint32x4_t emm2_0 = vcvtq_u32_f32(y0);
-        emm2_0 = vandq_u32(vaddq_u32(emm2_0, CONST_1_U), CONST_NOT1);
-        y0 = vcvtq_f32_u32(emm2_0);
+        // n = round(x * 2/pi) using ARMv8 vrndnq_f32
+        float32x4_t n_f = vrndnq_f32(vmulq_f32(x, two_over_pi));
+        int32x4_t n = vcvtq_s32_f32(n_f);
 
-        /* For cos: use sin poly when (j & 2) != 0, cos poly when (j & 2) == 0 */
-        uint32x4_t poly_mask0 = vtstq_u32(emm2_0, CONST_2);
+        // r = x - n * (pi/2) using FMA for extended precision
+        float32x4_t r = vfmsq_f32(x, n_f, pi_over_2_hi);
+        r = vfmsq_f32(r, n_f, pi_over_2_lo);
 
-        x0 = vfmaq_f32(x0, y0, c_minus_cephes_DP1);
-        x0 = vfmaq_f32(x0, y0, c_minus_cephes_DP2);
-        x0 = vfmaq_f32(x0, y0, c_minus_cephes_DP3);
+        // Evaluate sin and cos polynomials using FMA
+        float32x4_t sin_r = _vsin_poly_neonv8(r);
+        float32x4_t cos_r = _vcos_poly_neonv8(r);
 
-        /* For cos: sign_mask = ((j+2) & 4) != 0 */
-        uint32x4_t sign_mask0 = vtstq_u32(vaddq_u32(emm2_0, CONST_2), CONST_4);
+        // Quadrant-based reconstruction for cos:
+        // n&1 == 0: use cos_r, n&1 == 1: use sin_r
+        // (n+1)&2 == 0: positive, (n+1)&2 == 2: negative
+        int32x4_t n_and_1 = vandq_s32(n, ones);
+        int32x4_t n_plus_1_and_2 = vandq_s32(vaddq_s32(n, ones), twos);
 
-        float32x4_t z0 = vmulq_f32(x0, x0);
+        uint32x4_t swap_mask = vceqq_s32(n_and_1, ones);
+        float32x4_t result = vbslq_f32(swap_mask, sin_r, cos_r);
 
-        /* Cos polynomial */
-        float32x4_t y1_0 = vfmaq_f32(c_coscof_p1, z0, c_coscof_p0);
-        y1_0 = vfmaq_f32(c_coscof_p2, z0, y1_0);
-        y1_0 = vmulq_f32(y1_0, z0);
-        y1_0 = vmulq_f32(y1_0, z0);
-        y1_0 = vfmsq_f32(y1_0, z0, CONST_1_2);
-        y1_0 = vaddq_f32(y1_0, CONST_1);
+        uint32x4_t neg_mask = vceqq_s32(n_plus_1_and_2, twos);
+        result = vreinterpretq_f32_u32(
+            veorq_u32(vreinterpretq_u32_f32(result),
+                      vandq_u32(neg_mask, vreinterpretq_u32_f32(sign_bit))));
 
-        /* Sin polynomial */
-        float32x4_t y2_0 = vfmaq_f32(c_sincof_p1, z0, c_sincof_p0);
-        y2_0 = vfmaq_f32(c_sincof_p2, z0, y2_0);
-        y2_0 = vmulq_f32(y2_0, z0);
-        y2_0 = vfmaq_f32(x0, x0, y2_0);
-
-        /* Select: cos uses cos poly when poly_mask==0, sin poly when poly_mask==1 */
-        float32x4_t ys0 = vbslq_f32(poly_mask0, y2_0, y1_0);
-        float32x4_t result0 = vbslq_f32(sign_mask0, vnegq_f32(ys0), ys0);
-
-        /* Process second 4 */
-        x1 = vabsq_f32(x1);
-        float32x4_t y1 = vmulq_f32(x1, c_cephes_FOPI);
-        uint32x4_t emm2_1 = vcvtq_u32_f32(y1);
-        emm2_1 = vandq_u32(vaddq_u32(emm2_1, CONST_1_U), CONST_NOT1);
-        y1 = vcvtq_f32_u32(emm2_1);
-        uint32x4_t poly_mask1 = vtstq_u32(emm2_1, CONST_2);
-        x1 = vfmaq_f32(x1, y1, c_minus_cephes_DP1);
-        x1 = vfmaq_f32(x1, y1, c_minus_cephes_DP2);
-        x1 = vfmaq_f32(x1, y1, c_minus_cephes_DP3);
-        uint32x4_t sign_mask1 = vtstq_u32(vaddq_u32(emm2_1, CONST_2), CONST_4);
-        float32x4_t z1 = vmulq_f32(x1, x1);
-        float32x4_t y1_1 = vfmaq_f32(c_coscof_p1, z1, c_coscof_p0);
-        y1_1 = vfmaq_f32(c_coscof_p2, z1, y1_1);
-        y1_1 = vmulq_f32(y1_1, z1);
-        y1_1 = vmulq_f32(y1_1, z1);
-        y1_1 = vfmsq_f32(y1_1, z1, CONST_1_2);
-        y1_1 = vaddq_f32(y1_1, CONST_1);
-        float32x4_t y2_1 = vfmaq_f32(c_sincof_p1, z1, c_sincof_p0);
-        y2_1 = vfmaq_f32(c_sincof_p2, z1, y2_1);
-        y2_1 = vmulq_f32(y2_1, z1);
-        y2_1 = vfmaq_f32(x1, x1, y2_1);
-        float32x4_t ys1 = vbslq_f32(poly_mask1, y2_1, y1_1);
-        float32x4_t result1 = vbslq_f32(sign_mask1, vnegq_f32(ys1), ys1);
-
-        vst1q_f32(bVector, result0);
-        vst1q_f32(bVector + 4, result1);
-        bVector += 8;
+        vst1q_f32(bVector, result);
+        bVector += 4;
     }
 
-    /* Handle remaining */
-    for (number = eighth_points * 8; number < num_points; number++) {
+    for (number = quarterPoints * 4; number < num_points; number++) {
         *bVector++ = cosf(*aVector++);
     }
 }
 
 #endif /* LV_HAVE_NEONV8 */
-
 
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>

--- a/kernels/volk/volk_32f_sin_32f.h
+++ b/kernels/volk/volk_32f_sin_32f.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2014 Free Software Foundation, Inc.
+ * Copyright 2025 Magnus Lundmark <magnuslundmark@gmail.com>
  *
  * This file is part of VOLK
  *
@@ -62,9 +63,11 @@
 
 #ifndef INCLUDED_volk_32f_sin_32f_a_H
 #define INCLUDED_volk_32f_sin_32f_a_H
-#ifdef LV_HAVE_AVX512F
 
+#ifdef LV_HAVE_AVX512F
 #include <immintrin.h>
+#include <volk/volk_avx512_intrinsics.h>
+
 static inline void volk_32f_sin_32f_a_avx512f(float* sinVector,
                                               const float* inVector,
                                               unsigned int num_points)
@@ -74,76 +77,51 @@ static inline void volk_32f_sin_32f_a_avx512f(float* sinVector,
 
     unsigned int number = 0;
     unsigned int sixteenPoints = num_points / 16;
-    unsigned int i = 0;
 
-    __m512 aVal, s, r, m4pi, pio4A, pio4B, pio4C, cp1, cp2, cp3, cp4, cp5, ffours, ftwos,
-        fones;
-    __m512 sine, cosine;
-    __m512i q, zeros, ones, twos, fours;
+    // Constants for Cody-Waite argument reduction
+    // n = round(x * 2/pi), then r = x - n * pi/2
+    const __m512 two_over_pi = _mm512_set1_ps(0x1.45f306p-1f);    // 2/pi
+    const __m512 pi_over_2_hi = _mm512_set1_ps(0x1.921fb6p+0f);   // pi/2 high
+    const __m512 pi_over_2_lo = _mm512_set1_ps(-0x1.777a5cp-25f); // pi/2 low
 
-    m4pi = _mm512_set1_ps(1.273239544735162542821171882678754627704620361328125);
-    pio4A = _mm512_set1_ps(0.7853981554508209228515625);
-    pio4B = _mm512_set1_ps(0.794662735614792836713604629039764404296875e-8);
-    pio4C = _mm512_set1_ps(0.306161699786838294306516483068750264552437361480769e-16);
-    ffours = _mm512_set1_ps(4.0);
-    ftwos = _mm512_set1_ps(2.0);
-    fones = _mm512_set1_ps(1.0);
-    zeros = _mm512_setzero_epi32();
-    ones = _mm512_set1_epi32(1);
-    twos = _mm512_set1_epi32(2);
-    fours = _mm512_set1_epi32(4);
-
-    cp1 = _mm512_set1_ps(1.0);
-    cp2 = _mm512_set1_ps(0.08333333333333333);
-    cp3 = _mm512_set1_ps(0.002777777777777778);
-    cp4 = _mm512_set1_ps(4.96031746031746e-05);
-    cp5 = _mm512_set1_ps(5.511463844797178e-07);
-    __mmask16 condition1, condition2, ltZero;
+    const __m512i ones = _mm512_set1_epi32(1);
+    const __m512i twos = _mm512_set1_epi32(2);
+    const __m512i sign_bit = _mm512_set1_epi32(0x80000000);
 
     for (; number < sixteenPoints; number++) {
-        aVal = _mm512_load_ps(inPtr);
-        // s = fabs(aVal)
-        s = (__m512)(_mm512_and_si512((__m512i)(aVal), _mm512_set1_epi32(0x7fffffff)));
+        __m512 x = _mm512_load_ps(inPtr);
 
-        // q = (int) (s * (4/pi)), floor(aVal / (pi/4))
-        q = _mm512_cvtps_epi32(_mm512_floor_ps(_mm512_mul_ps(s, m4pi)));
-        // r = q + q&1, q indicates quadrant, r gives
-        r = _mm512_cvtepi32_ps(_mm512_add_epi32(q, _mm512_and_si512(q, ones)));
+        // Argument reduction: n = round(x * 2/pi)
+        __m512 n_f = _mm512_roundscale_ps(_mm512_mul_ps(x, two_over_pi),
+                                          _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m512i n = _mm512_cvtps_epi32(n_f);
 
-        s = _mm512_fnmadd_ps(r, pio4A, s);
-        s = _mm512_fnmadd_ps(r, pio4B, s);
-        s = _mm512_fnmadd_ps(r, pio4C, s);
+        // r = x - n * (pi/2), using extended precision
+        __m512 r = _mm512_fnmadd_ps(n_f, pi_over_2_hi, x);
+        r = _mm512_fnmadd_ps(n_f, pi_over_2_lo, r);
 
-        s = _mm512_div_ps(
-            s,
-            _mm512_set1_ps(8.0f)); // The constant is 2^N, for 3 times argument reduction
-        s = _mm512_mul_ps(s, s);
-        // Evaluate Taylor series
-        s = _mm512_mul_ps(
-            _mm512_fmadd_ps(
-                _mm512_fmsub_ps(
-                    _mm512_fmadd_ps(_mm512_fmsub_ps(s, cp5, cp4), s, cp3), s, cp2),
-                s,
-                cp1),
-            s);
+        // Evaluate both sin and cos polynomials
+        __m512 sin_r = _mm512_sin_poly_avx512(r);
+        __m512 cos_r = _mm512_cos_poly_avx512(r);
 
-        for (i = 0; i < 3; i++) {
-            s = _mm512_mul_ps(s, _mm512_sub_ps(ffours, s));
-        }
-        s = _mm512_div_ps(s, ftwos);
+        // Reconstruct sin(x) based on quadrant (n mod 4):
+        // n&1 == 0: use sin_r, n&1 == 1: use cos_r
+        // n&2 == 0: positive, n&2 == 2: negative
+        __m512i n_and_1 = _mm512_and_si512(n, ones);
+        __m512i n_and_2 = _mm512_and_si512(n, twos);
 
-        sine = _mm512_sqrt_ps(_mm512_mul_ps(_mm512_sub_ps(ftwos, s), s));
-        cosine = _mm512_sub_ps(fones, s);
+        // swap_mask: where n&1 != 0, we use cos instead of sin
+        __mmask16 swap_mask = _mm512_cmpeq_epi32_mask(n_and_1, ones);
+        __m512 result = _mm512_mask_blend_ps(swap_mask, sin_r, cos_r);
 
-        condition1 = _mm512_cmpneq_epi32_mask(
-            _mm512_and_si512(_mm512_add_epi32(q, ones), twos), zeros);
-        ltZero = _mm512_cmp_ps_mask(aVal, _mm512_setzero_ps(), _CMP_LT_OS);
-        condition2 = _mm512_kxor(
-            _mm512_cmpneq_epi32_mask(_mm512_and_epi32(q, fours), zeros), ltZero);
+        // neg_mask: where n&2 != 0, we negate the result (use integer xor for AVX512F)
+        __mmask16 neg_mask = _mm512_cmpeq_epi32_mask(n_and_2, twos);
+        result = _mm512_castsi512_ps(_mm512_mask_xor_epi32(_mm512_castps_si512(result),
+                                                           neg_mask,
+                                                           _mm512_castps_si512(result),
+                                                           sign_bit));
 
-        sine = _mm512_mask_blend_ps(condition1, sine, cosine);
-        sine = _mm512_mask_mul_ps(sine, condition2, sine, _mm512_set1_ps(-1.f));
-        _mm512_store_ps(sinPtr, sine);
+        _mm512_store_ps(sinPtr, result);
         inPtr += 16;
         sinPtr += 16;
     }
@@ -153,9 +131,11 @@ static inline void volk_32f_sin_32f_a_avx512f(float* sinVector,
         *sinPtr++ = sinf(*inPtr++);
     }
 }
-#endif
+#endif /* LV_HAVE_AVX512F */
+
 #if LV_HAVE_AVX2 && LV_HAVE_FMA
 #include <immintrin.h>
+#include <volk/volk_avx2_fma_intrinsics.h>
 
 static inline void
 volk_32f_sin_32f_a_avx2_fma(float* bVector, const float* aVector, unsigned int num_points)
@@ -165,94 +145,63 @@ volk_32f_sin_32f_a_avx2_fma(float* bVector, const float* aVector, unsigned int n
 
     unsigned int number = 0;
     unsigned int eighthPoints = num_points / 8;
-    unsigned int i = 0;
 
-    __m256 aVal, s, m4pi, pio4A, pio4B, cp1, cp2, cp3, cp4, cp5, ffours, ftwos, fones,
-        fzeroes;
-    __m256 sine, cosine, condition1, condition2;
-    __m256i q, r, ones, twos, fours;
+    // Constants for Cody-Waite argument reduction
+    // n = round(x * 2/pi), then r = x - n * pi/2
+    const __m256 two_over_pi = _mm256_set1_ps(0x1.45f306p-1f);    // 2/pi
+    const __m256 pi_over_2_hi = _mm256_set1_ps(0x1.921fb6p+0f);   // pi/2 high
+    const __m256 pi_over_2_lo = _mm256_set1_ps(-0x1.777a5cp-25f); // pi/2 low
 
-    m4pi = _mm256_set1_ps(1.273239545);
-    pio4A = _mm256_set1_ps(0.78515625);
-    pio4B = _mm256_set1_ps(0.241876e-3);
-    ffours = _mm256_set1_ps(4.0);
-    ftwos = _mm256_set1_ps(2.0);
-    fones = _mm256_set1_ps(1.0);
-    fzeroes = _mm256_setzero_ps();
-    ones = _mm256_set1_epi32(1);
-    twos = _mm256_set1_epi32(2);
-    fours = _mm256_set1_epi32(4);
-
-    cp1 = _mm256_set1_ps(1.0);
-    cp2 = _mm256_set1_ps(0.83333333e-1);
-    cp3 = _mm256_set1_ps(0.2777778e-2);
-    cp4 = _mm256_set1_ps(0.49603e-4);
-    cp5 = _mm256_set1_ps(0.551e-6);
+    const __m256i ones = _mm256_set1_epi32(1);
+    const __m256i twos = _mm256_set1_epi32(2);
+    const __m256 sign_bit = _mm256_set1_ps(-0.0f);
 
     for (; number < eighthPoints; number++) {
-        aVal = _mm256_load_ps(aPtr);
-        s = _mm256_sub_ps(aVal,
-                          _mm256_and_ps(_mm256_mul_ps(aVal, ftwos),
-                                        _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS)));
-        q = _mm256_cvtps_epi32(_mm256_floor_ps(_mm256_mul_ps(s, m4pi)));
-        r = _mm256_add_epi32(q, _mm256_and_si256(q, ones));
+        __m256 x = _mm256_load_ps(aPtr);
 
-        s = _mm256_fnmadd_ps(_mm256_cvtepi32_ps(r), pio4A, s);
-        s = _mm256_fnmadd_ps(_mm256_cvtepi32_ps(r), pio4B, s);
+        // Argument reduction: n = round(x * 2/pi)
+        __m256 n_f = _mm256_round_ps(_mm256_mul_ps(x, two_over_pi),
+                                     _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m256i n = _mm256_cvtps_epi32(n_f);
 
-        s = _mm256_div_ps(
-            s,
-            _mm256_set1_ps(8.0)); // The constant is 2^N, for 3 times argument reduction
-        s = _mm256_mul_ps(s, s);
-        // Evaluate Taylor series
-        s = _mm256_mul_ps(
-            _mm256_fmadd_ps(
-                _mm256_fmsub_ps(
-                    _mm256_fmadd_ps(_mm256_fmsub_ps(s, cp5, cp4), s, cp3), s, cp2),
-                s,
-                cp1),
-            s);
+        // r = x - n * (pi/2), using extended precision
+        __m256 r = _mm256_fnmadd_ps(n_f, pi_over_2_hi, x);
+        r = _mm256_fnmadd_ps(n_f, pi_over_2_lo, r);
 
-        for (i = 0; i < 3; i++) {
-            s = _mm256_mul_ps(s, _mm256_sub_ps(ffours, s));
-        }
-        s = _mm256_div_ps(s, ftwos);
+        // Evaluate both sin and cos polynomials
+        __m256 sin_r = _mm256_sin_poly_avx2_fma(r);
+        __m256 cos_r = _mm256_cos_poly_avx2_fma(r);
 
-        sine = _mm256_sqrt_ps(_mm256_mul_ps(_mm256_sub_ps(ftwos, s), s));
-        cosine = _mm256_sub_ps(fones, s);
+        // Reconstruct sin(x) based on quadrant (n mod 4):
+        // n&1 == 0: use sin_r, n&1 == 1: use cos_r
+        // n&2 == 0: positive, n&2 == 2: negative
+        __m256i n_and_1 = _mm256_and_si256(n, ones);
+        __m256i n_and_2 = _mm256_and_si256(n, twos);
 
-        condition1 = _mm256_cmp_ps(
-            _mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)),
-            fzeroes,
-            _CMP_NEQ_UQ);
-        condition2 = _mm256_cmp_ps(
-            _mm256_cmp_ps(
-                _mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes, _CMP_NEQ_UQ),
-            _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS),
-            _CMP_NEQ_UQ);
-        // Need this condition only for cos
-        // condition3 = _mm_cmpneq_ps(_mm_cvtepi32_ps(_mm_and_si128(_mm_add_epi32(q,
-        // twos), fours)), fzeroes);
+        // swap_mask: where n&1 != 0, we use cos instead of sin
+        __m256 swap_mask = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_and_1, ones));
+        __m256 result = _mm256_blendv_ps(sin_r, cos_r, swap_mask);
 
-        sine =
-            _mm256_add_ps(sine, _mm256_and_ps(_mm256_sub_ps(cosine, sine), condition1));
-        sine = _mm256_sub_ps(
-            sine, _mm256_and_ps(_mm256_mul_ps(sine, _mm256_set1_ps(2.0f)), condition2));
-        _mm256_store_ps(bPtr, sine);
+        // neg_mask: where n&2 != 0, we negate the result
+        __m256 neg_mask = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_and_2, twos));
+        result = _mm256_xor_ps(result, _mm256_and_ps(neg_mask, sign_bit));
+
+        _mm256_store_ps(bPtr, result);
         aPtr += 8;
         bPtr += 8;
     }
 
     number = eighthPoints * 8;
     for (; number < num_points; number++) {
-        *bPtr++ = sin(*aPtr++);
+        *bPtr++ = sinf(*aPtr++);
     }
 }
 
-#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA for aligned */
+#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA */
 
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
+#include <volk/volk_avx2_intrinsics.h>
 
 static inline void
 volk_32f_sin_32f_a_avx2(float* bVector, const float* aVector, unsigned int num_points)
@@ -262,101 +211,63 @@ volk_32f_sin_32f_a_avx2(float* bVector, const float* aVector, unsigned int num_p
 
     unsigned int number = 0;
     unsigned int eighthPoints = num_points / 8;
-    unsigned int i = 0;
 
-    __m256 aVal, s, m4pi, pio4A, pio4B, cp1, cp2, cp3, cp4, cp5, ffours, ftwos, fones,
-        fzeroes;
-    __m256 sine, cosine, condition1, condition2;
-    __m256i q, r, ones, twos, fours;
+    // Constants for Cody-Waite argument reduction
+    // n = round(x * 2/pi), then r = x - n * pi/2
+    const __m256 two_over_pi = _mm256_set1_ps(0x1.45f306p-1f);    // 2/pi
+    const __m256 pi_over_2_hi = _mm256_set1_ps(0x1.921fb6p+0f);   // pi/2 high
+    const __m256 pi_over_2_lo = _mm256_set1_ps(-0x1.777a5cp-25f); // pi/2 low
 
-    m4pi = _mm256_set1_ps(1.273239545);
-    pio4A = _mm256_set1_ps(0.78515625);
-    pio4B = _mm256_set1_ps(0.241876e-3);
-    ffours = _mm256_set1_ps(4.0);
-    ftwos = _mm256_set1_ps(2.0);
-    fones = _mm256_set1_ps(1.0);
-    fzeroes = _mm256_setzero_ps();
-    ones = _mm256_set1_epi32(1);
-    twos = _mm256_set1_epi32(2);
-    fours = _mm256_set1_epi32(4);
-
-    cp1 = _mm256_set1_ps(1.0);
-    cp2 = _mm256_set1_ps(0.83333333e-1);
-    cp3 = _mm256_set1_ps(0.2777778e-2);
-    cp4 = _mm256_set1_ps(0.49603e-4);
-    cp5 = _mm256_set1_ps(0.551e-6);
+    const __m256i ones = _mm256_set1_epi32(1);
+    const __m256i twos = _mm256_set1_epi32(2);
+    const __m256 sign_bit = _mm256_set1_ps(-0.0f);
 
     for (; number < eighthPoints; number++) {
-        aVal = _mm256_load_ps(aPtr);
-        s = _mm256_sub_ps(aVal,
-                          _mm256_and_ps(_mm256_mul_ps(aVal, ftwos),
-                                        _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS)));
-        q = _mm256_cvtps_epi32(_mm256_floor_ps(_mm256_mul_ps(s, m4pi)));
-        r = _mm256_add_epi32(q, _mm256_and_si256(q, ones));
+        __m256 x = _mm256_load_ps(aPtr);
 
-        s = _mm256_sub_ps(s, _mm256_mul_ps(_mm256_cvtepi32_ps(r), pio4A));
-        s = _mm256_sub_ps(s, _mm256_mul_ps(_mm256_cvtepi32_ps(r), pio4B));
+        // Argument reduction: n = round(x * 2/pi)
+        __m256 n_f = _mm256_round_ps(_mm256_mul_ps(x, two_over_pi),
+                                     _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m256i n = _mm256_cvtps_epi32(n_f);
 
-        s = _mm256_div_ps(
-            s,
-            _mm256_set1_ps(8.0)); // The constant is 2^N, for 3 times argument reduction
-        s = _mm256_mul_ps(s, s);
-        // Evaluate Taylor series
-        s = _mm256_mul_ps(
-            _mm256_add_ps(
-                _mm256_mul_ps(
-                    _mm256_sub_ps(
-                        _mm256_mul_ps(
-                            _mm256_add_ps(
-                                _mm256_mul_ps(_mm256_sub_ps(_mm256_mul_ps(s, cp5), cp4),
-                                              s),
-                                cp3),
-                            s),
-                        cp2),
-                    s),
-                cp1),
-            s);
+        // r = x - n * (pi/2), using extended precision
+        __m256 r = _mm256_sub_ps(x, _mm256_mul_ps(n_f, pi_over_2_hi));
+        r = _mm256_sub_ps(r, _mm256_mul_ps(n_f, pi_over_2_lo));
 
-        for (i = 0; i < 3; i++) {
-            s = _mm256_mul_ps(s, _mm256_sub_ps(ffours, s));
-        }
-        s = _mm256_div_ps(s, ftwos);
+        // Evaluate both sin and cos polynomials
+        __m256 sin_r = _mm256_sin_poly_avx2(r);
+        __m256 cos_r = _mm256_cos_poly_avx2(r);
 
-        sine = _mm256_sqrt_ps(_mm256_mul_ps(_mm256_sub_ps(ftwos, s), s));
-        cosine = _mm256_sub_ps(fones, s);
+        // Reconstruct sin(x) based on quadrant (n mod 4):
+        // n&1 == 0: use sin_r, n&1 == 1: use cos_r
+        // n&2 == 0: positive, n&2 == 2: negative
+        __m256i n_and_1 = _mm256_and_si256(n, ones);
+        __m256i n_and_2 = _mm256_and_si256(n, twos);
 
-        condition1 = _mm256_cmp_ps(
-            _mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)),
-            fzeroes,
-            _CMP_NEQ_UQ);
-        condition2 = _mm256_cmp_ps(
-            _mm256_cmp_ps(
-                _mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes, _CMP_NEQ_UQ),
-            _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS),
-            _CMP_NEQ_UQ);
-        // Need this condition only for cos
-        // condition3 = _mm_cmpneq_ps(_mm_cvtepi32_ps(_mm_and_si128(_mm_add_epi32(q,
-        // twos), fours)), fzeroes);
+        // swap_mask: where n&1 != 0, we use cos instead of sin
+        __m256 swap_mask = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_and_1, ones));
+        __m256 result = _mm256_blendv_ps(sin_r, cos_r, swap_mask);
 
-        sine =
-            _mm256_add_ps(sine, _mm256_and_ps(_mm256_sub_ps(cosine, sine), condition1));
-        sine = _mm256_sub_ps(
-            sine, _mm256_and_ps(_mm256_mul_ps(sine, _mm256_set1_ps(2.0f)), condition2));
-        _mm256_store_ps(bPtr, sine);
+        // neg_mask: where n&2 != 0, we negate the result
+        __m256 neg_mask = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_and_2, twos));
+        result = _mm256_xor_ps(result, _mm256_and_ps(neg_mask, sign_bit));
+
+        _mm256_store_ps(bPtr, result);
         aPtr += 8;
         bPtr += 8;
     }
 
     number = eighthPoints * 8;
     for (; number < num_points; number++) {
-        *bPtr++ = sin(*aPtr++);
+        *bPtr++ = sinf(*aPtr++);
     }
 }
 
-#endif /* LV_HAVE_AVX2 for aligned */
+#endif /* LV_HAVE_AVX2 */
 
 #ifdef LV_HAVE_SSE4_1
 #include <smmintrin.h>
+#include <volk/volk_sse_intrinsics.h>
 
 static inline void
 volk_32f_sin_32f_a_sse4_1(float* bVector, const float* aVector, unsigned int num_points)
@@ -366,78 +277,48 @@ volk_32f_sin_32f_a_sse4_1(float* bVector, const float* aVector, unsigned int num
 
     unsigned int number = 0;
     unsigned int quarterPoints = num_points / 4;
-    unsigned int i = 0;
 
-    __m128 aVal, s, m4pi, pio4A, pio4B, cp1, cp2, cp3, cp4, cp5, ffours, ftwos, fones,
-        fzeroes;
-    __m128 sine, cosine, condition1, condition2;
-    __m128i q, r, ones, twos, fours;
+    // Constants for Cody-Waite argument reduction
+    // n = round(x * 2/pi), then r = x - n * pi/2
+    const __m128 two_over_pi = _mm_set1_ps(0x1.45f306p-1f);    // 2/pi
+    const __m128 pi_over_2_hi = _mm_set1_ps(0x1.921fb6p+0f);   // pi/2 high
+    const __m128 pi_over_2_lo = _mm_set1_ps(-0x1.777a5cp-25f); // pi/2 low
 
-    m4pi = _mm_set1_ps(1.273239545);
-    pio4A = _mm_set1_ps(0.78515625);
-    pio4B = _mm_set1_ps(0.241876e-3);
-    ffours = _mm_set1_ps(4.0);
-    ftwos = _mm_set1_ps(2.0);
-    fones = _mm_set1_ps(1.0);
-    fzeroes = _mm_setzero_ps();
-    ones = _mm_set1_epi32(1);
-    twos = _mm_set1_epi32(2);
-    fours = _mm_set1_epi32(4);
-
-    cp1 = _mm_set1_ps(1.0);
-    cp2 = _mm_set1_ps(0.83333333e-1);
-    cp3 = _mm_set1_ps(0.2777778e-2);
-    cp4 = _mm_set1_ps(0.49603e-4);
-    cp5 = _mm_set1_ps(0.551e-6);
+    const __m128i ones = _mm_set1_epi32(1);
+    const __m128i twos = _mm_set1_epi32(2);
+    const __m128 sign_bit = _mm_set1_ps(-0.0f);
 
     for (; number < quarterPoints; number++) {
-        aVal = _mm_load_ps(aPtr);
-        s = _mm_sub_ps(aVal,
-                       _mm_and_ps(_mm_mul_ps(aVal, ftwos), _mm_cmplt_ps(aVal, fzeroes)));
-        q = _mm_cvtps_epi32(_mm_floor_ps(_mm_mul_ps(s, m4pi)));
-        r = _mm_add_epi32(q, _mm_and_si128(q, ones));
+        __m128 x = _mm_load_ps(aPtr);
 
-        s = _mm_sub_ps(s, _mm_mul_ps(_mm_cvtepi32_ps(r), pio4A));
-        s = _mm_sub_ps(s, _mm_mul_ps(_mm_cvtepi32_ps(r), pio4B));
+        // Argument reduction: n = round(x * 2/pi)
+        __m128 n_f = _mm_round_ps(_mm_mul_ps(x, two_over_pi),
+                                  _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m128i n = _mm_cvtps_epi32(n_f);
 
-        s = _mm_div_ps(
-            s, _mm_set1_ps(8.0)); // The constant is 2^N, for 3 times argument reduction
-        s = _mm_mul_ps(s, s);
-        // Evaluate Taylor series
-        s = _mm_mul_ps(
-            _mm_add_ps(
-                _mm_mul_ps(
-                    _mm_sub_ps(
-                        _mm_mul_ps(
-                            _mm_add_ps(_mm_mul_ps(_mm_sub_ps(_mm_mul_ps(s, cp5), cp4), s),
-                                       cp3),
-                            s),
-                        cp2),
-                    s),
-                cp1),
-            s);
+        // r = x - n * (pi/2), using extended precision
+        __m128 r = _mm_sub_ps(x, _mm_mul_ps(n_f, pi_over_2_hi));
+        r = _mm_sub_ps(r, _mm_mul_ps(n_f, pi_over_2_lo));
 
-        for (i = 0; i < 3; i++) {
-            s = _mm_mul_ps(s, _mm_sub_ps(ffours, s));
-        }
-        s = _mm_div_ps(s, ftwos);
+        // Evaluate both sin and cos polynomials
+        __m128 sin_r = _mm_sin_poly_sse(r);
+        __m128 cos_r = _mm_cos_poly_sse(r);
 
-        sine = _mm_sqrt_ps(_mm_mul_ps(_mm_sub_ps(ftwos, s), s));
-        cosine = _mm_sub_ps(fones, s);
+        // Reconstruct sin(x) based on quadrant (n mod 4):
+        // n&1 == 0: use sin_r, n&1 == 1: use cos_r
+        // n&2 == 0: positive, n&2 == 2: negative
+        __m128i n_and_1 = _mm_and_si128(n, ones);
+        __m128i n_and_2 = _mm_and_si128(n, twos);
 
-        condition1 = _mm_cmpneq_ps(
-            _mm_cvtepi32_ps(_mm_and_si128(_mm_add_epi32(q, ones), twos)), fzeroes);
-        condition2 = _mm_cmpneq_ps(
-            _mm_cmpneq_ps(_mm_cvtepi32_ps(_mm_and_si128(q, fours)), fzeroes),
-            _mm_cmplt_ps(aVal, fzeroes));
-        // Need this condition only for cos
-        // condition3 = _mm_cmpneq_ps(_mm_cvtepi32_ps(_mm_and_si128(_mm_add_epi32(q,
-        // twos), fours)), fzeroes);
+        // swap_mask: where n&1 != 0, we use cos instead of sin
+        __m128 swap_mask = _mm_castsi128_ps(_mm_cmpeq_epi32(n_and_1, ones));
+        __m128 result = _mm_blendv_ps(sin_r, cos_r, swap_mask);
 
-        sine = _mm_add_ps(sine, _mm_and_ps(_mm_sub_ps(cosine, sine), condition1));
-        sine =
-            _mm_sub_ps(sine, _mm_and_ps(_mm_mul_ps(sine, _mm_set1_ps(2.0f)), condition2));
-        _mm_store_ps(bPtr, sine);
+        // neg_mask: where n&2 != 0, we negate the result
+        __m128 neg_mask = _mm_castsi128_ps(_mm_cmpeq_epi32(n_and_2, twos));
+        result = _mm_xor_ps(result, _mm_and_ps(neg_mask, sign_bit));
+
+        _mm_store_ps(bPtr, result);
         aPtr += 4;
         bPtr += 4;
     }
@@ -448,7 +329,7 @@ volk_32f_sin_32f_a_sse4_1(float* bVector, const float* aVector, unsigned int num
     }
 }
 
-#endif /* LV_HAVE_SSE4_1 for aligned */
+#endif /* LV_HAVE_SSE4_1 */
 
 
 #endif /* INCLUDED_volk_32f_sin_32f_a_H */
@@ -457,8 +338,9 @@ volk_32f_sin_32f_a_sse4_1(float* bVector, const float* aVector, unsigned int num
 #define INCLUDED_volk_32f_sin_32f_u_H
 
 #ifdef LV_HAVE_AVX512F
-
 #include <immintrin.h>
+#include <volk/volk_avx512_intrinsics.h>
+
 static inline void volk_32f_sin_32f_u_avx512f(float* sinVector,
                                               const float* inVector,
                                               unsigned int num_points)
@@ -468,76 +350,51 @@ static inline void volk_32f_sin_32f_u_avx512f(float* sinVector,
 
     unsigned int number = 0;
     unsigned int sixteenPoints = num_points / 16;
-    unsigned int i = 0;
 
-    __m512 aVal, s, r, m4pi, pio4A, pio4B, pio4C, cp1, cp2, cp3, cp4, cp5, ffours, ftwos,
-        fones;
-    __m512 sine, cosine;
-    __m512i q, zeros, ones, twos, fours;
+    // Constants for Cody-Waite argument reduction
+    // n = round(x * 2/pi), then r = x - n * pi/2
+    const __m512 two_over_pi = _mm512_set1_ps(0x1.45f306p-1f);    // 2/pi
+    const __m512 pi_over_2_hi = _mm512_set1_ps(0x1.921fb6p+0f);   // pi/2 high
+    const __m512 pi_over_2_lo = _mm512_set1_ps(-0x1.777a5cp-25f); // pi/2 low
 
-    m4pi = _mm512_set1_ps(1.273239544735162542821171882678754627704620361328125);
-    pio4A = _mm512_set1_ps(0.7853981554508209228515625);
-    pio4B = _mm512_set1_ps(0.794662735614792836713604629039764404296875e-8);
-    pio4C = _mm512_set1_ps(0.306161699786838294306516483068750264552437361480769e-16);
-    ffours = _mm512_set1_ps(4.0);
-    ftwos = _mm512_set1_ps(2.0);
-    fones = _mm512_set1_ps(1.0);
-    zeros = _mm512_setzero_epi32();
-    ones = _mm512_set1_epi32(1);
-    twos = _mm512_set1_epi32(2);
-    fours = _mm512_set1_epi32(4);
-
-    cp1 = _mm512_set1_ps(1.0);
-    cp2 = _mm512_set1_ps(0.08333333333333333);
-    cp3 = _mm512_set1_ps(0.002777777777777778);
-    cp4 = _mm512_set1_ps(4.96031746031746e-05);
-    cp5 = _mm512_set1_ps(5.511463844797178e-07);
-    __mmask16 condition1, condition2, ltZero;
+    const __m512i ones = _mm512_set1_epi32(1);
+    const __m512i twos = _mm512_set1_epi32(2);
+    const __m512i sign_bit = _mm512_set1_epi32(0x80000000);
 
     for (; number < sixteenPoints; number++) {
-        aVal = _mm512_loadu_ps(inPtr);
-        // s = fabs(aVal)
-        s = (__m512)(_mm512_and_si512((__m512i)(aVal), _mm512_set1_epi32(0x7fffffff)));
+        __m512 x = _mm512_loadu_ps(inPtr);
 
-        // q = (int) (s * (4/pi)), floor(aVal / (pi/4))
-        q = _mm512_cvtps_epi32(_mm512_floor_ps(_mm512_mul_ps(s, m4pi)));
-        // r = q + q&1, q indicates quadrant, r gives
-        r = _mm512_cvtepi32_ps(_mm512_add_epi32(q, _mm512_and_si512(q, ones)));
+        // Argument reduction: n = round(x * 2/pi)
+        __m512 n_f = _mm512_roundscale_ps(_mm512_mul_ps(x, two_over_pi),
+                                          _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m512i n = _mm512_cvtps_epi32(n_f);
 
-        s = _mm512_fnmadd_ps(r, pio4A, s);
-        s = _mm512_fnmadd_ps(r, pio4B, s);
-        s = _mm512_fnmadd_ps(r, pio4C, s);
+        // r = x - n * (pi/2), using extended precision
+        __m512 r = _mm512_fnmadd_ps(n_f, pi_over_2_hi, x);
+        r = _mm512_fnmadd_ps(n_f, pi_over_2_lo, r);
 
-        s = _mm512_div_ps(
-            s,
-            _mm512_set1_ps(8.0f)); // The constant is 2^N, for 3 times argument reduction
-        s = _mm512_mul_ps(s, s);
-        // Evaluate Taylor series
-        s = _mm512_mul_ps(
-            _mm512_fmadd_ps(
-                _mm512_fmsub_ps(
-                    _mm512_fmadd_ps(_mm512_fmsub_ps(s, cp5, cp4), s, cp3), s, cp2),
-                s,
-                cp1),
-            s);
+        // Evaluate both sin and cos polynomials
+        __m512 sin_r = _mm512_sin_poly_avx512(r);
+        __m512 cos_r = _mm512_cos_poly_avx512(r);
 
-        for (i = 0; i < 3; i++) {
-            s = _mm512_mul_ps(s, _mm512_sub_ps(ffours, s));
-        }
-        s = _mm512_div_ps(s, ftwos);
+        // Reconstruct sin(x) based on quadrant (n mod 4):
+        // n&1 == 0: use sin_r, n&1 == 1: use cos_r
+        // n&2 == 0: positive, n&2 == 2: negative
+        __m512i n_and_1 = _mm512_and_si512(n, ones);
+        __m512i n_and_2 = _mm512_and_si512(n, twos);
 
-        sine = _mm512_sqrt_ps(_mm512_mul_ps(_mm512_sub_ps(ftwos, s), s));
-        cosine = _mm512_sub_ps(fones, s);
+        // swap_mask: where n&1 != 0, we use cos instead of sin
+        __mmask16 swap_mask = _mm512_cmpeq_epi32_mask(n_and_1, ones);
+        __m512 result = _mm512_mask_blend_ps(swap_mask, sin_r, cos_r);
 
-        condition1 = _mm512_cmpneq_epi32_mask(
-            _mm512_and_si512(_mm512_add_epi32(q, ones), twos), zeros);
-        ltZero = _mm512_cmp_ps_mask(aVal, _mm512_setzero_ps(), _CMP_LT_OS);
-        condition2 = _mm512_kxor(
-            _mm512_cmpneq_epi32_mask(_mm512_and_epi32(q, fours), zeros), ltZero);
+        // neg_mask: where n&2 != 0, we negate the result (use integer xor for AVX512F)
+        __mmask16 neg_mask = _mm512_cmpeq_epi32_mask(n_and_2, twos);
+        result = _mm512_castsi512_ps(_mm512_mask_xor_epi32(_mm512_castps_si512(result),
+                                                           neg_mask,
+                                                           _mm512_castps_si512(result),
+                                                           sign_bit));
 
-        sine = _mm512_mask_blend_ps(condition1, sine, cosine);
-        sine = _mm512_mask_mul_ps(sine, condition2, sine, _mm512_set1_ps(-1.f));
-        _mm512_storeu_ps(sinPtr, sine);
+        _mm512_storeu_ps(sinPtr, result);
         inPtr += 16;
         sinPtr += 16;
     }
@@ -547,10 +404,11 @@ static inline void volk_32f_sin_32f_u_avx512f(float* sinVector,
         *sinPtr++ = sinf(*inPtr++);
     }
 }
-#endif
+#endif /* LV_HAVE_AVX512F */
 
 #if LV_HAVE_AVX2 && LV_HAVE_FMA
 #include <immintrin.h>
+#include <volk/volk_avx2_fma_intrinsics.h>
 
 static inline void
 volk_32f_sin_32f_u_avx2_fma(float* bVector, const float* aVector, unsigned int num_points)
@@ -560,94 +418,63 @@ volk_32f_sin_32f_u_avx2_fma(float* bVector, const float* aVector, unsigned int n
 
     unsigned int number = 0;
     unsigned int eighthPoints = num_points / 8;
-    unsigned int i = 0;
 
-    __m256 aVal, s, m4pi, pio4A, pio4B, cp1, cp2, cp3, cp4, cp5, ffours, ftwos, fones,
-        fzeroes;
-    __m256 sine, cosine, condition1, condition2;
-    __m256i q, r, ones, twos, fours;
+    // Constants for Cody-Waite argument reduction
+    // n = round(x * 2/pi), then r = x - n * pi/2
+    const __m256 two_over_pi = _mm256_set1_ps(0x1.45f306p-1f);    // 2/pi
+    const __m256 pi_over_2_hi = _mm256_set1_ps(0x1.921fb6p+0f);   // pi/2 high
+    const __m256 pi_over_2_lo = _mm256_set1_ps(-0x1.777a5cp-25f); // pi/2 low
 
-    m4pi = _mm256_set1_ps(1.273239545);
-    pio4A = _mm256_set1_ps(0.78515625);
-    pio4B = _mm256_set1_ps(0.241876e-3);
-    ffours = _mm256_set1_ps(4.0);
-    ftwos = _mm256_set1_ps(2.0);
-    fones = _mm256_set1_ps(1.0);
-    fzeroes = _mm256_setzero_ps();
-    ones = _mm256_set1_epi32(1);
-    twos = _mm256_set1_epi32(2);
-    fours = _mm256_set1_epi32(4);
-
-    cp1 = _mm256_set1_ps(1.0);
-    cp2 = _mm256_set1_ps(0.83333333e-1);
-    cp3 = _mm256_set1_ps(0.2777778e-2);
-    cp4 = _mm256_set1_ps(0.49603e-4);
-    cp5 = _mm256_set1_ps(0.551e-6);
+    const __m256i ones = _mm256_set1_epi32(1);
+    const __m256i twos = _mm256_set1_epi32(2);
+    const __m256 sign_bit = _mm256_set1_ps(-0.0f);
 
     for (; number < eighthPoints; number++) {
-        aVal = _mm256_loadu_ps(aPtr);
-        s = _mm256_sub_ps(aVal,
-                          _mm256_and_ps(_mm256_mul_ps(aVal, ftwos),
-                                        _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS)));
-        q = _mm256_cvtps_epi32(_mm256_floor_ps(_mm256_mul_ps(s, m4pi)));
-        r = _mm256_add_epi32(q, _mm256_and_si256(q, ones));
+        __m256 x = _mm256_loadu_ps(aPtr);
 
-        s = _mm256_fnmadd_ps(_mm256_cvtepi32_ps(r), pio4A, s);
-        s = _mm256_fnmadd_ps(_mm256_cvtepi32_ps(r), pio4B, s);
+        // Argument reduction: n = round(x * 2/pi)
+        __m256 n_f = _mm256_round_ps(_mm256_mul_ps(x, two_over_pi),
+                                     _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m256i n = _mm256_cvtps_epi32(n_f);
 
-        s = _mm256_div_ps(
-            s,
-            _mm256_set1_ps(8.0)); // The constant is 2^N, for 3 times argument reduction
-        s = _mm256_mul_ps(s, s);
-        // Evaluate Taylor series
-        s = _mm256_mul_ps(
-            _mm256_fmadd_ps(
-                _mm256_fmsub_ps(
-                    _mm256_fmadd_ps(_mm256_fmsub_ps(s, cp5, cp4), s, cp3), s, cp2),
-                s,
-                cp1),
-            s);
+        // r = x - n * (pi/2), using extended precision
+        __m256 r = _mm256_fnmadd_ps(n_f, pi_over_2_hi, x);
+        r = _mm256_fnmadd_ps(n_f, pi_over_2_lo, r);
 
-        for (i = 0; i < 3; i++) {
-            s = _mm256_mul_ps(s, _mm256_sub_ps(ffours, s));
-        }
-        s = _mm256_div_ps(s, ftwos);
+        // Evaluate both sin and cos polynomials
+        __m256 sin_r = _mm256_sin_poly_avx2_fma(r);
+        __m256 cos_r = _mm256_cos_poly_avx2_fma(r);
 
-        sine = _mm256_sqrt_ps(_mm256_mul_ps(_mm256_sub_ps(ftwos, s), s));
-        cosine = _mm256_sub_ps(fones, s);
+        // Reconstruct sin(x) based on quadrant (n mod 4):
+        // n&1 == 0: use sin_r, n&1 == 1: use cos_r
+        // n&2 == 0: positive, n&2 == 2: negative
+        __m256i n_and_1 = _mm256_and_si256(n, ones);
+        __m256i n_and_2 = _mm256_and_si256(n, twos);
 
-        condition1 = _mm256_cmp_ps(
-            _mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)),
-            fzeroes,
-            _CMP_NEQ_UQ);
-        condition2 = _mm256_cmp_ps(
-            _mm256_cmp_ps(
-                _mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes, _CMP_NEQ_UQ),
-            _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS),
-            _CMP_NEQ_UQ);
-        // Need this condition only for cos
-        // condition3 = _mm_cmpneq_ps(_mm_cvtepi32_ps(_mm_and_si128(_mm_add_epi32(q,
-        // twos), fours)), fzeroes);
+        // swap_mask: where n&1 != 0, we use cos instead of sin
+        __m256 swap_mask = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_and_1, ones));
+        __m256 result = _mm256_blendv_ps(sin_r, cos_r, swap_mask);
 
-        sine =
-            _mm256_add_ps(sine, _mm256_and_ps(_mm256_sub_ps(cosine, sine), condition1));
-        sine = _mm256_sub_ps(
-            sine, _mm256_and_ps(_mm256_mul_ps(sine, _mm256_set1_ps(2.0f)), condition2));
-        _mm256_storeu_ps(bPtr, sine);
+        // neg_mask: where n&2 != 0, we negate the result
+        __m256 neg_mask = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_and_2, twos));
+        result = _mm256_xor_ps(result, _mm256_and_ps(neg_mask, sign_bit));
+
+        _mm256_storeu_ps(bPtr, result);
         aPtr += 8;
         bPtr += 8;
     }
 
     number = eighthPoints * 8;
     for (; number < num_points; number++) {
-        *bPtr++ = sin(*aPtr++);
+        *bPtr++ = sinf(*aPtr++);
     }
 }
 
-#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA for unaligned */
+#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA */
 
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
+#include <volk/volk_avx2_intrinsics.h>
 
 static inline void
 volk_32f_sin_32f_u_avx2(float* bVector, const float* aVector, unsigned int num_points)
@@ -657,102 +484,64 @@ volk_32f_sin_32f_u_avx2(float* bVector, const float* aVector, unsigned int num_p
 
     unsigned int number = 0;
     unsigned int eighthPoints = num_points / 8;
-    unsigned int i = 0;
 
-    __m256 aVal, s, m4pi, pio4A, pio4B, cp1, cp2, cp3, cp4, cp5, ffours, ftwos, fones,
-        fzeroes;
-    __m256 sine, cosine, condition1, condition2;
-    __m256i q, r, ones, twos, fours;
+    // Constants for Cody-Waite argument reduction
+    // n = round(x * 2/pi), then r = x - n * pi/2
+    const __m256 two_over_pi = _mm256_set1_ps(0x1.45f306p-1f);    // 2/pi
+    const __m256 pi_over_2_hi = _mm256_set1_ps(0x1.921fb6p+0f);   // pi/2 high
+    const __m256 pi_over_2_lo = _mm256_set1_ps(-0x1.777a5cp-25f); // pi/2 low
 
-    m4pi = _mm256_set1_ps(1.273239545);
-    pio4A = _mm256_set1_ps(0.78515625);
-    pio4B = _mm256_set1_ps(0.241876e-3);
-    ffours = _mm256_set1_ps(4.0);
-    ftwos = _mm256_set1_ps(2.0);
-    fones = _mm256_set1_ps(1.0);
-    fzeroes = _mm256_setzero_ps();
-    ones = _mm256_set1_epi32(1);
-    twos = _mm256_set1_epi32(2);
-    fours = _mm256_set1_epi32(4);
-
-    cp1 = _mm256_set1_ps(1.0);
-    cp2 = _mm256_set1_ps(0.83333333e-1);
-    cp3 = _mm256_set1_ps(0.2777778e-2);
-    cp4 = _mm256_set1_ps(0.49603e-4);
-    cp5 = _mm256_set1_ps(0.551e-6);
+    const __m256i ones = _mm256_set1_epi32(1);
+    const __m256i twos = _mm256_set1_epi32(2);
+    const __m256 sign_bit = _mm256_set1_ps(-0.0f);
 
     for (; number < eighthPoints; number++) {
-        aVal = _mm256_loadu_ps(aPtr);
-        s = _mm256_sub_ps(aVal,
-                          _mm256_and_ps(_mm256_mul_ps(aVal, ftwos),
-                                        _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS)));
-        q = _mm256_cvtps_epi32(_mm256_floor_ps(_mm256_mul_ps(s, m4pi)));
-        r = _mm256_add_epi32(q, _mm256_and_si256(q, ones));
+        __m256 x = _mm256_loadu_ps(aPtr);
 
-        s = _mm256_sub_ps(s, _mm256_mul_ps(_mm256_cvtepi32_ps(r), pio4A));
-        s = _mm256_sub_ps(s, _mm256_mul_ps(_mm256_cvtepi32_ps(r), pio4B));
+        // Argument reduction: n = round(x * 2/pi)
+        __m256 n_f = _mm256_round_ps(_mm256_mul_ps(x, two_over_pi),
+                                     _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m256i n = _mm256_cvtps_epi32(n_f);
 
-        s = _mm256_div_ps(
-            s,
-            _mm256_set1_ps(8.0)); // The constant is 2^N, for 3 times argument reduction
-        s = _mm256_mul_ps(s, s);
-        // Evaluate Taylor series
-        s = _mm256_mul_ps(
-            _mm256_add_ps(
-                _mm256_mul_ps(
-                    _mm256_sub_ps(
-                        _mm256_mul_ps(
-                            _mm256_add_ps(
-                                _mm256_mul_ps(_mm256_sub_ps(_mm256_mul_ps(s, cp5), cp4),
-                                              s),
-                                cp3),
-                            s),
-                        cp2),
-                    s),
-                cp1),
-            s);
+        // r = x - n * (pi/2), using extended precision
+        __m256 r = _mm256_sub_ps(x, _mm256_mul_ps(n_f, pi_over_2_hi));
+        r = _mm256_sub_ps(r, _mm256_mul_ps(n_f, pi_over_2_lo));
 
-        for (i = 0; i < 3; i++) {
-            s = _mm256_mul_ps(s, _mm256_sub_ps(ffours, s));
-        }
-        s = _mm256_div_ps(s, ftwos);
+        // Evaluate both sin and cos polynomials
+        __m256 sin_r = _mm256_sin_poly_avx2(r);
+        __m256 cos_r = _mm256_cos_poly_avx2(r);
 
-        sine = _mm256_sqrt_ps(_mm256_mul_ps(_mm256_sub_ps(ftwos, s), s));
-        cosine = _mm256_sub_ps(fones, s);
+        // Reconstruct sin(x) based on quadrant (n mod 4):
+        // n&1 == 0: use sin_r, n&1 == 1: use cos_r
+        // n&2 == 0: positive, n&2 == 2: negative
+        __m256i n_and_1 = _mm256_and_si256(n, ones);
+        __m256i n_and_2 = _mm256_and_si256(n, twos);
 
-        condition1 = _mm256_cmp_ps(
-            _mm256_cvtepi32_ps(_mm256_and_si256(_mm256_add_epi32(q, ones), twos)),
-            fzeroes,
-            _CMP_NEQ_UQ);
-        condition2 = _mm256_cmp_ps(
-            _mm256_cmp_ps(
-                _mm256_cvtepi32_ps(_mm256_and_si256(q, fours)), fzeroes, _CMP_NEQ_UQ),
-            _mm256_cmp_ps(aVal, fzeroes, _CMP_LT_OS),
-            _CMP_NEQ_UQ);
-        // Need this condition only for cos
-        // condition3 = _mm_cmpneq_ps(_mm_cvtepi32_ps(_mm_and_si128(_mm_add_epi32(q,
-        // twos), fours)), fzeroes);
+        // swap_mask: where n&1 != 0, we use cos instead of sin
+        __m256 swap_mask = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_and_1, ones));
+        __m256 result = _mm256_blendv_ps(sin_r, cos_r, swap_mask);
 
-        sine =
-            _mm256_add_ps(sine, _mm256_and_ps(_mm256_sub_ps(cosine, sine), condition1));
-        sine = _mm256_sub_ps(
-            sine, _mm256_and_ps(_mm256_mul_ps(sine, _mm256_set1_ps(2.0f)), condition2));
-        _mm256_storeu_ps(bPtr, sine);
+        // neg_mask: where n&2 != 0, we negate the result
+        __m256 neg_mask = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_and_2, twos));
+        result = _mm256_xor_ps(result, _mm256_and_ps(neg_mask, sign_bit));
+
+        _mm256_storeu_ps(bPtr, result);
         aPtr += 8;
         bPtr += 8;
     }
 
     number = eighthPoints * 8;
     for (; number < num_points; number++) {
-        *bPtr++ = sin(*aPtr++);
+        *bPtr++ = sinf(*aPtr++);
     }
 }
 
-#endif /* LV_HAVE_AVX2 for unaligned */
+#endif /* LV_HAVE_AVX2 */
 
 
 #ifdef LV_HAVE_SSE4_1
 #include <smmintrin.h>
+#include <volk/volk_sse_intrinsics.h>
 
 static inline void
 volk_32f_sin_32f_u_sse4_1(float* bVector, const float* aVector, unsigned int num_points)
@@ -762,75 +551,48 @@ volk_32f_sin_32f_u_sse4_1(float* bVector, const float* aVector, unsigned int num
 
     unsigned int number = 0;
     unsigned int quarterPoints = num_points / 4;
-    unsigned int i = 0;
 
-    __m128 aVal, s, m4pi, pio4A, pio4B, cp1, cp2, cp3, cp4, cp5, ffours, ftwos, fones,
-        fzeroes;
-    __m128 sine, cosine, condition1, condition2;
-    __m128i q, r, ones, twos, fours;
+    // Constants for Cody-Waite argument reduction
+    // n = round(x * 2/pi), then r = x - n * pi/2
+    const __m128 two_over_pi = _mm_set1_ps(0x1.45f306p-1f);    // 2/pi
+    const __m128 pi_over_2_hi = _mm_set1_ps(0x1.921fb6p+0f);   // pi/2 high
+    const __m128 pi_over_2_lo = _mm_set1_ps(-0x1.777a5cp-25f); // pi/2 low
 
-    m4pi = _mm_set1_ps(1.273239545);
-    pio4A = _mm_set1_ps(0.78515625);
-    pio4B = _mm_set1_ps(0.241876e-3);
-    ffours = _mm_set1_ps(4.0);
-    ftwos = _mm_set1_ps(2.0);
-    fones = _mm_set1_ps(1.0);
-    fzeroes = _mm_setzero_ps();
-    ones = _mm_set1_epi32(1);
-    twos = _mm_set1_epi32(2);
-    fours = _mm_set1_epi32(4);
-
-    cp1 = _mm_set1_ps(1.0);
-    cp2 = _mm_set1_ps(0.83333333e-1);
-    cp3 = _mm_set1_ps(0.2777778e-2);
-    cp4 = _mm_set1_ps(0.49603e-4);
-    cp5 = _mm_set1_ps(0.551e-6);
+    const __m128i ones = _mm_set1_epi32(1);
+    const __m128i twos = _mm_set1_epi32(2);
+    const __m128 sign_bit = _mm_set1_ps(-0.0f);
 
     for (; number < quarterPoints; number++) {
-        aVal = _mm_loadu_ps(aPtr);
-        s = _mm_sub_ps(aVal,
-                       _mm_and_ps(_mm_mul_ps(aVal, ftwos), _mm_cmplt_ps(aVal, fzeroes)));
-        q = _mm_cvtps_epi32(_mm_floor_ps(_mm_mul_ps(s, m4pi)));
-        r = _mm_add_epi32(q, _mm_and_si128(q, ones));
+        __m128 x = _mm_loadu_ps(aPtr);
 
-        s = _mm_sub_ps(s, _mm_mul_ps(_mm_cvtepi32_ps(r), pio4A));
-        s = _mm_sub_ps(s, _mm_mul_ps(_mm_cvtepi32_ps(r), pio4B));
+        // Argument reduction: n = round(x * 2/pi)
+        __m128 n_f = _mm_round_ps(_mm_mul_ps(x, two_over_pi),
+                                  _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m128i n = _mm_cvtps_epi32(n_f);
 
-        s = _mm_div_ps(
-            s, _mm_set1_ps(8.0)); // The constant is 2^N, for 3 times argument reduction
-        s = _mm_mul_ps(s, s);
-        // Evaluate Taylor series
-        s = _mm_mul_ps(
-            _mm_add_ps(
-                _mm_mul_ps(
-                    _mm_sub_ps(
-                        _mm_mul_ps(
-                            _mm_add_ps(_mm_mul_ps(_mm_sub_ps(_mm_mul_ps(s, cp5), cp4), s),
-                                       cp3),
-                            s),
-                        cp2),
-                    s),
-                cp1),
-            s);
+        // r = x - n * (pi/2), using extended precision
+        __m128 r = _mm_sub_ps(x, _mm_mul_ps(n_f, pi_over_2_hi));
+        r = _mm_sub_ps(r, _mm_mul_ps(n_f, pi_over_2_lo));
 
-        for (i = 0; i < 3; i++) {
-            s = _mm_mul_ps(s, _mm_sub_ps(ffours, s));
-        }
-        s = _mm_div_ps(s, ftwos);
+        // Evaluate both sin and cos polynomials
+        __m128 sin_r = _mm_sin_poly_sse(r);
+        __m128 cos_r = _mm_cos_poly_sse(r);
 
-        sine = _mm_sqrt_ps(_mm_mul_ps(_mm_sub_ps(ftwos, s), s));
-        cosine = _mm_sub_ps(fones, s);
+        // Reconstruct sin(x) based on quadrant (n mod 4):
+        // n&1 == 0: use sin_r, n&1 == 1: use cos_r
+        // n&2 == 0: positive, n&2 == 2: negative
+        __m128i n_and_1 = _mm_and_si128(n, ones);
+        __m128i n_and_2 = _mm_and_si128(n, twos);
 
-        condition1 = _mm_cmpneq_ps(
-            _mm_cvtepi32_ps(_mm_and_si128(_mm_add_epi32(q, ones), twos)), fzeroes);
-        condition2 = _mm_cmpneq_ps(
-            _mm_cmpneq_ps(_mm_cvtepi32_ps(_mm_and_si128(q, fours)), fzeroes),
-            _mm_cmplt_ps(aVal, fzeroes));
+        // swap_mask: where n&1 != 0, we use cos instead of sin
+        __m128 swap_mask = _mm_castsi128_ps(_mm_cmpeq_epi32(n_and_1, ones));
+        __m128 result = _mm_blendv_ps(sin_r, cos_r, swap_mask);
 
-        sine = _mm_add_ps(sine, _mm_and_ps(_mm_sub_ps(cosine, sine), condition1));
-        sine =
-            _mm_sub_ps(sine, _mm_and_ps(_mm_mul_ps(sine, _mm_set1_ps(2.0f)), condition2));
-        _mm_storeu_ps(bPtr, sine);
+        // neg_mask: where n&2 != 0, we negate the result
+        __m128 neg_mask = _mm_castsi128_ps(_mm_cmpeq_epi32(n_and_2, twos));
+        result = _mm_xor_ps(result, _mm_and_ps(neg_mask, sign_bit));
+
+        _mm_storeu_ps(bPtr, result);
         aPtr += 4;
         bPtr += 4;
     }
@@ -841,7 +603,7 @@ volk_32f_sin_32f_u_sse4_1(float* bVector, const float* aVector, unsigned int num
     }
 }
 
-#endif /* LV_HAVE_SSE4_1 for unaligned */
+#endif /* LV_HAVE_SSE4_1 */
 
 
 #ifdef LV_HAVE_GENERIC
@@ -860,134 +622,127 @@ volk_32f_sin_32f_generic(float* bVector, const float* aVector, unsigned int num_
 
 #endif /* LV_HAVE_GENERIC */
 
-
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
 #include <volk/volk_neon_intrinsics.h>
 
+/* NEON polynomial-based sin using Cody-Waite argument reduction */
 static inline void
 volk_32f_sin_32f_neon(float* bVector, const float* aVector, unsigned int num_points)
 {
+    // Cody-Waite argument reduction: n = round(x * 2/pi), r = x - n * pi/2
+    const float32x4_t two_over_pi = vdupq_n_f32(0x1.45f306p-1f);    // 2/pi
+    const float32x4_t pi_over_2_hi = vdupq_n_f32(0x1.921fb6p+0f);   // pi/2 high
+    const float32x4_t pi_over_2_lo = vdupq_n_f32(-0x1.777a5cp-25f); // pi/2 low
+
+    const int32x4_t ones = vdupq_n_s32(1);
+    const int32x4_t twos = vdupq_n_s32(2);
+    const float32x4_t sign_bit = vdupq_n_f32(-0.0f);
+    const float32x4_t half = vdupq_n_f32(0.5f);
+    const float32x4_t neg_half = vdupq_n_f32(-0.5f);
+    const float32x4_t fzeroes = vdupq_n_f32(0.0f);
+
     unsigned int number = 0;
-    unsigned int quarter_points = num_points / 4;
-    float* bVectorPtr = bVector;
-    const float* aVectorPtr = aVector;
+    const unsigned int quarterPoints = num_points / 4;
 
-    float32x4_t b_vec;
-    float32x4_t a_vec;
+    for (; number < quarterPoints; number++) {
+        float32x4_t x = vld1q_f32(aVector);
+        aVector += 4;
 
-    for (number = 0; number < quarter_points; number++) {
-        a_vec = vld1q_f32(aVectorPtr);
-        // Prefetch next one, speeds things up
-        __VOLK_PREFETCH(aVectorPtr + 4);
-        b_vec = _vsinq_f32(a_vec);
-        vst1q_f32(bVectorPtr, b_vec);
-        // move pointers ahead
-        bVectorPtr += 4;
-        aVectorPtr += 4;
+        // n = round(x * 2/pi) - emulate round-to-nearest for ARMv7
+        float32x4_t scaled = vmulq_f32(x, two_over_pi);
+        uint32x4_t is_neg = vcltq_f32(scaled, fzeroes);
+        float32x4_t adj = vbslq_f32(is_neg, neg_half, half);
+        float32x4_t n_f = vcvtq_f32_s32(vcvtq_s32_f32(vaddq_f32(scaled, adj)));
+        int32x4_t n = vcvtq_s32_f32(n_f);
+
+        // r = x - n * (pi/2) using extended precision
+        float32x4_t r = vmlsq_f32(x, n_f, pi_over_2_hi);
+        r = vmlsq_f32(r, n_f, pi_over_2_lo);
+
+        // Evaluate sin and cos polynomials
+        float32x4_t sin_r = _vsin_poly_f32(r);
+        float32x4_t cos_r = _vcos_poly_f32(r);
+
+        // Quadrant-based reconstruction:
+        // n&1 == 0: use sin_r, n&1 == 1: use cos_r
+        // n&2 == 0: positive, n&2 == 2: negative
+        int32x4_t n_and_1 = vandq_s32(n, ones);
+        int32x4_t n_and_2 = vandq_s32(n, twos);
+
+        uint32x4_t swap_mask = vceqq_s32(n_and_1, ones);
+        float32x4_t result = vbslq_f32(swap_mask, cos_r, sin_r);
+
+        uint32x4_t neg_mask = vceqq_s32(n_and_2, twos);
+        result = vreinterpretq_f32_u32(
+            veorq_u32(vreinterpretq_u32_f32(result),
+                      vandq_u32(neg_mask, vreinterpretq_u32_f32(sign_bit))));
+
+        vst1q_f32(bVector, result);
+        bVector += 4;
     }
 
-    // Deal with the rest
-    for (number = quarter_points * 4; number < num_points; number++) {
-        *bVectorPtr++ = sinf(*aVectorPtr++);
+    for (number = quarterPoints * 4; number < num_points; number++) {
+        *bVector++ = sinf(*aVector++);
     }
 }
-
 #endif /* LV_HAVE_NEON */
 
 #ifdef LV_HAVE_NEONV8
 #include <arm_neon.h>
+#include <volk/volk_neon_intrinsics.h>
 
-/* ARMv8 NEON with FMA: sin-only polynomial, 2x unroll for better ILP */
+/* NEONv8 polynomial-based sin using Cody-Waite argument reduction with FMA */
 static inline void
 volk_32f_sin_32f_neonv8(float* bVector, const float* aVector, unsigned int num_points)
 {
-    const float32x4_t c_minus_cephes_DP1 = vdupq_n_f32(-0.78515625f);
-    const float32x4_t c_minus_cephes_DP2 = vdupq_n_f32(-2.4187564849853515625e-4f);
-    const float32x4_t c_minus_cephes_DP3 = vdupq_n_f32(-3.77489497744594108e-8f);
-    const float32x4_t c_sincof_p0 = vdupq_n_f32(-1.9515295891e-4f);
-    const float32x4_t c_sincof_p1 = vdupq_n_f32(8.3321608736e-3f);
-    const float32x4_t c_sincof_p2 = vdupq_n_f32(-1.6666654611e-1f);
-    const float32x4_t c_coscof_p0 = vdupq_n_f32(2.443315711809948e-005f);
-    const float32x4_t c_coscof_p1 = vdupq_n_f32(-1.388731625493765e-003f);
-    const float32x4_t c_coscof_p2 = vdupq_n_f32(4.166664568298827e-002f);
-    const float32x4_t c_cephes_FOPI = vdupq_n_f32(1.27323954473516f);
-    const float32x4_t CONST_1 = vdupq_n_f32(1.f);
-    const float32x4_t CONST_1_2 = vdupq_n_f32(0.5f);
-    const float32x4_t CONST_0 = vdupq_n_f32(0.f);
-    const uint32x4_t CONST_2 = vdupq_n_u32(2);
-    const uint32x4_t CONST_4 = vdupq_n_u32(4);
-    const uint32x4_t CONST_1_U = vdupq_n_u32(1);
-    const uint32x4_t CONST_NOT1 = vdupq_n_u32(~1u);
+    // Cody-Waite argument reduction: n = round(x * 2/pi), r = x - n * pi/2
+    const float32x4_t two_over_pi = vdupq_n_f32(0x1.45f306p-1f);    // 2/pi
+    const float32x4_t pi_over_2_hi = vdupq_n_f32(0x1.921fb6p+0f);   // pi/2 high
+    const float32x4_t pi_over_2_lo = vdupq_n_f32(-0x1.777a5cp-25f); // pi/2 low
+
+    const int32x4_t ones = vdupq_n_s32(1);
+    const int32x4_t twos = vdupq_n_s32(2);
+    const float32x4_t sign_bit = vdupq_n_f32(-0.0f);
 
     unsigned int number = 0;
-    const unsigned int eighth_points = num_points / 8;
+    const unsigned int quarterPoints = num_points / 4;
 
-    for (; number < eighth_points; number++) {
-        /* Load 8 floats (2 x float32x4) */
-        float32x4_t x0 = vld1q_f32(aVector);
-        float32x4_t x1 = vld1q_f32(aVector + 4);
-        aVector += 8;
+    for (; number < quarterPoints; number++) {
+        float32x4_t x = vld1q_f32(aVector);
+        aVector += 4;
 
-        /* Process first 4 */
-        uint32x4_t sign_mask0 = vcltq_f32(x0, CONST_0);
-        x0 = vabsq_f32(x0);
-        float32x4_t y0 = vmulq_f32(x0, c_cephes_FOPI);
-        uint32x4_t emm2_0 = vcvtq_u32_f32(y0);
-        emm2_0 = vandq_u32(vaddq_u32(emm2_0, CONST_1_U), CONST_NOT1);
-        y0 = vcvtq_f32_u32(emm2_0);
-        uint32x4_t poly_mask0 = vtstq_u32(emm2_0, CONST_2);
-        x0 = vfmaq_f32(x0, y0, c_minus_cephes_DP1);
-        x0 = vfmaq_f32(x0, y0, c_minus_cephes_DP2);
-        x0 = vfmaq_f32(x0, y0, c_minus_cephes_DP3);
-        sign_mask0 = veorq_u32(sign_mask0, vtstq_u32(emm2_0, CONST_4));
-        float32x4_t z0 = vmulq_f32(x0, x0);
-        float32x4_t y1_0 = vfmaq_f32(c_coscof_p1, z0, c_coscof_p0);
-        y1_0 = vfmaq_f32(c_coscof_p2, z0, y1_0);
-        y1_0 = vmulq_f32(y1_0, z0);
-        y1_0 = vmulq_f32(y1_0, z0);
-        y1_0 = vfmsq_f32(y1_0, z0, CONST_1_2);
-        y1_0 = vaddq_f32(y1_0, CONST_1);
-        float32x4_t y2_0 = vfmaq_f32(c_sincof_p1, z0, c_sincof_p0);
-        y2_0 = vfmaq_f32(c_sincof_p2, z0, y2_0);
-        y2_0 = vmulq_f32(y2_0, z0);
-        y2_0 = vfmaq_f32(x0, x0, y2_0);
-        float32x4_t ys0 = vbslq_f32(poly_mask0, y1_0, y2_0);
-        float32x4_t result0 = vbslq_f32(sign_mask0, vnegq_f32(ys0), ys0);
+        // n = round(x * 2/pi) using ARMv8 vrndnq_f32
+        float32x4_t n_f = vrndnq_f32(vmulq_f32(x, two_over_pi));
+        int32x4_t n = vcvtq_s32_f32(n_f);
 
-        /* Process second 4 */
-        uint32x4_t sign_mask1 = vcltq_f32(x1, CONST_0);
-        x1 = vabsq_f32(x1);
-        float32x4_t y1 = vmulq_f32(x1, c_cephes_FOPI);
-        uint32x4_t emm2_1 = vcvtq_u32_f32(y1);
-        emm2_1 = vandq_u32(vaddq_u32(emm2_1, CONST_1_U), CONST_NOT1);
-        y1 = vcvtq_f32_u32(emm2_1);
-        uint32x4_t poly_mask1 = vtstq_u32(emm2_1, CONST_2);
-        x1 = vfmaq_f32(x1, y1, c_minus_cephes_DP1);
-        x1 = vfmaq_f32(x1, y1, c_minus_cephes_DP2);
-        x1 = vfmaq_f32(x1, y1, c_minus_cephes_DP3);
-        sign_mask1 = veorq_u32(sign_mask1, vtstq_u32(emm2_1, CONST_4));
-        float32x4_t z1 = vmulq_f32(x1, x1);
-        float32x4_t y1_1 = vfmaq_f32(c_coscof_p1, z1, c_coscof_p0);
-        y1_1 = vfmaq_f32(c_coscof_p2, z1, y1_1);
-        y1_1 = vmulq_f32(y1_1, z1);
-        y1_1 = vmulq_f32(y1_1, z1);
-        y1_1 = vfmsq_f32(y1_1, z1, CONST_1_2);
-        y1_1 = vaddq_f32(y1_1, CONST_1);
-        float32x4_t y2_1 = vfmaq_f32(c_sincof_p1, z1, c_sincof_p0);
-        y2_1 = vfmaq_f32(c_sincof_p2, z1, y2_1);
-        y2_1 = vmulq_f32(y2_1, z1);
-        y2_1 = vfmaq_f32(x1, x1, y2_1);
-        float32x4_t ys1 = vbslq_f32(poly_mask1, y1_1, y2_1);
-        float32x4_t result1 = vbslq_f32(sign_mask1, vnegq_f32(ys1), ys1);
+        // r = x - n * (pi/2) using FMA for extended precision
+        float32x4_t r = vfmsq_f32(x, n_f, pi_over_2_hi);
+        r = vfmsq_f32(r, n_f, pi_over_2_lo);
 
-        vst1q_f32(bVector, result0);
-        vst1q_f32(bVector + 4, result1);
-        bVector += 8;
+        // Evaluate sin and cos polynomials using FMA
+        float32x4_t sin_r = _vsin_poly_neonv8(r);
+        float32x4_t cos_r = _vcos_poly_neonv8(r);
+
+        // Quadrant-based reconstruction:
+        // n&1 == 0: use sin_r, n&1 == 1: use cos_r
+        // n&2 == 0: positive, n&2 == 2: negative
+        int32x4_t n_and_1 = vandq_s32(n, ones);
+        int32x4_t n_and_2 = vandq_s32(n, twos);
+
+        uint32x4_t swap_mask = vceqq_s32(n_and_1, ones);
+        float32x4_t result = vbslq_f32(swap_mask, cos_r, sin_r);
+
+        uint32x4_t neg_mask = vceqq_s32(n_and_2, twos);
+        result = vreinterpretq_f32_u32(
+            veorq_u32(vreinterpretq_u32_f32(result),
+                      vandq_u32(neg_mask, vreinterpretq_u32_f32(sign_bit))));
+
+        vst1q_f32(bVector, result);
+        bVector += 4;
     }
 
-    /* Handle remaining */
-    for (number = eighth_points * 8; number < num_points; number++) {
+    for (number = quarterPoints * 4; number < num_points; number++) {
         *bVector++ = sinf(*aVector++);
     }
 }

--- a/kernels/volk/volk_32f_sin_32f.h
+++ b/kernels/volk/volk_32f_sin_32f.h
@@ -64,6 +64,18 @@
 #ifndef INCLUDED_volk_32f_sin_32f_a_H
 #define INCLUDED_volk_32f_sin_32f_a_H
 
+#ifdef LV_HAVE_GENERIC
+#include <volk/volk_common.h>
+
+static inline void
+volk_32f_sin_32f_polynomial(float* bVector, const float* aVector, unsigned int num_points)
+{
+    for (unsigned int number = 0; number < num_points; number++) {
+        *bVector++ = volk_sin(*aVector++);
+    }
+}
+#endif /* LV_HAVE_GENERIC */
+
 #ifdef LV_HAVE_AVX512F
 #include <immintrin.h>
 #include <volk/volk_avx512_intrinsics.h>

--- a/kernels/volk/volk_32f_sincos_32f_x2.h
+++ b/kernels/volk/volk_32f_sincos_32f_x2.h
@@ -1,0 +1,838 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2025 Magnus Lundmark <magnuslundmark@gmail.com>
+ *
+ * This file is part of VOLK
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+/*!
+ * \page volk_32f_sincos_32f_x2
+ *
+ * \b Overview
+ *
+ * Computes sine and cosine of the input vector simultaneously.
+ * More efficient than calling sin and cos separately since
+ * argument reduction is shared.
+ *
+ * <b>Dispatcher Prototype</b>
+ * \code
+ * void volk_32f_sincos_32f_x2(float* sinVector, float* cosVector, const float* inVector,
+ * unsigned int num_points) \endcode
+ *
+ * \b Inputs
+ * \li inVector: The input vector of angles in radians.
+ * \li num_points: The number of data points.
+ *
+ * \b Outputs
+ * \li sinVector: The output vector of sine values.
+ * \li cosVector: The output vector of cosine values.
+ *
+ * \b Example
+ * Calculate sin and cos for common angles.
+ * \code
+ *   int N = 4;
+ *   unsigned int alignment = volk_get_alignment();
+ *   float* in = (float*)volk_malloc(sizeof(float)*N, alignment);
+ *   float* sin_out = (float*)volk_malloc(sizeof(float)*N, alignment);
+ *   float* cos_out = (float*)volk_malloc(sizeof(float)*N, alignment);
+ *
+ *   in[0] = 0.000;
+ *   in[1] = 0.524;    // ~pi/6
+ *   in[2] = 1.047;    // ~pi/3
+ *   in[3] = 1.571;    // ~pi/2
+ *
+ *   volk_32f_sincos_32f_x2(sin_out, cos_out, in, N);
+ *
+ *   for(unsigned int ii = 0; ii < N; ++ii){
+ *       printf("sincos(%1.3f) = (%1.3f, %1.3f)\n", in[ii], sin_out[ii], cos_out[ii]);
+ *   }
+ *
+ *   volk_free(in);
+ *   volk_free(sin_out);
+ *   volk_free(cos_out);
+ * \endcode
+ */
+
+#include <inttypes.h>
+#include <math.h>
+#include <stdio.h>
+
+#ifndef INCLUDED_volk_32f_sincos_32f_x2_a_H
+#define INCLUDED_volk_32f_sincos_32f_x2_a_H
+
+#ifdef LV_HAVE_GENERIC
+
+static inline void volk_32f_sincos_32f_x2_generic(float* sinVector,
+                                                  float* cosVector,
+                                                  const float* inVector,
+                                                  unsigned int num_points)
+{
+    for (unsigned int i = 0; i < num_points; i++) {
+        sinVector[i] = sinf(inVector[i]);
+        cosVector[i] = cosf(inVector[i]);
+    }
+}
+
+#endif /* LV_HAVE_GENERIC */
+
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+#include <volk/volk_avx512_intrinsics.h>
+
+static inline void volk_32f_sincos_32f_x2_a_avx512f(float* sinVector,
+                                                    float* cosVector,
+                                                    const float* inVector,
+                                                    unsigned int num_points)
+{
+    float* sinPtr = sinVector;
+    float* cosPtr = cosVector;
+    const float* inPtr = inVector;
+
+    unsigned int number = 0;
+    unsigned int sixteenPoints = num_points / 16;
+
+    // Constants for Cody-Waite argument reduction
+    const __m512 two_over_pi = _mm512_set1_ps(0x1.45f306p-1f);
+    const __m512 pi_over_2_hi = _mm512_set1_ps(0x1.921fb6p+0f);
+    const __m512 pi_over_2_lo = _mm512_set1_ps(-0x1.777a5cp-25f);
+
+    const __m512i ones = _mm512_set1_epi32(1);
+    const __m512i twos = _mm512_set1_epi32(2);
+    const __m512i sign_bit = _mm512_set1_epi32(0x80000000);
+
+    for (; number < sixteenPoints; number++) {
+        __m512 x = _mm512_load_ps(inPtr);
+
+        // Argument reduction: n = round(x * 2/pi)
+        __m512 n_f = _mm512_roundscale_ps(_mm512_mul_ps(x, two_over_pi),
+                                          _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m512i n = _mm512_cvtps_epi32(n_f);
+
+        // r = x - n * (pi/2)
+        __m512 r = _mm512_fnmadd_ps(n_f, pi_over_2_hi, x);
+        r = _mm512_fnmadd_ps(n_f, pi_over_2_lo, r);
+
+        // Evaluate both sin and cos polynomials
+        __m512 sin_r = _mm512_sin_poly_avx512(r);
+        __m512 cos_r = _mm512_cos_poly_avx512(r);
+
+        // Quadrant selection
+        __m512i n_and_1 = _mm512_and_si512(n, ones);
+        __m512i n_and_2 = _mm512_and_si512(n, twos);
+        __m512i n_plus_1_and_2 = _mm512_and_si512(_mm512_add_epi32(n, ones), twos);
+
+        // For sin: swap when n&1, negate when n&2
+        __mmask16 sin_swap = _mm512_cmpeq_epi32_mask(n_and_1, ones);
+        __m512 sin_result = _mm512_mask_blend_ps(sin_swap, sin_r, cos_r);
+        __mmask16 sin_neg = _mm512_cmpeq_epi32_mask(n_and_2, twos);
+        sin_result =
+            _mm512_castsi512_ps(_mm512_mask_xor_epi32(_mm512_castps_si512(sin_result),
+                                                      sin_neg,
+                                                      _mm512_castps_si512(sin_result),
+                                                      sign_bit));
+
+        // For cos: swap when n&1, negate when (n+1)&2
+        __mmask16 cos_swap = sin_swap;
+        __m512 cos_result = _mm512_mask_blend_ps(cos_swap, cos_r, sin_r);
+        __mmask16 cos_neg = _mm512_cmpeq_epi32_mask(n_plus_1_and_2, twos);
+        cos_result =
+            _mm512_castsi512_ps(_mm512_mask_xor_epi32(_mm512_castps_si512(cos_result),
+                                                      cos_neg,
+                                                      _mm512_castps_si512(cos_result),
+                                                      sign_bit));
+
+        _mm512_store_ps(sinPtr, sin_result);
+        _mm512_store_ps(cosPtr, cos_result);
+        inPtr += 16;
+        sinPtr += 16;
+        cosPtr += 16;
+    }
+
+    number = sixteenPoints * 16;
+    for (; number < num_points; number++) {
+        *sinPtr++ = sinf(*inPtr);
+        *cosPtr++ = cosf(*inPtr++);
+    }
+}
+
+#endif /* LV_HAVE_AVX512F for aligned */
+
+#if LV_HAVE_AVX2 && LV_HAVE_FMA
+#include <immintrin.h>
+#include <volk/volk_avx2_fma_intrinsics.h>
+
+static inline void volk_32f_sincos_32f_x2_a_avx2_fma(float* sinVector,
+                                                     float* cosVector,
+                                                     const float* inVector,
+                                                     unsigned int num_points)
+{
+    float* sinPtr = sinVector;
+    float* cosPtr = cosVector;
+    const float* inPtr = inVector;
+
+    unsigned int number = 0;
+    unsigned int eighthPoints = num_points / 8;
+
+    // Constants for Cody-Waite argument reduction
+    const __m256 two_over_pi = _mm256_set1_ps(0x1.45f306p-1f);
+    const __m256 pi_over_2_hi = _mm256_set1_ps(0x1.921fb6p+0f);
+    const __m256 pi_over_2_lo = _mm256_set1_ps(-0x1.777a5cp-25f);
+
+    const __m256i ones = _mm256_set1_epi32(1);
+    const __m256i twos = _mm256_set1_epi32(2);
+    const __m256 sign_bit = _mm256_set1_ps(-0.0f);
+
+    for (; number < eighthPoints; number++) {
+        __m256 x = _mm256_load_ps(inPtr);
+
+        // Argument reduction: n = round(x * 2/pi)
+        __m256 n_f = _mm256_round_ps(_mm256_mul_ps(x, two_over_pi),
+                                     _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m256i n = _mm256_cvtps_epi32(n_f);
+
+        // r = x - n * (pi/2)
+        __m256 r = _mm256_fnmadd_ps(n_f, pi_over_2_hi, x);
+        r = _mm256_fnmadd_ps(n_f, pi_over_2_lo, r);
+
+        // Evaluate both sin and cos polynomials
+        __m256 sin_r = _mm256_sin_poly_avx2_fma(r);
+        __m256 cos_r = _mm256_cos_poly_avx2_fma(r);
+
+        // Quadrant selection
+        __m256i n_and_1 = _mm256_and_si256(n, ones);
+        __m256i n_and_2 = _mm256_and_si256(n, twos);
+        __m256i n_plus_1_and_2 = _mm256_and_si256(_mm256_add_epi32(n, ones), twos);
+
+        // For sin: swap when n&1, negate when n&2
+        __m256 sin_swap = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_and_1, ones));
+        __m256 sin_result = _mm256_blendv_ps(sin_r, cos_r, sin_swap);
+        __m256 sin_neg = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_and_2, twos));
+        sin_result = _mm256_xor_ps(sin_result, _mm256_and_ps(sin_neg, sign_bit));
+
+        // For cos: swap when n&1, negate when (n+1)&2
+        __m256 cos_result = _mm256_blendv_ps(cos_r, sin_r, sin_swap);
+        __m256 cos_neg = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_plus_1_and_2, twos));
+        cos_result = _mm256_xor_ps(cos_result, _mm256_and_ps(cos_neg, sign_bit));
+
+        _mm256_store_ps(sinPtr, sin_result);
+        _mm256_store_ps(cosPtr, cos_result);
+        inPtr += 8;
+        sinPtr += 8;
+        cosPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *sinPtr++ = sinf(*inPtr);
+        *cosPtr++ = cosf(*inPtr++);
+    }
+}
+
+#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA for aligned */
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+#include <volk/volk_avx2_intrinsics.h>
+
+static inline void volk_32f_sincos_32f_x2_a_avx2(float* sinVector,
+                                                 float* cosVector,
+                                                 const float* inVector,
+                                                 unsigned int num_points)
+{
+    float* sinPtr = sinVector;
+    float* cosPtr = cosVector;
+    const float* inPtr = inVector;
+
+    unsigned int number = 0;
+    unsigned int eighthPoints = num_points / 8;
+
+    // Constants for Cody-Waite argument reduction
+    const __m256 two_over_pi = _mm256_set1_ps(0x1.45f306p-1f);
+    const __m256 pi_over_2_hi = _mm256_set1_ps(0x1.921fb6p+0f);
+    const __m256 pi_over_2_lo = _mm256_set1_ps(-0x1.777a5cp-25f);
+
+    const __m256i ones = _mm256_set1_epi32(1);
+    const __m256i twos = _mm256_set1_epi32(2);
+    const __m256 sign_bit = _mm256_set1_ps(-0.0f);
+
+    for (; number < eighthPoints; number++) {
+        __m256 x = _mm256_load_ps(inPtr);
+
+        // Argument reduction: n = round(x * 2/pi)
+        __m256 n_f = _mm256_round_ps(_mm256_mul_ps(x, two_over_pi),
+                                     _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m256i n = _mm256_cvtps_epi32(n_f);
+
+        // r = x - n * (pi/2)
+        __m256 r = _mm256_sub_ps(x, _mm256_mul_ps(n_f, pi_over_2_hi));
+        r = _mm256_sub_ps(r, _mm256_mul_ps(n_f, pi_over_2_lo));
+
+        // Evaluate both sin and cos polynomials
+        __m256 sin_r = _mm256_sin_poly_avx2(r);
+        __m256 cos_r = _mm256_cos_poly_avx2(r);
+
+        // Quadrant selection
+        __m256i n_and_1 = _mm256_and_si256(n, ones);
+        __m256i n_and_2 = _mm256_and_si256(n, twos);
+        __m256i n_plus_1_and_2 = _mm256_and_si256(_mm256_add_epi32(n, ones), twos);
+
+        // For sin: swap when n&1, negate when n&2
+        __m256 sin_swap = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_and_1, ones));
+        __m256 sin_result = _mm256_blendv_ps(sin_r, cos_r, sin_swap);
+        __m256 sin_neg = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_and_2, twos));
+        sin_result = _mm256_xor_ps(sin_result, _mm256_and_ps(sin_neg, sign_bit));
+
+        // For cos: swap when n&1, negate when (n+1)&2
+        __m256 cos_result = _mm256_blendv_ps(cos_r, sin_r, sin_swap);
+        __m256 cos_neg = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_plus_1_and_2, twos));
+        cos_result = _mm256_xor_ps(cos_result, _mm256_and_ps(cos_neg, sign_bit));
+
+        _mm256_store_ps(sinPtr, sin_result);
+        _mm256_store_ps(cosPtr, cos_result);
+        inPtr += 8;
+        sinPtr += 8;
+        cosPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *sinPtr++ = sinf(*inPtr);
+        *cosPtr++ = cosf(*inPtr++);
+    }
+}
+
+#endif /* LV_HAVE_AVX2 for aligned */
+
+#ifdef LV_HAVE_SSE4_1
+#include <smmintrin.h>
+#include <volk/volk_sse_intrinsics.h>
+
+static inline void volk_32f_sincos_32f_x2_a_sse4_1(float* sinVector,
+                                                   float* cosVector,
+                                                   const float* inVector,
+                                                   unsigned int num_points)
+{
+    float* sinPtr = sinVector;
+    float* cosPtr = cosVector;
+    const float* inPtr = inVector;
+
+    unsigned int number = 0;
+    unsigned int quarterPoints = num_points / 4;
+
+    // Constants for Cody-Waite argument reduction
+    const __m128 two_over_pi = _mm_set1_ps(0x1.45f306p-1f);
+    const __m128 pi_over_2_hi = _mm_set1_ps(0x1.921fb6p+0f);
+    const __m128 pi_over_2_lo = _mm_set1_ps(-0x1.777a5cp-25f);
+
+    const __m128i ones = _mm_set1_epi32(1);
+    const __m128i twos = _mm_set1_epi32(2);
+    const __m128 sign_bit = _mm_set1_ps(-0.0f);
+
+    for (; number < quarterPoints; number++) {
+        __m128 x = _mm_load_ps(inPtr);
+
+        // Argument reduction: n = round(x * 2/pi)
+        __m128 n_f = _mm_round_ps(_mm_mul_ps(x, two_over_pi),
+                                  _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m128i n = _mm_cvtps_epi32(n_f);
+
+        // r = x - n * (pi/2)
+        __m128 r = _mm_sub_ps(x, _mm_mul_ps(n_f, pi_over_2_hi));
+        r = _mm_sub_ps(r, _mm_mul_ps(n_f, pi_over_2_lo));
+
+        // Evaluate both sin and cos polynomials
+        __m128 sin_r = _mm_sin_poly_sse(r);
+        __m128 cos_r = _mm_cos_poly_sse(r);
+
+        // Quadrant selection
+        __m128i n_and_1 = _mm_and_si128(n, ones);
+        __m128i n_and_2 = _mm_and_si128(n, twos);
+        __m128i n_plus_1_and_2 = _mm_and_si128(_mm_add_epi32(n, ones), twos);
+
+        // For sin: swap when n&1, negate when n&2
+        __m128 sin_swap = _mm_castsi128_ps(_mm_cmpeq_epi32(n_and_1, ones));
+        __m128 sin_result = _mm_blendv_ps(sin_r, cos_r, sin_swap);
+        __m128 sin_neg = _mm_castsi128_ps(_mm_cmpeq_epi32(n_and_2, twos));
+        sin_result = _mm_xor_ps(sin_result, _mm_and_ps(sin_neg, sign_bit));
+
+        // For cos: swap when n&1, negate when (n+1)&2
+        __m128 cos_result = _mm_blendv_ps(cos_r, sin_r, sin_swap);
+        __m128 cos_neg = _mm_castsi128_ps(_mm_cmpeq_epi32(n_plus_1_and_2, twos));
+        cos_result = _mm_xor_ps(cos_result, _mm_and_ps(cos_neg, sign_bit));
+
+        _mm_store_ps(sinPtr, sin_result);
+        _mm_store_ps(cosPtr, cos_result);
+        inPtr += 4;
+        sinPtr += 4;
+        cosPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        *sinPtr++ = sinf(*inPtr);
+        *cosPtr++ = cosf(*inPtr++);
+    }
+}
+
+#endif /* LV_HAVE_SSE4_1 for aligned */
+
+#endif /* INCLUDED_volk_32f_sincos_32f_x2_a_H */
+
+
+#ifndef INCLUDED_volk_32f_sincos_32f_x2_u_H
+#define INCLUDED_volk_32f_sincos_32f_x2_u_H
+
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+#include <volk/volk_avx512_intrinsics.h>
+
+static inline void volk_32f_sincos_32f_x2_u_avx512f(float* sinVector,
+                                                    float* cosVector,
+                                                    const float* inVector,
+                                                    unsigned int num_points)
+{
+    float* sinPtr = sinVector;
+    float* cosPtr = cosVector;
+    const float* inPtr = inVector;
+
+    unsigned int number = 0;
+    unsigned int sixteenPoints = num_points / 16;
+
+    // Constants for Cody-Waite argument reduction
+    const __m512 two_over_pi = _mm512_set1_ps(0x1.45f306p-1f);
+    const __m512 pi_over_2_hi = _mm512_set1_ps(0x1.921fb6p+0f);
+    const __m512 pi_over_2_lo = _mm512_set1_ps(-0x1.777a5cp-25f);
+
+    const __m512i ones = _mm512_set1_epi32(1);
+    const __m512i twos = _mm512_set1_epi32(2);
+    const __m512i sign_bit = _mm512_set1_epi32(0x80000000);
+
+    for (; number < sixteenPoints; number++) {
+        __m512 x = _mm512_loadu_ps(inPtr);
+
+        // Argument reduction: n = round(x * 2/pi)
+        __m512 n_f = _mm512_roundscale_ps(_mm512_mul_ps(x, two_over_pi),
+                                          _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m512i n = _mm512_cvtps_epi32(n_f);
+
+        // r = x - n * (pi/2)
+        __m512 r = _mm512_fnmadd_ps(n_f, pi_over_2_hi, x);
+        r = _mm512_fnmadd_ps(n_f, pi_over_2_lo, r);
+
+        // Evaluate both sin and cos polynomials
+        __m512 sin_r = _mm512_sin_poly_avx512(r);
+        __m512 cos_r = _mm512_cos_poly_avx512(r);
+
+        // Quadrant selection
+        __m512i n_and_1 = _mm512_and_si512(n, ones);
+        __m512i n_and_2 = _mm512_and_si512(n, twos);
+        __m512i n_plus_1_and_2 = _mm512_and_si512(_mm512_add_epi32(n, ones), twos);
+
+        // For sin: swap when n&1, negate when n&2
+        __mmask16 sin_swap = _mm512_cmpeq_epi32_mask(n_and_1, ones);
+        __m512 sin_result = _mm512_mask_blend_ps(sin_swap, sin_r, cos_r);
+        __mmask16 sin_neg = _mm512_cmpeq_epi32_mask(n_and_2, twos);
+        sin_result =
+            _mm512_castsi512_ps(_mm512_mask_xor_epi32(_mm512_castps_si512(sin_result),
+                                                      sin_neg,
+                                                      _mm512_castps_si512(sin_result),
+                                                      sign_bit));
+
+        // For cos: swap when n&1, negate when (n+1)&2
+        __mmask16 cos_swap = sin_swap;
+        __m512 cos_result = _mm512_mask_blend_ps(cos_swap, cos_r, sin_r);
+        __mmask16 cos_neg = _mm512_cmpeq_epi32_mask(n_plus_1_and_2, twos);
+        cos_result =
+            _mm512_castsi512_ps(_mm512_mask_xor_epi32(_mm512_castps_si512(cos_result),
+                                                      cos_neg,
+                                                      _mm512_castps_si512(cos_result),
+                                                      sign_bit));
+
+        _mm512_storeu_ps(sinPtr, sin_result);
+        _mm512_storeu_ps(cosPtr, cos_result);
+        inPtr += 16;
+        sinPtr += 16;
+        cosPtr += 16;
+    }
+
+    number = sixteenPoints * 16;
+    for (; number < num_points; number++) {
+        *sinPtr++ = sinf(*inPtr);
+        *cosPtr++ = cosf(*inPtr++);
+    }
+}
+
+#endif /* LV_HAVE_AVX512F for unaligned */
+
+#if LV_HAVE_AVX2 && LV_HAVE_FMA
+#include <immintrin.h>
+#include <volk/volk_avx2_fma_intrinsics.h>
+
+static inline void volk_32f_sincos_32f_x2_u_avx2_fma(float* sinVector,
+                                                     float* cosVector,
+                                                     const float* inVector,
+                                                     unsigned int num_points)
+{
+    float* sinPtr = sinVector;
+    float* cosPtr = cosVector;
+    const float* inPtr = inVector;
+
+    unsigned int number = 0;
+    unsigned int eighthPoints = num_points / 8;
+
+    // Constants for Cody-Waite argument reduction
+    const __m256 two_over_pi = _mm256_set1_ps(0x1.45f306p-1f);
+    const __m256 pi_over_2_hi = _mm256_set1_ps(0x1.921fb6p+0f);
+    const __m256 pi_over_2_lo = _mm256_set1_ps(-0x1.777a5cp-25f);
+
+    const __m256i ones = _mm256_set1_epi32(1);
+    const __m256i twos = _mm256_set1_epi32(2);
+    const __m256 sign_bit = _mm256_set1_ps(-0.0f);
+
+    for (; number < eighthPoints; number++) {
+        __m256 x = _mm256_loadu_ps(inPtr);
+
+        // Argument reduction: n = round(x * 2/pi)
+        __m256 n_f = _mm256_round_ps(_mm256_mul_ps(x, two_over_pi),
+                                     _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m256i n = _mm256_cvtps_epi32(n_f);
+
+        // r = x - n * (pi/2)
+        __m256 r = _mm256_fnmadd_ps(n_f, pi_over_2_hi, x);
+        r = _mm256_fnmadd_ps(n_f, pi_over_2_lo, r);
+
+        // Evaluate both sin and cos polynomials
+        __m256 sin_r = _mm256_sin_poly_avx2_fma(r);
+        __m256 cos_r = _mm256_cos_poly_avx2_fma(r);
+
+        // Quadrant selection
+        __m256i n_and_1 = _mm256_and_si256(n, ones);
+        __m256i n_and_2 = _mm256_and_si256(n, twos);
+        __m256i n_plus_1_and_2 = _mm256_and_si256(_mm256_add_epi32(n, ones), twos);
+
+        // For sin: swap when n&1, negate when n&2
+        __m256 sin_swap = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_and_1, ones));
+        __m256 sin_result = _mm256_blendv_ps(sin_r, cos_r, sin_swap);
+        __m256 sin_neg = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_and_2, twos));
+        sin_result = _mm256_xor_ps(sin_result, _mm256_and_ps(sin_neg, sign_bit));
+
+        // For cos: swap when n&1, negate when (n+1)&2
+        __m256 cos_result = _mm256_blendv_ps(cos_r, sin_r, sin_swap);
+        __m256 cos_neg = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_plus_1_and_2, twos));
+        cos_result = _mm256_xor_ps(cos_result, _mm256_and_ps(cos_neg, sign_bit));
+
+        _mm256_storeu_ps(sinPtr, sin_result);
+        _mm256_storeu_ps(cosPtr, cos_result);
+        inPtr += 8;
+        sinPtr += 8;
+        cosPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *sinPtr++ = sinf(*inPtr);
+        *cosPtr++ = cosf(*inPtr++);
+    }
+}
+
+#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA for unaligned */
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+#include <volk/volk_avx2_intrinsics.h>
+
+static inline void volk_32f_sincos_32f_x2_u_avx2(float* sinVector,
+                                                 float* cosVector,
+                                                 const float* inVector,
+                                                 unsigned int num_points)
+{
+    float* sinPtr = sinVector;
+    float* cosPtr = cosVector;
+    const float* inPtr = inVector;
+
+    unsigned int number = 0;
+    unsigned int eighthPoints = num_points / 8;
+
+    // Constants for Cody-Waite argument reduction
+    const __m256 two_over_pi = _mm256_set1_ps(0x1.45f306p-1f);
+    const __m256 pi_over_2_hi = _mm256_set1_ps(0x1.921fb6p+0f);
+    const __m256 pi_over_2_lo = _mm256_set1_ps(-0x1.777a5cp-25f);
+
+    const __m256i ones = _mm256_set1_epi32(1);
+    const __m256i twos = _mm256_set1_epi32(2);
+    const __m256 sign_bit = _mm256_set1_ps(-0.0f);
+
+    for (; number < eighthPoints; number++) {
+        __m256 x = _mm256_loadu_ps(inPtr);
+
+        // Argument reduction: n = round(x * 2/pi)
+        __m256 n_f = _mm256_round_ps(_mm256_mul_ps(x, two_over_pi),
+                                     _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m256i n = _mm256_cvtps_epi32(n_f);
+
+        // r = x - n * (pi/2)
+        __m256 r = _mm256_sub_ps(x, _mm256_mul_ps(n_f, pi_over_2_hi));
+        r = _mm256_sub_ps(r, _mm256_mul_ps(n_f, pi_over_2_lo));
+
+        // Evaluate both sin and cos polynomials
+        __m256 sin_r = _mm256_sin_poly_avx2(r);
+        __m256 cos_r = _mm256_cos_poly_avx2(r);
+
+        // Quadrant selection
+        __m256i n_and_1 = _mm256_and_si256(n, ones);
+        __m256i n_and_2 = _mm256_and_si256(n, twos);
+        __m256i n_plus_1_and_2 = _mm256_and_si256(_mm256_add_epi32(n, ones), twos);
+
+        // For sin: swap when n&1, negate when n&2
+        __m256 sin_swap = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_and_1, ones));
+        __m256 sin_result = _mm256_blendv_ps(sin_r, cos_r, sin_swap);
+        __m256 sin_neg = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_and_2, twos));
+        sin_result = _mm256_xor_ps(sin_result, _mm256_and_ps(sin_neg, sign_bit));
+
+        // For cos: swap when n&1, negate when (n+1)&2
+        __m256 cos_result = _mm256_blendv_ps(cos_r, sin_r, sin_swap);
+        __m256 cos_neg = _mm256_castsi256_ps(_mm256_cmpeq_epi32(n_plus_1_and_2, twos));
+        cos_result = _mm256_xor_ps(cos_result, _mm256_and_ps(cos_neg, sign_bit));
+
+        _mm256_storeu_ps(sinPtr, sin_result);
+        _mm256_storeu_ps(cosPtr, cos_result);
+        inPtr += 8;
+        sinPtr += 8;
+        cosPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *sinPtr++ = sinf(*inPtr);
+        *cosPtr++ = cosf(*inPtr++);
+    }
+}
+
+#endif /* LV_HAVE_AVX2 for unaligned */
+
+#ifdef LV_HAVE_SSE4_1
+#include <smmintrin.h>
+#include <volk/volk_sse_intrinsics.h>
+
+static inline void volk_32f_sincos_32f_x2_u_sse4_1(float* sinVector,
+                                                   float* cosVector,
+                                                   const float* inVector,
+                                                   unsigned int num_points)
+{
+    float* sinPtr = sinVector;
+    float* cosPtr = cosVector;
+    const float* inPtr = inVector;
+
+    unsigned int number = 0;
+    unsigned int quarterPoints = num_points / 4;
+
+    // Constants for Cody-Waite argument reduction
+    const __m128 two_over_pi = _mm_set1_ps(0x1.45f306p-1f);
+    const __m128 pi_over_2_hi = _mm_set1_ps(0x1.921fb6p+0f);
+    const __m128 pi_over_2_lo = _mm_set1_ps(-0x1.777a5cp-25f);
+
+    const __m128i ones = _mm_set1_epi32(1);
+    const __m128i twos = _mm_set1_epi32(2);
+    const __m128 sign_bit = _mm_set1_ps(-0.0f);
+
+    for (; number < quarterPoints; number++) {
+        __m128 x = _mm_loadu_ps(inPtr);
+
+        // Argument reduction: n = round(x * 2/pi)
+        __m128 n_f = _mm_round_ps(_mm_mul_ps(x, two_over_pi),
+                                  _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC);
+        __m128i n = _mm_cvtps_epi32(n_f);
+
+        // r = x - n * (pi/2)
+        __m128 r = _mm_sub_ps(x, _mm_mul_ps(n_f, pi_over_2_hi));
+        r = _mm_sub_ps(r, _mm_mul_ps(n_f, pi_over_2_lo));
+
+        // Evaluate both sin and cos polynomials
+        __m128 sin_r = _mm_sin_poly_sse(r);
+        __m128 cos_r = _mm_cos_poly_sse(r);
+
+        // Quadrant selection
+        __m128i n_and_1 = _mm_and_si128(n, ones);
+        __m128i n_and_2 = _mm_and_si128(n, twos);
+        __m128i n_plus_1_and_2 = _mm_and_si128(_mm_add_epi32(n, ones), twos);
+
+        // For sin: swap when n&1, negate when n&2
+        __m128 sin_swap = _mm_castsi128_ps(_mm_cmpeq_epi32(n_and_1, ones));
+        __m128 sin_result = _mm_blendv_ps(sin_r, cos_r, sin_swap);
+        __m128 sin_neg = _mm_castsi128_ps(_mm_cmpeq_epi32(n_and_2, twos));
+        sin_result = _mm_xor_ps(sin_result, _mm_and_ps(sin_neg, sign_bit));
+
+        // For cos: swap when n&1, negate when (n+1)&2
+        __m128 cos_result = _mm_blendv_ps(cos_r, sin_r, sin_swap);
+        __m128 cos_neg = _mm_castsi128_ps(_mm_cmpeq_epi32(n_plus_1_and_2, twos));
+        cos_result = _mm_xor_ps(cos_result, _mm_and_ps(cos_neg, sign_bit));
+
+        _mm_storeu_ps(sinPtr, sin_result);
+        _mm_storeu_ps(cosPtr, cos_result);
+        inPtr += 4;
+        sinPtr += 4;
+        cosPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        *sinPtr++ = sinf(*inPtr);
+        *cosPtr++ = cosf(*inPtr++);
+    }
+}
+
+#endif /* LV_HAVE_SSE4_1 for unaligned */
+
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+#include <volk/volk_neon_intrinsics.h>
+
+/* NEON polynomial-based sincos with shared argument reduction */
+static inline void volk_32f_sincos_32f_x2_neon(float* sinVector,
+                                               float* cosVector,
+                                               const float* inVector,
+                                               unsigned int num_points)
+{
+    // Cody-Waite argument reduction: n = round(x * 2/pi), r = x - n * pi/2
+    const float32x4_t two_over_pi = vdupq_n_f32(0x1.45f306p-1f);
+    const float32x4_t pi_over_2_hi = vdupq_n_f32(0x1.921fb6p+0f);
+    const float32x4_t pi_over_2_lo = vdupq_n_f32(-0x1.777a5cp-25f);
+
+    const int32x4_t ones = vdupq_n_s32(1);
+    const int32x4_t twos = vdupq_n_s32(2);
+    const float32x4_t sign_bit = vdupq_n_f32(-0.0f);
+    const float32x4_t half = vdupq_n_f32(0.5f);
+    const float32x4_t neg_half = vdupq_n_f32(-0.5f);
+    const float32x4_t fzeroes = vdupq_n_f32(0.0f);
+
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    for (; number < quarterPoints; number++) {
+        float32x4_t x = vld1q_f32(inVector);
+        inVector += 4;
+
+        // n = round(x * 2/pi) - emulate round-to-nearest for ARMv7
+        float32x4_t scaled = vmulq_f32(x, two_over_pi);
+        uint32x4_t is_neg = vcltq_f32(scaled, fzeroes);
+        float32x4_t adj = vbslq_f32(is_neg, neg_half, half);
+        float32x4_t n_f = vcvtq_f32_s32(vcvtq_s32_f32(vaddq_f32(scaled, adj)));
+        int32x4_t n = vcvtq_s32_f32(n_f);
+
+        // r = x - n * (pi/2) using extended precision
+        float32x4_t r = vmlsq_f32(x, n_f, pi_over_2_hi);
+        r = vmlsq_f32(r, n_f, pi_over_2_lo);
+
+        // Evaluate sin and cos polynomials (shared for both outputs)
+        float32x4_t sin_r = _vsin_poly_f32(r);
+        float32x4_t cos_r = _vcos_poly_f32(r);
+
+        // Quadrant selection
+        int32x4_t n_and_1 = vandq_s32(n, ones);
+        int32x4_t n_and_2 = vandq_s32(n, twos);
+        int32x4_t n_plus_1_and_2 = vandq_s32(vaddq_s32(n, ones), twos);
+
+        uint32x4_t swap_mask = vceqq_s32(n_and_1, ones);
+
+        // Sin result: use cos when n&1, negate when n&2
+        float32x4_t sin_result = vbslq_f32(swap_mask, cos_r, sin_r);
+        uint32x4_t sin_neg = vceqq_s32(n_and_2, twos);
+        sin_result = vreinterpretq_f32_u32(
+            veorq_u32(vreinterpretq_u32_f32(sin_result),
+                      vandq_u32(sin_neg, vreinterpretq_u32_f32(sign_bit))));
+
+        // Cos result: use sin when n&1, negate when (n+1)&2
+        float32x4_t cos_result = vbslq_f32(swap_mask, sin_r, cos_r);
+        uint32x4_t cos_neg = vceqq_s32(n_plus_1_and_2, twos);
+        cos_result = vreinterpretq_f32_u32(
+            veorq_u32(vreinterpretq_u32_f32(cos_result),
+                      vandq_u32(cos_neg, vreinterpretq_u32_f32(sign_bit))));
+
+        vst1q_f32(sinVector, sin_result);
+        vst1q_f32(cosVector, cos_result);
+        sinVector += 4;
+        cosVector += 4;
+    }
+
+    for (number = quarterPoints * 4; number < num_points; number++) {
+        *sinVector++ = sinf(*inVector);
+        *cosVector++ = cosf(*inVector++);
+    }
+}
+#endif /* LV_HAVE_NEON */
+
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+#include <volk/volk_neon_intrinsics.h>
+
+/* NEONv8 polynomial-based sincos with FMA and shared argument reduction */
+static inline void volk_32f_sincos_32f_x2_neonv8(float* sinVector,
+                                                 float* cosVector,
+                                                 const float* inVector,
+                                                 unsigned int num_points)
+{
+    // Cody-Waite argument reduction: n = round(x * 2/pi), r = x - n * pi/2
+    const float32x4_t two_over_pi = vdupq_n_f32(0x1.45f306p-1f);
+    const float32x4_t pi_over_2_hi = vdupq_n_f32(0x1.921fb6p+0f);
+    const float32x4_t pi_over_2_lo = vdupq_n_f32(-0x1.777a5cp-25f);
+
+    const int32x4_t ones = vdupq_n_s32(1);
+    const int32x4_t twos = vdupq_n_s32(2);
+    const float32x4_t sign_bit = vdupq_n_f32(-0.0f);
+
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    for (; number < quarterPoints; number++) {
+        float32x4_t x = vld1q_f32(inVector);
+        inVector += 4;
+
+        // n = round(x * 2/pi) using ARMv8 vrndnq_f32
+        float32x4_t n_f = vrndnq_f32(vmulq_f32(x, two_over_pi));
+        int32x4_t n = vcvtq_s32_f32(n_f);
+
+        // r = x - n * (pi/2) using FMA for extended precision
+        float32x4_t r = vfmsq_f32(x, n_f, pi_over_2_hi);
+        r = vfmsq_f32(r, n_f, pi_over_2_lo);
+
+        // Evaluate sin and cos polynomials using FMA (shared for both outputs)
+        float32x4_t sin_r = _vsin_poly_neonv8(r);
+        float32x4_t cos_r = _vcos_poly_neonv8(r);
+
+        // Quadrant selection
+        int32x4_t n_and_1 = vandq_s32(n, ones);
+        int32x4_t n_and_2 = vandq_s32(n, twos);
+        int32x4_t n_plus_1_and_2 = vandq_s32(vaddq_s32(n, ones), twos);
+
+        uint32x4_t swap_mask = vceqq_s32(n_and_1, ones);
+
+        // Sin result: use cos when n&1, negate when n&2
+        float32x4_t sin_result = vbslq_f32(swap_mask, cos_r, sin_r);
+        uint32x4_t sin_neg = vceqq_s32(n_and_2, twos);
+        sin_result = vreinterpretq_f32_u32(
+            veorq_u32(vreinterpretq_u32_f32(sin_result),
+                      vandq_u32(sin_neg, vreinterpretq_u32_f32(sign_bit))));
+
+        // Cos result: use sin when n&1, negate when (n+1)&2
+        float32x4_t cos_result = vbslq_f32(swap_mask, sin_r, cos_r);
+        uint32x4_t cos_neg = vceqq_s32(n_plus_1_and_2, twos);
+        cos_result = vreinterpretq_f32_u32(
+            veorq_u32(vreinterpretq_u32_f32(cos_result),
+                      vandq_u32(cos_neg, vreinterpretq_u32_f32(sign_bit))));
+
+        vst1q_f32(sinVector, sin_result);
+        vst1q_f32(cosVector, cos_result);
+        sinVector += 4;
+        cosVector += 4;
+    }
+
+    for (number = quarterPoints * 4; number < num_points; number++) {
+        *sinVector++ = sinf(*inVector);
+        *cosVector++ = cosf(*inVector++);
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
+#endif /* INCLUDED_volk_32f_sincos_32f_x2_u_H */

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -1,7 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2014 - 2021 Free Software Foundation, Inc.
- * Copyright 2023, 2024 Magnus Lundmark <magnuslundmark@gmail.com>
+ * Copyright 2023 - 2025 Magnus Lundmark <magnuslundmark@gmail.com>
  *
  * This file is part of VOLK
  *
@@ -113,8 +113,9 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     QA(VOLK_INIT_TEST(volk_32fc_32f_add_32fc, test_params))
     QA(VOLK_INIT_TEST(volk_32f_log2_32f, test_params.make_absolute(1.5e-5)))
     QA(VOLK_INIT_TEST(volk_32f_expfast_32f, test_params_inacc_tenth))
-    QA(VOLK_INIT_TEST(volk_32f_sin_32f, test_params_inacc))
-    QA(VOLK_INIT_TEST(volk_32f_cos_32f, test_params_inacc))
+    QA(VOLK_INIT_TEST(volk_32f_sin_32f, test_params))
+    QA(VOLK_INIT_TEST(volk_32f_cos_32f, test_params))
+    QA(VOLK_INIT_TEST(volk_32f_sincos_32f_x2, test_params))
     QA(VOLK_INIT_TEST(volk_32f_tan_32f, test_params_inacc))
 
     volk_test_params_t test_params_atan(test_params);


### PR DESCRIPTION
Replace old Cephes-based sin/cos implementations with new polynomial approximations using Cody-Waite argument reduction for extended precision.

Tightened tolerances and faster performance.

Before this PR:
```
RUN_VOLK_TESTS: volk_32f_sin_32f(vlen=131071, iter=997, tol=1e-02)
arch                 |         time |     throughput |    max_err |
---------------------+--------------+----------------+------------+
generic              |  749.2136 ms |    1395.4 MB/s |          - |
neon                 |  419.8234 ms |    2490.2 MB/s |    1.2e-07 |
neonv8               |  298.8025 ms |    3498.8 MB/s |    1.2e-07 | *
Best aligned arch    | neonv8 (2.51x)
Best unaligned arch  | neonv8 (2.51x)
--------------------------------------------------------------------------------

RUN_VOLK_TESTS: volk_32f_cos_32f(vlen=131071, iter=997, tol=1e-02)
arch                 |         time |     throughput |    max_err |
---------------------+--------------+----------------+------------+
generic              |  784.3280 ms |    1332.9 MB/s |          - |
generic_fast         | 3212.9636 ms |     325.4 MB/s |    2.2e-07 |
neon                 |  418.4082 ms |    2498.7 MB/s |    1.1e-07 |
neonv8               |  289.8234 ms |    3607.2 MB/s |    1.1e-07 | *
Best aligned arch    | neonv8 (2.71x)
Best unaligned arch  | neonv8 (2.71x)
--------------------------------------------------------------------------------

Session summary (2 kernels):
  Average speedup vs generic: 2.61x
  Max speedup vs generic: 2.71x (volk_32f_cos_32f)
```

 ```
RUN_VOLK_TESTS: volk_32f_sin_32f(vlen=131071, iter=997, tol=1e-02)
arch                 |         time |     throughput |    max_err |
---------------------+--------------+----------------+------------+
generic              |  383.6998 ms |    2724.7 MB/s |          - |
a_avx512f            |   31.6185 ms |   33064.8 MB/s |    2.2e-07 |
a_avx2_fma           |   83.1701 ms |   12570.2 MB/s |    2.2e-07 |
a_avx2               |   83.6796 ms |   12493.6 MB/s |    2.2e-07 |
a_sse4_1             |  166.0830 ms |    6294.8 MB/s |    2.2e-07 |
u_avx512f            |   31.5559 ms |   33130.5 MB/s |    2.2e-07 | *
u_avx2_fma           |   83.3774 ms |   12538.9 MB/s |    2.2e-07 |
u_avx2               |   83.1202 ms |   12577.7 MB/s |    2.2e-07 |
u_sse4_1             |  166.1839 ms |    6291.0 MB/s |    2.2e-07 |
Best aligned arch    | u_avx512f (12.16x)
Best unaligned arch  | u_avx512f (12.16x)
--------------------------------------------------------------------------------

RUN_VOLK_TESTS: volk_32f_cos_32f(vlen=131071, iter=997, tol=1e-02)
arch                 |         time |     throughput |    max_err |
---------------------+--------------+----------------+------------+
generic              |  405.4441 ms |    2578.6 MB/s |          - |
generic_fast         |  806.9449 ms |    1295.6 MB/s |    2.2e-07 |
a_avx512f            |   30.5416 ms |   34230.8 MB/s |    2.7e-07 | *
a_avx2_fma           |   86.3201 ms |   12111.5 MB/s |    2.7e-07 |
a_avx2               |   86.3623 ms |   12105.5 MB/s |    2.7e-07 |
a_sse4_1             |  172.0183 ms |    6077.6 MB/s |    2.7e-07 |
u_avx512f            |   30.6677 ms |   34090.0 MB/s |    2.7e-07 | *
u_avx2_fma           |   86.3510 ms |   12107.1 MB/s |    2.7e-07 |
u_avx2               |   86.1275 ms |   12138.5 MB/s |    2.7e-07 |
u_sse4_1             |  164.7134 ms |    6347.2 MB/s |    2.7e-07 |
Best aligned arch    | a_avx512f (13.28x)
Best unaligned arch  | u_avx512f (13.22x)
--------------------------------------------------------------------------------

Session summary (2 kernels):
  Average speedup vs generic: 12.72x
  Max speedup vs generic: 13.28x (volk_32f_cos_32f)
```

After this PR:

```
RUN_VOLK_TESTS: volk_32f_sin_32f(vlen=131071, iter=997, tol=1e-06)
arch                 |         time |     throughput |    max_err |
---------------------+--------------+----------------+------------+
generic              |  753.5666 ms |    1387.4 MB/s |          - |
neon                 |  371.6167 ms |    2813.3 MB/s |    2.5e-07 |
neonv8               |  210.0691 ms |    4976.8 MB/s |    1.7e-07 | *
Best aligned arch    | neonv8 (3.59x)
Best unaligned arch  | neonv8 (3.59x)
--------------------------------------------------------------------------------

RUN_VOLK_TESTS: volk_32f_cos_32f(vlen=131071, iter=997, tol=1e-06)
arch                 |         time |     throughput |    max_err |
---------------------+--------------+----------------+------------+
generic              |  785.9267 ms |    1330.2 MB/s |          - |
neon                 |  392.5334 ms |    2663.4 MB/s |    2.5e-07 |
neonv8               |  221.5695 ms |    4718.4 MB/s |    2.5e-07 | *
Best aligned arch    | neonv8 (3.55x)
Best unaligned arch  | neonv8 (3.55x)
--------------------------------------------------------------------------------

RUN_VOLK_TESTS: volk_32f_sincos_32f_x2(vlen=131071, iter=997, tol=1e-06)
arch                 |         time |     throughput |    max_err |
---------------------+--------------+----------------+------------+
generic              | 1237.5753 ms |    1267.1 MB/s |          - |
neon                 |  443.6866 ms |    3534.5 MB/s |    2.5e-07 |
neonv8               |  279.8062 ms |    5604.6 MB/s |    2.5e-07 | *
Best aligned arch    | neonv8 (4.42x)
Best unaligned arch  | neonv8 (4.42x)
--------------------------------------------------------------------------------

Session summary (3 kernels):
  Average speedup vs generic: 3.85x
  Max speedup vs generic: 4.42x (volk_32f_sincos_32f_x2)
```

```
RUN_VOLK_TESTS: volk_32f_sin_32f(vlen=131071, iter=997, tol=1e-06)
arch                 |         time |     throughput |    max_err |
---------------------+--------------+----------------+------------+
generic              |  382.3344 ms |    2734.4 MB/s |          - |
a_avx512f            |   11.3167 ms |   92382.4 MB/s |    1.7e-07 | *
a_avx2_fma           |   22.2564 ms |   46973.5 MB/s |    1.7e-07 |
a_avx2               |   22.0664 ms |   47378.0 MB/s |    1.7e-07 |
a_sse4_1             |   43.2522 ms |   24171.3 MB/s |    1.7e-07 |
u_avx512f            |   11.3470 ms |   92135.2 MB/s |    1.7e-07 | *
u_avx2_fma           |   22.2746 ms |   46935.1 MB/s |    1.7e-07 |
u_avx2               |   22.1501 ms |   47199.1 MB/s |    1.7e-07 |
u_sse4_1             |   43.3173 ms |   24135.0 MB/s |    1.7e-07 |
Best aligned arch    | a_avx512f (33.79x)
Best unaligned arch  | u_avx512f (33.69x)
--------------------------------------------------------------------------------

RUN_VOLK_TESTS: volk_32f_cos_32f(vlen=131071, iter=997, tol=1e-06)
arch                 |         time |     throughput |    max_err |
---------------------+--------------+----------------+------------+
generic              |  434.0374 ms |    2408.7 MB/s |          - |
a_avx512f            |   11.8019 ms |   88584.3 MB/s |    1.7e-07 |
a_avx2_fma           |   22.9454 ms |   45563.1 MB/s |    1.7e-07 |
a_avx2               |   22.7586 ms |   45936.9 MB/s |    1.7e-07 |
a_sse4_1             |   44.9318 ms |   23267.7 MB/s |    1.7e-07 |
u_avx512f            |   11.7879 ms |   88689.1 MB/s |    1.7e-07 | *
u_avx2_fma           |   22.9174 ms |   45618.7 MB/s |    1.7e-07 |
u_avx2               |   22.9252 ms |   45603.1 MB/s |    1.7e-07 |
u_sse4_1             |   44.9629 ms |   23251.6 MB/s |    1.7e-07 |
Best aligned arch    | u_avx512f (36.82x)
Best unaligned arch  | u_avx512f (36.82x)
--------------------------------------------------------------------------------

RUN_VOLK_TESTS: volk_32f_sincos_32f_x2(vlen=131071, iter=997, tol=1e-06)
arch                 |         time |     throughput |    max_err |
---------------------+--------------+----------------+------------+
generic              |  571.9032 ms |    2742.1 MB/s |          - |
a_avx512f            |   14.6113 ms |  107327.8 MB/s |    1.7e-07 |
a_avx2_fma           |   27.7086 ms |   56596.0 MB/s |    1.7e-07 |
a_avx2               |   27.7421 ms |   56527.5 MB/s |    1.7e-07 |
a_sse4_1             |   55.0146 ms |   28505.0 MB/s |    1.7e-07 |
u_avx512f            |   14.5684 ms |  107643.8 MB/s |    1.7e-07 | *
u_avx2_fma           |   27.8473 ms |   56314.0 MB/s |    1.7e-07 |
u_avx2               |   27.6788 ms |   56656.9 MB/s |    1.7e-07 |
u_sse4_1             |   55.2005 ms |   28409.0 MB/s |    1.7e-07 |
Best aligned arch    | u_avx512f (39.26x)
Best unaligned arch  | u_avx512f (39.26x)
--------------------------------------------------------------------------------

Session summary (3 kernels):
  Average speedup vs generic: 36.62x
```
