### PR TITLE
reintroduce invsqrt and modernize it.

### DIFF
--- a/kernels/volk/volk_32f_invsqrt_32f.h
+++ b/kernels/volk/volk_32f_invsqrt_32f.h
@@ -1,6 +1,7 @@
 /* -*- c++ -*- */
 /*
  * Copyright 2013, 2014 Free Software Foundation, Inc.
+ * Copyright 2026 Magnus Lundmark <magnuslundmark@gmail.com>
  *
  * This file is part of VOLK
  *
@@ -52,59 +53,73 @@
 #ifndef INCLUDED_volk_32f_invsqrt_32f_a_H
 #define INCLUDED_volk_32f_invsqrt_32f_a_H
 
-#include <inttypes.h>
 #include <math.h>
-#include <stdio.h>
-#include <string.h>
+#include <volk/volk_common.h>
 
-static inline float Q_rsqrt(float number)
+#ifdef LV_HAVE_GENERIC
+
+static inline void volk_32f_invsqrt_32f_generic(float* cVector,
+                                                const float* aVector,
+                                                unsigned int num_points)
 {
-    float x2;
-    const float threehalfs = 1.5F;
-    union f32_to_i32 {
-        int32_t i;
+    for (unsigned int number = 0; number < num_points; number++) {
+        cVector[number] = sqrtf(1.0f / aVector[number]);
+    }
+}
+#endif /* LV_HAVE_GENERIC */
+
+#ifdef LV_HAVE_GENERIC
+
+static inline void volk_32f_invsqrt_32f_recip_sqrt(float* cVector,
+                                                   const float* aVector,
+                                                   unsigned int num_points)
+{
+    for (unsigned int number = 0; number < num_points; number++) {
+        cVector[number] = 1.0f / sqrtf(aVector[number]);
+    }
+}
+#endif /* LV_HAVE_GENERIC */
+
+#ifdef LV_HAVE_GENERIC
+
+static inline void volk_32f_invsqrt_32f_Q_rsqrt(float* cVector,
+                                                const float* aVector,
+                                                unsigned int num_points)
+{
+    // The famous fast inverse square root from Quake III Arena
+    union {
         float f;
-    } u;
+        uint32_t u;
+    } conv, result;
 
-    x2 = number * 0.5F;
-    u.f = number;
-    u.i = 0x5f3759df - (u.i >> 1);               // what the fuck?
-    u.f = u.f * (threehalfs - (x2 * u.f * u.f)); // 1st iteration
-    // u.f  = u.f * ( threehalfs - ( x2 * u.f * u.f ) );   // 2nd iteration, this can be
-    // removed
+    for (unsigned int number = 0; number < num_points; number++) {
+        float a = aVector[number];
+        float xhalf = 0.5f * a;
+        conv.f = a;
+        uint32_t input_bits = conv.u;        // Save original bits for edge case detection
+        conv.u = 0x5f3759df - (conv.u >> 1); // The magic (note: use unsigned for shift)
+        float x = conv.f;
+        x = x * (1.5f - xhalf * x * x); // Newton-Raphson iteration 1
+        x = x * (1.5f - xhalf * x * x);
+        x = x * (1.5f - xhalf * x * x);
 
-    return u.f;
-}
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-
-static inline void
-volk_32f_invsqrt_32f_a_avx(float* cVector, const float* aVector, unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int eighthPoints = num_points / 8;
-
-    float* cPtr = cVector;
-    const float* aPtr = aVector;
-    __m256 aVal, cVal;
-    for (; number < eighthPoints; number++) {
-        aVal = _mm256_load_ps(aPtr);
-        cVal = _mm256_rsqrt_ps(aVal);
-        _mm256_store_ps(cPtr, cVal);
-        aPtr += 8;
-        cPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        *cPtr++ = Q_rsqrt(*aPtr++);
+        // Branchless special case handling
+        result.f = x;
+        uint32_t is_positive = (uint32_t)(-(int32_t)(a > 0.0f));
+        uint32_t is_zero = (uint32_t)(-(int32_t)(input_bits == 0x00000000));
+        uint32_t is_inf = (uint32_t)(-(int32_t)(input_bits == 0x7F800000));
+        uint32_t is_normal_pos = is_positive & ~is_inf;
+        result.u = (result.u & is_normal_pos) | // Normal positive: keep result
+                   (0x7F800000u & is_zero) |    // +0 → +Inf
+                   (0x7FC00000u & ~is_positive & ~is_zero); // Negative/NaN → NaN
+        // Note: +Inf → 0 is handled implicitly (all terms are 0 when is_inf)
+        cVector[number] = result.f;
     }
 }
