### PR TITLE
fix: add const to input pointer casts in 50 kernels

### DIFF
--- a/kernels/volk/volk_32f_index_min_16u.h
+++ b/kernels/volk/volk_32f_index_min_16u.h
@@ -72,7 +72,7 @@ volk_32f_index_min_16u_a_avx(uint16_t* target, const float* source, uint32_t num
     num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
     const uint32_t eighthPoints = num_points / 8;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
 
     __m256 indexIncrementValues = _mm256_set1_ps(8);
     __m256 currentIndexes = _mm256_set_ps(-1, -2, -3, -4, -5, -6, -7, -8);
@@ -134,7 +134,7 @@ static inline void volk_32f_index_min_16u_a_sse4_1(uint16_t* target,
     num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
     const uint32_t quarterPoints = num_points / 4;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
 
     __m128 indexIncrementValues = _mm_set1_ps(4);
     __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);
@@ -197,7 +197,7 @@ volk_32f_index_min_16u_a_sse(uint16_t* target, const float* source, uint32_t num
     num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
     const uint32_t quarterPoints = num_points / 4;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
 
     __m128 indexIncrementValues = _mm_set1_ps(4);
     __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);
@@ -483,7 +483,7 @@ volk_32f_index_min_16u_u_avx(uint16_t* target, const float* source, uint32_t num
     num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
     const uint32_t eighthPoints = num_points / 8;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
 
     __m256 indexIncrementValues = _mm256_set1_ps(8);
     __m256 currentIndexes = _mm256_set_ps(-1, -2, -3, -4, -5, -6, -7, -8);

--- a/kernels/volk/volk_32f_index_min_32u.h
+++ b/kernels/volk/volk_32f_index_min_32u.h
@@ -65,7 +65,7 @@ static inline void volk_32f_index_min_32u_a_sse4_1(uint32_t* target,
 {
     const uint32_t quarterPoints = num_points / 4;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
 
     __m128 indexIncrementValues = _mm_set1_ps(4);
     __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);
@@ -127,7 +127,7 @@ volk_32f_index_min_32u_a_sse(uint32_t* target, const float* source, uint32_t num
 {
     const uint32_t quarterPoints = num_points / 4;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
 
     __m128 indexIncrementValues = _mm_set1_ps(4);
     __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);
@@ -191,7 +191,7 @@ volk_32f_index_min_32u_a_avx(uint32_t* target, const float* source, uint32_t num
 {
     const uint32_t quarterPoints = num_points / 8;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
 
     __m256 indexIncrementValues = _mm256_set1_ps(8);
     __m256 currentIndexes = _mm256_set_ps(-1, -2, -3, -4, -5, -6, -7, -8);
@@ -249,7 +249,7 @@ volk_32f_index_min_32u_neon(uint32_t* target, const float* source, uint32_t num_
 {
     const uint32_t quarterPoints = num_points / 4;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
     float32x4_t indexIncrementValues = vdupq_n_f32(4);
     __VOLK_ATTR_ALIGNED(16)
     float currentIndexes_float[4] = { -4.0f, -3.0f, -2.0f, -1.0f };
@@ -460,7 +460,7 @@ volk_32f_index_min_32u_u_avx(uint32_t* target, const float* source, uint32_t num
 {
     const uint32_t quarterPoints = num_points / 8;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
 
     __m256 indexIncrementValues = _mm256_set1_ps(8);
     __m256 currentIndexes = _mm256_set_ps(-1, -2, -3, -4, -5, -6, -7, -8);
@@ -519,7 +519,7 @@ static inline void volk_32f_index_min_32u_u_sse4_1(uint32_t* target,
 {
     const uint32_t quarterPoints = num_points / 4;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
 
     __m128 indexIncrementValues = _mm_set1_ps(4);
     __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);
@@ -576,7 +576,7 @@ volk_32f_index_min_32u_u_sse(uint32_t* target, const float* source, uint32_t num
 {
     const uint32_t quarterPoints = num_points / 4;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
 
     __m128 indexIncrementValues = _mm_set1_ps(4);
     __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);

--- a/kernels/volk/volk_32f_s32f_32f_fm_detect_32f.h
+++ b/kernels/volk/volk_32f_s32f_32f_fm_detect_32f.h
@@ -94,7 +94,7 @@ static inline void volk_32f_s32f_32f_fm_detect_32f_a_avx(float* outputVector,
 
     for (; number < eighthPoints; number++) {
         // Load data
-        next3old1 = _mm256_loadu_ps((float*)(inPtr - 1));
+        next3old1 = _mm256_loadu_ps((const float*)(inPtr - 1));
         next4 = _mm256_load_ps(inPtr);
         inPtr += 8;
         // Subtract and store:
@@ -174,7 +174,7 @@ static inline void volk_32f_s32f_32f_fm_detect_32f_a_sse(float* outputVector,
 
     for (; number < quarterPoints; number++) {
         // Load data
-        next3old1 = _mm_loadu_ps((float*)(inPtr - 1));
+        next3old1 = _mm_loadu_ps((const float*)(inPtr - 1));
         next4 = _mm_load_ps(inPtr);
         inPtr += 4;
         // Subtract and store:
@@ -477,7 +477,7 @@ static inline void volk_32f_s32f_32f_fm_detect_32f_u_avx(float* outputVector,
 
     for (; number < eighthPoints; number++) {
         // Load data
-        next3old1 = _mm256_loadu_ps((float*)(inPtr - 1));
+        next3old1 = _mm256_loadu_ps((const float*)(inPtr - 1));
         next4 = _mm256_loadu_ps(inPtr);
         inPtr += 8;
         // Subtract and store:

--- a/kernels/volk/volk_32f_x3_sum_of_poly_32f.h
+++ b/kernels/volk/volk_32f_x3_sum_of_poly_32f.h
@@ -84,9 +84,9 @@
 #include <xmmintrin.h>
 
 static inline void volk_32f_x3_sum_of_poly_32f_a_sse3(float* target,
-                                                      float* src0,
-                                                      float* center_point_array,
-                                                      float* cutoff,
+                                                      const float* src0,
+                                                      const float* center_point_array,
+                                                      const float* cutoff,
                                                       unsigned int num_points)
 {
     float result = 0.0f;
@@ -175,9 +175,9 @@ static inline void volk_32f_x3_sum_of_poly_32f_a_sse3(float* target,
 #include <immintrin.h>
 
 static inline void volk_32f_x3_sum_of_poly_32f_a_avx2_fma(float* target,
-                                                          float* src0,
-                                                          float* center_point_array,
-                                                          float* cutoff,
+                                                          const float* src0,
+                                                          const float* center_point_array,
+                                                          const float* cutoff,
                                                           unsigned int num_points)
 {
     const unsigned int eighth_points = num_points / 8;
@@ -244,9 +244,9 @@ static inline void volk_32f_x3_sum_of_poly_32f_a_avx2_fma(float* target,
 #include <immintrin.h>
 
 static inline void volk_32f_x3_sum_of_poly_32f_a_avx(float* target,
-                                                     float* src0,
-                                                     float* center_point_array,
-                                                     float* cutoff,
+                                                     const float* src0,
+                                                     const float* center_point_array,
+                                                     const float* cutoff,
                                                      unsigned int num_points)
 {
     const unsigned int eighth_points = num_points / 8;
@@ -315,9 +315,9 @@ static inline void volk_32f_x3_sum_of_poly_32f_a_avx(float* target,
 #ifdef LV_HAVE_GENERIC
 
 static inline void volk_32f_x3_sum_of_poly_32f_generic(float* target,
-                                                       float* src0,
-                                                       float* center_point_array,
-                                                       float* cutoff,
+                                                       const float* src0,
+                                                       const float* center_point_array,
+                                                       const float* cutoff,
                                                        unsigned int num_points)
 {
     const unsigned int eighth_points = num_points / 8;
@@ -365,9 +365,9 @@ static inline void volk_32f_x3_sum_of_poly_32f_generic(float* target,
 #include <arm_neon.h>
 
 static inline void volk_32f_x3_sum_of_poly_32f_neon(float* __restrict target,
-                                                    float* __restrict src0,
-                                                    float* __restrict center_point_array,
-                                                    float* __restrict cutoff,
+                                                    const float* __restrict src0,
+                                                    const float* __restrict center_point_array,
+                                                    const float* __restrict cutoff,
                                                     unsigned int num_points)
 {
     unsigned int i;
@@ -460,9 +460,9 @@ static inline void volk_32f_x3_sum_of_poly_32f_neon(float* __restrict target,
 #include <immintrin.h>
 
 static inline void volk_32f_x3_sum_of_poly_32f_u_avx_fma(float* target,
-                                                         float* src0,
-                                                         float* center_point_array,
-                                                         float* cutoff,
+                                                         const float* src0,
+                                                         const float* center_point_array,
+                                                         const float* cutoff,
                                                          unsigned int num_points)
 {
     const unsigned int eighth_points = num_points / 8;
@@ -530,9 +530,9 @@ static inline void volk_32f_x3_sum_of_poly_32f_u_avx_fma(float* target,
 #include <immintrin.h>
 
 static inline void volk_32f_x3_sum_of_poly_32f_u_avx(float* target,
-                                                     float* src0,
-                                                     float* center_point_array,
-                                                     float* cutoff,
+                                                     const float* src0,
+                                                     const float* center_point_array,
+                                                     const float* cutoff,
                                                      unsigned int num_points)
 {
     const unsigned int eighth_points = num_points / 8;
@@ -604,9 +604,9 @@ static inline void volk_32f_x3_sum_of_poly_32f_u_avx(float* target,
 #include <volk/volk_rvv_intrinsics.h>
 
 static inline void volk_32f_x3_sum_of_poly_32f_rvv(float* target,
-                                                   float* src0,
-                                                   float* center_point_array,
-                                                   float* cutoff,
+                                                   const float* src0,
+                                                   const float* center_point_array,
+                                                   const float* cutoff,
                                                    unsigned int num_points)
 {
     size_t vlmax = __riscv_vsetvlmax_e32m4();

--- a/kernels/volk/volk_32fc_32f_add_32fc.h
+++ b/kernels/volk/volk_32fc_32f_add_32fc.h
@@ -102,8 +102,8 @@ static inline void volk_32fc_32f_add_32fc_u_avx(lv_32fc_t* cVector,
     __m256 tmp1, tmp2;
     for (; number < eighthPoints; number++) {
 
-        aVal1 = _mm256_loadu_ps((float*)aPtr);
-        aVal2 = _mm256_loadu_ps((float*)(aPtr + 4));
+        aVal1 = _mm256_loadu_ps((const float*)aPtr);
+        aVal2 = _mm256_loadu_ps((const float*)(aPtr + 4));
         bVal = _mm256_loadu_ps(bPtr);
         cpx_b1 = _mm256_unpacklo_ps(bVal, zero); // b0, 0, b1, 0, b4, 0, b5, 0
         cpx_b2 = _mm256_unpackhi_ps(bVal, zero); // b2, 0, b3, 0, b6, 0, b7, 0
@@ -153,8 +153,8 @@ static inline void volk_32fc_32f_add_32fc_a_avx(lv_32fc_t* cVector,
     __m256 tmp1, tmp2;
     for (; number < eighthPoints; number++) {
 
-        aVal1 = _mm256_load_ps((float*)aPtr);
-        aVal2 = _mm256_load_ps((float*)(aPtr + 4));
+        aVal1 = _mm256_load_ps((const float*)aPtr);
+        aVal2 = _mm256_load_ps((const float*)(aPtr + 4));
         bVal = _mm256_load_ps(bPtr);
         cpx_b1 = _mm256_unpacklo_ps(bVal, zero); // b0, 0, b1, 0, b4, 0, b5, 0
         cpx_b2 = _mm256_unpackhi_ps(bVal, zero); // b2, 0, b3, 0, b6, 0, b7, 0

--- a/kernels/volk/volk_32fc_32f_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_32f_dot_prod_32fc.h
@@ -62,7 +62,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_generic(lv_32fc_t* result,
 {
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* aPtr = (float*)input;
+    const float* aPtr = (const float*)input;
     const float* bPtr = taps;
     unsigned int number = 0;
 
@@ -90,7 +90,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_a_avx512f(lv_32fc_t* result,
     const unsigned int sixteenthPoints = num_points / 16;
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* aPtr = (float*)input;
+    const float* aPtr = (const float*)input;
     const float* bPtr = taps;
 
     __m512 a0Val, a1Val;
@@ -158,7 +158,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_a_avx2_fma(lv_32fc_t* result,
     const unsigned int sixteenthPoints = num_points / 16;
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* aPtr = (float*)input;
+    const float* aPtr = (const float*)input;
     const float* bPtr = taps;
 
     __m256 a0Val, a1Val, a2Val, a3Val;
@@ -238,7 +238,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_a_avx(lv_32fc_t* result,
     const unsigned int sixteenthPoints = num_points / 16;
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* aPtr = (float*)input;
+    const float* aPtr = (const float*)input;
     const float* bPtr = taps;
 
     __m256 a0Val, a1Val, a2Val, a3Val;
@@ -325,7 +325,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_a_sse(lv_32fc_t* result,
     const unsigned int eighthPoints = num_points / 8;
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* aPtr = (float*)input;
+    const float* aPtr = (const float*)input;
     const float* bPtr = taps;
 
     __m128 a0Val, a1Val, a2Val, a3Val;
@@ -405,7 +405,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_u_avx512f(lv_32fc_t* result,
     const unsigned int sixteenthPoints = num_points / 16;
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* aPtr = (float*)input;
+    const float* aPtr = (const float*)input;
     const float* bPtr = taps;
 
     __m512 a0Val, a1Val;
@@ -473,7 +473,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_u_avx2_fma(lv_32fc_t* result,
     const unsigned int sixteenthPoints = num_points / 16;
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* aPtr = (float*)input;
+    const float* aPtr = (const float*)input;
     const float* bPtr = taps;
 
     __m256 a0Val, a1Val, a2Val, a3Val;
@@ -554,7 +554,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_u_avx(lv_32fc_t* result,
     const unsigned int sixteenthPoints = num_points / 16;
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* aPtr = (float*)input;
+    const float* aPtr = (const float*)input;
     const float* bPtr = taps;
 
     __m256 a0Val, a1Val, a2Val, a3Val;
@@ -640,7 +640,7 @@ volk_32fc_32f_dot_prod_32fc_neon_unroll(lv_32fc_t* __restrict result,
     const unsigned int quarterPoints = num_points / 8;
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* inputPtr = (float*)input;
+    const float* inputPtr = (const float*)input;
     const float* tapsPtr = taps;
     float zero[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
     float accVector_real[4];
@@ -721,7 +721,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_a_neon(lv_32fc_t* __restrict resu
     const unsigned int quarterPoints = num_points / 4;
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* inputPtr = (float*)input;
+    const float* inputPtr = (const float*)input;
     const float* tapsPtr = taps;
     float zero[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
     float accVector_real[4];
@@ -869,7 +869,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_u_sse(lv_32fc_t* result,
     const unsigned int eighthPoints = num_points / 8;
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* aPtr = (float*)input;
+    const float* aPtr = (const float*)input;
     const float* bPtr = taps;
 
     __m128 a0Val, a1Val, a2Val, a3Val;

--- a/kernels/volk/volk_32fc_32f_multiply_32fc.h
+++ b/kernels/volk/volk_32fc_32f_multiply_32fc.h
@@ -66,10 +66,10 @@ static inline void volk_32fc_32f_multiply_32fc_a_avx(lv_32fc_t* cVector,
 
     for (; number < eighthPoints; number++) {
 
-        aVal1 = _mm256_load_ps((float*)aPtr);
+        aVal1 = _mm256_load_ps((const float*)aPtr);
         aPtr += 4;
 
-        aVal2 = _mm256_load_ps((float*)aPtr);
+        aVal2 = _mm256_load_ps((const float*)aPtr);
         aPtr += 4;
 
         bVal = _mm256_load_ps(bPtr); // b0|b1|b2|b3|b4|b5|b6|b7
@@ -188,7 +188,7 @@ static inline void volk_32fc_32f_multiply_32fc_neon(lv_32fc_t* cVector,
     float32x4x2_t inputVector, outputVector;
     float32x4_t tapsVector;
     for (number = 0; number < quarter_points; number++) {
-        inputVector = vld2q_f32((float*)aPtr);
+        inputVector = vld2q_f32((const float*)aPtr);
         tapsVector = vld1q_f32(bPtr);
 
         outputVector.val[0] = vmulq_f32(inputVector.val[0], tapsVector);

--- a/kernels/volk/volk_32fc_accumulator_s32fc.h
+++ b/kernels/volk/volk_32fc_accumulator_s32fc.h
@@ -72,7 +72,7 @@ static inline void volk_32fc_accumulator_s32fc_a_avx512f(lv_32fc_t* result,
     __m512 aVal = _mm512_setzero_ps();
 
     for (; number < eighthPoints; number++) {
-        aVal = _mm512_load_ps((float*)aPtr);
+        aVal = _mm512_load_ps((const float*)aPtr);
         accumulator = _mm512_add_ps(accumulator, aVal);
         aPtr += 8;
     }
@@ -116,7 +116,7 @@ static inline void volk_32fc_accumulator_s32fc_u_avx512f(lv_32fc_t* result,
     __m512 aVal = _mm512_setzero_ps();
 
     for (; number < eighthPoints; number++) {
-        aVal = _mm512_loadu_ps((float*)aPtr);
+        aVal = _mm512_loadu_ps((const float*)aPtr);
         accumulator = _mm512_add_ps(accumulator, aVal);
         aPtr += 8;
     }
@@ -176,7 +176,7 @@ static inline void volk_32fc_accumulator_s32fc_u_avx(lv_32fc_t* result,
     __m256 aVal = _mm256_setzero_ps();
 
     for (; number < quarterPoints; number++) {
-        aVal = _mm256_loadu_ps((float*)aPtr);
+        aVal = _mm256_loadu_ps((const float*)aPtr);
         accumulator = _mm256_add_ps(accumulator, aVal);
         aPtr += 4;
     }
@@ -214,7 +214,7 @@ static inline void volk_32fc_accumulator_s32fc_u_sse(lv_32fc_t* result,
     __m128 aVal = _mm_setzero_ps();
 
     for (; number < halfPoints; number++) {
-        aVal = _mm_loadu_ps((float*)aPtr);
+        aVal = _mm_loadu_ps((const float*)aPtr);
         accumulator = _mm_add_ps(accumulator, aVal);
         aPtr += 2;
     }
@@ -250,7 +250,7 @@ static inline void volk_32fc_accumulator_s32fc_a_avx(lv_32fc_t* result,
     __m256 aVal = _mm256_setzero_ps();
 
     for (; number < quarterPoints; number++) {
-        aVal = _mm256_load_ps((float*)aPtr);
+        aVal = _mm256_load_ps((const float*)aPtr);
         accumulator = _mm256_add_ps(accumulator, aVal);
         aPtr += 4;
     }
@@ -288,7 +288,7 @@ static inline void volk_32fc_accumulator_s32fc_a_sse(lv_32fc_t* result,
     __m128 aVal = _mm_setzero_ps();
 
     for (; number < halfPoints; number++) {
-        aVal = _mm_load_ps((float*)aPtr);
+        aVal = _mm_load_ps((const float*)aPtr);
         accumulator = _mm_add_ps(accumulator, aVal);
         aPtr += 2;
     }
@@ -324,19 +324,19 @@ static inline void volk_32fc_accumulator_s32fc_neon(lv_32fc_t* result,
     __VOLK_ATTR_ALIGNED(32) float tempBuffer[4];
 
     for (; number < eighthPoints; number++) {
-        in_vec = vld1q_f32((float*)aPtr);
+        in_vec = vld1q_f32((const float*)aPtr);
         out_vec0 = vaddq_f32(in_vec, out_vec0);
         aPtr += 2;
 
-        in_vec = vld1q_f32((float*)aPtr);
+        in_vec = vld1q_f32((const float*)aPtr);
         out_vec1 = vaddq_f32(in_vec, out_vec1);
         aPtr += 2;
 
-        in_vec = vld1q_f32((float*)aPtr);
+        in_vec = vld1q_f32((const float*)aPtr);
         out_vec2 = vaddq_f32(in_vec, out_vec2);
         aPtr += 2;
 
-        in_vec = vld1q_f32((float*)aPtr);
+        in_vec = vld1q_f32((const float*)aPtr);
         out_vec3 = vaddq_f32(in_vec, out_vec3);
         aPtr += 2;
     }
@@ -383,19 +383,19 @@ static inline void volk_32fc_accumulator_s32fc_neonv8(lv_32fc_t* result,
     float32x4_t out_vec3 = vdupq_n_f32(0.f);
 
     for (; number < eighthPoints; number++) {
-        in_vec = vld1q_f32((float*)aPtr);
+        in_vec = vld1q_f32((const float*)aPtr);
         out_vec0 = vaddq_f32(in_vec, out_vec0);
         aPtr += 2;
 
-        in_vec = vld1q_f32((float*)aPtr);
+        in_vec = vld1q_f32((const float*)aPtr);
         out_vec1 = vaddq_f32(in_vec, out_vec1);
         aPtr += 2;
 
-        in_vec = vld1q_f32((float*)aPtr);
+        in_vec = vld1q_f32((const float*)aPtr);
         out_vec2 = vaddq_f32(in_vec, out_vec2);
         aPtr += 2;
 
-        in_vec = vld1q_f32((float*)aPtr);
+        in_vec = vld1q_f32((const float*)aPtr);
         out_vec3 = vaddq_f32(in_vec, out_vec3);
         aPtr += 2;
     }

--- a/kernels/volk/volk_32fc_conjugate_32fc.h
+++ b/kernels/volk/volk_32fc_conjugate_32fc.h
@@ -78,7 +78,7 @@ static inline void volk_32fc_conjugate_32fc_u_avx(lv_32fc_t* cVector,
 
     for (; number < quarterPoints; number++) {
 
-        x = _mm256_loadu_ps((float*)a); // Load the complex data as ar,ai,br,bi
+        x = _mm256_loadu_ps((const float*)a); // Load the complex data as ar,ai,br,bi
 
         x = _mm256_xor_ps(x, conjugator); // conjugate register
 
@@ -114,7 +114,7 @@ static inline void volk_32fc_conjugate_32fc_u_sse3(lv_32fc_t* cVector,
 
     for (; number < halfPoints; number++) {
 
-        x = _mm_loadu_ps((float*)a); // Load the complex data as ar,ai,br,bi
+        x = _mm_loadu_ps((const float*)a); // Load the complex data as ar,ai,br,bi
 
         x = _mm_xor_ps(x, conjugator); // conjugate register
 
@@ -174,7 +174,7 @@ static inline void volk_32fc_conjugate_32fc_a_avx(lv_32fc_t* cVector,
 
     for (; number < quarterPoints; number++) {
 
-        x = _mm256_load_ps((float*)a); // Load the complex data as ar,ai,br,bi
+        x = _mm256_load_ps((const float*)a); // Load the complex data as ar,ai,br,bi
 
         x = _mm256_xor_ps(x, conjugator); // conjugate register
 
@@ -210,7 +210,7 @@ static inline void volk_32fc_conjugate_32fc_a_sse3(lv_32fc_t* cVector,
 
     for (; number < halfPoints; number++) {
 
-        x = _mm_load_ps((float*)a); // Load the complex data as ar,ai,br,bi
+        x = _mm_load_ps((const float*)a); // Load the complex data as ar,ai,br,bi
 
         x = _mm_xor_ps(x, conjugator); // conjugate register
 
@@ -242,7 +242,7 @@ static inline void volk_32fc_conjugate_32fc_a_neon(lv_32fc_t* cVector,
 
     for (number = 0; number < quarterPoints; number++) {
         __VOLK_PREFETCH(a + 4);
-        x = vld2q_f32((float*)a); // Load the complex data as ar,br,cr,dr; ai,bi,ci,di
+        x = vld2q_f32((const float*)a); // Load the complex data as ar,br,cr,dr; ai,bi,ci,di
 
         // xor the imaginary lane
         x.val[1] = vnegq_f32(x.val[1]);

--- a/kernels/volk/volk_32fc_convert_16ic.h
+++ b/kernels/volk/volk_32fc_convert_16ic.h
@@ -46,7 +46,7 @@ static inline void volk_32fc_convert_16ic_a_avx2(lv_16sc_t* outputVector,
 {
     const unsigned int avx_iters = num_points / 8;
 
-    float* inputVectorPtr = (float*)inputVector;
+    const float* inputVectorPtr = (const float*)inputVector;
     int16_t* outputVectorPtr = (int16_t*)outputVector;
     float aux;
 
@@ -61,9 +61,9 @@ static inline void volk_32fc_convert_16ic_a_avx2(lv_16sc_t* outputVector,
     unsigned int i;
 
     for (i = 0; i < avx_iters; i++) {
-        inputVal1 = _mm256_load_ps((float*)inputVectorPtr);
+        inputVal1 = _mm256_load_ps(inputVectorPtr);
         inputVectorPtr += 8;
-        inputVal2 = _mm256_load_ps((float*)inputVectorPtr);
+        inputVal2 = _mm256_load_ps(inputVectorPtr);
         inputVectorPtr += 8;
         __VOLK_PREFETCH(inputVectorPtr + 16);
 
@@ -101,7 +101,7 @@ static inline void volk_32fc_convert_16ic_a_avx512(lv_16sc_t* outputVector,
 {
     const unsigned int avx512_iters = num_points / 8;
 
-    float* inputVectorPtr = (float*)inputVector;
+    const float* inputVectorPtr = (const float*)inputVector;
     int16_t* outputVectorPtr = (int16_t*)outputVector;
     float aux;
 
@@ -116,7 +116,7 @@ static inline void volk_32fc_convert_16ic_a_avx512(lv_16sc_t* outputVector,
     unsigned int i;
 
     for (i = 0; i < avx512_iters; i++) {
-        inputVal1 = _mm512_load_ps((float*)inputVectorPtr);
+        inputVal1 = _mm512_load_ps(inputVectorPtr);
         inputVectorPtr += 16;
         __VOLK_PREFETCH(inputVectorPtr + 16);
 
@@ -150,7 +150,7 @@ static inline void volk_32fc_convert_16ic_a_sse2(lv_16sc_t* outputVector,
 {
     const unsigned int sse_iters = num_points / 4;
 
-    float* inputVectorPtr = (float*)inputVector;
+    const float* inputVectorPtr = (const float*)inputVector;
     int16_t* outputVectorPtr = (int16_t*)outputVector;
     float aux;
 
@@ -165,9 +165,9 @@ static inline void volk_32fc_convert_16ic_a_sse2(lv_16sc_t* outputVector,
     unsigned int i;
 
     for (i = 0; i < sse_iters; i++) {
-        inputVal1 = _mm_load_ps((float*)inputVectorPtr);
+        inputVal1 = _mm_load_ps(inputVectorPtr);
         inputVectorPtr += 4;
-        inputVal2 = _mm_load_ps((float*)inputVectorPtr);
+        inputVal2 = _mm_load_ps(inputVectorPtr);
         inputVectorPtr += 4;
         __VOLK_PREFETCH(inputVectorPtr + 8);
 
@@ -206,7 +206,7 @@ static inline void volk_32fc_convert_16ic_neon(lv_16sc_t* outputVector,
 
     const unsigned int neon_iters = num_points / 4;
 
-    float32_t* inputVectorPtr = (float32_t*)inputVector;
+    const float32_t* inputVectorPtr = (const float32_t*)inputVector;
     int16_t* outputVectorPtr = (int16_t*)outputVector;
 
     const float min_val_f = (float)SHRT_MIN;
@@ -273,7 +273,7 @@ static inline void volk_32fc_convert_16ic_neonv8(lv_16sc_t* outputVector,
 {
     const unsigned int neon_iters = num_points / 4;
 
-    float32_t* inputVectorPtr = (float32_t*)inputVector;
+    const float32_t* inputVectorPtr = (const float32_t*)inputVector;
     int16_t* outputVectorPtr = (int16_t*)outputVector;
 
     const float min_val_f = (float)SHRT_MIN;
@@ -329,7 +329,7 @@ static inline void volk_32fc_convert_16ic_generic(lv_16sc_t* outputVector,
                                                   const lv_32fc_t* inputVector,
                                                   unsigned int num_points)
 {
-    float* inputVectorPtr = (float*)inputVector;
+    const float* inputVectorPtr = (const float*)inputVector;
     int16_t* outputVectorPtr = (int16_t*)outputVector;
     const float min_val = (float)SHRT_MIN;
     const float max_val = (float)SHRT_MAX;
@@ -365,7 +365,7 @@ static inline void volk_32fc_convert_16ic_u_avx2(lv_16sc_t* outputVector,
 {
     const unsigned int avx_iters = num_points / 8;
 
-    float* inputVectorPtr = (float*)inputVector;
+    const float* inputVectorPtr = (const float*)inputVector;
     int16_t* outputVectorPtr = (int16_t*)outputVector;
     float aux;
 
@@ -380,9 +380,9 @@ static inline void volk_32fc_convert_16ic_u_avx2(lv_16sc_t* outputVector,
     unsigned int i;
 
     for (i = 0; i < avx_iters; i++) {
-        inputVal1 = _mm256_loadu_ps((float*)inputVectorPtr);
+        inputVal1 = _mm256_loadu_ps(inputVectorPtr);
         inputVectorPtr += 8;
-        inputVal2 = _mm256_loadu_ps((float*)inputVectorPtr);
+        inputVal2 = _mm256_loadu_ps(inputVectorPtr);
         inputVectorPtr += 8;
         __VOLK_PREFETCH(inputVectorPtr + 16);
 
@@ -420,7 +420,7 @@ static inline void volk_32fc_convert_16ic_u_avx512(lv_16sc_t* outputVector,
 {
     const unsigned int avx512_iters = num_points / 8;
 
-    float* inputVectorPtr = (float*)inputVector;
+    const float* inputVectorPtr = (const float*)inputVector;
     int16_t* outputVectorPtr = (int16_t*)outputVector;
     float aux;
 
@@ -435,7 +435,7 @@ static inline void volk_32fc_convert_16ic_u_avx512(lv_16sc_t* outputVector,
     unsigned int i;
 
     for (i = 0; i < avx512_iters; i++) {
-        inputVal1 = _mm512_loadu_ps((float*)inputVectorPtr);
+        inputVal1 = _mm512_loadu_ps(inputVectorPtr);
         inputVectorPtr += 16;
         __VOLK_PREFETCH(inputVectorPtr + 16);
 
@@ -470,7 +470,7 @@ static inline void volk_32fc_convert_16ic_u_sse2(lv_16sc_t* outputVector,
 {
     const unsigned int sse_iters = num_points / 4;
 
-    float* inputVectorPtr = (float*)inputVector;
+    const float* inputVectorPtr = (const float*)inputVector;
     int16_t* outputVectorPtr = (int16_t*)outputVector;
     float aux;
 
@@ -485,9 +485,9 @@ static inline void volk_32fc_convert_16ic_u_sse2(lv_16sc_t* outputVector,
 
     unsigned int i;
     for (i = 0; i < sse_iters; i++) {
-        inputVal1 = _mm_loadu_ps((float*)inputVectorPtr);
+        inputVal1 = _mm_loadu_ps(inputVectorPtr);
         inputVectorPtr += 4;
-        inputVal2 = _mm_loadu_ps((float*)inputVectorPtr);
+        inputVal2 = _mm_loadu_ps(inputVectorPtr);
         inputVectorPtr += 4;
         __VOLK_PREFETCH(inputVectorPtr + 8);
 
@@ -523,7 +523,7 @@ static inline void volk_32fc_convert_16ic_rvv(lv_16sc_t* outputVector,
                                               unsigned int num_points)
 {
     int16_t* out = (int16_t*)outputVector;
-    float* in = (float*)inputVector;
+    const float* in = (const float*)inputVector;
     size_t n = num_points * 2;
     for (size_t vl; n > 0; n -= vl, in += vl, out += vl) {
         vl = __riscv_vsetvl_e32m8(n);

--- a/kernels/volk/volk_32fc_deinterleave_32f_x2.h
+++ b/kernels/volk/volk_32fc_deinterleave_32f_x2.h
@@ -70,7 +70,7 @@ static inline void volk_32fc_deinterleave_32f_x2_generic(float* iBuffer,
                                                          const lv_32fc_t* complexVector,
                                                          unsigned int num_points)
 {
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
     float* qBufferPtr = qBuffer;
     unsigned int number;
@@ -89,7 +89,7 @@ static inline void volk_32fc_deinterleave_32f_x2_a_avx512f(float* iBuffer,
                                                            const lv_32fc_t* complexVector,
                                                            unsigned int num_points)
 {
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
     float* qBufferPtr = qBuffer;
 
@@ -136,7 +136,7 @@ static inline void volk_32fc_deinterleave_32f_x2_a_avx(float* iBuffer,
                                                        const lv_32fc_t* complexVector,
                                                        unsigned int num_points)
 {
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
     float* qBufferPtr = qBuffer;
 
@@ -182,7 +182,7 @@ static inline void volk_32fc_deinterleave_32f_x2_a_sse(float* iBuffer,
                                                        const lv_32fc_t* complexVector,
                                                        unsigned int num_points)
 {
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
     float* qBufferPtr = qBuffer;
 
@@ -227,7 +227,7 @@ static inline void volk_32fc_deinterleave_32f_x2_neon(float* iBuffer,
 {
     unsigned int number = 0;
     unsigned int quarter_points = num_points / 4;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
     float* qBufferPtr = qBuffer;
     float32x4x2_t complexInput;
@@ -257,7 +257,7 @@ static inline void volk_32fc_deinterleave_32f_x2_neonv8(float* iBuffer,
                                                         unsigned int num_points)
 {
     const unsigned int eighthPoints = num_points / 8;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
     float* qBufferPtr = qBuffer;
 
@@ -300,7 +300,7 @@ static inline void volk_32fc_deinterleave_32f_x2_u_avx512f(float* iBuffer,
                                                            const lv_32fc_t* complexVector,
                                                            unsigned int num_points)
 {
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
     float* qBufferPtr = qBuffer;
 
@@ -347,7 +347,7 @@ static inline void volk_32fc_deinterleave_32f_x2_u_avx(float* iBuffer,
                                                        const lv_32fc_t* complexVector,
                                                        unsigned int num_points)
 {
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
     float* qBufferPtr = qBuffer;
 

--- a/kernels/volk/volk_32fc_deinterleave_64f_x2.h
+++ b/kernels/volk/volk_32fc_deinterleave_64f_x2.h
@@ -73,7 +73,7 @@ static inline void volk_32fc_deinterleave_64f_x2_u_avx(double* iBuffer,
 {
     unsigned int number = 0;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
     double* qBufferPtr = qBuffer;
 
@@ -122,7 +122,7 @@ static inline void volk_32fc_deinterleave_64f_x2_u_sse2(double* iBuffer,
 {
     unsigned int number = 0;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
     double* qBufferPtr = qBuffer;
 
@@ -165,7 +165,7 @@ static inline void volk_32fc_deinterleave_64f_x2_generic(double* iBuffer,
                                                          unsigned int num_points)
 {
     unsigned int number = 0;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
     double* qBufferPtr = qBuffer;
 
@@ -193,7 +193,7 @@ static inline void volk_32fc_deinterleave_64f_x2_a_avx(double* iBuffer,
 {
     unsigned int number = 0;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
     double* qBufferPtr = qBuffer;
 
@@ -242,7 +242,7 @@ static inline void volk_32fc_deinterleave_64f_x2_a_sse2(double* iBuffer,
 {
     unsigned int number = 0;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
     double* qBufferPtr = qBuffer;
 
@@ -287,7 +287,7 @@ static inline void volk_32fc_deinterleave_64f_x2_neon(double* iBuffer,
 {
     unsigned int number = 0;
     unsigned int half_points = num_points / 2;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
     double* qBufferPtr = qBuffer;
     float32x2x2_t complexInput;

--- a/kernels/volk/volk_32fc_deinterleave_imag_32f.h
+++ b/kernels/volk/volk_32fc_deinterleave_imag_32f.h
@@ -147,7 +147,7 @@ static inline void volk_32fc_deinterleave_imag_32f_neon(float* qBuffer,
 {
     unsigned int number = 0;
     unsigned int quarter_points = num_points / 4;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* qBufferPtr = qBuffer;
     float32x4x2_t complexInput;
 
@@ -173,7 +173,7 @@ static inline void volk_32fc_deinterleave_imag_32f_neonv8(float* qBuffer,
                                                           unsigned int num_points)
 {
     const unsigned int eighthPoints = num_points / 8;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* qBufferPtr = qBuffer;
 
     for (unsigned int number = 0; number < eighthPoints; number++) {
@@ -202,7 +202,7 @@ static inline void volk_32fc_deinterleave_imag_32f_generic(float* qBuffer,
                                                            unsigned int num_points)
 {
     unsigned int number = 0;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* qBufferPtr = qBuffer;
     for (number = 0; number < num_points; number++) {
         complexVectorPtr++;

--- a/kernels/volk/volk_32fc_deinterleave_real_32f.h
+++ b/kernels/volk/volk_32fc_deinterleave_real_32f.h
@@ -147,7 +147,7 @@ static inline void volk_32fc_deinterleave_real_32f_generic(float* iBuffer,
                                                            unsigned int num_points)
 {
     unsigned int number = 0;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
     for (number = 0; number < num_points; number++) {
         *iBufferPtr++ = *complexVectorPtr++;
@@ -166,7 +166,7 @@ static inline void volk_32fc_deinterleave_real_32f_neon(float* iBuffer,
 {
     unsigned int number = 0;
     unsigned int quarter_points = num_points / 4;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
     float32x4x2_t complexInput;
 
@@ -192,7 +192,7 @@ static inline void volk_32fc_deinterleave_real_32f_neonv8(float* iBuffer,
                                                           unsigned int num_points)
 {
     const unsigned int eighthPoints = num_points / 8;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
 
     for (unsigned int number = 0; number < eighthPoints; number++) {

--- a/kernels/volk/volk_32fc_deinterleave_real_64f.h
+++ b/kernels/volk/volk_32fc_deinterleave_real_64f.h
@@ -70,7 +70,7 @@ static inline void volk_32fc_deinterleave_real_64f_a_avx2(double* iBuffer,
 {
     unsigned int number = 0;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
 
     const unsigned int quarterPoints = num_points / 4;
@@ -109,7 +109,7 @@ static inline void volk_32fc_deinterleave_real_64f_a_sse2(double* iBuffer,
 {
     unsigned int number = 0;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
 
     const unsigned int halfPoints = num_points / 2;
@@ -143,7 +143,7 @@ static inline void volk_32fc_deinterleave_real_64f_generic(double* iBuffer,
                                                            unsigned int num_points)
 {
     unsigned int number = 0;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
     for (number = 0; number < num_points; number++) {
         *iBufferPtr++ = (double)*complexVectorPtr++;
@@ -161,7 +161,7 @@ static inline void volk_32fc_deinterleave_real_64f_neon(double* iBuffer,
 {
     unsigned int number = 0;
     unsigned int quarter_points = num_points / 4;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
     float32x2x4_t complexInput;
     float64x2_t iVal1;
@@ -210,7 +210,7 @@ static inline void volk_32fc_deinterleave_real_64f_u_avx2(double* iBuffer,
 {
     unsigned int number = 0;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
 
     const unsigned int quarterPoints = num_points / 4;

--- a/kernels/volk/volk_32fc_index_max_16u.h
+++ b/kernels/volk/volk_32fc_index_max_16u.h
@@ -91,8 +91,8 @@ static inline void volk_32fc_index_max_16u_a_avx2_variant_0(uint16_t* target,
     __m256i max_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((float*)src0);
-        __m256 in1 = _mm256_load_ps((float*)(src0 + 4));
+        __m256 in0 = _mm256_load_ps((const float*)src0);
+        __m256 in1 = _mm256_load_ps((const float*)(src0 + 4));
         vector_32fc_index_max_variant0(
             in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
         src0 += 8;
@@ -151,8 +151,8 @@ static inline void volk_32fc_index_max_16u_a_avx2_variant_1(uint16_t* target,
     __m256i max_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((float*)src0);
-        __m256 in1 = _mm256_load_ps((float*)(src0 + 4));
+        __m256 in0 = _mm256_load_ps((const float*)src0);
+        __m256 in1 = _mm256_load_ps((const float*)(src0 + 4));
         vector_32fc_index_max_variant1(
             in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
         src0 += 8;
@@ -222,8 +222,8 @@ static inline void volk_32fc_index_max_16u_a_sse3(uint16_t* target,
     xmm3 = _mm_setzero_ps();
 
     for (; i < bound; ++i) {
-        xmm1 = _mm_load_ps((float*)src0);
-        xmm2 = _mm_load_ps((float*)&src0[2]);
+        xmm1 = _mm_load_ps((const float*)src0);
+        xmm2 = _mm_load_ps((const float*)&src0[2]);
 
         src0 += 4;
 
@@ -246,7 +246,7 @@ static inline void volk_32fc_index_max_16u_a_sse3(uint16_t* target,
     }
 
     if (num_bytes >> 4 & 1) {
-        xmm2 = _mm_load_ps((float*)src0);
+        xmm2 = _mm_load_ps((const float*)src0);
 
         xmm1 = _mm_movelh_ps(bit128_p(&xmm8)->float_vec, bit128_p(&xmm8)->float_vec);
         xmm8 = bit128_p(&xmm1)->int_vec;
@@ -598,8 +598,8 @@ static inline void volk_32fc_index_max_16u_u_avx2_variant_0(uint16_t* target,
     __m256i max_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_loadu_ps((float*)src0);
-        __m256 in1 = _mm256_loadu_ps((float*)(src0 + 4));
+        __m256 in0 = _mm256_loadu_ps((const float*)src0);
+        __m256 in1 = _mm256_loadu_ps((const float*)(src0 + 4));
         vector_32fc_index_max_variant0(
             in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
         src0 += 8;
@@ -658,8 +658,8 @@ static inline void volk_32fc_index_max_16u_u_avx2_variant_1(uint16_t* target,
     __m256i max_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_loadu_ps((float*)src0);
-        __m256 in1 = _mm256_loadu_ps((float*)(src0 + 4));
+        __m256 in0 = _mm256_loadu_ps((const float*)src0);
+        __m256 in1 = _mm256_loadu_ps((const float*)(src0 + 4));
         vector_32fc_index_max_variant1(
             in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
         src0 += 8;

--- a/kernels/volk/volk_32fc_index_max_32u.h
+++ b/kernels/volk/volk_32fc_index_max_32u.h
@@ -81,8 +81,8 @@ static inline void volk_32fc_index_max_32u_a_avx2_variant_0(uint32_t* target,
     __m256i max_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((float*)src0);
-        __m256 in1 = _mm256_load_ps((float*)(src0 + 4));
+        __m256 in0 = _mm256_load_ps((const float*)src0);
+        __m256 in1 = _mm256_load_ps((const float*)(src0 + 4));
         vector_32fc_index_max_variant0(
             in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
         src0 += 8;
@@ -139,8 +139,8 @@ static inline void volk_32fc_index_max_32u_a_avx2_variant_1(uint32_t* target,
     __m256i max_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((float*)src0);
-        __m256 in1 = _mm256_load_ps((float*)(src0 + 4));
+        __m256 in0 = _mm256_load_ps((const float*)src0);
+        __m256 in1 = _mm256_load_ps((const float*)(src0 + 4));
         vector_32fc_index_max_variant1(
             in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
         src0 += 8;
@@ -209,8 +209,8 @@ static inline void volk_32fc_index_max_32u_a_sse3(uint32_t* target,
     xmm3 = _mm_setzero_ps();
 
     for (; i < bound; ++i) {
-        xmm1 = _mm_load_ps((float*)src0);
-        xmm2 = _mm_load_ps((float*)&src0[2]);
+        xmm1 = _mm_load_ps((const float*)src0);
+        xmm2 = _mm_load_ps((const float*)&src0[2]);
 
         src0 += 4;
 
@@ -233,7 +233,7 @@ static inline void volk_32fc_index_max_32u_a_sse3(uint32_t* target,
     }
 
     if (num_bytes >> 4 & 1) {
-        xmm2 = _mm_load_ps((float*)src0);
+        xmm2 = _mm_load_ps((const float*)src0);
 
         xmm1 = _mm_movelh_ps(bit128_p(&xmm8)->float_vec, bit128_p(&xmm8)->float_vec);
         xmm8 = bit128_p(&xmm1)->int_vec;
@@ -432,8 +432,8 @@ static inline void volk_32fc_index_max_32u_u_avx2_variant_0(uint32_t* target,
     __m256i max_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_loadu_ps((float*)src0);
-        __m256 in1 = _mm256_loadu_ps((float*)(src0 + 4));
+        __m256 in0 = _mm256_loadu_ps((const float*)src0);
+        __m256 in1 = _mm256_loadu_ps((const float*)(src0 + 4));
         vector_32fc_index_max_variant0(
             in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
         src0 += 8;
@@ -490,8 +490,8 @@ static inline void volk_32fc_index_max_32u_u_avx2_variant_1(uint32_t* target,
     __m256i max_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_loadu_ps((float*)src0);
-        __m256 in1 = _mm256_loadu_ps((float*)(src0 + 4));
+        __m256 in0 = _mm256_loadu_ps((const float*)src0);
+        __m256 in1 = _mm256_loadu_ps((const float*)(src0 + 4));
         vector_32fc_index_max_variant1(
             in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
         src0 += 8;
@@ -553,7 +553,7 @@ volk_32fc_index_max_32u_neon(uint32_t* target, const lv_32fc_t* src0, uint32_t n
         for (; number < quarter_points; number++) {
             // Load complex and compute magnitude squared
             const float32x4_t vec_mag2 =
-                _vmagnitudesquaredq_f32(vld2q_f32((float*)src0Ptr));
+                _vmagnitudesquaredq_f32(vld2q_f32((const float*)src0Ptr));
             __VOLK_PREFETCH(src0Ptr += 4);
             // a > b?
             const uint32x4_t gt_mask = vcgtq_f32(vec_mag2, vec_max);

--- a/kernels/volk/volk_32fc_index_min_16u.h
+++ b/kernels/volk/volk_32fc_index_min_16u.h
@@ -91,8 +91,8 @@ static inline void volk_32fc_index_min_16u_a_avx2_variant_0(uint16_t* target,
     __m256i min_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((float*)source);
-        __m256 in1 = _mm256_load_ps((float*)(source + 4));
+        __m256 in0 = _mm256_load_ps((const float*)source);
+        __m256 in1 = _mm256_load_ps((const float*)(source + 4));
         vector_32fc_index_min_variant0(
             in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
         source += 8;
@@ -151,8 +151,8 @@ static inline void volk_32fc_index_min_16u_a_avx2_variant_1(uint16_t* target,
     __m256i min_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((float*)source);
-        __m256 in1 = _mm256_load_ps((float*)(source + 4));
+        __m256 in0 = _mm256_load_ps((const float*)source);
+        __m256 in1 = _mm256_load_ps((const float*)(source + 4));
         vector_32fc_index_min_variant1(
             in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
         source += 8;
@@ -220,8 +220,8 @@ static inline void volk_32fc_index_min_16u_a_sse3(uint16_t* target,
     int bound = num_points >> 2;
 
     for (int i = 0; i < bound; ++i) {
-        xmm1 = _mm_load_ps((float*)source);
-        xmm2 = _mm_load_ps((float*)&source[2]);
+        xmm1 = _mm_load_ps((const float*)source);
+        xmm2 = _mm_load_ps((const float*)&source[2]);
 
         source += 4;
 
@@ -244,7 +244,7 @@ static inline void volk_32fc_index_min_16u_a_sse3(uint16_t* target,
     }
 
     if (num_points >> 1 & 1) {
-        xmm2 = _mm_load_ps((float*)source);
+        xmm2 = _mm_load_ps((const float*)source);
 
         xmm1 = _mm_movelh_ps(bit128_p(&xmm8)->float_vec, bit128_p(&xmm8)->float_vec);
         xmm8 = bit128_p(&xmm1)->int_vec;
@@ -594,8 +594,8 @@ static inline void volk_32fc_index_min_16u_u_avx2_variant_0(uint16_t* target,
     __m256i min_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_loadu_ps((float*)source);
-        __m256 in1 = _mm256_loadu_ps((float*)(source + 4));
+        __m256 in0 = _mm256_loadu_ps((const float*)source);
+        __m256 in1 = _mm256_loadu_ps((const float*)(source + 4));
         vector_32fc_index_min_variant0(
             in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
         source += 8;
@@ -654,8 +654,8 @@ static inline void volk_32fc_index_min_16u_u_avx2_variant_1(uint16_t* target,
     __m256i min_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_loadu_ps((float*)source);
-        __m256 in1 = _mm256_loadu_ps((float*)(source + 4));
+        __m256 in0 = _mm256_loadu_ps((const float*)source);
+        __m256 in1 = _mm256_loadu_ps((const float*)(source + 4));
         vector_32fc_index_min_variant1(
             in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
         source += 8;

--- a/kernels/volk/volk_32fc_index_min_32u.h
+++ b/kernels/volk/volk_32fc_index_min_32u.h
@@ -82,8 +82,8 @@ static inline void volk_32fc_index_min_32u_a_avx2_variant_0(uint32_t* target,
     __m256i min_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((float*)source);
-        __m256 in1 = _mm256_load_ps((float*)(source + 4));
+        __m256 in0 = _mm256_load_ps((const float*)source);
+        __m256 in1 = _mm256_load_ps((const float*)(source + 4));
         vector_32fc_index_min_variant0(
             in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
         source += 8;
@@ -140,8 +140,8 @@ static inline void volk_32fc_index_min_32u_a_avx2_variant_1(uint32_t* target,
     __m256i min_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((float*)source);
-        __m256 in1 = _mm256_load_ps((float*)(source + 4));
+        __m256 in0 = _mm256_load_ps((const float*)source);
+        __m256 in1 = _mm256_load_ps((const float*)(source + 4));
         vector_32fc_index_min_variant1(
             in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
         source += 8;
@@ -207,8 +207,8 @@ static inline void volk_32fc_index_min_32u_a_sse3(uint32_t* target,
     int bound = num_points >> 2;
 
     for (int i = 0; i < bound; ++i) {
-        xmm1 = _mm_load_ps((float*)source);
-        xmm2 = _mm_load_ps((float*)&source[2]);
+        xmm1 = _mm_load_ps((const float*)source);
+        xmm2 = _mm_load_ps((const float*)&source[2]);
 
         source += 4;
 
@@ -231,7 +231,7 @@ static inline void volk_32fc_index_min_32u_a_sse3(uint32_t* target,
     }
 
     if (num_points >> 1 & 1) {
-        xmm2 = _mm_load_ps((float*)source);
+        xmm2 = _mm_load_ps((const float*)source);
 
         xmm1 = _mm_movelh_ps(bit128_p(&xmm8)->float_vec, bit128_p(&xmm8)->float_vec);
         xmm8 = bit128_p(&xmm1)->int_vec;
@@ -428,8 +428,8 @@ static inline void volk_32fc_index_min_32u_u_avx2_variant_0(uint32_t* target,
     __m256i min_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_loadu_ps((float*)source);
-        __m256 in1 = _mm256_loadu_ps((float*)(source + 4));
+        __m256 in0 = _mm256_loadu_ps((const float*)source);
+        __m256 in1 = _mm256_loadu_ps((const float*)(source + 4));
         vector_32fc_index_min_variant0(
             in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
         source += 8;
@@ -486,8 +486,8 @@ static inline void volk_32fc_index_min_32u_u_avx2_variant_1(uint32_t* target,
     __m256i min_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_loadu_ps((float*)source);
-        __m256 in1 = _mm256_loadu_ps((float*)(source + 4));
+        __m256 in0 = _mm256_loadu_ps((const float*)source);
+        __m256 in1 = _mm256_loadu_ps((const float*)(source + 4));
         vector_32fc_index_min_variant1(
             in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
         source += 8;
@@ -549,7 +549,7 @@ static inline void volk_32fc_index_min_32u_neon(uint32_t* target,
         for (uint32_t number = 0; number < quarter_points; number++) {
             // Load complex and compute magnitude squared
             const float32x4_t vec_mag2 =
-                _vmagnitudesquaredq_f32(vld2q_f32((float*)sourcePtr));
+                _vmagnitudesquaredq_f32(vld2q_f32((const float*)sourcePtr));
             __VOLK_PREFETCH(sourcePtr += 4);
             // a < b?
             const uint32x4_t lt_mask = vcltq_f32(vec_mag2, vec_min);

--- a/kernels/volk/volk_32fc_magnitude_32f.h
+++ b/kernels/volk/volk_32fc_magnitude_32f.h
@@ -68,7 +68,7 @@ static inline void volk_32fc_magnitude_32f_generic(float* magnitudeVector,
                                                    const lv_32fc_t* complexVector,
                                                    unsigned int num_points)
 {
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
     unsigned int number = 0;
     for (number = 0; number < num_points; number++) {
@@ -89,7 +89,7 @@ static inline void volk_32fc_magnitude_32f_u_avx512f(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int eighthPoints = num_points / 8;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m512 cplxValue;
@@ -140,7 +140,7 @@ static inline void volk_32fc_magnitude_32f_u_avx(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int eighthPoints = num_points / 8;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m256 cplxValue1, cplxValue2, result;
@@ -175,7 +175,7 @@ static inline void volk_32fc_magnitude_32f_u_sse3(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int quarterPoints = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m128 cplxValue1, cplxValue2, result;
@@ -213,7 +213,7 @@ static inline void volk_32fc_magnitude_32f_u_sse(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int quarterPoints = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m128 cplxValue1, cplxValue2, result;
@@ -257,7 +257,7 @@ static inline void volk_32fc_magnitude_32f_a_avx512f(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int eighthPoints = num_points / 8;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m512 cplxValue;
@@ -306,7 +306,7 @@ static inline void volk_32fc_magnitude_32f_a_avx(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int eighthPoints = num_points / 8;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m256 cplxValue1, cplxValue2, result;
@@ -342,7 +342,7 @@ static inline void volk_32fc_magnitude_32f_a_sse3(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int quarterPoints = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m128 cplxValue1, cplxValue2, result;
@@ -378,7 +378,7 @@ static inline void volk_32fc_magnitude_32f_a_sse(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int quarterPoints = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m128 cplxValue1, cplxValue2, result;
@@ -413,7 +413,7 @@ static inline void volk_32fc_magnitude_32f_neon(float* magnitudeVector,
 {
     unsigned int number;
     unsigned int quarter_points = num_points / 4;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     float32x4x2_t complex_vec;
@@ -449,7 +449,7 @@ static inline void volk_32fc_magnitude_32f_neonv8(float* magnitudeVector,
 {
     unsigned int number;
     unsigned int quarter_points = num_points / 4;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     float32x4x2_t complex_vec;
@@ -500,7 +500,7 @@ static inline void volk_32fc_magnitude_32f_neon_fancy_sweet(
 {
     unsigned int number;
     unsigned int quarter_points = num_points / 4;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     const float threshold = 0.4142135;

--- a/kernels/volk/volk_32fc_magnitude_squared_32f.h
+++ b/kernels/volk/volk_32fc_magnitude_squared_32f.h
@@ -73,7 +73,7 @@ static inline void volk_32fc_magnitude_squared_32f_u_avx(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int eighthPoints = num_points / 8;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m256 cplxValue1, cplxValue2, result;
@@ -109,7 +109,7 @@ static inline void volk_32fc_magnitude_squared_32f_u_sse3(float* magnitudeVector
     unsigned int number = 0;
     const unsigned int quarterPoints = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m128 cplxValue1, cplxValue2, result;
@@ -146,7 +146,7 @@ static inline void volk_32fc_magnitude_squared_32f_u_sse(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int quarterPoints = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m128 cplxValue1, cplxValue2, result;
@@ -179,7 +179,7 @@ static inline void volk_32fc_magnitude_squared_32f_generic(float* magnitudeVecto
                                                            const lv_32fc_t* complexVector,
                                                            unsigned int num_points)
 {
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
     unsigned int number = 0;
     for (number = 0; number < num_points; number++) {
@@ -210,7 +210,7 @@ static inline void volk_32fc_magnitude_squared_32f_a_avx(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int eighthPoints = num_points / 8;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m256 cplxValue1, cplxValue2, result;
@@ -247,7 +247,7 @@ static inline void volk_32fc_magnitude_squared_32f_a_sse3(float* magnitudeVector
     unsigned int number = 0;
     const unsigned int quarterPoints = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m128 cplxValue1, cplxValue2, result;
@@ -284,7 +284,7 @@ static inline void volk_32fc_magnitude_squared_32f_a_sse(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int quarterPoints = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m128 cplxValue1, cplxValue2, result;
@@ -320,7 +320,7 @@ static inline void volk_32fc_magnitude_squared_32f_neon(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int quarterPoints = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     float32x4x2_t cmplx_val;

--- a/kernels/volk/volk_32fc_s32f_atan2_32f.h
+++ b/kernels/volk/volk_32fc_s32f_atan2_32f.h
@@ -72,7 +72,7 @@ static inline void volk_32fc_s32f_atan2_32f_generic(float* outputVector,
                                                     unsigned int num_points)
 {
     float* outPtr = outputVector;
-    const float* inPtr = (float*)inputVector;
+    const float* inPtr = (const float*)inputVector;
     const float invNormalizeFactor = 1.f / normalizeFactor;
 
     for (unsigned int number = 0; number < num_points; number++) {
@@ -91,7 +91,7 @@ static inline void volk_32fc_s32f_atan2_32f_polynomial(float* outputVector,
                                                        unsigned int num_points)
 {
     float* outPtr = outputVector;
-    const float* inPtr = (float*)inputVector;
+    const float* inPtr = (const float*)inputVector;
     const float invNormalizeFactor = 1.f / normalizeFactor;
 
     for (unsigned int number = 0; number < num_points; number++) {
@@ -110,7 +110,7 @@ static inline void volk_32fc_s32f_atan2_32f_a_avx512dq(float* outputVector,
                                                        const float normalizeFactor,
                                                        unsigned int num_points)
 {
-    const float* in = (float*)complexVector;
+    const float* in = (const float*)complexVector;
     float* out = (float*)outputVector;
 
     const float invNormalizeFactor = 1.f / normalizeFactor;
@@ -214,7 +214,7 @@ static inline void volk_32fc_s32f_atan2_32f_a_avx2_fma(float* outputVector,
                                                        const float normalizeFactor,
                                                        unsigned int num_points)
 {
-    const float* in = (float*)complexVector;
+    const float* in = (const float*)complexVector;
     float* out = (float*)outputVector;
 
     const float invNormalizeFactor = 1.f / normalizeFactor;
@@ -309,7 +309,7 @@ static inline void volk_32fc_s32f_atan2_32f_a_avx2_fma(float* outputVector,
 
     number = eighth_points * 8;
     volk_32fc_s32f_atan2_32f_polynomial(
-        out, (lv_32fc_t*)in, normalizeFactor, num_points - number);
+        out, (const lv_32fc_t*)in, normalizeFactor, num_points - number);
 }
 #endif /* LV_HAVE_AVX2 && LV_HAVE_FMA for aligned */
 
@@ -321,7 +321,7 @@ static inline void volk_32fc_s32f_atan2_32f_a_avx2(float* outputVector,
                                                    const float normalizeFactor,
                                                    unsigned int num_points)
 {
-    const float* in = (float*)complexVector;
+    const float* in = (const float*)complexVector;
     float* out = (float*)outputVector;
 
     const float invNormalizeFactor = 1.f / normalizeFactor;
@@ -416,7 +416,7 @@ static inline void volk_32fc_s32f_atan2_32f_a_avx2(float* outputVector,
 
     number = eighth_points * 8;
     volk_32fc_s32f_atan2_32f_polynomial(
-        out, (lv_32fc_t*)in, normalizeFactor, num_points - number);
+        out, (const lv_32fc_t*)in, normalizeFactor, num_points - number);
 }
 #endif /* LV_HAVE_AVX2 for aligned */
 
@@ -428,7 +428,7 @@ static inline void volk_32fc_s32f_atan2_32f_neon(float* outputVector,
                                                  const float normalizeFactor,
                                                  unsigned int num_points)
 {
-    const float* in = (float*)complexVector;
+    const float* in = (const float*)complexVector;
     float* out = outputVector;
 
     const float invNormalizeFactor = 1.f / normalizeFactor;
@@ -532,7 +532,7 @@ static inline void volk_32fc_s32f_atan2_32f_neonv8(float* outputVector,
                                                    const float normalizeFactor,
                                                    unsigned int num_points)
 {
-    const float* in = (float*)complexVector;
+    const float* in = (const float*)complexVector;
     float* out = outputVector;
 
     const float invNormalizeFactor = 1.f / normalizeFactor;
@@ -697,7 +697,7 @@ static inline void volk_32fc_s32f_atan2_32f_u_avx512dq(float* outputVector,
                                                        const float normalizeFactor,
                                                        unsigned int num_points)
 {
-    const float* in = (float*)complexVector;
+    const float* in = (const float*)complexVector;
     float* out = (float*)outputVector;
 
     const float invNormalizeFactor = 1.f / normalizeFactor;
@@ -801,7 +801,7 @@ static inline void volk_32fc_s32f_atan2_32f_u_avx2_fma(float* outputVector,
                                                        const float normalizeFactor,
                                                        unsigned int num_points)
 {
-    const float* in = (float*)complexVector;
+    const float* in = (const float*)complexVector;
     float* out = (float*)outputVector;
 
     const float invNormalizeFactor = 1.f / normalizeFactor;
@@ -896,7 +896,7 @@ static inline void volk_32fc_s32f_atan2_32f_u_avx2_fma(float* outputVector,
 
     number = eighth_points * 8;
     volk_32fc_s32f_atan2_32f_polynomial(
-        out, (lv_32fc_t*)in, normalizeFactor, num_points - number);
+        out, (const lv_32fc_t*)in, normalizeFactor, num_points - number);
 }
 #endif /* LV_HAVE_AVX2 && LV_HAVE_FMA for unaligned */
 
@@ -908,7 +908,7 @@ static inline void volk_32fc_s32f_atan2_32f_u_avx2(float* outputVector,
                                                    const float normalizeFactor,
                                                    unsigned int num_points)
 {
-    const float* in = (float*)complexVector;
+    const float* in = (const float*)complexVector;
     float* out = (float*)outputVector;
 
     const float invNormalizeFactor = 1.f / normalizeFactor;
@@ -1003,7 +1003,7 @@ static inline void volk_32fc_s32f_atan2_32f_u_avx2(float* outputVector,
 
     number = eighth_points * 8;
     volk_32fc_s32f_atan2_32f_polynomial(
-        out, (lv_32fc_t*)in, normalizeFactor, num_points - number);
+        out, (const lv_32fc_t*)in, normalizeFactor, num_points - number);
 }
 #endif /* LV_HAVE_AVX2 for unaligned */
 

--- a/kernels/volk/volk_32fc_s32f_deinterleave_real_16i.h
+++ b/kernels/volk/volk_32fc_s32f_deinterleave_real_16i.h
@@ -77,7 +77,7 @@ volk_32fc_s32f_deinterleave_real_16i_a_avx2(int16_t* iBuffer,
     unsigned int number = 0;
     const unsigned int eighthPoints = num_points / 8;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     int16_t* iBufferPtr = iBuffer;
 
     __m256 vScalar = _mm256_set1_ps(scalar);
@@ -132,7 +132,7 @@ volk_32fc_s32f_deinterleave_real_16i_a_sse(int16_t* iBuffer,
     unsigned int number = 0;
     const unsigned int quarterPoints = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     int16_t* iBufferPtr = iBuffer;
 
     __m128 vScalar = _mm_set_ps1(scalar);
@@ -179,7 +179,7 @@ volk_32fc_s32f_deinterleave_real_16i_generic(int16_t* iBuffer,
                                              const float scalar,
                                              unsigned int num_points)
 {
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     unsigned int number = 0;
     for (number = 0; number < num_points; number++) {
@@ -211,7 +211,7 @@ volk_32fc_s32f_deinterleave_real_16i_u_avx2(int16_t* iBuffer,
     unsigned int number = 0;
     const unsigned int eighthPoints = num_points / 8;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     int16_t* iBufferPtr = iBuffer;
 
     __m256 vScalar = _mm256_set1_ps(scalar);
@@ -265,7 +265,7 @@ volk_32fc_s32f_deinterleave_real_16i_neon(int16_t* iBuffer,
     unsigned int number = 0;
     const unsigned int quarter_points = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     float32x4_t vScalar = vdupq_n_f32(scalar);
 
@@ -308,7 +308,7 @@ volk_32fc_s32f_deinterleave_real_16i_neonv8(int16_t* iBuffer,
     unsigned int number = 0;
     const unsigned int eighth_points = num_points / 8;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     float32x4_t vScalar = vdupq_n_f32(scalar);
 

--- a/kernels/volk/volk_32fc_s32f_magnitude_16i.h
+++ b/kernels/volk/volk_32fc_s32f_magnitude_16i.h
@@ -72,7 +72,7 @@ static inline void volk_32fc_s32f_magnitude_16i_generic(int16_t* magnitudeVector
                                                         const float scalar,
                                                         unsigned int num_points)
 {
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     int16_t* magnitudeVectorPtr = magnitudeVector;
     unsigned int number = 0;
     for (number = 0; number < num_points; number++) {

--- a/kernels/volk/volk_32fc_s32f_power_spectrum_32f.h
+++ b/kernels/volk/volk_32fc_s32f_power_spectrum_32f.h
@@ -115,7 +115,7 @@ volk_32fc_s32f_power_spectrum_32f_neon(float* logPowerOutput,
 
     for (number = 0; number < quarter_points; number++) {
         // Load
-        fft_vec = vld2q_f32((float*)complexFFTInputPtr);
+        fft_vec = vld2q_f32((const float*)complexFFTInputPtr);
         // Prefetch next 4
         __VOLK_PREFETCH(complexFFTInputPtr + 4);
         // Normalize

--- a/kernels/volk/volk_32fc_s32fc_multiply2_32fc.h
+++ b/kernels/volk/volk_32fc_s32fc_multiply2_32fc.h
@@ -89,7 +89,7 @@ static inline void volk_32fc_s32fc_multiply2_32fc_u_avx_fma(lv_32fc_t* cVector,
     yh = _mm256_set1_ps(lv_cimag(*scalar));
 
     for (; number < quarterPoints; number++) {
-        x = _mm256_loadu_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        x = _mm256_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
 
         tmp1 = x;
 
@@ -133,7 +133,7 @@ static inline void volk_32fc_s32fc_multiply2_32fc_u_avx(lv_32fc_t* cVector,
     yh = _mm256_set1_ps(lv_cimag(*scalar));
 
     for (; number < quarterPoints; number++) {
-        x = _mm256_loadu_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        x = _mm256_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
 
         tmp1 = _mm256_mul_ps(x, yl); // tmp1 = ar*cr,ai*cr,br*dr,bi*dr
 
@@ -177,7 +177,7 @@ static inline void volk_32fc_s32fc_multiply2_32fc_u_sse3(lv_32fc_t* cVector,
 
     for (; number < halfPoints; number++) {
 
-        x = _mm_loadu_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        x = _mm_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
 
         tmp1 = _mm_mul_ps(x, yl); // tmp1 = ar*cr,ai*cr,br*dr,bi*dr
 
@@ -261,7 +261,7 @@ static inline void volk_32fc_s32fc_multiply2_32fc_a_avx_fma(lv_32fc_t* cVector,
     yh = _mm256_set1_ps(lv_cimag(*scalar));
 
     for (; number < quarterPoints; number++) {
-        x = _mm256_load_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        x = _mm256_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
 
         tmp1 = x;
 
@@ -306,7 +306,7 @@ static inline void volk_32fc_s32fc_multiply2_32fc_a_avx(lv_32fc_t* cVector,
     yh = _mm256_set1_ps(lv_cimag(*scalar));
 
     for (; number < quarterPoints; number++) {
-        x = _mm256_load_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        x = _mm256_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
 
         tmp1 = _mm256_mul_ps(x, yl); // tmp1 = ar*cr,ai*cr,br*dr,bi*dr
 
@@ -350,7 +350,7 @@ static inline void volk_32fc_s32fc_multiply2_32fc_a_sse3(lv_32fc_t* cVector,
 
     for (; number < halfPoints; number++) {
 
-        x = _mm_load_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        x = _mm_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
 
         tmp1 = _mm_mul_ps(x, yl); // tmp1 = ar*cr,ai*cr,br*dr,bi*dr
 
@@ -392,7 +392,7 @@ static inline void volk_32fc_s32fc_multiply2_32fc_neon(lv_32fc_t* cVector,
     scalar_val.val[0] = vld1q_dup_f32((const float*)scalar);
     scalar_val.val[1] = vld1q_dup_f32(((const float*)scalar) + 1);
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld2q_f32((float*)aPtr);
+        a_val = vld2q_f32((const float*)aPtr);
         tmp_imag.val[1] = vmulq_f32(a_val.val[1], scalar_val.val[0]);
         tmp_imag.val[0] = vmulq_f32(a_val.val[0], scalar_val.val[0]);
 

--- a/kernels/volk/volk_32fc_s32fc_x2_rotator2_32fc.h
+++ b/kernels/volk/volk_32fc_s32fc_x2_rotator2_32fc.h
@@ -155,7 +155,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_neon(lv_32fc_t* outVector,
     lv_32fc_t phasePtr[4];
 
     const lv_32fc_t incrPtr[4] = { incr, incr, incr, incr };
-    const float32x4x2_t incr_vec = vld2q_f32((float*)incrPtr);
+    const float32x4x2_t incr_vec = vld2q_f32((const float*)incrPtr);
     float32x4x2_t phase_vec;
 
 // Helper macro for angle reduction
@@ -182,7 +182,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_neon(lv_32fc_t* outVector,
     for (i = 0; i < (unsigned int)(num_points / ROTATOR_RELOAD); i++) {
         // Inner loop: use fast SIMD multiply
         for (j = 0; j < ROTATOR_RELOAD_4; j++) {
-            input_vec = vld2q_f32((float*)inputVectorPtr);
+            input_vec = vld2q_f32((const float*)inputVectorPtr);
             __VOLK_PREFETCH(inputVectorPtr + 4);
 
             // Rotate
@@ -215,7 +215,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_neon(lv_32fc_t* outVector,
 
     // Handle remainder
     for (i = 0; i < (num_points % ROTATOR_RELOAD) / 4; i++) {
-        input_vec = vld2q_f32((float*)inputVectorPtr);
+        input_vec = vld2q_f32((const float*)inputVectorPtr);
         __VOLK_PREFETCH(inputVectorPtr + 4);
 
         output_vec = _vmultiply_complexq_f32(input_vec, phase_vec);
@@ -337,7 +337,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_a_avx(lv_32fc_t* outVector,
     for (i = 0; i < (unsigned int)(num_points / ROTATOR_RELOAD); ++i) {
         // Inner loop: use fast SIMD multiply
         for (j = 0; j < ROTATOR_RELOAD_4; ++j) {
-            aVal = _mm256_loadu_ps((float*)aPtr);
+            aVal = _mm256_loadu_ps((const float*)aPtr);
 
             z = _mm256_complexmul_ps(aVal, phase_Val);
             phase_Val = _mm256_complexmul_ps(phase_Val, inc_Val);
@@ -367,7 +367,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_a_avx(lv_32fc_t* outVector,
 
     // Handle remainder
     for (i = 0; i < (num_points % ROTATOR_RELOAD) / 4; ++i) {
-        aVal = _mm256_loadu_ps((float*)aPtr);
+        aVal = _mm256_loadu_ps((const float*)aPtr);
 
         z = _mm256_complexmul_ps(aVal, phase_Val);
         phase_Val = _mm256_complexmul_ps(phase_Val, inc_Val);
@@ -482,7 +482,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_u_avx(lv_32fc_t* outVector,
     // Main loop with periodic resync
     for (i = 0; i < (unsigned int)(num_points / ROTATOR_RELOAD); ++i) {
         for (j = 0; j < ROTATOR_RELOAD_4; ++j) {
-            aVal = _mm256_loadu_ps((float*)aPtr);
+            aVal = _mm256_loadu_ps((const float*)aPtr);
             z = _mm256_complexmul_ps(aVal, phase_Val);
             phase_Val = _mm256_complexmul_ps(phase_Val, inc_Val);
             _mm256_storeu_ps((float*)cPtr, z);
@@ -509,7 +509,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_u_avx(lv_32fc_t* outVector,
 
     // Handle remainder
     for (i = 0; i < (num_points % ROTATOR_RELOAD) / 4; ++i) {
-        aVal = _mm256_loadu_ps((float*)aPtr);
+        aVal = _mm256_loadu_ps((const float*)aPtr);
         z = _mm256_complexmul_ps(aVal, phase_Val);
         phase_Val = _mm256_complexmul_ps(phase_Val, inc_Val);
         _mm256_storeu_ps((float*)cPtr, z);
@@ -630,7 +630,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_a_avx512f(lv_32fc_t* outVect
     // Main loop with periodic resync
     for (i = 0; i < (unsigned int)(num_points / ROTATOR_RELOAD); ++i) {
         for (j = 0; j < ROTATOR_RELOAD_8; ++j) {
-            aVal = _mm512_load_ps((float*)aPtr);
+            aVal = _mm512_load_ps((const float*)aPtr);
             z = _mm512_complexmul_ps(aVal, phase_Val);
             phase_Val = _mm512_complexmul_ps(phase_Val, inc_Val);
             _mm512_store_ps((float*)cPtr, z);
@@ -657,7 +657,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_a_avx512f(lv_32fc_t* outVect
 
     // Handle remainder
     for (i = 0; i < (num_points % ROTATOR_RELOAD) / 8; ++i) {
-        aVal = _mm512_load_ps((float*)aPtr);
+        aVal = _mm512_load_ps((const float*)aPtr);
         z = _mm512_complexmul_ps(aVal, phase_Val);
         phase_Val = _mm512_complexmul_ps(phase_Val, inc_Val);
         _mm512_store_ps((float*)cPtr, z);
@@ -769,7 +769,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_u_avx512f(lv_32fc_t* outVect
 
     for (i = 0; i < (unsigned int)(num_points / ROTATOR_RELOAD); ++i) {
         for (j = 0; j < ROTATOR_RELOAD_8; ++j) {
-            aVal = _mm512_loadu_ps((float*)aPtr);
+            aVal = _mm512_loadu_ps((const float*)aPtr);
             z = _mm512_complexmul_ps(aVal, phase_Val);
             phase_Val = _mm512_complexmul_ps(phase_Val, inc_Val);
             _mm512_storeu_ps((float*)cPtr, z);
@@ -793,7 +793,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_u_avx512f(lv_32fc_t* outVect
     }
 
     for (i = 0; i < (num_points % ROTATOR_RELOAD) / 8; ++i) {
-        aVal = _mm512_loadu_ps((float*)aPtr);
+        aVal = _mm512_loadu_ps((const float*)aPtr);
         z = _mm512_complexmul_ps(aVal, phase_Val);
         phase_Val = _mm512_complexmul_ps(phase_Val, inc_Val);
         _mm512_storeu_ps((float*)cPtr, z);

--- a/kernels/volk/volk_32fc_x2_add_32fc.h
+++ b/kernels/volk/volk_32fc_x2_add_32fc.h
@@ -79,8 +79,8 @@ static inline void volk_32fc_x2_add_32fc_u_avx(lv_32fc_t* cVector,
     __m256 aVal, bVal, cVal;
     for (; number < quarterPoints; number++) {
 
-        aVal = _mm256_loadu_ps((float*)aPtr);
-        bVal = _mm256_loadu_ps((float*)bPtr);
+        aVal = _mm256_loadu_ps((const float*)aPtr);
+        bVal = _mm256_loadu_ps((const float*)bPtr);
 
         cVal = _mm256_add_ps(aVal, bVal);
 
@@ -118,8 +118,8 @@ static inline void volk_32fc_x2_add_32fc_a_avx(lv_32fc_t* cVector,
     __m256 aVal, bVal, cVal;
     for (; number < quarterPoints; number++) {
 
-        aVal = _mm256_load_ps((float*)aPtr);
-        bVal = _mm256_load_ps((float*)bPtr);
+        aVal = _mm256_load_ps((const float*)aPtr);
+        bVal = _mm256_load_ps((const float*)bPtr);
 
         cVal = _mm256_add_ps(aVal, bVal);
 
@@ -157,8 +157,8 @@ static inline void volk_32fc_x2_add_32fc_u_sse(lv_32fc_t* cVector,
     __m128 aVal, bVal, cVal;
     for (; number < halfPoints; number++) {
 
-        aVal = _mm_loadu_ps((float*)aPtr);
-        bVal = _mm_loadu_ps((float*)bPtr);
+        aVal = _mm_loadu_ps((const float*)aPtr);
+        bVal = _mm_loadu_ps((const float*)bPtr);
 
         cVal = _mm_add_ps(aVal, bVal);
 
@@ -213,8 +213,8 @@ static inline void volk_32fc_x2_add_32fc_a_sse(lv_32fc_t* cVector,
 
     __m128 aVal, bVal, cVal;
     for (; number < halfPoints; number++) {
-        aVal = _mm_load_ps((float*)aPtr);
-        bVal = _mm_load_ps((float*)bPtr);
+        aVal = _mm_load_ps((const float*)aPtr);
+        bVal = _mm_load_ps((const float*)bPtr);
 
         cVal = _mm_add_ps(aVal, bVal);
 

--- a/kernels/volk/volk_32fc_x2_conjugate_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_x2_conjugate_dot_prod_32fc.h
@@ -92,8 +92,8 @@ static inline void volk_32fc_x2_conjugate_dot_prod_32fc_block(lv_32fc_t* result,
     const unsigned int num_bytes = num_points * 8;
 
     float* res = (float*)result;
-    float* in = (float*)input;
-    float* tp = (float*)taps;
+    const float* in = (const float*)input;
+    const float* tp = (const float*)taps;
     unsigned int n_2_ccomplex_blocks = num_bytes >> 4;
 
     float sum0[2] = { 0, 0 };
@@ -538,8 +538,8 @@ static inline void volk_32fc_x2_conjugate_dot_prod_32fc_neon(lv_32fc_t* result,
     unsigned int quarter_points = num_points / 4;
     unsigned int number;
 
-    lv_32fc_t* a_ptr = (lv_32fc_t*)taps;
-    lv_32fc_t* b_ptr = (lv_32fc_t*)input;
+    const lv_32fc_t* a_ptr = taps;
+    const lv_32fc_t* b_ptr = input;
     // for 2-lane vectors, 1st lane holds the real part,
     // 2nd lane holds the imaginary part
     float32x4x2_t a_val, b_val, accumulator;
@@ -548,8 +548,8 @@ static inline void volk_32fc_x2_conjugate_dot_prod_32fc_neon(lv_32fc_t* result,
     accumulator.val[1] = vdupq_n_f32(0);
 
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld2q_f32((float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
-        b_val = vld2q_f32((float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
+        a_val = vld2q_f32((const float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
+        b_val = vld2q_f32((const float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
         __VOLK_PREFETCH(a_ptr + 8);
         __VOLK_PREFETCH(b_ptr + 8);
 

--- a/kernels/volk/volk_32fc_x2_divide_32fc.h
+++ b/kernels/volk/volk_32fc_x2_divide_32fc.h
@@ -145,14 +145,14 @@ static inline void volk_32fc_x2_divide_32fc_u_sse3(lv_32fc_t* cVector,
     const lv_32fc_t* b = denumeratorVector;
 
     for (; number < quarterPoints; number++) {
-        num01 = _mm_loadu_ps((float*)a);                  // first pair
-        den01 = _mm_loadu_ps((float*)b);                  // first pair
+        num01 = _mm_loadu_ps((const float*)a);                  // first pair
+        den01 = _mm_loadu_ps((const float*)b);                  // first pair
         num01 = _mm_complexconjugatemul_ps(num01, den01); // a conj(b)
         a += 2;
         b += 2;
 
-        num23 = _mm_loadu_ps((float*)a);                  // second pair
-        den23 = _mm_loadu_ps((float*)b);                  // second pair
+        num23 = _mm_loadu_ps((const float*)a);                  // second pair
+        den23 = _mm_loadu_ps((const float*)b);                  // second pair
         num23 = _mm_complexconjugatemul_ps(num23, den23); // a conj(b)
         a += 2;
         b += 2;
@@ -205,9 +205,9 @@ static inline void volk_32fc_x2_divide_32fc_u_avx(lv_32fc_t* cVector,
 
     for (; number < quarterPoints; number++) {
         num = _mm256_loadu_ps(
-            (float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
+            (const float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
         denum = _mm256_loadu_ps(
-            (float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
+            (const float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
         mul_conj = _mm256_complexconjugatemul_ps(num, denum);
         sq = _mm256_mul_ps(denum, denum); // Square the values
         mag_sq_un = _mm256_hadd_ps(
@@ -251,14 +251,14 @@ static inline void volk_32fc_x2_divide_32fc_u_avx2_fma(lv_32fc_t* cVector,
     __m256 num01, num23, denum01, denum23, complex_result, result0, result1;
 
     for (unsigned int number = 0; number < eighthPoints; number++) {
-        num01 = _mm256_loadu_ps((float*)a);
-        denum01 = _mm256_loadu_ps((float*)b);
+        num01 = _mm256_loadu_ps((const float*)a);
+        denum01 = _mm256_loadu_ps((const float*)b);
         num01 = _mm256_complexconjugatemul_ps(num01, denum01);
         a += 4;
         b += 4;
 
-        num23 = _mm256_loadu_ps((float*)a);
-        denum23 = _mm256_loadu_ps((float*)b);
+        num23 = _mm256_loadu_ps((const float*)a);
+        denum23 = _mm256_loadu_ps((const float*)b);
         num23 = _mm256_complexconjugatemul_ps(num23, denum23);
         a += 4;
         b += 4;
@@ -303,14 +303,14 @@ static inline void volk_32fc_x2_divide_32fc_u_avx512(lv_32fc_t* cVector,
     __m512 result0, result1;
 
     for (unsigned int number = 0; number < sixteenthPoints; number++) {
-        num01 = _mm512_loadu_ps((float*)a);
-        denum01 = _mm512_loadu_ps((float*)b);
+        num01 = _mm512_loadu_ps((const float*)a);
+        denum01 = _mm512_loadu_ps((const float*)b);
         num01 = _mm512_complexconjugatemul_ps(num01, denum01);
         a += 8;
         b += 8;
 
-        num23 = _mm512_loadu_ps((float*)a);
-        denum23 = _mm512_loadu_ps((float*)b);
+        num23 = _mm512_loadu_ps((const float*)a);
+        denum23 = _mm512_loadu_ps((const float*)b);
         num23 = _mm512_complexconjugatemul_ps(num23, denum23);
         a += 8;
         b += 8;
@@ -373,14 +373,14 @@ static inline void volk_32fc_x2_divide_32fc_a_sse3(lv_32fc_t* cVector,
     const lv_32fc_t* b = denumeratorVector;
 
     for (; number < quarterPoints; number++) {
-        num01 = _mm_load_ps((float*)a);                   // first pair
-        den01 = _mm_load_ps((float*)b);                   // first pair
+        num01 = _mm_load_ps((const float*)a);                   // first pair
+        den01 = _mm_load_ps((const float*)b);                   // first pair
         num01 = _mm_complexconjugatemul_ps(num01, den01); // a conj(b)
         a += 2;
         b += 2;
 
-        num23 = _mm_load_ps((float*)a);                   // second pair
-        den23 = _mm_load_ps((float*)b);                   // second pair
+        num23 = _mm_load_ps((const float*)a);                   // second pair
+        den23 = _mm_load_ps((const float*)b);                   // second pair
         num23 = _mm_complexconjugatemul_ps(num23, den23); // a conj(b)
         a += 2;
         b += 2;
@@ -437,15 +437,15 @@ static inline void volk_32fc_x2_divide_32fc_a_avx(lv_32fc_t* cVector,
 
     for (unsigned int number = 0; number < eigthPoints; number++) {
         // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
-        num01 = _mm256_load_ps((float*)a);
-        denum01 = _mm256_load_ps((float*)b);
+        num01 = _mm256_load_ps((const float*)a);
+        denum01 = _mm256_load_ps((const float*)b);
 
         num01 = _mm256_complexconjugatemul_ps(num01, denum01);
         a += 4;
         b += 4;
 
-        num23 = _mm256_load_ps((float*)a);
-        denum23 = _mm256_load_ps((float*)b);
+        num23 = _mm256_load_ps((const float*)a);
+        denum23 = _mm256_load_ps((const float*)b);
         num23 = _mm256_complexconjugatemul_ps(num23, denum23);
         a += 4;
         b += 4;
@@ -488,14 +488,14 @@ static inline void volk_32fc_x2_divide_32fc_a_avx2_fma(lv_32fc_t* cVector,
     __m256 num01, num23, denum01, denum23, complex_result, result0, result1;
 
     for (unsigned int number = 0; number < eighthPoints; number++) {
-        num01 = _mm256_load_ps((float*)a);
-        denum01 = _mm256_load_ps((float*)b);
+        num01 = _mm256_load_ps((const float*)a);
+        denum01 = _mm256_load_ps((const float*)b);
         num01 = _mm256_complexconjugatemul_ps(num01, denum01);
         a += 4;
         b += 4;
 
-        num23 = _mm256_load_ps((float*)a);
-        denum23 = _mm256_load_ps((float*)b);
+        num23 = _mm256_load_ps((const float*)a);
+        denum23 = _mm256_load_ps((const float*)b);
         num23 = _mm256_complexconjugatemul_ps(num23, denum23);
         a += 4;
         b += 4;
@@ -540,14 +540,14 @@ static inline void volk_32fc_x2_divide_32fc_a_avx512(lv_32fc_t* cVector,
     __m512 result0, result1;
 
     for (unsigned int number = 0; number < sixteenthPoints; number++) {
-        num01 = _mm512_load_ps((float*)a);
-        denum01 = _mm512_load_ps((float*)b);
+        num01 = _mm512_load_ps((const float*)a);
+        denum01 = _mm512_load_ps((const float*)b);
         num01 = _mm512_complexconjugatemul_ps(num01, denum01);
         a += 8;
         b += 8;
 
-        num23 = _mm512_load_ps((float*)a);
-        denum23 = _mm512_load_ps((float*)b);
+        num23 = _mm512_load_ps((const float*)a);
+        denum23 = _mm512_load_ps((const float*)b);
         num23 = _mm512_complexconjugatemul_ps(num23, denum23);
         a += 8;
         b += 8;

--- a/kernels/volk/volk_32fc_x2_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_x2_dot_prod_32fc.h
@@ -68,8 +68,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_generic(lv_32fc_t* result,
 {
 
     float* res = (float*)result;
-    float* in = (float*)input;
-    float* tp = (float*)taps;
+    const float* in = (const float*)input;
+    const float* tp = (const float*)taps;
     unsigned int n_2_ccomplex_blocks = num_points / 2;
 
     float sum0[2] = { 0, 0 };
@@ -124,8 +124,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_u_sse3(lv_32fc_t* result,
 
     for (; number < halfPoints; number++) {
 
-        x = _mm_loadu_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
-        y = _mm_loadu_ps((float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+        x = _mm_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        y = _mm_loadu_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
 
         yl = _mm_moveldup_ps(y); // Load yl with cr,cr,dr,dr
         yh = _mm_movehdup_ps(y); // Load yh with ci,ci,di,di
@@ -188,8 +188,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_u_avx(lv_32fc_t* result,
     dotProdVal = _mm256_setzero_ps();
 
     for (; number < quarterPoints; number++) {
-        x = _mm256_loadu_ps((float*)a); // Load a,b,e,f as ar,ai,br,bi,er,ei,fr,fi
-        y = _mm256_loadu_ps((float*)b); // Load c,d,g,h as cr,ci,dr,di,gr,gi,hr,hi
+        x = _mm256_loadu_ps((const float*)a); // Load a,b,e,f as ar,ai,br,bi,er,ei,fr,fi
+        y = _mm256_loadu_ps((const float*)b); // Load c,d,g,h as cr,ci,dr,di,gr,gi,hr,hi
 
         yl = _mm256_moveldup_ps(y); // Load yl with cr,cr,dr,dr,gr,gr,hr,hr
         yh = _mm256_movehdup_ps(y); // Load yh with ci,ci,di,di,gi,gi,hi,hi
@@ -253,8 +253,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_u_avx_fma(lv_32fc_t* result,
 
     for (; number < quarterPoints; number++) {
 
-        x = _mm256_loadu_ps((float*)a); // Load a,b,e,f as ar,ai,br,bi,er,ei,fr,fi
-        y = _mm256_loadu_ps((float*)b); // Load c,d,g,h as cr,ci,dr,di,gr,gi,hr,hi
+        x = _mm256_loadu_ps((const float*)a); // Load a,b,e,f as ar,ai,br,bi,er,ei,fr,fi
+        y = _mm256_loadu_ps((const float*)b); // Load c,d,g,h as cr,ci,dr,di,gr,gi,hr,hi
 
         yl = _mm256_moveldup_ps(y); // Load yl with cr,cr,dr,dr,gr,gr,hr,hr
         yh = _mm256_movehdup_ps(y); // Load yh with ci,ci,di,di,gi,gi,hi,hi
@@ -331,8 +331,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_a_sse3(lv_32fc_t* result,
 
     for (; number < halfPoints; number++) {
 
-        x = _mm_load_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
-        y = _mm_load_ps((float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+        x = _mm_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        y = _mm_load_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
 
         yl = _mm_moveldup_ps(y); // Load yl with cr,cr,dr,dr
         yh = _mm_movehdup_ps(y); // Load yh with ci,ci,di,di
@@ -382,8 +382,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_neon(lv_32fc_t* result,
     unsigned int quarter_points = num_points / 4;
     unsigned int number;
 
-    lv_32fc_t* a_ptr = (lv_32fc_t*)taps;
-    lv_32fc_t* b_ptr = (lv_32fc_t*)input;
+    const lv_32fc_t* a_ptr = taps;
+    const lv_32fc_t* b_ptr = input;
     // for 2-lane vectors, 1st lane holds the real part,
     // 2nd lane holds the imaginary part
     float32x4x2_t a_val, b_val, c_val, accumulator;
@@ -392,8 +392,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_neon(lv_32fc_t* result,
     accumulator.val[1] = vdupq_n_f32(0);
 
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld2q_f32((float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
-        b_val = vld2q_f32((float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
+        a_val = vld2q_f32((const float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
+        b_val = vld2q_f32((const float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
         __VOLK_PREFETCH(a_ptr + 8);
         __VOLK_PREFETCH(b_ptr + 8);
 
@@ -440,8 +440,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_neon_opttests(lv_32fc_t* result,
     unsigned int quarter_points = num_points / 4;
     unsigned int number;
 
-    lv_32fc_t* a_ptr = (lv_32fc_t*)taps;
-    lv_32fc_t* b_ptr = (lv_32fc_t*)input;
+    const lv_32fc_t* a_ptr = taps;
+    const lv_32fc_t* b_ptr = input;
     // for 2-lane vectors, 1st lane holds the real part,
     // 2nd lane holds the imaginary part
     float32x4x2_t a_val, b_val, accumulator;
@@ -450,8 +450,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_neon_opttests(lv_32fc_t* result,
     accumulator.val[1] = vdupq_n_f32(0);
 
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld2q_f32((float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
-        b_val = vld2q_f32((float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
+        a_val = vld2q_f32((const float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
+        b_val = vld2q_f32((const float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
         __VOLK_PREFETCH(a_ptr + 8);
         __VOLK_PREFETCH(b_ptr + 8);
 
@@ -491,8 +491,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_neon_optfma(lv_32fc_t* result,
     unsigned int quarter_points = num_points / 4;
     unsigned int number;
 
-    lv_32fc_t* a_ptr = (lv_32fc_t*)taps;
-    lv_32fc_t* b_ptr = (lv_32fc_t*)input;
+    const lv_32fc_t* a_ptr = taps;
+    const lv_32fc_t* b_ptr = input;
     // for 2-lane vectors, 1st lane holds the real part,
     // 2nd lane holds the imaginary part
     float32x4x2_t a_val, b_val, accumulator1, accumulator2;
@@ -502,8 +502,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_neon_optfma(lv_32fc_t* result,
     accumulator2.val[1] = vdupq_n_f32(0);
 
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld2q_f32((float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
-        b_val = vld2q_f32((float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
+        a_val = vld2q_f32((const float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
+        b_val = vld2q_f32((const float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
         __VOLK_PREFETCH(a_ptr + 8);
         __VOLK_PREFETCH(b_ptr + 8);
 
@@ -541,8 +541,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_neon_optfmaunroll(lv_32fc_t* resul
     unsigned int quarter_points = num_points / 8;
     unsigned int number;
 
-    lv_32fc_t* a_ptr = (lv_32fc_t*)taps;
-    lv_32fc_t* b_ptr = (lv_32fc_t*)input;
+    const lv_32fc_t* a_ptr = taps;
+    const lv_32fc_t* b_ptr = input;
     // for 2-lane vectors, 1st lane holds the real part,
     // 2nd lane holds the imaginary part
     float32x4x4_t a_val, b_val, accumulator1, accumulator2;
@@ -558,8 +558,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_neon_optfmaunroll(lv_32fc_t* resul
 
     // 8 input regs, 8 accumulators -> 16/16 neon regs are used
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld4q_f32((float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
-        b_val = vld4q_f32((float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
+        a_val = vld4q_f32((const float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
+        b_val = vld4q_f32((const float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
         __VOLK_PREFETCH(a_ptr + 8);
         __VOLK_PREFETCH(b_ptr + 8);
 
@@ -715,8 +715,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_a_avx(lv_32fc_t* result,
 
     for (; number < quarterPoints; number++) {
 
-        x = _mm256_load_ps((float*)a); // Load a,b,e,f as ar,ai,br,bi,er,ei,fr,fi
-        y = _mm256_load_ps((float*)b); // Load c,d,g,h as cr,ci,dr,di,gr,gi,hr,hi
+        x = _mm256_load_ps((const float*)a); // Load a,b,e,f as ar,ai,br,bi,er,ei,fr,fi
+        y = _mm256_load_ps((const float*)b); // Load c,d,g,h as cr,ci,dr,di,gr,gi,hr,hi
 
         yl = _mm256_moveldup_ps(y); // Load yl with cr,cr,dr,dr,gr,gr,hr,hr
         yh = _mm256_movehdup_ps(y); // Load yh with ci,ci,di,di,gi,gi,hi,hi
@@ -780,8 +780,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_a_avx_fma(lv_32fc_t* result,
 
     for (; number < quarterPoints; number++) {
 
-        x = _mm256_load_ps((float*)a); // Load a,b,e,f as ar,ai,br,bi,er,ei,fr,fi
-        y = _mm256_load_ps((float*)b); // Load c,d,g,h as cr,ci,dr,di,gr,gi,hr,hi
+        x = _mm256_load_ps((const float*)a); // Load a,b,e,f as ar,ai,br,bi,er,ei,fr,fi
+        y = _mm256_load_ps((const float*)b); // Load c,d,g,h as cr,ci,dr,di,gr,gi,hr,hi
 
         yl = _mm256_moveldup_ps(y); // Load yl with cr,cr,dr,dr,gr,gr,hr,hr
         yh = _mm256_movehdup_ps(y); // Load yh with ci,ci,di,di,gi,gi,hi,hi

--- a/kernels/volk/volk_32fc_x2_multiply_32fc.h
+++ b/kernels/volk/volk_32fc_x2_multiply_32fc.h
@@ -86,9 +86,9 @@ static inline void volk_32fc_x2_multiply_32fc_u_avx2_fma(lv_32fc_t* cVector,
     for (; number < quarterPoints; number++) {
 
         const __m256 x =
-            _mm256_loadu_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+            _mm256_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
         const __m256 y =
-            _mm256_loadu_ps((float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+            _mm256_loadu_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
 
         const __m256 yl = _mm256_moveldup_ps(y); // Load yl with cr,cr,dr,dr
         const __m256 yh = _mm256_movehdup_ps(y); // Load yh with ci,ci,di,di
@@ -134,9 +134,9 @@ static inline void volk_32fc_x2_multiply_32fc_u_avx(lv_32fc_t* cVector,
 
     for (; number < quarterPoints; number++) {
         x = _mm256_loadu_ps(
-            (float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
+            (const float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
         y = _mm256_loadu_ps(
-            (float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
+            (const float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
         z = _mm256_complexmul_ps(x, y);
         _mm256_storeu_ps((float*)c, z); // Store the results back into the C container
 
@@ -172,8 +172,8 @@ static inline void volk_32fc_x2_multiply_32fc_u_sse3(lv_32fc_t* cVector,
     const lv_32fc_t* b = bVector;
 
     for (; number < halfPoints; number++) {
-        x = _mm_loadu_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
-        y = _mm_loadu_ps((float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+        x = _mm_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        y = _mm_loadu_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
         z = _mm_complexmul_ps(x, y);
         _mm_storeu_ps((float*)c, z); // Store the results back into the C container
 
@@ -241,9 +241,9 @@ static inline void volk_32fc_x2_multiply_32fc_a_avx2_fma(lv_32fc_t* cVector,
     for (; number < quarterPoints; number++) {
 
         const __m256 x =
-            _mm256_load_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+            _mm256_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
         const __m256 y =
-            _mm256_load_ps((float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+            _mm256_load_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
 
         const __m256 yl = _mm256_moveldup_ps(y); // Load yl with cr,cr,dr,dr
         const __m256 yh = _mm256_movehdup_ps(y); // Load yh with ci,ci,di,di
@@ -288,8 +288,8 @@ static inline void volk_32fc_x2_multiply_32fc_a_avx(lv_32fc_t* cVector,
     const lv_32fc_t* b = bVector;
 
     for (; number < quarterPoints; number++) {
-        x = _mm256_load_ps((float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
-        y = _mm256_load_ps((float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
+        x = _mm256_load_ps((const float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
+        y = _mm256_load_ps((const float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
         z = _mm256_complexmul_ps(x, y);
         _mm256_store_ps((float*)c, z); // Store the results back into the C container
 
@@ -324,8 +324,8 @@ static inline void volk_32fc_x2_multiply_32fc_a_sse3(lv_32fc_t* cVector,
     const lv_32fc_t* b = bVector;
 
     for (; number < halfPoints; number++) {
-        x = _mm_load_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
-        y = _mm_load_ps((float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+        x = _mm_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        y = _mm_load_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
         z = _mm_complexmul_ps(x, y);
         _mm_store_ps((float*)c, z); // Store the results back into the C container
 
@@ -349,16 +349,16 @@ static inline void volk_32fc_x2_multiply_32fc_neon(lv_32fc_t* cVector,
                                                    const lv_32fc_t* bVector,
                                                    unsigned int num_points)
 {
-    lv_32fc_t* a_ptr = (lv_32fc_t*)aVector;
-    lv_32fc_t* b_ptr = (lv_32fc_t*)bVector;
+    const lv_32fc_t* a_ptr = aVector;
+    const lv_32fc_t* b_ptr = bVector;
     unsigned int quarter_points = num_points / 4;
     float32x4x2_t a_val, b_val, c_val;
     float32x4x2_t tmp_real, tmp_imag;
     unsigned int number = 0;
 
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld2q_f32((float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
-        b_val = vld2q_f32((float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
+        a_val = vld2q_f32((const float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
+        b_val = vld2q_f32((const float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
         __VOLK_PREFETCH(a_ptr + 4);
         __VOLK_PREFETCH(b_ptr + 4);
 

--- a/kernels/volk/volk_32fc_x2_multiply_conjugate_32fc.h
+++ b/kernels/volk/volk_32fc_x2_multiply_conjugate_32fc.h
@@ -82,9 +82,9 @@ static inline void volk_32fc_x2_multiply_conjugate_32fc_u_avx(lv_32fc_t* cVector
 
     for (; number < quarterPoints; number++) {
         x = _mm256_loadu_ps(
-            (float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
+            (const float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
         y = _mm256_loadu_ps(
-            (float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
+            (const float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
         z = _mm256_complexconjugatemul_ps(x, y);
         _mm256_storeu_ps((float*)c, z); // Store the results back into the C container
 
@@ -120,8 +120,8 @@ static inline void volk_32fc_x2_multiply_conjugate_32fc_u_sse3(lv_32fc_t* cVecto
     const lv_32fc_t* b = bVector;
 
     for (; number < halfPoints; number++) {
-        x = _mm_loadu_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
-        y = _mm_loadu_ps((float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+        x = _mm_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        y = _mm_loadu_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
         z = _mm_complexconjugatemul_ps(x, y);
         _mm_storeu_ps((float*)c, z); // Store the results back into the C container
 
@@ -183,8 +183,8 @@ static inline void volk_32fc_x2_multiply_conjugate_32fc_a_avx(lv_32fc_t* cVector
     const lv_32fc_t* b = bVector;
 
     for (; number < quarterPoints; number++) {
-        x = _mm256_load_ps((float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
-        y = _mm256_load_ps((float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
+        x = _mm256_load_ps((const float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
+        y = _mm256_load_ps((const float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
         z = _mm256_complexconjugatemul_ps(x, y);
         _mm256_store_ps((float*)c, z); // Store the results back into the C container
 
@@ -220,8 +220,8 @@ static inline void volk_32fc_x2_multiply_conjugate_32fc_a_sse3(lv_32fc_t* cVecto
     const lv_32fc_t* b = bVector;
 
     for (; number < halfPoints; number++) {
-        x = _mm_load_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
-        y = _mm_load_ps((float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+        x = _mm_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        y = _mm_load_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
         z = _mm_complexconjugatemul_ps(x, y);
         _mm_store_ps((float*)c, z); // Store the results back into the C container
 
@@ -245,16 +245,16 @@ static inline void volk_32fc_x2_multiply_conjugate_32fc_neon(lv_32fc_t* cVector,
                                                              const lv_32fc_t* bVector,
                                                              unsigned int num_points)
 {
-    lv_32fc_t* a_ptr = (lv_32fc_t*)aVector;
-    lv_32fc_t* b_ptr = (lv_32fc_t*)bVector;
+    const lv_32fc_t* a_ptr = aVector;
+    const lv_32fc_t* b_ptr = bVector;
     unsigned int quarter_points = num_points / 4;
     float32x4x2_t a_val, b_val, c_val;
     float32x4x2_t tmp_real, tmp_imag;
     unsigned int number = 0;
 
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld2q_f32((float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
-        b_val = vld2q_f32((float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
+        a_val = vld2q_f32((const float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
+        b_val = vld2q_f32((const float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
         b_val.val[1] = vnegq_f32(b_val.val[1]);
         __VOLK_PREFETCH(a_ptr + 4);
         __VOLK_PREFETCH(b_ptr + 4);
@@ -302,8 +302,8 @@ static inline void volk_32fc_x2_multiply_conjugate_32fc_neonv8(lv_32fc_t* cVecto
     unsigned int number = 0;
 
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld2q_f32((float*)a_ptr);
-        b_val = vld2q_f32((float*)b_ptr);
+        a_val = vld2q_f32((const float*)a_ptr);
+        b_val = vld2q_f32((const float*)b_ptr);
         __VOLK_PREFETCH(a_ptr + 8);
         __VOLK_PREFETCH(b_ptr + 8);
 

--- a/kernels/volk/volk_32fc_x2_s32f_square_dist_scalar_mult_32f.h
+++ b/kernels/volk/volk_32fc_x2_s32f_square_dist_scalar_mult_32f.h
@@ -118,8 +118,8 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_avx2(float* target,
     const __m256i idx = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
 
     for (unsigned int i = 0; i < bound; ++i) {
-        xmm_points0 = _mm256_load_ps((float*)points);
-        xmm_points1 = _mm256_load_ps((float*)(points + 4));
+        xmm_points0 = _mm256_load_ps((const float*)points);
+        xmm_points1 = _mm256_load_ps((const float*)(points + 4));
         points += 8;
         __VOLK_PREFETCH(points);
 
@@ -131,7 +131,7 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_avx2(float* target,
     }
 
     if (num_bytes >> 5 & 1) {
-        xmm_points0 = _mm256_load_ps((float*)points);
+        xmm_points0 = _mm256_load_ps((const float*)points);
 
         xmm4 = _mm256_sub_ps(xmm_symbol, xmm_points0);
 
@@ -150,7 +150,7 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_avx2(float* target,
     }
 
     if (num_bytes >> 4 & 1) {
-        xmm9 = _mm_load_ps((float*)points);
+        xmm9 = _mm_load_ps((const float*)points);
 
         xmm10 = _mm_sub_ps(xmm128_symbol, xmm9);
 
@@ -195,8 +195,8 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_avx(float* target,
     const __m256 xmm_scalar = _mm256_broadcast_ss(&scalar);
 
     for (int i = 0; i < eightsPoints; ++i) {
-        xmm_points0 = _mm256_load_ps((float*)points);
-        xmm_points1 = _mm256_load_ps((float*)(points + 4));
+        xmm_points0 = _mm256_load_ps((const float*)points);
+        xmm_points1 = _mm256_load_ps((const float*)(points + 4));
         points += 8;
 
         xmm_result = _mm256_scaled_norm_dist_ps(
@@ -243,8 +243,8 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_sse3(float* target,
     const __m128 xmm_scalar = _mm_load1_ps(&scalar);
 
     for (int i = 0; i < quarterPoints; ++i) {
-        xmm_points0 = _mm_load_ps((float*)points);
-        xmm_points1 = _mm_load_ps((float*)(points + 2));
+        xmm_points0 = _mm_load_ps((const float*)points);
+        xmm_points1 = _mm_load_ps((const float*)(points + 2));
         points += 4;
         __VOLK_PREFETCH(points);
         // calculate distances
@@ -256,7 +256,7 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_sse3(float* target,
     }
 
     for (int i = 0; i < leftovers0; ++i) {
-        xmm_points0 = _mm_load_ps((float*)points);
+        xmm_points0 = _mm_load_ps((const float*)points);
         points += 2;
 
         xmm_points0 = _mm_sub_ps(xmm_symbol, xmm_points0);
@@ -287,8 +287,8 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_sse(float* target,
     const __m128 xmm_symbol = _mm_castpd_ps(_mm_load1_pd((const double*)src0));
 
     for (unsigned i = 0; i < num_points / 4; ++i) {
-        __m128 xmm_points0 = _mm_load_ps((float*)points);
-        __m128 xmm_points1 = _mm_load_ps((float*)(points + 2));
+        __m128 xmm_points0 = _mm_load_ps((const float*)points);
+        __m128 xmm_points1 = _mm_load_ps((const float*)(points + 2));
         points += 4;
         __m128 xmm_result = _mm_scaled_norm_dist_ps_sse(
             xmm_symbol, xmm_symbol, xmm_points0, xmm_points1, xmm_scalar);
@@ -449,8 +449,8 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_avx2(float* target,
     const __m256i idx = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
 
     for (unsigned int i = 0; i < bound; ++i) {
-        xmm_points0 = _mm256_loadu_ps((float*)points);
-        xmm_points1 = _mm256_loadu_ps((float*)(points + 4));
+        xmm_points0 = _mm256_loadu_ps((const float*)points);
+        xmm_points1 = _mm256_loadu_ps((const float*)(points + 4));
         points += 8;
         __VOLK_PREFETCH(points);
 
@@ -462,7 +462,7 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_avx2(float* target,
     }
 
     if (num_bytes >> 5 & 1) {
-        xmm_points0 = _mm256_loadu_ps((float*)points);
+        xmm_points0 = _mm256_loadu_ps((const float*)points);
 
         xmm4 = _mm256_sub_ps(xmm_symbol, xmm_points0);
 
@@ -481,7 +481,7 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_avx2(float* target,
     }
 
     if (num_bytes >> 4 & 1) {
-        xmm9 = _mm_loadu_ps((float*)points);
+        xmm9 = _mm_loadu_ps((const float*)points);
 
         xmm10 = _mm_sub_ps(xmm128_symbol, xmm9);
 
@@ -526,8 +526,8 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_avx(float* target,
     const __m256 xmm_scalar = _mm256_broadcast_ss(&scalar);
 
     for (int i = 0; i < eightsPoints; ++i) {
-        xmm_points0 = _mm256_loadu_ps((float*)points);
-        xmm_points1 = _mm256_loadu_ps((float*)(points + 4));
+        xmm_points0 = _mm256_loadu_ps((const float*)points);
+        xmm_points1 = _mm256_loadu_ps((const float*)(points + 4));
         points += 8;
 
         xmm_result = _mm256_scaled_norm_dist_ps(
@@ -574,8 +574,8 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_sse3(float* target,
     const __m128 xmm_scalar = _mm_load1_ps(&scalar);
 
     for (int i = 0; i < quarterPoints; ++i) {
-        xmm_points0 = _mm_loadu_ps((float*)points);
-        xmm_points1 = _mm_loadu_ps((float*)(points + 2));
+        xmm_points0 = _mm_loadu_ps((const float*)points);
+        xmm_points1 = _mm_loadu_ps((const float*)(points + 2));
         points += 4;
         __VOLK_PREFETCH(points);
         // calculate distances
@@ -587,7 +587,7 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_sse3(float* target,
     }
 
     for (int i = 0; i < leftovers0; ++i) {
-        xmm_points0 = _mm_loadu_ps((float*)points);
+        xmm_points0 = _mm_loadu_ps((const float*)points);
         points += 2;
 
         xmm_points0 = _mm_sub_ps(xmm_symbol, xmm_points0);
@@ -618,8 +618,8 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_sse(float* target,
     const __m128 xmm_symbol = _mm_castpd_ps(_mm_load1_pd((const double*)src0));
 
     for (unsigned i = 0; i < num_points / 4; ++i) {
-        __m128 xmm_points0 = _mm_loadu_ps((float*)points);
-        __m128 xmm_points1 = _mm_loadu_ps((float*)(points + 2));
+        __m128 xmm_points0 = _mm_loadu_ps((const float*)points);
+        __m128 xmm_points1 = _mm_loadu_ps((const float*)(points + 2));
         points += 4;
         __m128 xmm_result = _mm_scaled_norm_dist_ps_sse(
             xmm_symbol, xmm_symbol, xmm_points0, xmm_points1, xmm_scalar);

--- a/kernels/volk/volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc.h
+++ b/kernels/volk/volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc.h
@@ -142,8 +142,8 @@ volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_u_avx(lv_32fc_t* cVector,
     s = _mm256_loadu_ps((float*)v_scalar);
 
     for (; number < quarterPoints; number++) {
-        x = _mm256_loadu_ps((float*)b);
-        y = _mm256_loadu_ps((float*)a);
+        x = _mm256_loadu_ps((const float*)b);
+        y = _mm256_loadu_ps((const float*)a);
         z = _mm256_complexconjugatemul_ps(s, x);
         z = _mm256_add_ps(y, z);
         _mm256_storeu_ps((float*)c, z);
@@ -185,8 +185,8 @@ volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_u_sse3(lv_32fc_t* cVector,
     s = _mm_loadu_ps((float*)v_scalar);
 
     for (; number < halfPoints; number++) {
-        x = _mm_loadu_ps((float*)b);
-        y = _mm_loadu_ps((float*)a);
+        x = _mm_loadu_ps((const float*)b);
+        y = _mm_loadu_ps((const float*)a);
         z = _mm_complexconjugatemul_ps(s, x);
         z = _mm_add_ps(y, z);
         _mm_storeu_ps((float*)c, z);
@@ -230,8 +230,8 @@ volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_a_avx(lv_32fc_t* cVector,
     s = _mm256_loadu_ps((float*)v_scalar);
 
     for (; number < quarterPoints; number++) {
-        x = _mm256_load_ps((float*)b);
-        y = _mm256_load_ps((float*)a);
+        x = _mm256_load_ps((const float*)b);
+        y = _mm256_load_ps((const float*)a);
         z = _mm256_complexconjugatemul_ps(s, x);
         z = _mm256_add_ps(y, z);
         _mm256_store_ps((float*)c, z);
@@ -273,8 +273,8 @@ volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_a_sse3(lv_32fc_t* cVector,
     s = _mm_loadu_ps((float*)v_scalar);
 
     for (; number < halfPoints; number++) {
-        x = _mm_load_ps((float*)b);
-        y = _mm_load_ps((float*)a);
+        x = _mm_load_ps((const float*)b);
+        y = _mm_load_ps((const float*)a);
         z = _mm_complexconjugatemul_ps(s, x);
         z = _mm_add_ps(y, z);
         _mm_store_ps((float*)c, z);
@@ -314,8 +314,8 @@ volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_neon(lv_32fc_t* cVector,
     scalar_val.val[1] = vld1q_dup_f32(((const float*)scalar) + 1);
 
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld2q_f32((float*)aPtr);
-        b_val = vld2q_f32((float*)bPtr);
+        a_val = vld2q_f32((const float*)aPtr);
+        b_val = vld2q_f32((const float*)bPtr);
         b_val.val[1] = vnegq_f32(b_val.val[1]);
         __VOLK_PREFETCH(aPtr + 8);
         __VOLK_PREFETCH(bPtr + 8);
@@ -365,8 +365,8 @@ volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_neonv8(lv_32fc_t* cVector,
     float32x4_t scalar_imag = vdupq_n_f32(lv_cimag(*scalar));
 
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld2q_f32((float*)aPtr);
-        b_val = vld2q_f32((float*)bPtr);
+        a_val = vld2q_f32((const float*)aPtr);
+        b_val = vld2q_f32((const float*)bPtr);
         __VOLK_PREFETCH(aPtr + 8);
         __VOLK_PREFETCH(bPtr + 8);
 

--- a/kernels/volk/volk_32fc_x2_square_dist_32f.h
+++ b/kernels/volk/volk_32fc_x2_square_dist_32f.h
@@ -91,14 +91,14 @@ static inline void volk_32fc_x2_square_dist_32f_a_avx2(float* target,
 
     __m256i idx = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
     xmm1 = _mm256_setzero_ps();
-    xmm0 = _mm_load_ps((float*)src0);
+    xmm0 = _mm_load_ps((const float*)src0);
     xmm0 = _mm_permute_ps(xmm0, 0b01000100);
     xmm1 = _mm256_insertf128_ps(xmm1, xmm0, 0);
     xmm1 = _mm256_insertf128_ps(xmm1, xmm0, 1);
 
     for (; i < bound; ++i) {
-        xmm2 = _mm256_load_ps((float*)&points[0]);
-        xmm3 = _mm256_load_ps((float*)&points[4]);
+        xmm2 = _mm256_load_ps((const float*)&points[0]);
+        xmm3 = _mm256_load_ps((const float*)&points[4]);
         points += 8;
 
         xmm4 = _mm256_sub_ps(xmm1, xmm2);
@@ -116,7 +116,7 @@ static inline void volk_32fc_x2_square_dist_32f_a_avx2(float* target,
 
     for (i = 0; i < leftovers0; ++i) {
 
-        xmm2 = _mm256_load_ps((float*)&points[0]);
+        xmm2 = _mm256_load_ps((const float*)&points[0]);
 
         xmm4 = _mm256_sub_ps(xmm1, xmm2);
 
@@ -134,7 +134,7 @@ static inline void volk_32fc_x2_square_dist_32f_a_avx2(float* target,
     }
 
     for (i = 0; i < leftovers1; ++i) {
-        xmm9 = _mm_load_ps((float*)&points[0]);
+        xmm9 = _mm_load_ps((const float*)&points[0]);
 
         xmm10 = _mm_sub_ps(xmm0, xmm9);
 
@@ -180,13 +180,13 @@ static inline void volk_32fc_x2_square_dist_32f_a_sse3(float* target,
     int i = 0;
 
     xmm1 = _mm_setzero_ps();
-    xmm1 = _mm_loadl_pi(xmm1, (__m64*)src0);
+    xmm1 = _mm_loadl_pi(xmm1, (const __m64*)src0);
     xmm1 = _mm_movelh_ps(xmm1, xmm1);
 
     for (; i < bound; ++i) {
-        xmm2 = _mm_load_ps((float*)&points[0]);
+        xmm2 = _mm_load_ps((const float*)&points[0]);
         xmm4 = _mm_sub_ps(xmm1, xmm2);
-        xmm3 = _mm_load_ps((float*)&points[2]);
+        xmm3 = _mm_load_ps((const float*)&points[2]);
         xmm5 = _mm_sub_ps(xmm1, xmm3);
 
         xmm6 = _mm_mul_ps(xmm4, xmm4);
@@ -202,7 +202,7 @@ static inline void volk_32fc_x2_square_dist_32f_a_sse3(float* target,
 
     if (num_bytes >> 4 & 1) {
 
-        xmm2 = _mm_load_ps((float*)&points[0]);
+        xmm2 = _mm_load_ps((const float*)&points[0]);
 
         xmm4 = _mm_sub_ps(xmm1, xmm2);
 
@@ -246,7 +246,7 @@ static inline void volk_32fc_x2_square_dist_32f_neon(float* target,
     a_vec.val[0] = vdupq_n_f32(lv_creal(src0[0]));
     a_vec.val[1] = vdupq_n_f32(lv_cimag(src0[0]));
     for (number = 0; number < quarter_points; ++number) {
-        b_vec = vld2q_f32((float*)points);
+        b_vec = vld2q_f32((const float*)points);
         diff_vec.val[0] = vsubq_f32(a_vec.val[0], b_vec.val[0]);
         diff_vec.val[1] = vsubq_f32(a_vec.val[1], b_vec.val[1]);
         tmp = vmulq_f32(diff_vec.val[0], diff_vec.val[0]);
@@ -281,7 +281,7 @@ static inline void volk_32fc_x2_square_dist_32f_neonv8(float* target,
     float32x4_t a_imag = vdupq_n_f32(lv_cimag(src0[0]));
 
     for (number = 0; number < quarter_points; ++number) {
-        b_vec = vld2q_f32((float*)points);
+        b_vec = vld2q_f32((const float*)points);
         __VOLK_PREFETCH(points + 8);
 
         diff_real = vsubq_f32(a_real, b_vec.val[0]);
@@ -356,14 +356,14 @@ static inline void volk_32fc_x2_square_dist_32f_u_avx2(float* target,
 
     __m256i idx = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
     xmm1 = _mm256_setzero_ps();
-    xmm0 = _mm_loadu_ps((float*)src0);
+    xmm0 = _mm_loadu_ps((const float*)src0);
     xmm0 = _mm_permute_ps(xmm0, 0b01000100);
     xmm1 = _mm256_insertf128_ps(xmm1, xmm0, 0);
     xmm1 = _mm256_insertf128_ps(xmm1, xmm0, 1);
 
     for (; i < bound; ++i) {
-        xmm2 = _mm256_loadu_ps((float*)&points[0]);
-        xmm3 = _mm256_loadu_ps((float*)&points[4]);
+        xmm2 = _mm256_loadu_ps((const float*)&points[0]);
+        xmm3 = _mm256_loadu_ps((const float*)&points[4]);
         points += 8;
 
         xmm4 = _mm256_sub_ps(xmm1, xmm2);
@@ -381,7 +381,7 @@ static inline void volk_32fc_x2_square_dist_32f_u_avx2(float* target,
 
     if (num_bytes >> 5 & 1) {
 
-        xmm2 = _mm256_loadu_ps((float*)&points[0]);
+        xmm2 = _mm256_loadu_ps((const float*)&points[0]);
 
         xmm4 = _mm256_sub_ps(xmm1, xmm2);
 

--- a/kernels/volk/volk_32i_s32f_convert_32f.h
+++ b/kernels/volk/volk_32i_s32f_convert_32f.h
@@ -68,13 +68,13 @@ static inline void volk_32i_s32f_convert_32f_u_avx512f(float* outputVector,
     float* outputVectorPtr = outputVector;
     const float iScalar = 1.0 / scalar;
     __m512 invScalar = _mm512_set1_ps(iScalar);
-    int32_t* inputPtr = (int32_t*)inputVector;
+    const int32_t* inputPtr = (const int32_t*)inputVector;
     __m512i inputVal;
     __m512 ret;
 
     for (; number < onesixteenthPoints; number++) {
         // Load the values
-        inputVal = _mm512_loadu_si512((__m512i*)inputPtr);
+        inputVal = _mm512_loadu_si512((const __m512i*)inputPtr);
 
         ret = _mm512_cvtepi32_ps(inputVal);
         ret = _mm512_mul_ps(ret, invScalar);
@@ -107,13 +107,13 @@ static inline void volk_32i_s32f_convert_32f_u_avx2(float* outputVector,
     float* outputVectorPtr = outputVector;
     const float iScalar = 1.0 / scalar;
     __m256 invScalar = _mm256_set1_ps(iScalar);
-    int32_t* inputPtr = (int32_t*)inputVector;
+    const int32_t* inputPtr = (const int32_t*)inputVector;
     __m256i inputVal;
     __m256 ret;
 
     for (; number < oneEightPoints; number++) {
         // Load the 4 values
-        inputVal = _mm256_loadu_si256((__m256i*)inputPtr);
+        inputVal = _mm256_loadu_si256((const __m256i*)inputPtr);
 
         ret = _mm256_cvtepi32_ps(inputVal);
         ret = _mm256_mul_ps(ret, invScalar);
@@ -146,13 +146,13 @@ static inline void volk_32i_s32f_convert_32f_u_sse2(float* outputVector,
     float* outputVectorPtr = outputVector;
     const float iScalar = 1.0 / scalar;
     __m128 invScalar = _mm_set_ps1(iScalar);
-    int32_t* inputPtr = (int32_t*)inputVector;
+    const int32_t* inputPtr = (const int32_t*)inputVector;
     __m128i inputVal;
     __m128 ret;
 
     for (; number < quarterPoints; number++) {
         // Load the 4 values
-        inputVal = _mm_loadu_si128((__m128i*)inputPtr);
+        inputVal = _mm_loadu_si128((const __m128i*)inputPtr);
 
         ret = _mm_cvtepi32_ps(inputVal);
         ret = _mm_mul_ps(ret, invScalar);
@@ -212,13 +212,13 @@ static inline void volk_32i_s32f_convert_32f_a_avx512f(float* outputVector,
     float* outputVectorPtr = outputVector;
     const float iScalar = 1.0 / scalar;
     __m512 invScalar = _mm512_set1_ps(iScalar);
-    int32_t* inputPtr = (int32_t*)inputVector;
+    const int32_t* inputPtr = (const int32_t*)inputVector;
     __m512i inputVal;
     __m512 ret;
 
     for (; number < onesixteenthPoints; number++) {
         // Load the values
-        inputVal = _mm512_load_si512((__m512i*)inputPtr);
+        inputVal = _mm512_load_si512((const __m512i*)inputPtr);
 
         ret = _mm512_cvtepi32_ps(inputVal);
         ret = _mm512_mul_ps(ret, invScalar);
@@ -250,13 +250,13 @@ static inline void volk_32i_s32f_convert_32f_a_avx2(float* outputVector,
     float* outputVectorPtr = outputVector;
     const float iScalar = 1.0 / scalar;
     __m256 invScalar = _mm256_set1_ps(iScalar);
-    int32_t* inputPtr = (int32_t*)inputVector;
+    const int32_t* inputPtr = (const int32_t*)inputVector;
     __m256i inputVal;
     __m256 ret;
 
     for (; number < oneEightPoints; number++) {
         // Load the 4 values
-        inputVal = _mm256_load_si256((__m256i*)inputPtr);
+        inputVal = _mm256_load_si256((const __m256i*)inputPtr);
 
         ret = _mm256_cvtepi32_ps(inputVal);
         ret = _mm256_mul_ps(ret, invScalar);
@@ -289,13 +289,13 @@ static inline void volk_32i_s32f_convert_32f_a_sse2(float* outputVector,
     float* outputVectorPtr = outputVector;
     const float iScalar = 1.0 / scalar;
     __m128 invScalar = _mm_set_ps1(iScalar);
-    int32_t* inputPtr = (int32_t*)inputVector;
+    const int32_t* inputPtr = (const int32_t*)inputVector;
     __m128i inputVal;
     __m128 ret;
 
     for (; number < quarterPoints; number++) {
         // Load the 4 values
-        inputVal = _mm_load_si128((__m128i*)inputPtr);
+        inputVal = _mm_load_si128((const __m128i*)inputPtr);
 
         ret = _mm_cvtepi32_ps(inputVal);
         ret = _mm_mul_ps(ret, invScalar);

--- a/kernels/volk/volk_32i_x2_and_32i.h
+++ b/kernels/volk/volk_32i_x2_and_32i.h
@@ -83,8 +83,8 @@ static inline void volk_32i_x2_and_32i_a_avx512f(int32_t* cVector,
     const unsigned int sixteenthPoints = num_points / 16;
 
     int32_t* cPtr = (int32_t*)cVector;
-    const int32_t* aPtr = (int32_t*)aVector;
-    const int32_t* bPtr = (int32_t*)bVector;
+    const int32_t* aPtr = aVector;
+    const int32_t* bPtr = bVector;
 
     __m512i aVal, bVal, cVal;
     for (; number < sixteenthPoints; number++) {
@@ -126,8 +126,8 @@ static inline void volk_32i_x2_and_32i_a_avx2(int32_t* cVector,
     __m256i aVal, bVal, cVal;
     for (; number < oneEightPoints; number++) {
 
-        aVal = _mm256_load_si256((__m256i*)aPtr);
-        bVal = _mm256_load_si256((__m256i*)bPtr);
+        aVal = _mm256_load_si256((const __m256i*)aPtr);
+        bVal = _mm256_load_si256((const __m256i*)bPtr);
 
         cVal = _mm256_and_si256(aVal, bVal);
 
@@ -159,8 +159,8 @@ static inline void volk_32i_x2_and_32i_a_sse(int32_t* cVector,
     const unsigned int quarterPoints = num_points / 4;
 
     float* cPtr = (float*)cVector;
-    const float* aPtr = (float*)aVector;
-    const float* bPtr = (float*)bVector;
+    const float* aPtr = (const float*)aVector;
+    const float* bPtr = (const float*)bVector;
 
     __m128 aVal, bVal, cVal;
     for (; number < quarterPoints; number++) {
@@ -310,8 +310,8 @@ static inline void volk_32i_x2_and_32i_u_avx512f(int32_t* cVector,
     const unsigned int sixteenthPoints = num_points / 16;
 
     int32_t* cPtr = (int32_t*)cVector;
-    const int32_t* aPtr = (int32_t*)aVector;
-    const int32_t* bPtr = (int32_t*)bVector;
+    const int32_t* aPtr = aVector;
+    const int32_t* bPtr = bVector;
 
     __m512i aVal, bVal, cVal;
     for (; number < sixteenthPoints; number++) {
@@ -353,8 +353,8 @@ static inline void volk_32i_x2_and_32i_u_avx2(int32_t* cVector,
     __m256i aVal, bVal, cVal;
     for (; number < oneEightPoints; number++) {
 
-        aVal = _mm256_loadu_si256((__m256i*)aPtr);
-        bVal = _mm256_loadu_si256((__m256i*)bPtr);
+        aVal = _mm256_loadu_si256((const __m256i*)aPtr);
+        bVal = _mm256_loadu_si256((const __m256i*)bPtr);
 
         cVal = _mm256_and_si256(aVal, bVal);
 

--- a/kernels/volk/volk_32i_x2_or_32i.h
+++ b/kernels/volk/volk_32i_x2_or_32i.h
@@ -83,8 +83,8 @@ static inline void volk_32i_x2_or_32i_a_avx512f(int32_t* cVector,
     const unsigned int sixteenthPoints = num_points / 16;
 
     int32_t* cPtr = (int32_t*)cVector;
-    const int32_t* aPtr = (int32_t*)aVector;
-    const int32_t* bPtr = (int32_t*)bVector;
+    const int32_t* aPtr = aVector;
+    const int32_t* bPtr = bVector;
 
     __m512i aVal, bVal, cVal;
     for (; number < sixteenthPoints; number++) {
@@ -126,8 +126,8 @@ static inline void volk_32i_x2_or_32i_a_avx2(int32_t* cVector,
     __m256i aVal, bVal, cVal;
     for (; number < oneEightPoints; number++) {
 
-        aVal = _mm256_load_si256((__m256i*)aPtr);
-        bVal = _mm256_load_si256((__m256i*)bPtr);
+        aVal = _mm256_load_si256((const __m256i*)aPtr);
+        bVal = _mm256_load_si256((const __m256i*)bPtr);
 
         cVal = _mm256_or_si256(aVal, bVal);
 
@@ -159,8 +159,8 @@ static inline void volk_32i_x2_or_32i_a_sse(int32_t* cVector,
     const unsigned int quarterPoints = num_points / 4;
 
     float* cPtr = (float*)cVector;
-    const float* aPtr = (float*)aVector;
-    const float* bPtr = (float*)bVector;
+    const float* aPtr = (const float*)aVector;
+    const float* bPtr = (const float*)bVector;
 
     __m128 aVal, bVal, cVal;
     for (; number < quarterPoints; number++) {
@@ -309,8 +309,8 @@ static inline void volk_32i_x2_or_32i_u_avx512f(int32_t* cVector,
     const unsigned int sixteenthPoints = num_points / 16;
 
     int32_t* cPtr = (int32_t*)cVector;
-    const int32_t* aPtr = (int32_t*)aVector;
-    const int32_t* bPtr = (int32_t*)bVector;
+    const int32_t* aPtr = aVector;
+    const int32_t* bPtr = bVector;
 
     __m512i aVal, bVal, cVal;
     for (; number < sixteenthPoints; number++) {
@@ -352,8 +352,8 @@ static inline void volk_32i_x2_or_32i_u_avx2(int32_t* cVector,
     __m256i aVal, bVal, cVal;
     for (; number < oneEightPoints; number++) {
 
-        aVal = _mm256_loadu_si256((__m256i*)aPtr);
-        bVal = _mm256_loadu_si256((__m256i*)bPtr);
+        aVal = _mm256_loadu_si256((const __m256i*)aPtr);
+        bVal = _mm256_loadu_si256((const __m256i*)bPtr);
 
         cVal = _mm256_or_si256(aVal, bVal);
 

--- a/kernels/volk/volk_64u_popcnt.h
+++ b/kernels/volk/volk_64u_popcnt.h
@@ -105,7 +105,7 @@ static inline void volk_64u_popcnt_neon(uint64_t* ret, const uint64_t value)
     uint32x2_t count32x2_val;
     uint64x1_t count64x1_val;
 
-    input_val = vld1_u8((unsigned char*)&value);
+    input_val = vld1_u8((const unsigned char*)&value);
     count8x8_val = vcnt_u8(input_val);
     count16x4_val = vpaddl_u8(count8x8_val);
     count32x2_val = vpaddl_u16(count16x4_val);

--- a/kernels/volk/volk_8i_s32f_convert_32f.h
+++ b/kernels/volk/volk_8i_s32f_convert_32f.h
@@ -64,7 +64,7 @@ static inline void volk_8i_s32f_convert_32f_u_avx2(float* outputVector,
     __m256i interimVal;
 
     for (; number < sixteenthPoints; number++) {
-        inputVal128 = _mm_loadu_si128((__m128i*)inputVectorPtr);
+        inputVal128 = _mm_loadu_si128((const __m128i*)inputVectorPtr);
 
         interimVal = _mm256_cvtepi8_epi32(inputVal128);
         ret = _mm256_cvtepi32_ps(interimVal);
@@ -109,7 +109,7 @@ static inline void volk_8i_s32f_convert_32f_u_avx512(float* outputVector,
     __m512i interimVal;
 
     for (; number < sixteenthPoints; number++) {
-        inputVal128 = _mm_loadu_si128((__m128i*)inputVectorPtr);
+        inputVal128 = _mm_loadu_si128((const __m128i*)inputVectorPtr);
 
         interimVal = _mm512_cvtepi8_epi32(inputVal128);
         ret = _mm512_cvtepi32_ps(interimVal);
@@ -148,7 +148,7 @@ static inline void volk_8i_s32f_convert_32f_u_sse4_1(float* outputVector,
     __m128i interimVal;
 
     for (; number < sixteenthPoints; number++) {
-        inputVal = _mm_loadu_si128((__m128i*)inputVectorPtr);
+        inputVal = _mm_loadu_si128((const __m128i*)inputVectorPtr);
 
         interimVal = _mm_cvtepi8_epi32(inputVal);
         ret = _mm_cvtepi32_ps(interimVal);
@@ -234,7 +234,7 @@ static inline void volk_8i_s32f_convert_32f_a_avx2(float* outputVector,
     __m256i interimVal;
 
     for (; number < sixteenthPoints; number++) {
-        inputVal128 = _mm_load_si128((__m128i*)inputVectorPtr);
+        inputVal128 = _mm_load_si128((const __m128i*)inputVectorPtr);
 
         interimVal = _mm256_cvtepi8_epi32(inputVal128);
         ret = _mm256_cvtepi32_ps(interimVal);
@@ -279,7 +279,7 @@ static inline void volk_8i_s32f_convert_32f_a_avx512(float* outputVector,
     __m512i interimVal;
 
     for (; number < sixteenthPoints; number++) {
-        inputVal128 = _mm_load_si128((__m128i*)inputVectorPtr);
+        inputVal128 = _mm_load_si128((const __m128i*)inputVectorPtr);
 
         interimVal = _mm512_cvtepi8_epi32(inputVal128);
         ret = _mm512_cvtepi32_ps(interimVal);
@@ -317,7 +317,7 @@ static inline void volk_8i_s32f_convert_32f_a_sse4_1(float* outputVector,
     __m128i interimVal;
 
     for (; number < sixteenthPoints; number++) {
-        inputVal = _mm_load_si128((__m128i*)inputVectorPtr);
+        inputVal = _mm_load_si128((const __m128i*)inputVectorPtr);
 
         interimVal = _mm_cvtepi8_epi32(inputVal);
         ret = _mm_cvtepi32_ps(interimVal);

--- a/kernels/volk/volk_8ic_deinterleave_16i_x2.h
+++ b/kernels/volk/volk_8ic_deinterleave_16i_x2.h
@@ -53,7 +53,7 @@ static inline void volk_8ic_deinterleave_16i_x2_a_avx2(int16_t* iBuffer,
                                                        unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     int16_t* qBufferPtr = qBuffer;
     __m256i MoveMask = _mm256_set_epi8(15,
@@ -94,7 +94,7 @@ static inline void volk_8ic_deinterleave_16i_x2_a_avx2(int16_t* iBuffer,
     unsigned int sixteenthPoints = num_points / 16;
 
     for (number = 0; number < sixteenthPoints; number++) {
-        complexVal = _mm256_load_si256((__m256i*)complexVectorPtr);
+        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
 
         complexVal = _mm256_shuffle_epi8(complexVal, MoveMask);
@@ -135,7 +135,7 @@ static inline void volk_8ic_deinterleave_16i_x2_a_sse4_1(int16_t* iBuffer,
                                                          unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     int16_t* qBufferPtr = qBuffer;
     __m128i iMoveMask = _mm_set_epi8(0x80,
@@ -161,7 +161,7 @@ static inline void volk_8ic_deinterleave_16i_x2_a_sse4_1(int16_t* iBuffer,
     unsigned int eighthPoints = num_points / 8;
 
     for (number = 0; number < eighthPoints; number++) {
-        complexVal = _mm_load_si128((__m128i*)complexVectorPtr);
+        complexVal = _mm_load_si128((const __m128i*)complexVectorPtr);
         complexVectorPtr += 16; // aligned load
 
         iOutputVal = _mm_shuffle_epi8(complexVal,
@@ -204,7 +204,7 @@ static inline void volk_8ic_deinterleave_16i_x2_a_avx(int16_t* iBuffer,
                                                       unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     int16_t* qBufferPtr = qBuffer;
     __m128i iMoveMask = _mm_set_epi8(0x80,
@@ -232,7 +232,7 @@ static inline void volk_8ic_deinterleave_16i_x2_a_avx(int16_t* iBuffer,
     unsigned int sixteenthPoints = num_points / 16;
 
     for (number = 0; number < sixteenthPoints; number++) {
-        complexVal = _mm256_load_si256((__m256i*)complexVectorPtr);
+        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32; // aligned load
 
         // Extract from complexVal to iOutputVal and qOutputVal
@@ -320,7 +320,7 @@ static inline void volk_8ic_deinterleave_16i_x2_u_avx2(int16_t* iBuffer,
                                                        unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     int16_t* qBufferPtr = qBuffer;
     __m256i MoveMask = _mm256_set_epi8(15,
@@ -361,7 +361,7 @@ static inline void volk_8ic_deinterleave_16i_x2_u_avx2(int16_t* iBuffer,
     unsigned int sixteenthPoints = num_points / 16;
 
     for (number = 0; number < sixteenthPoints; number++) {
-        complexVal = _mm256_loadu_si256((__m256i*)complexVectorPtr);
+        complexVal = _mm256_loadu_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
 
         complexVal = _mm256_shuffle_epi8(complexVal, MoveMask);

--- a/kernels/volk/volk_8ic_deinterleave_real_16i.h
+++ b/kernels/volk/volk_8ic_deinterleave_real_16i.h
@@ -52,7 +52,7 @@ static inline void volk_8ic_deinterleave_real_16i_a_avx2(int16_t* iBuffer,
                                                          unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     __m256i moveMask = _mm256_set_epi8(0x80,
                                        0x80,
@@ -92,7 +92,7 @@ static inline void volk_8ic_deinterleave_real_16i_a_avx2(int16_t* iBuffer,
     unsigned int sixteenthPoints = num_points / 16;
 
     for (number = 0; number < sixteenthPoints; number++) {
-        complexVal = _mm256_load_si256((__m256i*)complexVectorPtr);
+        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
 
         complexVal = _mm256_shuffle_epi8(complexVal, moveMask);
@@ -124,7 +124,7 @@ static inline void volk_8ic_deinterleave_real_16i_a_sse4_1(int16_t* iBuffer,
                                                            unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     __m128i moveMask = _mm_set_epi8(
         0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
@@ -133,7 +133,7 @@ static inline void volk_8ic_deinterleave_real_16i_a_sse4_1(int16_t* iBuffer,
     unsigned int eighthPoints = num_points / 8;
 
     for (number = 0; number < eighthPoints; number++) {
-        complexVal = _mm_load_si128((__m128i*)complexVectorPtr);
+        complexVal = _mm_load_si128((const __m128i*)complexVectorPtr);
         complexVectorPtr += 16;
 
         complexVal = _mm_shuffle_epi8(complexVal, moveMask);
@@ -162,7 +162,7 @@ static inline void volk_8ic_deinterleave_real_16i_a_avx(int16_t* iBuffer,
                                                         unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     __m128i moveMask = _mm_set_epi8(
         0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
@@ -172,7 +172,7 @@ static inline void volk_8ic_deinterleave_real_16i_a_avx(int16_t* iBuffer,
     unsigned int sixteenthPoints = num_points / 16;
 
     for (number = 0; number < sixteenthPoints; number++) {
-        complexVal = _mm256_load_si256((__m256i*)complexVectorPtr);
+        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
 
         complexVal1 = _mm256_extractf128_si256(complexVal, 1);
@@ -237,7 +237,7 @@ static inline void volk_8ic_deinterleave_real_16i_u_avx2(int16_t* iBuffer,
                                                          unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     __m256i moveMask = _mm256_set_epi8(0x80,
                                        0x80,
@@ -277,7 +277,7 @@ static inline void volk_8ic_deinterleave_real_16i_u_avx2(int16_t* iBuffer,
     unsigned int sixteenthPoints = num_points / 16;
 
     for (number = 0; number < sixteenthPoints; number++) {
-        complexVal = _mm256_loadu_si256((__m256i*)complexVectorPtr);
+        complexVal = _mm256_loadu_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
 
         complexVal = _mm256_shuffle_epi8(complexVal, moveMask);

--- a/kernels/volk/volk_8ic_deinterleave_real_8i.h
+++ b/kernels/volk/volk_8ic_deinterleave_real_8i.h
@@ -51,7 +51,7 @@ static inline void volk_8ic_deinterleave_real_8i_a_avx2(int8_t* iBuffer,
                                                         unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int8_t* iBufferPtr = iBuffer;
     __m256i moveMask1 = _mm256_set_epi8(0x80,
                                         0x80,
@@ -123,9 +123,9 @@ static inline void volk_8ic_deinterleave_real_8i_a_avx2(int8_t* iBuffer,
 
     for (number = 0; number < thirtysecondPoints; number++) {
 
-        complexVal1 = _mm256_load_si256((__m256i*)complexVectorPtr);
+        complexVal1 = _mm256_load_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
-        complexVal2 = _mm256_load_si256((__m256i*)complexVectorPtr);
+        complexVal2 = _mm256_load_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
 
         complexVal1 = _mm256_shuffle_epi8(complexVal1, moveMask1);
@@ -154,7 +154,7 @@ static inline void volk_8ic_deinterleave_real_8i_a_ssse3(int8_t* iBuffer,
                                                          unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int8_t* iBufferPtr = iBuffer;
     __m128i moveMask1 = _mm_set_epi8(
         0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
@@ -165,9 +165,9 @@ static inline void volk_8ic_deinterleave_real_8i_a_ssse3(int8_t* iBuffer,
     unsigned int sixteenthPoints = num_points / 16;
 
     for (number = 0; number < sixteenthPoints; number++) {
-        complexVal1 = _mm_load_si128((__m128i*)complexVectorPtr);
+        complexVal1 = _mm_load_si128((const __m128i*)complexVectorPtr);
         complexVectorPtr += 16;
-        complexVal2 = _mm_load_si128((__m128i*)complexVectorPtr);
+        complexVal2 = _mm_load_si128((const __m128i*)complexVectorPtr);
         complexVectorPtr += 16;
 
         complexVal1 = _mm_shuffle_epi8(complexVal1, moveMask1);
@@ -196,7 +196,7 @@ static inline void volk_8ic_deinterleave_real_8i_a_avx(int8_t* iBuffer,
                                                        unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int8_t* iBufferPtr = iBuffer;
     __m128i moveMaskL = _mm_set_epi8(
         0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
@@ -210,9 +210,9 @@ static inline void volk_8ic_deinterleave_real_8i_a_avx(int8_t* iBuffer,
 
     for (number = 0; number < thirtysecondPoints; number++) {
 
-        complexVal1 = _mm256_load_si256((__m256i*)complexVectorPtr);
+        complexVal1 = _mm256_load_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
-        complexVal2 = _mm256_load_si256((__m256i*)complexVectorPtr);
+        complexVal2 = _mm256_load_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
 
         complexVal1H = _mm256_extractf128_si256(complexVal1, 1);
@@ -254,7 +254,7 @@ static inline void volk_8ic_deinterleave_real_8i_generic(int8_t* iBuffer,
                                                          unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int8_t* iBufferPtr = iBuffer;
     for (number = 0; number < num_points; number++) {
         *iBufferPtr++ = *complexVectorPtr++;
@@ -276,13 +276,13 @@ static inline void volk_8ic_deinterleave_real_8i_neon(int8_t* iBuffer,
 
     int8x16x2_t input_vector;
     for (number = 0; number < sixteenth_points; ++number) {
-        input_vector = vld2q_s8((int8_t*)complexVector);
+        input_vector = vld2q_s8((const int8_t*)complexVector);
         vst1q_s8(iBuffer, input_vector.val[0]);
         iBuffer += 16;
         complexVector += 16;
     }
 
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int8_t* iBufferPtr = iBuffer;
     for (number = sixteenth_points * 16; number < num_points; number++) {
         *iBufferPtr++ = *complexVectorPtr++;
@@ -337,7 +337,7 @@ static inline void volk_8ic_deinterleave_real_8i_u_avx2(int8_t* iBuffer,
                                                         unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int8_t* iBufferPtr = iBuffer;
     __m256i moveMask1 = _mm256_set_epi8(0x80,
                                         0x80,
@@ -409,9 +409,9 @@ static inline void volk_8ic_deinterleave_real_8i_u_avx2(int8_t* iBuffer,
 
     for (number = 0; number < thirtysecondPoints; number++) {
 
-        complexVal1 = _mm256_loadu_si256((__m256i*)complexVectorPtr);
+        complexVal1 = _mm256_loadu_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
-        complexVal2 = _mm256_loadu_si256((__m256i*)complexVectorPtr);
+        complexVal2 = _mm256_loadu_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
 
         complexVal1 = _mm256_shuffle_epi8(complexVal1, moveMask1);

--- a/kernels/volk/volk_8ic_s32f_deinterleave_32f_x2.h
+++ b/kernels/volk/volk_8ic_s32f_deinterleave_32f_x2.h
@@ -68,7 +68,7 @@ volk_8ic_s32f_deinterleave_32f_x2_a_sse4_1(float* iBuffer,
     const float iScalar = 1.0 / scalar;
     __m128 invScalar = _mm_set_ps1(iScalar);
     __m128i complexVal, iIntVal, qIntVal, iComplexVal, qComplexVal;
-    int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
 
     __m128i iMoveMask = _mm_set_epi8(
         0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
@@ -76,7 +76,7 @@ volk_8ic_s32f_deinterleave_32f_x2_a_sse4_1(float* iBuffer,
         0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 15, 13, 11, 9, 7, 5, 3, 1);
 
     for (; number < eighthPoints; number++) {
-        complexVal = _mm_load_si128((__m128i*)complexVectorPtr);
+        complexVal = _mm_load_si128((const __m128i*)complexVectorPtr);
         complexVectorPtr += 16;
         iComplexVal = _mm_shuffle_epi8(complexVal, iMoveMask);
         qComplexVal = _mm_shuffle_epi8(complexVal, qMoveMask);
@@ -137,7 +137,7 @@ static inline void volk_8ic_s32f_deinterleave_32f_x2_a_sse(float* iBuffer,
     __m128 cplxValue1, cplxValue2, iValue, qValue;
 
     __m128 invScalar = _mm_set_ps1(1.0 / scalar);
-    int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
 
     __VOLK_ATTR_ALIGNED(16) float floatBuffer[8];
 
@@ -172,7 +172,7 @@ static inline void volk_8ic_s32f_deinterleave_32f_x2_a_sse(float* iBuffer,
     }
 
     number = quarterPoints * 4;
-    complexVectorPtr = (int8_t*)&complexVector[number];
+    complexVectorPtr = (const int8_t*)&complexVector[number];
     for (; number < num_points; number++) {
         *iBufferPtr++ = (float)(*complexVectorPtr++) / scalar;
         *qBufferPtr++ = (float)(*complexVectorPtr++) / scalar;
@@ -200,7 +200,7 @@ static inline void volk_8ic_s32f_deinterleave_32f_x2_a_avx2(float* iBuffer,
     const float iScalar = 1.0 / scalar;
     __m256 invScalar = _mm256_set1_ps(iScalar);
     __m256i complexVal, iIntVal, qIntVal, iComplexVal, qComplexVal;
-    int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
 
     __m256i iMoveMask = _mm256_set_epi8(0x80,
                                         0x80,
@@ -268,7 +268,7 @@ static inline void volk_8ic_s32f_deinterleave_32f_x2_a_avx2(float* iBuffer,
                                         1);
 
     for (; number < sixteenthPoints; number++) {
-        complexVal = _mm256_load_si256((__m256i*)complexVectorPtr);
+        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
         iComplexVal = _mm256_shuffle_epi8(complexVal, iMoveMask);
         qComplexVal = _mm256_shuffle_epi8(complexVal, qMoveMask);
@@ -361,7 +361,7 @@ static inline void volk_8ic_s32f_deinterleave_32f_x2_u_avx2(float* iBuffer,
     __m256 invScalar = _mm256_set1_ps(iScalar);
     __m256i complexVal, iIntVal, qIntVal;
     __m128i iComplexVal, qComplexVal;
-    int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
 
     __m256i MoveMask = _mm256_set_epi8(15,
                                        13,
@@ -397,7 +397,7 @@ static inline void volk_8ic_s32f_deinterleave_32f_x2_u_avx2(float* iBuffer,
                                        0);
 
     for (; number < sixteenthPoints; number++) {
-        complexVal = _mm256_loadu_si256((__m256i*)complexVectorPtr);
+        complexVal = _mm256_loadu_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
         complexVal = _mm256_shuffle_epi8(complexVal, MoveMask);
         complexVal = _mm256_permute4x64_epi64(complexVal, 0xd8);

--- a/kernels/volk/volk_8ic_s32f_deinterleave_real_32f.h
+++ b/kernels/volk/volk_8ic_s32f_deinterleave_real_32f.h
@@ -64,7 +64,7 @@ volk_8ic_s32f_deinterleave_real_32f_a_avx2(float* iBuffer,
     const float iScalar = 1.0 / scalar;
     __m256 invScalar = _mm256_set1_ps(iScalar);
     __m256i complexVal, iIntVal;
-    int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
 
     __m256i moveMask = _mm256_set_epi8(0x80,
                                        0x80,
@@ -99,7 +99,7 @@ volk_8ic_s32f_deinterleave_real_32f_a_avx2(float* iBuffer,
                                        2,
                                        0);
     for (; number < sixteenthPoints; number++) {
-        complexVal = _mm256_load_si256((__m256i*)complexVectorPtr);
+        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
         complexVal = _mm256_shuffle_epi8(complexVal, moveMask);
 
@@ -144,13 +144,13 @@ volk_8ic_s32f_deinterleave_real_32f_a_sse4_1(float* iBuffer,
     const float iScalar = 1.0 / scalar;
     __m128 invScalar = _mm_set_ps1(iScalar);
     __m128i complexVal, iIntVal;
-    int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
 
     __m128i moveMask = _mm_set_epi8(
         0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
 
     for (; number < eighthPoints; number++) {
-        complexVal = _mm_load_si128((__m128i*)complexVectorPtr);
+        complexVal = _mm_load_si128((const __m128i*)complexVectorPtr);
         complexVectorPtr += 16;
         complexVal = _mm_shuffle_epi8(complexVal, moveMask);
 
@@ -200,7 +200,7 @@ volk_8ic_s32f_deinterleave_real_32f_a_sse(float* iBuffer,
 
     const float iScalar = 1.0 / scalar;
     __m128 invScalar = _mm_set_ps1(iScalar);
-    int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
 
     __VOLK_ATTR_ALIGNED(16) float floatBuffer[4];
 
@@ -280,7 +280,7 @@ volk_8ic_s32f_deinterleave_real_32f_u_avx2(float* iBuffer,
     __m256 invScalar = _mm256_set1_ps(iScalar);
     __m256i complexVal, iIntVal;
     __m128i hcomplexVal;
-    int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
 
     __m256i moveMask = _mm256_set_epi8(0x80,
                                        0x80,
@@ -316,7 +316,7 @@ volk_8ic_s32f_deinterleave_real_32f_u_avx2(float* iBuffer,
                                        0);
 
     for (; number < sixteenthPoints; number++) {
-        complexVal = _mm256_loadu_si256((__m256i*)complexVectorPtr);
+        complexVal = _mm256_loadu_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
         complexVal = _mm256_shuffle_epi8(complexVal, moveMask);
 

--- a/kernels/volk/volk_8ic_x2_multiply_conjugate_16ic.h
+++ b/kernels/volk/volk_8ic_x2_multiply_conjugate_16ic.h
@@ -42,8 +42,8 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_a_avx2(lv_16sc_t* cVector
 
     for (; number < quarterPoints; number++) {
         // Convert 8 bit values into 16 bit values
-        x = _mm256_cvtepi8_epi16(_mm_load_si128((__m128i*)a));
-        y = _mm256_cvtepi8_epi16(_mm_load_si128((__m128i*)b));
+        x = _mm256_cvtepi8_epi16(_mm_load_si128((const __m128i*)a));
+        y = _mm256_cvtepi8_epi16(_mm_load_si128((const __m128i*)b));
 
         // Calculate the ar*cr - ai*(-ci) portions
         realz = _mm256_madd_epi16(x, y);
@@ -71,8 +71,8 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_a_avx2(lv_16sc_t* cVector
 
     number = quarterPoints * 8;
     int16_t* c16Ptr = (int16_t*)&cVector[number];
-    int8_t* a8Ptr = (int8_t*)&aVector[number];
-    int8_t* b8Ptr = (int8_t*)&bVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
     for (; number < num_points; number++) {
         float aReal = (float)*a8Ptr++;
         float aImag = (float)*a8Ptr++;
@@ -115,8 +115,8 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_a_sse4_1(lv_16sc_t* cVect
 
     for (; number < quarterPoints; number++) {
         // Convert into 8 bit values into 16 bit values
-        x = _mm_cvtepi8_epi16(_mm_loadl_epi64((__m128i*)a));
-        y = _mm_cvtepi8_epi16(_mm_loadl_epi64((__m128i*)b));
+        x = _mm_cvtepi8_epi16(_mm_loadl_epi64((const __m128i*)a));
+        y = _mm_cvtepi8_epi16(_mm_loadl_epi64((const __m128i*)b));
 
         // Calculate the ar*cr - ai*(-ci) portions
         realz = _mm_madd_epi16(x, y);
@@ -142,8 +142,8 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_a_sse4_1(lv_16sc_t* cVect
 
     number = quarterPoints * 4;
     int16_t* c16Ptr = (int16_t*)&cVector[number];
-    int8_t* a8Ptr = (int8_t*)&aVector[number];
-    int8_t* b8Ptr = (int8_t*)&bVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
     for (; number < num_points; number++) {
         float aReal = (float)*a8Ptr++;
         float aImag = (float)*a8Ptr++;
@@ -175,8 +175,8 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_generic(lv_16sc_t* cVecto
 {
     unsigned int number = 0;
     int16_t* c16Ptr = (int16_t*)cVector;
-    int8_t* a8Ptr = (int8_t*)aVector;
-    int8_t* b8Ptr = (int8_t*)bVector;
+    const int8_t* a8Ptr = (const int8_t*)aVector;
+    const int8_t* b8Ptr = (const int8_t*)bVector;
     for (number = 0; number < num_points; number++) {
         float aReal = (float)*a8Ptr++;
         float aImag = (float)*a8Ptr++;
@@ -267,8 +267,8 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_neon(lv_16sc_t* cVector,
 
     number = eighthPoints * 8;
     int16_t* c16Ptr = (int16_t*)&cVector[number];
-    int8_t* a8Ptr = (int8_t*)&aVector[number];
-    int8_t* b8Ptr = (int8_t*)&bVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
     for (; number < num_points; number++) {
         float aReal_f = (float)*a8Ptr++;
         float aImag_f = (float)*a8Ptr++;
@@ -321,8 +321,8 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_u_avx2(lv_16sc_t* cVector
 
     for (; number < oneEigthPoints; number++) {
         // Convert 8 bit values into 16 bit values
-        x = _mm256_cvtepi8_epi16(_mm_loadu_si128((__m128i*)a));
-        y = _mm256_cvtepi8_epi16(_mm_loadu_si128((__m128i*)b));
+        x = _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)a));
+        y = _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)b));
 
         // Calculate the ar*cr - ai*(-ci) portions
         realz = _mm256_madd_epi16(x, y);
@@ -350,8 +350,8 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_u_avx2(lv_16sc_t* cVector
 
     number = oneEigthPoints * 8;
     int16_t* c16Ptr = (int16_t*)&cVector[number];
-    int8_t* a8Ptr = (int8_t*)&aVector[number];
-    int8_t* b8Ptr = (int8_t*)&bVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
     for (; number < num_points; number++) {
         float aReal = (float)*a8Ptr++;
         float aImag = (float)*a8Ptr++;

--- a/kernels/volk/volk_8ic_x2_s32f_multiply_conjugate_32fc.h
+++ b/kernels/volk/volk_8ic_x2_s32f_multiply_conjugate_32fc.h
@@ -73,8 +73,8 @@ volk_8ic_x2_s32f_multiply_conjugate_32fc_a_avx2(lv_32fc_t* cVector,
 
     for (; number < oneEigthPoints; number++) {
         // Convert  8 bit values into 16 bit values
-        x = _mm256_cvtepi8_epi16(_mm_load_si128((__m128i*)a));
-        y = _mm256_cvtepi8_epi16(_mm_load_si128((__m128i*)b));
+        x = _mm256_cvtepi8_epi16(_mm_load_si128((const __m128i*)a));
+        y = _mm256_cvtepi8_epi16(_mm_load_si128((const __m128i*)b));
 
         // Calculate the ar*cr - ai*(-ci) portions
         realz = _mm256_madd_epi16(x, y);
@@ -115,8 +115,8 @@ volk_8ic_x2_s32f_multiply_conjugate_32fc_a_avx2(lv_32fc_t* cVector,
 
     number = oneEigthPoints * 8;
     float* cFloatPtr = (float*)&cVector[number];
-    int8_t* a8Ptr = (int8_t*)&aVector[number];
-    int8_t* b8Ptr = (int8_t*)&bVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
     for (; number < num_points; number++) {
         float aReal = (float)*a8Ptr++;
         float aImag = (float)*a8Ptr++;
@@ -157,8 +157,8 @@ volk_8ic_x2_s32f_multiply_conjugate_32fc_a_sse4_1(lv_32fc_t* cVector,
 
     for (; number < quarterPoints; number++) {
         // Convert into 8 bit values into 16 bit values
-        x = _mm_cvtepi8_epi16(_mm_loadl_epi64((__m128i*)a));
-        y = _mm_cvtepi8_epi16(_mm_loadl_epi64((__m128i*)b));
+        x = _mm_cvtepi8_epi16(_mm_loadl_epi64((const __m128i*)a));
+        y = _mm_cvtepi8_epi16(_mm_loadl_epi64((const __m128i*)b));
 
         // Calculate the ar*cr - ai*(-ci) portions
         realz = _mm_madd_epi16(x, y);
@@ -199,8 +199,8 @@ volk_8ic_x2_s32f_multiply_conjugate_32fc_a_sse4_1(lv_32fc_t* cVector,
 
     number = quarterPoints * 4;
     float* cFloatPtr = (float*)&cVector[number];
-    int8_t* a8Ptr = (int8_t*)&aVector[number];
-    int8_t* b8Ptr = (int8_t*)&bVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
     for (; number < num_points; number++) {
         float aReal = (float)*a8Ptr++;
         float aImag = (float)*a8Ptr++;
@@ -229,8 +229,8 @@ volk_8ic_x2_s32f_multiply_conjugate_32fc_generic(lv_32fc_t* cVector,
     unsigned int number = 0;
     float* cPtr = (float*)cVector;
     const float invScalar = 1.0 / scalar;
-    int8_t* a8Ptr = (int8_t*)aVector;
-    int8_t* b8Ptr = (int8_t*)bVector;
+    const int8_t* a8Ptr = (const int8_t*)aVector;
+    const int8_t* b8Ptr = (const int8_t*)bVector;
     for (number = 0; number < num_points; number++) {
         float aReal = (float)*a8Ptr++;
         float aImag = (float)*a8Ptr++;
@@ -327,8 +327,8 @@ static inline void volk_8ic_x2_s32f_multiply_conjugate_32fc_neon(lv_32fc_t* cVec
 
     number = eighthPoints * 8;
     float* cFloatPtr = (float*)&cVector[number];
-    int8_t* a8Ptr = (int8_t*)&aVector[number];
-    int8_t* b8Ptr = (int8_t*)&bVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
     for (; number < num_points; number++) {
         float aReal_f = (float)*a8Ptr++;
         float aImag_f = (float)*a8Ptr++;
@@ -379,8 +379,8 @@ volk_8ic_x2_s32f_multiply_conjugate_32fc_u_avx2(lv_32fc_t* cVector,
 
     for (; number < oneEigthPoints; number++) {
         // Convert  8 bit values into 16 bit values
-        x = _mm256_cvtepi8_epi16(_mm_loadu_si128((__m128i*)a));
-        y = _mm256_cvtepi8_epi16(_mm_loadu_si128((__m128i*)b));
+        x = _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)a));
+        y = _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)b));
 
         // Calculate the ar*cr - ai*(-ci) portions
         realz = _mm256_madd_epi16(x, y);
@@ -421,8 +421,8 @@ volk_8ic_x2_s32f_multiply_conjugate_32fc_u_avx2(lv_32fc_t* cVector,
 
     number = oneEigthPoints * 8;
     float* cFloatPtr = (float*)&cVector[number];
-    int8_t* a8Ptr = (int8_t*)&aVector[number];
-    int8_t* b8Ptr = (int8_t*)&bVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
     for (; number < num_points; number++) {
         float aReal = (float)*a8Ptr++;
         float aImag = (float)*a8Ptr++;

--- a/kernels/volk/volk_8u_x2_encodeframepolar_8u.h
+++ b/kernels/volk/volk_8u_x2_encodeframepolar_8u.h
@@ -86,7 +86,7 @@ static inline void volk_8u_x2_encodeframepolar_8u_u_ssse3(unsigned char* frame,
 
     unsigned int stage = po2;
     unsigned char* frame_ptr = frame;
-    unsigned char* temp_ptr = temp;
+    const unsigned char* temp_ptr = temp;
 
     unsigned int frame_half = frame_size >> 1;
     unsigned int num_branches = 1;
@@ -126,9 +126,9 @@ static inline void volk_8u_x2_encodeframepolar_8u_u_ssse3(unsigned char* frame,
             // for stage = 5 a branch has 32 elements. So upper stages are even bigger.
             for (branch = 0; branch < num_branches; ++branch) {
                 for (bit = 0; bit < frame_half; bit += 16) {
-                    r_temp0 = _mm_loadu_si128((__m128i*)temp_ptr);
+                    r_temp0 = _mm_loadu_si128((const __m128i*)temp_ptr);
                     temp_ptr += 16;
-                    r_temp1 = _mm_loadu_si128((__m128i*)temp_ptr);
+                    r_temp1 = _mm_loadu_si128((const __m128i*)temp_ptr);
                     temp_ptr += 16;
 
                     shifted = _mm_srli_si128(r_temp0, 1);
@@ -221,7 +221,7 @@ static inline void volk_8u_x2_encodeframepolar_8u_u_ssse3(unsigned char* frame,
                                              0xFF);
 
     for (branch = 0; branch < num_branches; ++branch) {
-        r_temp0 = _mm_loadu_si128((__m128i*)temp_ptr);
+        r_temp0 = _mm_loadu_si128((const __m128i*)temp_ptr);
 
         // prefetch next chunk
         temp_ptr += 16;
@@ -270,7 +270,7 @@ static inline void volk_8u_x2_encodeframepolar_8u_u_avx2(unsigned char* frame,
 
     unsigned int stage = po2;
     unsigned char* frame_ptr = frame;
-    unsigned char* temp_ptr = temp;
+    const unsigned char* temp_ptr = temp;
 
     unsigned int frame_half = frame_size >> 1;
     unsigned int num_branches = 1;
@@ -378,9 +378,9 @@ static inline void volk_8u_x2_encodeframepolar_8u_u_avx2(unsigned char* frame,
                     if ((frame_half - bit) <
                         32) // if only 16 bits remaining in frame, not 32
                     {
-                        r_temp2 = _mm_loadu_si128((__m128i*)temp_ptr);
+                        r_temp2 = _mm_loadu_si128((const __m128i*)temp_ptr);
                         temp_ptr += 16;
-                        r_temp3 = _mm_loadu_si128((__m128i*)temp_ptr);
+                        r_temp3 = _mm_loadu_si128((const __m128i*)temp_ptr);
                         temp_ptr += 16;
 
                         shifted2 = _mm_srli_si128(r_temp2, 1);
@@ -401,9 +401,9 @@ static inline void volk_8u_x2_encodeframepolar_8u_u_avx2(unsigned char* frame,
                         frame_ptr += 16;
                         break;
                     }
-                    r_temp0 = _mm256_loadu_si256((__m256i*)temp_ptr);
+                    r_temp0 = _mm256_loadu_si256((const __m256i*)temp_ptr);
                     temp_ptr += 32;
-                    r_temp1 = _mm256_loadu_si256((__m256i*)temp_ptr);
+                    r_temp1 = _mm256_loadu_si256((const __m256i*)temp_ptr);
                     temp_ptr += 32;
 
                     shifted = _mm256_srli_si256(r_temp0, 1); // operate on 128 bit lanes
@@ -577,7 +577,7 @@ static inline void volk_8u_x2_encodeframepolar_8u_u_avx2(unsigned char* frame,
                                                 0xFF);
 
     for (branch = 0; branch < num_branches / 2; ++branch) {
-        r_temp0 = _mm256_loadu_si256((__m256i*)temp_ptr);
+        r_temp0 = _mm256_loadu_si256((const __m256i*)temp_ptr);
 
         // prefetch next chunk
         temp_ptr += 32;
@@ -631,7 +631,7 @@ static inline void volk_8u_x2_encodeframepolar_8u_a_ssse3(unsigned char* frame,
 
     unsigned int stage = po2;
     unsigned char* frame_ptr = frame;
-    unsigned char* temp_ptr = temp;
+    const unsigned char* temp_ptr = temp;
 
     unsigned int frame_half = frame_size >> 1;
     unsigned int num_branches = 1;
@@ -671,9 +671,9 @@ static inline void volk_8u_x2_encodeframepolar_8u_a_ssse3(unsigned char* frame,
             // for stage = 5 a branch has 32 elements. So upper stages are even bigger.
             for (branch = 0; branch < num_branches; ++branch) {
                 for (bit = 0; bit < frame_half; bit += 16) {
-                    r_temp0 = _mm_load_si128((__m128i*)temp_ptr);
+                    r_temp0 = _mm_load_si128((const __m128i*)temp_ptr);
                     temp_ptr += 16;
-                    r_temp1 = _mm_load_si128((__m128i*)temp_ptr);
+                    r_temp1 = _mm_load_si128((const __m128i*)temp_ptr);
                     temp_ptr += 16;
 
                     shifted = _mm_srli_si128(r_temp0, 1);
@@ -766,7 +766,7 @@ static inline void volk_8u_x2_encodeframepolar_8u_a_ssse3(unsigned char* frame,
                                              0xFF);
 
     for (branch = 0; branch < num_branches; ++branch) {
-        r_temp0 = _mm_load_si128((__m128i*)temp_ptr);
+        r_temp0 = _mm_load_si128((const __m128i*)temp_ptr);
 
         // prefetch next chunk
         temp_ptr += 16;
@@ -814,7 +814,7 @@ static inline void volk_8u_x2_encodeframepolar_8u_a_avx2(unsigned char* frame,
 
     unsigned int stage = po2;
     unsigned char* frame_ptr = frame;
-    unsigned char* temp_ptr = temp;
+    const unsigned char* temp_ptr = temp;
 
     unsigned int frame_half = frame_size >> 1;
     unsigned int num_branches = 1;
@@ -922,9 +922,9 @@ static inline void volk_8u_x2_encodeframepolar_8u_a_avx2(unsigned char* frame,
                     if ((frame_half - bit) <
                         32) // if only 16 bits remaining in frame, not 32
                     {
-                        r_temp2 = _mm_load_si128((__m128i*)temp_ptr);
+                        r_temp2 = _mm_load_si128((const __m128i*)temp_ptr);
                         temp_ptr += 16;
-                        r_temp3 = _mm_load_si128((__m128i*)temp_ptr);
+                        r_temp3 = _mm_load_si128((const __m128i*)temp_ptr);
                         temp_ptr += 16;
 
                         shifted2 = _mm_srli_si128(r_temp2, 1);
@@ -945,9 +945,9 @@ static inline void volk_8u_x2_encodeframepolar_8u_a_avx2(unsigned char* frame,
                         frame_ptr += 16;
                         break;
                     }
-                    r_temp0 = _mm256_load_si256((__m256i*)temp_ptr);
+                    r_temp0 = _mm256_load_si256((const __m256i*)temp_ptr);
                     temp_ptr += 32;
-                    r_temp1 = _mm256_load_si256((__m256i*)temp_ptr);
+                    r_temp1 = _mm256_load_si256((const __m256i*)temp_ptr);
                     temp_ptr += 32;
 
                     shifted = _mm256_srli_si256(r_temp0, 1); // operate on 128 bit lanes
@@ -1121,7 +1121,7 @@ static inline void volk_8u_x2_encodeframepolar_8u_a_avx2(unsigned char* frame,
                                                 0xFF);
 
     for (branch = 0; branch < num_branches / 2; ++branch) {
-        r_temp0 = _mm256_load_si256((__m256i*)temp_ptr);
+        r_temp0 = _mm256_load_si256((const __m256i*)temp_ptr);
 
         // prefetch next chunk
         temp_ptr += 32;
@@ -1169,12 +1169,13 @@ static inline void volk_8u_x2_encodeframepolar_8u_rvv(unsigned char* frame,
         if (frame_half < 8) {
             encodepolar_single_stage(frame, temp, num_branches, frame_half);
         } else {
-            unsigned char *in = temp, *out = frame;
+            const unsigned char* in = temp;
+            unsigned char* out = frame;
             for (size_t branch = 0; branch < num_branches; ++branch) {
                 size_t n = frame_half;
                 for (size_t vl; n > 0; n -= vl, in += vl * 2, out += vl) {
                     vl = __riscv_vsetvl_e8m1(n);
-                    vuint16m2_t vc = __riscv_vle16_v_u16m2((uint16_t*)in, vl);
+                    vuint16m2_t vc = __riscv_vle16_v_u16m2((const uint16_t*)in, vl);
                     vuint8m1_t v1 = __riscv_vnsrl(vc, 0, vl);
                     vuint8m1_t v2 = __riscv_vnsrl(vc, 8, vl);
                     __riscv_vse8(out, __riscv_vxor(v1, v2, vl), vl);
@@ -1209,7 +1210,8 @@ static inline void volk_8u_x2_encodeframepolar_8u_rvvseg(unsigned char* frame,
         if (frame_half < 8) {
             encodepolar_single_stage(frame, temp, num_branches, frame_half);
         } else {
-            unsigned char *in = temp, *out = frame;
+            const unsigned char* in = temp;
+            unsigned char* out = frame;
             for (size_t branch = 0; branch < num_branches; ++branch) {
                 size_t n = frame_half;
                 for (size_t vl; n > 0; n -= vl, in += vl * 2, out += vl) {

--- a/kernels/volk/volk_8u_x4_conv_k7_r2_8u.h
+++ b/kernels/volk/volk_8u_x4_conv_k7_r2_8u.h
@@ -77,11 +77,11 @@ static inline void renormalize(unsigned char* X)
 // helper BFLY for GENERIC version
 static inline void BFLY(int i,
                         int s,
-                        unsigned char* syms,
+                        const unsigned char* syms,
                         unsigned char* Y,
-                        unsigned char* X,
+                        const unsigned char* X,
                         decision_t* d,
-                        unsigned char* Branchtab)
+                        const unsigned char* Branchtab)
 {
     int j;
     unsigned int decision0, decision1;
@@ -125,11 +125,11 @@ static inline void BFLY(int i,
 
 static inline void volk_8u_x4_conv_k7_r2_8u_avx2(unsigned char* Y,
                                                  unsigned char* X,
-                                                 unsigned char* syms,
+                                                 const unsigned char* syms,
                                                  unsigned char* dec,
                                                  unsigned int framebits,
                                                  unsigned int excess,
-                                                 unsigned char* Branchtab)
+                                                 const unsigned char* Branchtab)
 {
     unsigned int i;
     for (i = 0; i < framebits + excess; i++) {
@@ -142,10 +142,10 @@ static inline void volk_8u_x4_conv_k7_r2_8u_avx2(unsigned char* Y,
         s18 = ((__m256i*)X)[0];
         s19 = ((__m256i*)X)[1];
         a76 = _mm256_set1_epi8(syms[2 * i]);
-        a78 = ((__m256i*)Branchtab)[0];
+        a78 = ((const __m256i*)Branchtab)[0];
         a79 = _mm256_xor_si256(a76, a78);
         a82 = _mm256_set1_epi8(syms[2 * i + 1]);
-        a84 = ((__m256i*)Branchtab)[1];
+        a84 = ((const __m256i*)Branchtab)[1];
         a85 = _mm256_xor_si256(a82, a84);
         a86 = _mm256_avg_epu8(a79, a85);
         a88 = _mm256_srli_epi16(a86, 2);
@@ -211,11 +211,11 @@ static inline void volk_8u_x4_conv_k7_r2_8u_avx2(unsigned char* Y,
 
 static inline void volk_8u_x4_conv_k7_r2_8u_spiral(unsigned char* Y,
                                                    unsigned char* X,
-                                                   unsigned char* syms,
+                                                   const unsigned char* syms,
                                                    unsigned char* dec,
                                                    unsigned int framebits,
                                                    unsigned int excess,
-                                                   unsigned char* Branchtab)
+                                                   const unsigned char* Branchtab)
 {
     unsigned int i;
     for (i = 0; i < framebits + excess; i++) {
@@ -229,10 +229,10 @@ static inline void volk_8u_x4_conv_k7_r2_8u_spiral(unsigned char* Y,
         s18 = ((__m128i*)X)[0];
         s19 = ((__m128i*)X)[2];
         a76 = _mm_set1_epi8(syms[2 * i]);
-        a78 = ((__m128i*)Branchtab)[0];
+        a78 = ((const __m128i*)Branchtab)[0];
         a79 = _mm_xor_si128(a76, a78);
         a82 = _mm_set1_epi8(syms[2 * i + 1]);
-        a84 = ((__m128i*)Branchtab)[2];
+        a84 = ((const __m128i*)Branchtab)[2];
         a85 = _mm_xor_si128(a82, a84);
         a86 = _mm_avg_epu8(a79, a85);
         a88 = _mm_srli_epi16(a86, 2);
@@ -254,9 +254,9 @@ static inline void volk_8u_x4_conv_k7_r2_8u_spiral(unsigned char* Y,
         // Second half of butterfly
         s24 = ((__m128i*)X)[1];
         s25 = ((__m128i*)X)[3];
-        a100 = ((__m128i*)Branchtab)[1];
+        a100 = ((const __m128i*)Branchtab)[1];
         a101 = _mm_xor_si128(a76, a100);
-        a103 = ((__m128i*)Branchtab)[3];
+        a103 = ((const __m128i*)Branchtab)[3];
         a104 = _mm_xor_si128(a82, a103);
         a105 = _mm_avg_epu8(a101, a104);
         a107 = _mm_srli_epi16(a105, 2);
@@ -309,11 +309,11 @@ static inline void volk_8u_x4_conv_k7_r2_8u_spiral(unsigned char* Y,
 
 static inline void volk_8u_x4_conv_k7_r2_8u_neonspiral(unsigned char* Y,
                                                        unsigned char* X,
-                                                       unsigned char* syms,
+                                                       const unsigned char* syms,
                                                        unsigned char* dec,
                                                        unsigned int framebits,
                                                        unsigned int excess,
-                                                       unsigned char* Branchtab)
+                                                       const unsigned char* Branchtab)
 {
     unsigned int i;
     for (i = 0; i < framebits + excess; i++) {
@@ -332,10 +332,10 @@ static inline void volk_8u_x4_conv_k7_r2_8u_neonspiral(unsigned char* Y,
         s18 = ((uint8x16_t*)X)[0];
         s19 = ((uint8x16_t*)X)[2];
         a76 = vdupq_n_u8(syms[2 * i]);
-        a78 = ((uint8x16_t*)Branchtab)[0];
+        a78 = ((const uint8x16_t*)Branchtab)[0];
         a79 = veorq_u8(a76, a78);
         a82 = vdupq_n_u8(syms[2 * i + 1]);
-        a84 = ((uint8x16_t*)Branchtab)[2];
+        a84 = ((const uint8x16_t*)Branchtab)[2];
         a85 = veorq_u8(a82, a84);
         a86 = vrhaddq_u8(a79, a85);
         t14 = vshrq_n_u8(a86, 2);
@@ -374,9 +374,9 @@ static inline void volk_8u_x4_conv_k7_r2_8u_neonspiral(unsigned char* Y,
         // Second half of butterfly
         s24 = ((uint8x16_t*)X)[1];
         s25 = ((uint8x16_t*)X)[3];
-        a100 = ((uint8x16_t*)Branchtab)[1];
+        a100 = ((const uint8x16_t*)Branchtab)[1];
         a101 = veorq_u8(a76, a100);
-        a103 = ((uint8x16_t*)Branchtab)[3];
+        a103 = ((const uint8x16_t*)Branchtab)[3];
         a104 = veorq_u8(a82, a103);
         a105 = vrhaddq_u8(a101, a104);
         t17 = vshrq_n_u8(a105, 2);
@@ -442,11 +442,11 @@ static inline void volk_8u_x4_conv_k7_r2_8u_neonspiral(unsigned char* Y,
 
 static inline void volk_8u_x4_conv_k7_r2_8u_generic(unsigned char* Y,
                                                     unsigned char* X,
-                                                    unsigned char* syms,
+                                                    const unsigned char* syms,
                                                     unsigned char* dec,
                                                     unsigned int framebits,
                                                     unsigned int excess,
-                                                    unsigned char* Branchtab)
+                                                    const unsigned char* Branchtab)
 {
     int nbits = framebits + excess;
     int NUMSTATES = 64;
@@ -474,11 +474,11 @@ static inline void volk_8u_x4_conv_k7_r2_8u_generic(unsigned char* Y,
 
 static inline void volk_8u_x4_conv_k7_r2_8u_rvv(unsigned char* Y,
                                                 unsigned char* X,
-                                                unsigned char* syms,
+                                                const unsigned char* syms,
                                                 unsigned char* dec,
                                                 unsigned int framebits,
                                                 unsigned int excess,
-                                                unsigned char* Branchtab)
+                                                const unsigned char* Branchtab)
 {
     size_t vl = 256 / 8;
 


### PR DESCRIPTION
## Summary

Many VOLK kernels correctly declare their input parameters as `const T*` in the function signature, but then cast away const when creating local pointer variables:

```c
// Before: casts away const (technically UB)
float* ptr = (float*)input;

// After: preserves const through the cast
const float* ptr = (const float*)input;
```

This PR fixes all 50 affected kernels by preserving `const` through pointer casts. This eliminates technically-undefined behavior and enables compiler warnings about accidental writes through read-only pointers.

### Kernels fixed (50 files)

- `volk_32f_index_min_{16,32}u`, `volk_32f_s32f_32f_fm_detect_32f`, `volk_32f_x3_sum_of_poly_32f`
- `volk_32fc_32f_{add,dot_prod,multiply}_32fc`, `volk_32fc_accumulator_s32fc`
- `volk_32fc_conjugate_32fc`, `volk_32fc_convert_16ic`
- `volk_32fc_deinterleave_{32f_x2,64f_x2,imag_32f,real_32f,real_64f}`
- `volk_32fc_index_{max,min}_{16,32}u`
- `volk_32fc_magnitude_{32f,squared_32f}`
- `volk_32fc_s32f_{atan2_32f,deinterleave_real_16i,magnitude_16i,power_spectrum_32f}`
- `volk_32fc_s32fc_{multiply2,x2_rotator2}_32fc`
- `volk_32fc_x2_{add,conjugate_dot_prod,divide,dot_prod,multiply,multiply_conjugate}_32fc`
- `volk_32fc_x2_{s32f_square_dist_scalar_mult,s32fc_multiply_conjugate_add2,square_dist}_32f(c)`
- `volk_32i_{s32f_convert_32f,x2_and_32i,x2_or_32i}`
- `volk_64u_popcnt`
- `volk_8i_s32f_convert_32f`
- `volk_8ic_{deinterleave_16i_x2,deinterleave_real_{16i,8i}}`
- `volk_8ic_s32f_deinterleave_{32f_x2,real_32f}`
- `volk_8ic_x2_{multiply_conjugate_16ic,s32f_multiply_conjugate_32fc}`
- `volk_8u_x2_encodeframepolar_8u`, `volk_8u_x4_conv_k7_r2_8u`

## Test plan

- [ ] CI builds pass — no behavioral change, only pointer qualifier fix
- [ ] `volk_profile` produces identical results before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)