### PR TITLE
cmake: Use FindPython3 interpreter module

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -182,10 +182,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
       - name: dependencies
         run: pip install mako
       - name: configure
-        run: mkdir build && cd build && cmake ..
+        run: mkdir build && cd build && cmake -DPython3_FIND_REGISTRY=NEVER ..
       - name: build
         run: cmake --build build --config Release --target INSTALL -j4
       - name: test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,13 +179,7 @@ endif()
 
 # Python
 include(VolkPython) #sets PYTHON_EXECUTABLE and PYTHON_DASH_B
-volk_python_check_module("python >= 3.4" sys "sys.version_info >= (3, 4)"
-                         PYTHON_MIN_VER_FOUND)
 volk_python_check_module("mako >= 0.4.2" mako "mako.__version__ >= '0.4.2'" MAKO_FOUND)
-
-if(NOT PYTHON_MIN_VER_FOUND)
-    message(FATAL_ERROR "Python 3.4 or greater required to build VOLK")
-endif()
 
 # Mako
 if(NOT MAKO_FOUND)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
     - job_name: VS 17 2022 / python 3.12
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       CMAKE_GENERATOR: Visual Studio 17 2022
-      PYTHON: "C:\Python312-x64"
+      PYTHON: "C:\\Python312"
 
 install:
     # Prepend the selected Python to the PATH of this build
@@ -27,7 +27,7 @@ install:
     - pip install mako
 before_build:
     - git submodule update --init --recursive
-    - cmake -G "%CMAKE_GENERATOR%" -A x64 -DCMAKE_BUILD_TYPE:STRING=Release -DENABLE_ORC:BOOL=OFF -DENABLE_TESTING:BOOL=ON .
+    - cmake -G "%CMAKE_GENERATOR%" -A x64 -DCMAKE_BUILD_TYPE:STRING=Release -DENABLE_ORC:BOOL=OFF -DENABLE_TESTING:BOOL=ON -DPython3_FIND_REGISTRY=NEVER .
 build_script:
     - cmake --build . --config Release --target INSTALL
 test_script:

--- a/cmake/Modules/VolkPython.cmake
+++ b/cmake/Modules/VolkPython.cmake
@@ -15,48 +15,16 @@ set(__INCLUDED_VOLK_PYTHON_CMAKE TRUE)
 # This allows the user to specify a specific interpreter,
 # or finds the interpreter via the built-in cmake module.
 ########################################################################
-#this allows the user to override PYTHON_EXECUTABLE
-
-# `PythonInterp` is deprecated in 3.12, we should use `Python3` instead.
-# The `Python3` CMake module is introduced in CMake 3.12, e.g. Ubuntu 18.04 comes with CMake 3.10 though.
-# https://cmake.org/cmake/help/latest/module/FindPythonInterp.html
-# https://cmake.org/cmake/help/latest/module/FindPython3.html#module:FindPython3
-
-# FUTURE TODO: With CMake 3.12+ we can simply do:
-#if(PYTHON_EXECUTABLE)
-#    set(Python_EXECUTABLE ${PYTHON_EXECUTABLE})
-#else(PYTHON_EXECUTABLE)
-#    find_package(Python3 COMPONENTS Interpreter)
-#endif(PYTHON_EXECUTABLE)
-#
-##make the path to the executable appear in the cmake gui
-#set(PYTHON_EXECUTABLE ${Python_EXECUTABLE} CACHE FILEPATH "python interpreter")
-# END FUTURE TODO: Stick with following version as long as we set CMake 3.8 minimum.
-
+# Allow users/CI to override the interpreter explicitly.
+# FindPython3 uses Python3_EXECUTABLE as its override input.
 if(PYTHON_EXECUTABLE)
+    set(Python3_EXECUTABLE "${PYTHON_EXECUTABLE}")
+endif()
+find_package(Python3 3.4 COMPONENTS Interpreter REQUIRED)
 
-    set(PYTHONINTERP_FOUND TRUE)
-
-    #otherwise if not set, try to automatically find it
-else(PYTHON_EXECUTABLE)
-
-    #use the built-in find script
-    set(Python_ADDITIONAL_VERSIONS 3.4 3.5 3.6 3.7 3.8)
-    find_package(PythonInterp 3)
-
-    #and if that fails use the find program routine
-    if(NOT PYTHONINTERP_FOUND)
-        find_program(PYTHON_EXECUTABLE NAMES python3 python)
-        if(PYTHON_EXECUTABLE)
-            set(PYTHONINTERP_FOUND TRUE)
-        endif(PYTHON_EXECUTABLE)
-    endif(NOT PYTHONINTERP_FOUND)
-
-endif(PYTHON_EXECUTABLE)
-
-#make the path to the executable appear in the cmake gui
+# Expose the resolved interpreter path in the CMake cache/GUI.
 set(PYTHON_EXECUTABLE
-    ${PYTHON_EXECUTABLE}
+    ${Python3_EXECUTABLE}
     CACHE FILEPATH "python interpreter")
 
 ########################################################################


### PR DESCRIPTION
Replace deprecated FindPythonInterp usage with `find_package(Python3 COMPONENTS Interpreter)`. This removes CMP0148 developer warnings while preserving `PYTHON_EXECUTABLE` compatibility.

VOLK requires CMake 3.22, so using FindPython3 (introduced in CMake 3.12) is safe.

Related: https://github.com/gnuradio/gnuradio/issues/7882