-#endif /* LV_HAVE_AVX */
-
+#endif /* LV_HAVE_GENERIC */
 
 #ifdef LV_HAVE_SSE
+#include <volk/volk_sse_intrinsics.h>
 #include <xmmintrin.h>
 
 static inline void
@@ -115,30 +130,218 @@ volk_32f_invsqrt_32f_a_sse(float* cVector, const float* aVector, unsigned int nu
 
     float* cPtr = cVector;
     const float* aPtr = aVector;
-
-    __m128 aVal, cVal;
     for (; number < quarterPoints; number++) {
-
-        aVal = _mm_load_ps(aPtr);
-
-        cVal = _mm_rsqrt_ps(aVal);
-
-        _mm_store_ps(cPtr, cVal); // Store the results back into the C container
-
+        __m128 aVal = _mm_load_ps(aPtr);
+        __m128 cVal = _mm_rsqrt_nr_ps(aVal);
+        _mm_store_ps(cPtr, cVal);
         aPtr += 4;
         cPtr += 4;
     }
 
     number = quarterPoints * 4;
     for (; number < num_points; number++) {
-        *cPtr++ = Q_rsqrt(*aPtr++);
+        *cPtr++ = 1.0f / sqrtf(*aPtr++);
+    }
+}
+#endif /* LV_HAVE_SSE */
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
+static inline void
+volk_32f_invsqrt_32f_a_avx(float* cVector, const float* aVector, unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    float* cPtr = cVector;
+    const float* aPtr = aVector;
+    for (; number < eighthPoints; number++) {
+        __m256 aVal = _mm256_load_ps(aPtr);
+        __m256 cVal = _mm256_rsqrt_nr_ps(aVal);
+        _mm256_store_ps(cPtr, cVal);
+        aPtr += 8;
+        cPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *cPtr++ = 1.0f / sqrtf(*aPtr++);
+    }
+}
+#endif /* LV_HAVE_AVX */
+
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+#include <volk/volk_avx2_intrinsics.h>
+
+static inline void
+volk_32f_invsqrt_32f_a_avx2(float* cVector, const float* aVector, unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    float* cPtr = cVector;
+    const float* aPtr = aVector;
+    for (; number < eighthPoints; number++) {
+        __m256 aVal = _mm256_load_ps(aPtr);
+        __m256 cVal = _mm256_rsqrt_nr_avx2(aVal);
+        _mm256_store_ps(cPtr, cVal);
+        aPtr += 8;
+        cPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *cPtr++ = 1.0f / sqrtf(*aPtr++);
+    }
+}
+#endif /* LV_HAVE_AVX2 */
+
+
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+#include <volk/volk_avx512_intrinsics.h>
+
+static inline void volk_32f_invsqrt_32f_a_avx512f(float* cVector,
+                                                  const float* aVector,
+                                                  unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int sixteenthPoints = num_points / 16;
+
+    float* cPtr = cVector;
+    const float* aPtr = aVector;
+    for (; number < sixteenthPoints; number++) {
+        __m512 aVal = _mm512_load_ps(aPtr);
+        __m512 cVal = _mm512_rsqrt_nr_ps(aVal);
+        _mm512_store_ps(cPtr, cVal);
+        aPtr += 16;
+        cPtr += 16;
+    }
+
+    number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        *cPtr++ = 1.0f / sqrtf(*aPtr++);
+    }
+}
+#endif /* LV_HAVE_AVX512F */
+
+#ifdef LV_HAVE_SSE
+#include <volk/volk_sse_intrinsics.h>
+#include <xmmintrin.h>
+
+static inline void
+volk_32f_invsqrt_32f_u_sse(float* cVector, const float* aVector, unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    float* cPtr = cVector;
+    const float* aPtr = aVector;
+    for (; number < quarterPoints; number++) {
+        __m128 aVal = _mm_loadu_ps(aPtr);
+        __m128 cVal = _mm_rsqrt_nr_ps(aVal);
+        _mm_storeu_ps(cPtr, cVal);
+        aPtr += 4;
+        cPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        *cPtr++ = 1.0f / sqrtf(*aPtr++);
     }
 }
 #endif /* LV_HAVE_SSE */
 
 
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
+static inline void
+volk_32f_invsqrt_32f_u_avx(float* cVector, const float* aVector, unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    float* cPtr = cVector;
+    const float* aPtr = aVector;
+    for (; number < eighthPoints; number++) {
+        __m256 aVal = _mm256_loadu_ps(aPtr);
+        __m256 cVal = _mm256_rsqrt_nr_ps(aVal);
+        _mm256_storeu_ps(cPtr, cVal);
+        aPtr += 8;
+        cPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *cPtr++ = 1.0f / sqrtf(*aPtr++);
+    }
+}
+#endif /* LV_HAVE_AVX */
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+#include <volk/volk_avx2_intrinsics.h>
+
+static inline void
+volk_32f_invsqrt_32f_u_avx2(float* cVector, const float* aVector, unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    float* cPtr = cVector;
+    const float* aPtr = aVector;
+    for (; number < eighthPoints; number++) {
+        __m256 aVal = _mm256_loadu_ps(aPtr);
+        __m256 cVal = _mm256_rsqrt_nr_avx2(aVal);
+        _mm256_storeu_ps(cPtr, cVal);
+        aPtr += 8;
+        cPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *cPtr++ = 1.0f / sqrtf(*aPtr++);
+    }
+}
+#endif /* LV_HAVE_AVX2 */
+
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+#include <volk/volk_avx512_intrinsics.h>
+
+static inline void volk_32f_invsqrt_32f_u_avx512f(float* cVector,
+                                                  const float* aVector,
+                                                  unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int sixteenthPoints = num_points / 16;
+
+    float* cPtr = cVector;
+    const float* aPtr = aVector;
+    for (; number < sixteenthPoints; number++) {
+        __m512 aVal = _mm512_loadu_ps(aPtr);
+        __m512 cVal = _mm512_rsqrt_nr_ps(aVal);
+        _mm512_storeu_ps(cPtr, cVal);
+        aPtr += 16;
+        cPtr += 16;
+    }
+
+    number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        *cPtr++ = 1.0f / sqrtf(*aPtr++);
+    }
+}
+#endif /* LV_HAVE_AVX512F */
+
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
+#include <volk/volk_neon_intrinsics.h>
 
 static inline void
 volk_32f_invsqrt_32f_neon(float* cVector, const float* aVector, unsigned int num_points)
