### PR TITLE
fix: remove unused variables and dead assignments in 6 kernels

### DIFF
--- a/kernels/volk/volk_16i_max_star_horizontal_16i.h
+++ b/kernels/volk/volk_16i_max_star_horizontal_16i.h
@@ -133,7 +133,6 @@ static inline void volk_16i_max_star_horizontal_16i_a_ssse3(int16_t* target,
         xmm0 = _mm_load_si128(p_src0);
 
         xmm2 = _mm_xor_si128(xmm2, xmm2);
-        p_src0 += 1;
 
         xmm3 = _mm_hsub_epi16(xmm0, xmm1);
         xmm2 = _mm_cmpgt_epi16(xmm2, xmm3);
@@ -145,8 +144,6 @@ static inline void volk_16i_max_star_horizontal_16i_a_ssse3(int16_t* target,
         xmm0 = _mm_shuffle_epi8(xmm0, xmm3);
 
         _mm_storel_pd((double*)p_target, bit128_p(&xmm0)->double_vec);
-
-        p_target = (__m128i*)((int8_t*)p_target + 8);
     }
 
     for (i = (bound << 4) + (intermediate << 3);

--- a/kernels/volk/volk_32f_accumulator_s32f.h
+++ b/kernels/volk/volk_32f_accumulator_s32f.h
@@ -67,7 +67,7 @@ static inline void volk_32f_accumulator_s32f_a_avx512f(float* result,
     const float* aPtr = inputBuffer;
 
     __m512 accumulator = _mm512_setzero_ps();
-    __m512 aVal = _mm512_setzero_ps();
+    __m512 aVal;
 
     for (; number < sixteenthPoints; number++) {
         aVal = _mm512_load_ps(aPtr);
@@ -102,7 +102,7 @@ static inline void volk_32f_accumulator_s32f_a_avx(float* result,
     __VOLK_ATTR_ALIGNED(32) float tempBuffer[8];
 
     __m256 accumulator = _mm256_setzero_ps();
-    __m256 aVal = _mm256_setzero_ps();
+    __m256 aVal;
 
     for (; number < eighthPoints; number++) {
         aVal = _mm256_load_ps(aPtr);
@@ -144,7 +144,7 @@ static inline void volk_32f_accumulator_s32f_u_avx512f(float* result,
     const float* aPtr = inputBuffer;
 
     __m512 accumulator = _mm512_setzero_ps();
-    __m512 aVal = _mm512_setzero_ps();
+    __m512 aVal;
 
     for (; number < sixteenthPoints; number++) {
         aVal = _mm512_loadu_ps(aPtr);
@@ -179,7 +179,7 @@ static inline void volk_32f_accumulator_s32f_u_avx(float* result,
     __VOLK_ATTR_ALIGNED(32) float tempBuffer[8];
 
     __m256 accumulator = _mm256_setzero_ps();
-    __m256 aVal = _mm256_setzero_ps();
+    __m256 aVal;
 
     for (; number < eighthPoints; number++) {
         aVal = _mm256_loadu_ps(aPtr);
@@ -222,7 +222,7 @@ static inline void volk_32f_accumulator_s32f_a_sse(float* result,
     __VOLK_ATTR_ALIGNED(16) float tempBuffer[4];
 
     __m128 accumulator = _mm_setzero_ps();
-    __m128 aVal = _mm_setzero_ps();
+    __m128 aVal;
 
     for (; number < quarterPoints; number++) {
         aVal = _mm_load_ps(aPtr);
@@ -261,7 +261,7 @@ static inline void volk_32f_accumulator_s32f_u_sse(float* result,
     __VOLK_ATTR_ALIGNED(16) float tempBuffer[4];
 
     __m128 accumulator = _mm_setzero_ps();
-    __m128 aVal = _mm_setzero_ps();
+    __m128 aVal;
 
     for (; number < quarterPoints; number++) {
         aVal = _mm_loadu_ps(aPtr);

--- a/kernels/volk/volk_32f_exp_32f.h
+++ b/kernels/volk/volk_32f_exp_32f.h
@@ -122,7 +122,6 @@ volk_32f_exp_32f_a_sse2(float* bVector, const float* aVector, unsigned int num_p
 
     for (; number < quarterPoints; number++) {
         aVal = _mm_load_ps(aPtr);
-        tmp = _mm_setzero_ps();
 
         aVal = _mm_max_ps(_mm_min_ps(aVal, exp_hi), exp_lo);
 
@@ -207,7 +206,6 @@ volk_32f_exp_32f_u_sse2(float* bVector, const float* aVector, unsigned int num_p
 
     for (; number < quarterPoints; number++) {
         aVal = _mm_loadu_ps(aPtr);
-        tmp = _mm_setzero_ps();
 
         aVal = _mm_max_ps(_mm_min_ps(aVal, exp_hi), exp_lo);
 

--- a/kernels/volk/volk_32fc_accumulator_s32fc.h
+++ b/kernels/volk/volk_32fc_accumulator_s32fc.h
@@ -69,10 +69,9 @@ static inline void volk_32fc_accumulator_s32fc_a_avx512f(lv_32fc_t* result,
     __VOLK_ATTR_ALIGNED(64) float tempBuffer[16];
 
     __m512 accumulator = _mm512_setzero_ps();
-    __m512 aVal = _mm512_setzero_ps();
 
     for (; number < eighthPoints; number++) {
-        aVal = _mm512_load_ps((float*)aPtr);
+        __m512 aVal = _mm512_load_ps((float*)aPtr);
         accumulator = _mm512_add_ps(accumulator, aVal);
         aPtr += 8;
     }
@@ -113,10 +112,9 @@ static inline void volk_32fc_accumulator_s32fc_u_avx512f(lv_32fc_t* result,
     __VOLK_ATTR_ALIGNED(64) float tempBuffer[16];
 
     __m512 accumulator = _mm512_setzero_ps();
-    __m512 aVal = _mm512_setzero_ps();
 
     for (; number < eighthPoints; number++) {
-        aVal = _mm512_loadu_ps((float*)aPtr);
+        __m512 aVal = _mm512_loadu_ps((float*)aPtr);
         accumulator = _mm512_add_ps(accumulator, aVal);
         aPtr += 8;
     }
@@ -173,10 +171,9 @@ static inline void volk_32fc_accumulator_s32fc_u_avx(lv_32fc_t* result,
     __VOLK_ATTR_ALIGNED(32) float tempBuffer[8];
 
     __m256 accumulator = _mm256_setzero_ps();
-    __m256 aVal = _mm256_setzero_ps();
 
     for (; number < quarterPoints; number++) {
-        aVal = _mm256_loadu_ps((float*)aPtr);
+        __m256 aVal = _mm256_loadu_ps((float*)aPtr);
         accumulator = _mm256_add_ps(accumulator, aVal);
         aPtr += 4;
     }
@@ -211,10 +208,9 @@ static inline void volk_32fc_accumulator_s32fc_u_sse(lv_32fc_t* result,
     __VOLK_ATTR_ALIGNED(16) float tempBuffer[4];
 
     __m128 accumulator = _mm_setzero_ps();
-    __m128 aVal = _mm_setzero_ps();
 
     for (; number < halfPoints; number++) {
-        aVal = _mm_loadu_ps((float*)aPtr);
+        __m128 aVal = _mm_loadu_ps((float*)aPtr);
         accumulator = _mm_add_ps(accumulator, aVal);
         aPtr += 2;
     }
@@ -247,10 +243,9 @@ static inline void volk_32fc_accumulator_s32fc_a_avx(lv_32fc_t* result,
     __VOLK_ATTR_ALIGNED(32) float tempBuffer[8];
 
     __m256 accumulator = _mm256_setzero_ps();
-    __m256 aVal = _mm256_setzero_ps();
 
     for (; number < quarterPoints; number++) {
-        aVal = _mm256_load_ps((float*)aPtr);
+        __m256 aVal = _mm256_load_ps((float*)aPtr);
         accumulator = _mm256_add_ps(accumulator, aVal);
         aPtr += 4;
     }
@@ -285,10 +280,9 @@ static inline void volk_32fc_accumulator_s32fc_a_sse(lv_32fc_t* result,
     __VOLK_ATTR_ALIGNED(16) float tempBuffer[4];
 
     __m128 accumulator = _mm_setzero_ps();
-    __m128 aVal = _mm_setzero_ps();
 
     for (; number < halfPoints; number++) {
-        aVal = _mm_load_ps((float*)aPtr);
+        __m128 aVal = _mm_load_ps((float*)aPtr);
         accumulator = _mm_add_ps(accumulator, aVal);
         aPtr += 2;
     }

--- a/kernels/volk/volk_32fc_index_min_16u.h
+++ b/kernels/volk/volk_32fc_index_min_16u.h
@@ -301,7 +301,6 @@ static inline void volk_32fc_index_min_16u_a_sse3(uint16_t* target,
     target[0] = (holderf.f[2] < sq_dist) ? holderi.i[2] : target[0];
     sq_dist = (holderf.f[2] < sq_dist) ? holderf.f[2] : sq_dist;
     target[0] = (holderf.f[3] < sq_dist) ? holderi.i[3] : target[0];
-    sq_dist = (holderf.f[3] < sq_dist) ? holderf.f[3] : sq_dist;
 }
 
 #endif /*LV_HAVE_SSE3*/

--- a/kernels/volk/volk_32fc_index_min_32u.h
+++ b/kernels/volk/volk_32fc_index_min_32u.h
@@ -288,7 +288,6 @@ static inline void volk_32fc_index_min_32u_a_sse3(uint32_t* target,
     target[0] = (holderf.f[2] < sq_dist) ? holderi.i[2] : target[0];
     sq_dist = (holderf.f[2] < sq_dist) ? holderf.f[2] : sq_dist;
     target[0] = (holderf.f[3] < sq_dist) ? holderi.i[3] : target[0];
-    sq_dist = (holderf.f[3] < sq_dist) ? holderf.f[3] : sq_dist;
 }
 
 #endif /*LV_HAVE_SSE3*/


### PR DESCRIPTION
## Summary

Remove variables that are written but never subsequently read, and dead pointer increments at the end of loop bodies. These were identified by static analysis and manual review. No behavioral change — the generated code is semantically identical.

| Kernel | Implementation | Change |
|---|---|---|
| `volk_16i_max_star_horizontal_16i` | `a_ssse3` | Remove dead `p_src0` and `p_target` increments at end of SIMD loop body |
| `volk_32f_accumulator_s32f` | `a/u_avx512f`, `a/u_avx`, `a/u_sse` | Replace `aVal = _mm*_setzero_ps()` initializer with bare declaration; always overwritten by load before use |
| `volk_32f_exp_32f` | `a/u_sse2` | Remove `tmp = _mm_setzero_ps()` inside loop body; `tmp` is fully overwritten before it is read |
| `volk_32fc_accumulator_s32fc` | `a/u_avx512f`, `a/u_avx`, `a/u_sse` | Scope `aVal` as a loop-local variable and remove redundant `setzero` initializer |
| `volk_32fc_index_min_16u` | `a_sse3` | Remove final `sq_dist` update after last element comparison; value not read again |
| `volk_32fc_index_min_32u` | `a_sse3` | Same as above |

## Test plan

- [ ] `volk_profile -R volk_16i_max_star_horizontal_16i` — correctness check passes
- [ ] `volk_profile -R volk_32f_accumulator_s32f` — correctness check passes
- [ ] `volk_profile -R volk_32f_exp_32f` — correctness check passes
- [ ] `volk_profile -R volk_32fc_accumulator_s32fc` — correctness check passes
- [ ] `volk_profile -R volk_32fc_index_min_16u` — correctness check passes
- [ ] `volk_profile -R volk_32fc_index_min_32u` — correctness check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)