@@ -148,17 +351,16 @@ volk_32f_invsqrt_32f_neon(float* cVector, const float* aVector, unsigned int num
 
     float* cPtr = cVector;
     const float* aPtr = aVector;
-    float32x4_t a_val, c_val;
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld1q_f32(aPtr);
-        c_val = vrsqrteq_f32(a_val);
+        float32x4_t a_val = vld1q_f32(aPtr);
+        float32x4_t c_val = _vinvsqrtq_f32(a_val);
         vst1q_f32(cPtr, c_val);
         aPtr += 4;
         cPtr += 4;
     }
 
     for (number = quarter_points * 4; number < num_points; number++) {
-        *cPtr++ = Q_rsqrt(*aPtr++);
+        *cPtr++ = 1.0f / sqrtf(*aPtr++);
     }
 }
 #endif /* LV_HAVE_NEON */
@@ -174,65 +376,33 @@ volk_32f_invsqrt_32f_neonv8(float* cVector, const float* aVector, unsigned int n
 
     float* cPtr = cVector;
     const float* aPtr = aVector;
-    const float32x4_t fones = vdupq_n_f32(1.0f);
 
+    // Process 4 elements at a time (1 vector)
     for (number = 0; number < quarter_points; ++number) {
-        float32x4_t a_val = vld1q_f32(aPtr);
-        // Use native sqrt and division for accurate result
-        float32x4_t c_val = vdivq_f32(fones, vsqrtq_f32(a_val));
-        vst1q_f32(cPtr, c_val);
+        float32x4_t a = vld1q_f32(aPtr);
+        float32x4_t x0 = vrsqrteq_f32(a); // +Inf for +0, 0 for +Inf
+
+        // Two Newton-Raphson iterations for float32 accuracy
+        float32x4_t x1 = vmulq_f32(x0, vrsqrtsq_f32(vmulq_f32(a, x0), x0));
+        x1 = vmulq_f32(x1, vrsqrtsq_f32(vmulq_f32(a, x1), x1));
+
+        // For +0 and +Inf inputs, x0 is correct but NR produces NaN due to Inf*0
+        // Blend: use x0 where a == +0 or a == +Inf, else use x1
+        uint32x4_t a_bits = vreinterpretq_u32_f32(a);
+        uint32x4_t zero_mask = vceqq_u32(a_bits, vdupq_n_u32(0x00000000));
+        uint32x4_t inf_mask = vceqq_u32(a_bits, vdupq_n_u32(0x7F800000));
+        uint32x4_t special_mask = vorrq_u32(zero_mask, inf_mask);
+
+        vst1q_f32(cPtr, vbslq_f32(special_mask, x0, x1));
         aPtr += 4;
         cPtr += 4;
     }
 
     for (number = quarter_points * 4; number < num_points; number++) {
-        *cPtr++ = Q_rsqrt(*aPtr++);
+        *cPtr++ = 1.0f / sqrtf(*aPtr++);
     }
 }
 #endif /* LV_HAVE_NEONV8 */
-
-
-#ifdef LV_HAVE_GENERIC
-
-static inline void volk_32f_invsqrt_32f_generic(float* cVector,
-                                                const float* aVector,
-                                                unsigned int num_points)
-{
-    float* cPtr = cVector;
-    const float* aPtr = aVector;
-    unsigned int number = 0;
-    for (number = 0; number < num_points; number++) {
-        *cPtr++ = Q_rsqrt(*aPtr++);
-    }
-}
-#endif /* LV_HAVE_GENERIC */
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-
-static inline void
-volk_32f_invsqrt_32f_u_avx(float* cVector, const float* aVector, unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int eighthPoints = num_points / 8;
-
-    float* cPtr = cVector;
-    const float* aPtr = aVector;
-    __m256 aVal, cVal;
-    for (; number < eighthPoints; number++) {
-        aVal = _mm256_loadu_ps(aPtr);
-        cVal = _mm256_rsqrt_ps(aVal);
-        _mm256_storeu_ps(cPtr, cVal);
-        aPtr += 8;
-        cPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        *cPtr++ = Q_rsqrt(*aPtr++);
-    }
-}
-#endif /* LV_HAVE_AVX */
 
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
@@ -243,8 +413,29 @@ volk_32f_invsqrt_32f_rvv(float* cVector, const float* aVector, unsigned int num_
     size_t n = num_points;
     for (size_t vl; n > 0; n -= vl, aVector += vl, cVector += vl) {
         vl = __riscv_vsetvl_e32m8(n);
-        vfloat32m8_t v = __riscv_vle32_v_f32m8(aVector, vl);
-        __riscv_vse32(cVector, __riscv_vfrsqrt7(v, vl), vl);
+        vfloat32m8_t a = __riscv_vle32_v_f32m8(aVector, vl);
+        vfloat32m8_t half = __riscv_vfmv_v_f_f32m8(0.5f, vl);
+        vfloat32m8_t three_halfs = __riscv_vfmv_v_f_f32m8(1.5f, vl);
+
+        // Initial estimate (~7-bit precision): +Inf for +0, 0 for +Inf
+        vfloat32m8_t x0 = __riscv_vfrsqrt7(a, vl);
+
+        // Two Newton-Raphson iterations: x = x * (1.5 - 0.5 * a * x * x)
+        vfloat32m8_t half_a = __riscv_vfmul(half, a, vl);
+        vfloat32m8_t x1 = __riscv_vfmul(
+            x0, __riscv_vfnmsac(three_halfs, half_a, __riscv_vfmul(x0, x0, vl), vl), vl);
+        x1 = __riscv_vfmul(
+            x1, __riscv_vfnmsac(three_halfs, half_a, __riscv_vfmul(x1, x1, vl), vl), vl);
+
+        // For +0 and +Inf inputs, x0 is correct but NR produces NaN due to Inf*0
+        // Blend: use x0 where a == +0 or a == +Inf, else use x1
+        vuint32m8_t a_bits = __riscv_vreinterpret_v_f32m8_u32m8(a);
+        vbool4_t zero_mask = __riscv_vmseq_vx_u32m8_b4(a_bits, 0x00000000, vl);
+        vbool4_t inf_mask = __riscv_vmseq_vx_u32m8_b4(a_bits, 0x7F800000, vl);
+        vbool4_t special_mask = __riscv_vmor_mm_b4(zero_mask, inf_mask, vl);
+        vfloat32m8_t result = __riscv_vmerge_vvm_f32m8(x1, x0, special_mask, vl);
+
+        __riscv_vse32(cVector, result, vl);
     }
 }
 #endif /*LV_HAVE_RVV*/

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -232,7 +232,8 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     QA(VOLK_INIT_TEST(volk_32f_sqrt_32f, test_params_inacc))
 
     volk_test_params_t test_params_invsqrt(test_params.make_tol(1e-6));
-    test_params_invsqrt.add_float_edge_cases({ -1.f, 0.f, inf, 0.01f, 100.0f });
+    test_params_invsqrt.add_float_edge_cases(
+        { -1.f, 1.f, 0.f, inf, 1e-2f, 1e2f, 1e-10, 1e10 });
     QA(VOLK_INIT_TEST(volk_32f_invsqrt_32f, test_params_invsqrt))
     QA(VOLK_INIT_TEST(volk_32f_s32f_stddev_32f, test_params_inacc))
     QA(VOLK_INIT_TEST(volk_32f_stddev_and_mean_32f_x2, test_params.make_absolute(1e-5)))

--- a/lib/kernel_tests.h
+++ b/lib/kernel_tests.h
@@ -230,6 +230,10 @@ std::vector<volk_test_case_t> init_test_list(volk_test_params_t test_params)
     QA(VOLK_INIT_TEST(volk_32f_s32f_power_32f, test_params))
     QA(VOLK_INIT_TEST(volk_32f_reciprocal_32f, test_params.make_tol(6.15e-5)))
     QA(VOLK_INIT_TEST(volk_32f_sqrt_32f, test_params_inacc))
+
+    volk_test_params_t test_params_invsqrt(test_params.make_tol(1e-6));
+    test_params_invsqrt.add_float_edge_cases({ -1.f, 0.f, inf, 0.01f, 100.0f });
+    QA(VOLK_INIT_TEST(volk_32f_invsqrt_32f, test_params_invsqrt))
     QA(VOLK_INIT_TEST(volk_32f_s32f_stddev_32f, test_params_inacc))
     QA(VOLK_INIT_TEST(volk_32f_stddev_and_mean_32f_x2, test_params.make_absolute(1e-5)))
     QA(VOLK_INIT_TEST(volk_32f_x2_subtract_32f, test_params))

--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -1451,20 +1451,10 @@ bool run_volk_tests(volk_func_desc_t desc,
 
     // Helper for adaptive decimal places based on magnitude
     auto format_time = [](double ms) -> std::string {
-        if (ms >= 10000.0)
-            return fmt::format("{:.1f} ms", ms);
-        if (ms >= 1000.0)
-            return fmt::format("{:.2f} ms", ms);
-        if (ms >= 100.0)
-            return fmt::format("{:.3f} ms", ms);
-        return fmt::format("{:.4f} ms", ms);
+        return fmt::format("{:.2f} ms", ms);
     };
 
     auto format_throughput = [](double mbps) -> std::string {
-        if (mbps >= 100000.0)
-            return fmt::format("{:.0f} MB/s", mbps);
-        if (mbps >= 10000.0)
-            return fmt::format("{:.1f} MB/s", mbps);
         return fmt::format("{:.1f} MB/s", mbps);
     };
 
@@ -1504,12 +1494,7 @@ bool run_volk_tests(volk_func_desc_t desc,
             speedup_str = "-";
         } else {
             double speedup = generic_time / profile_times[i];
-            if (speedup >= 100.0)
-                speedup_str = fmt::format("{:.1f}x", speedup);
-            else if (speedup >= 10.0)
-                speedup_str = fmt::format("{:.2f}x", speedup);
-            else
-                speedup_str = fmt::format("{:.2f}x", speedup);
+            speedup_str = fmt::format("{:.2f}x", speedup);
         }
         std::string err_str =
             (arch_list[i] == "generic") ? "-" : fmt::format("{:.1e}", arch_max_err[i]);


### PR DESCRIPTION
This PR gets rid of the Q_rsqrt implementation and the puppet. Modern CPUs don't use that and it's hacky at best. Fails on negative inputs.

Tolerance is tightened from 1e-02 to 1e-6.

Last kernel before release!

```
RUN_VOLK_TESTS: volk_32f_invsqrt_32f(vlen=131071, iter=3000, tol=1e-06)
arch                       |         time |     throughput |    max_rel |
---------------------------+--------------+----------------+------------+
generic                    | 1797.7696 ms |    1749.8 MB/s |          - |
a_avx                      |   22.2048 ms |  141673.2 MB/s |    2.4e-07 |
a_avx512f                  |   15.3338 ms |  205156.5 MB/s |    2.1e-07 | *
a_sse                      |   38.4642 ms |   81785.7 MB/s |    2.4e-07 |
u_sse                      |   37.6666 ms |   83517.7 MB/s |    2.4e-07 |
u_avx                      |   19.6460 ms |  160125.7 MB/s |    2.4e-07 |
u_avx512f                  |   15.7183 ms |  200137.9 MB/s |    2.1e-07 | *
Best aligned arch          | a_avx512f (117.24x)
Best unaligned arch        | u_avx512f (114.37x)
--------------------------------------------------------------------------------

RUN_VOLK_TESTS: volk_32f_invsqrt_32f(vlen=131071, iter=597, tol=1e-06)
arch                       |         time |     throughput |    max_rel |
---------------------------+--------------+----------------+------------+
generic                    |  689.8667 ms |     907.4 MB/s |          - |
neon                       |   44.6217 ms |   14029.5 MB/s |    2.0e-07 |
neonv8                     |   43.7900 ms |   14295.9 MB/s |    2.0e-07 | *
Best aligned arch          | neonv8 (15.75x)
Best unaligned arch        | neonv8 (15.75x)
--------------------------------------------------------------------------------
```
