### PR TITLE
fix: standardize section ordering for remaining 50 kernels

### DIFF
--- a/kernels/volk/volk_32f_index_min_16u.h
+++ b/kernels/volk/volk_32f_index_min_16u.h
@@ -72,7 +72,7 @@ volk_32f_index_min_16u_a_avx(uint16_t* target, const float* source, uint32_t num
     num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
     const uint32_t eighthPoints = num_points / 8;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
 
     __m256 indexIncrementValues = _mm256_set1_ps(8);
     __m256 currentIndexes = _mm256_set_ps(-1, -2, -3, -4, -5, -6, -7, -8);
@@ -134,7 +134,7 @@ static inline void volk_32f_index_min_16u_a_sse4_1(uint16_t* target,
     num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
     const uint32_t quarterPoints = num_points / 4;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
 
     __m128 indexIncrementValues = _mm_set1_ps(4);
     __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);
@@ -197,7 +197,7 @@ volk_32f_index_min_16u_a_sse(uint16_t* target, const float* source, uint32_t num
     num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
     const uint32_t quarterPoints = num_points / 4;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
 
     __m128 indexIncrementValues = _mm_set1_ps(4);
     __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);
@@ -483,7 +483,7 @@ volk_32f_index_min_16u_u_avx(uint16_t* target, const float* source, uint32_t num
     num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
     const uint32_t eighthPoints = num_points / 8;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
 
     __m256 indexIncrementValues = _mm256_set1_ps(8);
     __m256 currentIndexes = _mm256_set_ps(-1, -2, -3, -4, -5, -6, -7, -8);

--- a/kernels/volk/volk_32f_index_min_16u.h
+++ b/kernels/volk/volk_32f_index_min_16u.h
@@ -55,327 +55,13 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32f_index_min_16u_a_H
-#define INCLUDED_volk_32f_index_min_16u_a_H
+#ifndef INCLUDED_volk_32f_index_min_16u_u_H
+#define INCLUDED_volk_32f_index_min_16u_u_H
 
 #include <inttypes.h>
 #include <limits.h>
 #include <stdio.h>
 #include <volk/volk_common.h>
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-
-static inline void
-volk_32f_index_min_16u_a_avx(uint16_t* target, const float* source, uint32_t num_points)
-{
-    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
-    const uint32_t eighthPoints = num_points / 8;
-
-    const float* inputPtr = source;
-
-    __m256 indexIncrementValues = _mm256_set1_ps(8);
-    __m256 currentIndexes = _mm256_set_ps(-1, -2, -3, -4, -5, -6, -7, -8);
-
-    float min = source[0];
-    float index = 0;
-    __m256 minValues = _mm256_set1_ps(min);
-    __m256 minValuesIndex = _mm256_setzero_ps();
-    __m256 compareResults;
-    __m256 currentValues;
-
-    __VOLK_ATTR_ALIGNED(32) float minValuesBuffer[8];
-    __VOLK_ATTR_ALIGNED(32) float minIndexesBuffer[8];
-
-    for (uint32_t number = 0; number < eighthPoints; number++) {
-
-        currentValues = _mm256_load_ps(inputPtr);
-        inputPtr += 8;
-        currentIndexes = _mm256_add_ps(currentIndexes, indexIncrementValues);
-
-        compareResults = _mm256_cmp_ps(currentValues, minValues, _CMP_LT_OS);
-
-        minValuesIndex = _mm256_blendv_ps(minValuesIndex, currentIndexes, compareResults);
-        minValues = _mm256_blendv_ps(minValues, currentValues, compareResults);
-    }
-
-    // Calculate the smallest value from the remaining 4 points
-    _mm256_store_ps(minValuesBuffer, minValues);
-    _mm256_store_ps(minIndexesBuffer, minValuesIndex);
-
-    for (uint32_t number = 0; number < 8; number++) {
-        if (minValuesBuffer[number] < min) {
-            index = minIndexesBuffer[number];
-            min = minValuesBuffer[number];
-        } else if (minValuesBuffer[number] == min) {
-            if (index > minIndexesBuffer[number])
-                index = minIndexesBuffer[number];
-        }
-    }
-
-    for (uint32_t number = eighthPoints * 8; number < num_points; number++) {
-        if (source[number] < min) {
-            index = number;
-            min = source[number];
-        }
-    }
-    target[0] = (uint16_t)index;
-}
-
-#endif /*LV_HAVE_AVX*/
-
-#ifdef LV_HAVE_SSE4_1
-#include <smmintrin.h>
-
-static inline void volk_32f_index_min_16u_a_sse4_1(uint16_t* target,
-                                                   const float* source,
-                                                   uint32_t num_points)
-{
-    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
-    const uint32_t quarterPoints = num_points / 4;
-
-    const float* inputPtr = source;
-
-    __m128 indexIncrementValues = _mm_set1_ps(4);
-    __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);
-
-    float min = source[0];
-    float index = 0;
-    __m128 minValues = _mm_set1_ps(min);
-    __m128 minValuesIndex = _mm_setzero_ps();
-    __m128 compareResults;
-    __m128 currentValues;
-
-    __VOLK_ATTR_ALIGNED(16) float minValuesBuffer[4];
-    __VOLK_ATTR_ALIGNED(16) float minIndexesBuffer[4];
-
-    for (uint32_t number = 0; number < quarterPoints; number++) {
-
-        currentValues = _mm_load_ps(inputPtr);
-        inputPtr += 4;
-        currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
-
-        compareResults = _mm_cmplt_ps(currentValues, minValues);
-
-        minValuesIndex = _mm_blendv_ps(minValuesIndex, currentIndexes, compareResults);
-        minValues = _mm_blendv_ps(minValues, currentValues, compareResults);
-    }
-
-    // Calculate the smallest value from the remaining 4 points
-    _mm_store_ps(minValuesBuffer, minValues);
-    _mm_store_ps(minIndexesBuffer, minValuesIndex);
-
-    for (uint32_t number = 0; number < 4; number++) {
-        if (minValuesBuffer[number] < min) {
-            index = minIndexesBuffer[number];
-            min = minValuesBuffer[number];
-        } else if (minValuesBuffer[number] == min) {
-            if (index > minIndexesBuffer[number])
-                index = minIndexesBuffer[number];
-        }
-    }
-
-    for (uint32_t number = quarterPoints * 4; number < num_points; number++) {
-        if (source[number] < min) {
-            index = number;
-            min = source[number];
-        }
-    }
-    target[0] = (uint16_t)index;
-}
-
-#endif /*LV_HAVE_SSE4_1*/
-
-
-#ifdef LV_HAVE_SSE
-
-#include <xmmintrin.h>
-
-static inline void
-volk_32f_index_min_16u_a_sse(uint16_t* target, const float* source, uint32_t num_points)
-{
-    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
-    const uint32_t quarterPoints = num_points / 4;
-
-    const float* inputPtr = source;
-
-    __m128 indexIncrementValues = _mm_set1_ps(4);
-    __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);
-
-    float min = source[0];
-    float index = 0;
-    __m128 minValues = _mm_set1_ps(min);
-    __m128 minValuesIndex = _mm_setzero_ps();
-    __m128 compareResults;
-    __m128 currentValues;
-
-    __VOLK_ATTR_ALIGNED(16) float minValuesBuffer[4];
-    __VOLK_ATTR_ALIGNED(16) float minIndexesBuffer[4];
-
-    for (uint32_t number = 0; number < quarterPoints; number++) {
-
-        currentValues = _mm_load_ps(inputPtr);
-        inputPtr += 4;
-        currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
-
-        compareResults = _mm_cmplt_ps(currentValues, minValues);
-
-        minValuesIndex = _mm_or_ps(_mm_and_ps(compareResults, currentIndexes),
-                                   _mm_andnot_ps(compareResults, minValuesIndex));
-        minValues = _mm_or_ps(_mm_and_ps(compareResults, currentValues),
-                              _mm_andnot_ps(compareResults, minValues));
-    }
-
-    // Calculate the smallest value from the remaining 4 points
-    _mm_store_ps(minValuesBuffer, minValues);
-    _mm_store_ps(minIndexesBuffer, minValuesIndex);
-
-    for (uint32_t number = 0; number < 4; number++) {
-        if (minValuesBuffer[number] < min) {
-            index = minIndexesBuffer[number];
-            min = minValuesBuffer[number];
-        } else if (minValuesBuffer[number] == min) {
-            if (index > minIndexesBuffer[number])
-                index = minIndexesBuffer[number];
-        }
-    }
-
-    for (uint32_t number = quarterPoints * 4; number < num_points; number++) {
-        if (source[number] < min) {
-            index = number;
-            min = source[number];
-        }
-    }
-    target[0] = (uint16_t)index;
-}
-
-#endif /*LV_HAVE_SSE*/
-
-
-#ifdef LV_HAVE_NEON
-#include <arm_neon.h>
-#include <float.h>
-#include <limits.h>
-
-static inline void
-volk_32f_index_min_16u_neon(uint16_t* target, const float* source, uint32_t num_points)
-{
-    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
-
-    if (num_points == 0)
-        return;
-
-    const uint32_t quarter_points = num_points / 4;
-    const float* inputPtr = source;
-
-    // Use integer indices directly
-    uint32x4_t vec_indices = { 0, 1, 2, 3 };
-    const uint32x4_t vec_incr = vdupq_n_u32(4);
-
-    float32x4_t vec_min = vdupq_n_f32(FLT_MAX);
-    uint32x4_t vec_min_idx = vdupq_n_u32(0);
-
-    for (uint32_t i = 0; i < quarter_points; i++) {
-        float32x4_t vec_val = vld1q_f32(inputPtr);
-        inputPtr += 4;
-
-        // Compare BEFORE min update to know which lanes change
-        uint32x4_t lt_mask = vcltq_f32(vec_val, vec_min);
-        vec_min_idx = vbslq_u32(lt_mask, vec_indices, vec_min_idx);
-
-        // vminq_f32 is single-cycle, no dependency on comparison result
-        vec_min = vminq_f32(vec_val, vec_min);
-
-        vec_indices = vaddq_u32(vec_indices, vec_incr);
-    }
-
-    // Scalar reduction
-    __VOLK_ATTR_ALIGNED(16) float min_buf[4];
-    __VOLK_ATTR_ALIGNED(16) uint32_t idx_buf[4];
-    vst1q_f32(min_buf, vec_min);
-    vst1q_u32(idx_buf, vec_min_idx);
-
-    float min_val = min_buf[0];
-    uint32_t result_idx = idx_buf[0];
-    for (int i = 1; i < 4; i++) {
-        if (min_buf[i] < min_val) {
-            min_val = min_buf[i];
-            result_idx = idx_buf[i];
-        } else if (min_buf[i] == min_val && idx_buf[i] < result_idx) {
-            result_idx = idx_buf[i];
-        }
-    }
-
-    // Handle tail
-    for (uint32_t i = quarter_points * 4; i < num_points; i++) {
-        if (source[i] < min_val) {
-            min_val = source[i];
-            result_idx = i;
-        }
-    }
-
-    *target = (uint16_t)result_idx;
-}
-
-#endif /*LV_HAVE_NEON*/
-
-
-#ifdef LV_HAVE_NEONV8
-#include <arm_neon.h>
-#include <float.h>
-#include <limits.h>
-
-static inline void
-volk_32f_index_min_16u_neonv8(uint16_t* target, const float* source, uint32_t num_points)
-{
-    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
-
-    if (num_points == 0)
-        return;
-
-    const uint32_t quarter_points = num_points / 4;
-    const float* inputPtr = source;
-
-    // Use integer indices directly (no float conversion overhead)
-    uint32x4_t vec_indices = { 0, 1, 2, 3 };
-    const uint32x4_t vec_incr = vdupq_n_u32(4);
-
-    float32x4_t vec_min = vdupq_n_f32(FLT_MAX);
-    uint32x4_t vec_min_idx = vdupq_n_u32(0);
-
-    for (uint32_t i = 0; i < quarter_points; i++) {
-        float32x4_t vec_val = vld1q_f32(inputPtr);
-        inputPtr += 4;
-
-        // Compare BEFORE min update to know which lanes change
-        uint32x4_t lt_mask = vcltq_f32(vec_val, vec_min);
-        vec_min_idx = vbslq_u32(lt_mask, vec_indices, vec_min_idx);
-
-        // vminq_f32 is single-cycle, no dependency on comparison result
-        vec_min = vminq_f32(vec_val, vec_min);
-
-        vec_indices = vaddq_u32(vec_indices, vec_incr);
-    }
-
-    // ARMv8 horizontal reduction
-    float min_val = vminvq_f32(vec_min);
-    uint32x4_t min_mask = vceqq_f32(vec_min, vdupq_n_f32(min_val));
-    uint32x4_t idx_masked = vbslq_u32(min_mask, vec_min_idx, vdupq_n_u32(UINT32_MAX));
-    uint32_t result_idx = vminvq_u32(idx_masked);
-
-    // Handle tail
-    for (uint32_t i = quarter_points * 4; i < num_points; i++) {
-        if (source[i] < min_val) {
-            min_val = source[i];
-            result_idx = i;
-        }
-    }
-
-    *target = (uint16_t)result_idx;
-}
-
-#endif /*LV_HAVE_NEONV8*/
-
 
 #ifdef LV_HAVE_GENERIC
 
@@ -397,82 +83,6 @@ volk_32f_index_min_16u_generic(uint16_t* target, const float* source, uint32_t n
 }
 
 #endif /*LV_HAVE_GENERIC*/
-
-#ifdef LV_HAVE_AVX512F
-#include <immintrin.h>
-#include <limits.h>
-
-static inline void volk_32f_index_min_16u_a_avx512f(uint16_t* target,
-                                                    const float* source,
-                                                    uint32_t num_points)
-{
-    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
-
-    uint32_t number = 0;
-    const uint32_t sixteenthPoints = num_points / 16;
-
-    const float* inputPtr = source;
-
-    __m512 indexIncrementValues = _mm512_set1_ps(16);
-    __m512 currentIndexes = _mm512_set_ps(
-        -1, -2, -3, -4, -5, -6, -7, -8, -9, -10, -11, -12, -13, -14, -15, -16);
-
-    float min = source[0];
-    float index = 0;
-    __m512 minValues = _mm512_set1_ps(min);
-    __m512 minValuesIndex = _mm512_setzero_ps();
-    __mmask16 compareResults;
-    __m512 currentValues;
-
-    __VOLK_ATTR_ALIGNED(64) float minValuesBuffer[16];
-    __VOLK_ATTR_ALIGNED(64) float minIndexesBuffer[16];
-
-    for (; number < sixteenthPoints; number++) {
-        currentValues = _mm512_load_ps(inputPtr);
-        inputPtr += 16;
-        currentIndexes = _mm512_add_ps(currentIndexes, indexIncrementValues);
-        compareResults = _mm512_cmp_ps_mask(currentValues, minValues, _CMP_LT_OS);
-        minValuesIndex =
-            _mm512_mask_blend_ps(compareResults, minValuesIndex, currentIndexes);
-        minValues = _mm512_mask_blend_ps(compareResults, minValues, currentValues);
-    }
-
-    // Calculate the smallest value from the remaining 16 points
-    _mm512_store_ps(minValuesBuffer, minValues);
-    _mm512_store_ps(minIndexesBuffer, minValuesIndex);
-
-    for (number = 0; number < 16; number++) {
-        if (minValuesBuffer[number] < min) {
-            index = minIndexesBuffer[number];
-            min = minValuesBuffer[number];
-        } else if (minValuesBuffer[number] == min) {
-            if (index > minIndexesBuffer[number])
-                index = minIndexesBuffer[number];
-        }
-    }
-
-    number = sixteenthPoints * 16;
-    for (; number < num_points; number++) {
-        if (source[number] < min) {
-            index = number;
-            min = source[number];
-        }
-    }
-    target[0] = (uint16_t)index;
-}
-
-#endif /*LV_HAVE_AVX512F*/
-
-#endif /*INCLUDED_volk_32f_index_min_16u_a_H*/
-
-
-#ifndef INCLUDED_volk_32f_index_min_16u_u_H
-#define INCLUDED_volk_32f_index_min_16u_u_H
-
-#include <inttypes.h>
-#include <limits.h>
-#include <stdio.h>
-#include <volk/volk_common.h>
 
 #ifdef LV_HAVE_AVX
 #include <immintrin.h>
@@ -600,6 +210,130 @@ static inline void volk_32f_index_min_16u_u_avx512f(uint16_t* target,
 
 #endif /*LV_HAVE_AVX512F*/
 
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+#include <float.h>
+#include <limits.h>
+
+static inline void
+volk_32f_index_min_16u_neon(uint16_t* target, const float* source, uint32_t num_points)
+{
+    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
+
+    if (num_points == 0)
+        return;
+
+    const uint32_t quarter_points = num_points / 4;
+    const float* inputPtr = source;
+
+    // Use integer indices directly
+    uint32x4_t vec_indices = { 0, 1, 2, 3 };
+    const uint32x4_t vec_incr = vdupq_n_u32(4);
+
+    float32x4_t vec_min = vdupq_n_f32(FLT_MAX);
+    uint32x4_t vec_min_idx = vdupq_n_u32(0);
+
+    for (uint32_t i = 0; i < quarter_points; i++) {
+        float32x4_t vec_val = vld1q_f32(inputPtr);
+        inputPtr += 4;
+
+        // Compare BEFORE min update to know which lanes change
+        uint32x4_t lt_mask = vcltq_f32(vec_val, vec_min);
+        vec_min_idx = vbslq_u32(lt_mask, vec_indices, vec_min_idx);
+
+        // vminq_f32 is single-cycle, no dependency on comparison result
+        vec_min = vminq_f32(vec_val, vec_min);
+
+        vec_indices = vaddq_u32(vec_indices, vec_incr);
+    }
+
+    // Scalar reduction
+    __VOLK_ATTR_ALIGNED(16) float min_buf[4];
+    __VOLK_ATTR_ALIGNED(16) uint32_t idx_buf[4];
+    vst1q_f32(min_buf, vec_min);
+    vst1q_u32(idx_buf, vec_min_idx);
+
+    float min_val = min_buf[0];
+    uint32_t result_idx = idx_buf[0];
+    for (int i = 1; i < 4; i++) {
+        if (min_buf[i] < min_val) {
+            min_val = min_buf[i];
+            result_idx = idx_buf[i];
+        } else if (min_buf[i] == min_val && idx_buf[i] < result_idx) {
+            result_idx = idx_buf[i];
+        }
+    }
+
+    // Handle tail
+    for (uint32_t i = quarter_points * 4; i < num_points; i++) {
+        if (source[i] < min_val) {
+            min_val = source[i];
+            result_idx = i;
+        }
+    }
+
+    *target = (uint16_t)result_idx;
+}
+
+#endif /*LV_HAVE_NEON*/
+
+
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+#include <float.h>
+#include <limits.h>
+
+static inline void
+volk_32f_index_min_16u_neonv8(uint16_t* target, const float* source, uint32_t num_points)
+{
+    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
+
+    if (num_points == 0)
+        return;
+
+    const uint32_t quarter_points = num_points / 4;
+    const float* inputPtr = source;
+
+    // Use integer indices directly (no float conversion overhead)
+    uint32x4_t vec_indices = { 0, 1, 2, 3 };
+    const uint32x4_t vec_incr = vdupq_n_u32(4);
+
+    float32x4_t vec_min = vdupq_n_f32(FLT_MAX);
+    uint32x4_t vec_min_idx = vdupq_n_u32(0);
+
+    for (uint32_t i = 0; i < quarter_points; i++) {
+        float32x4_t vec_val = vld1q_f32(inputPtr);
+        inputPtr += 4;
+
+        // Compare BEFORE min update to know which lanes change
+        uint32x4_t lt_mask = vcltq_f32(vec_val, vec_min);
+        vec_min_idx = vbslq_u32(lt_mask, vec_indices, vec_min_idx);
+
+        // vminq_f32 is single-cycle, no dependency on comparison result
+        vec_min = vminq_f32(vec_val, vec_min);
+
+        vec_indices = vaddq_u32(vec_indices, vec_incr);
+    }
+
+    // ARMv8 horizontal reduction
+    float min_val = vminvq_f32(vec_min);
+    uint32x4_t min_mask = vceqq_f32(vec_min, vdupq_n_f32(min_val));
+    uint32x4_t idx_masked = vbslq_u32(min_mask, vec_min_idx, vdupq_n_u32(UINT32_MAX));
+    uint32_t result_idx = vminvq_u32(idx_masked);
+
+    // Handle tail
+    for (uint32_t i = quarter_points * 4; i < num_points; i++) {
+        if (source[i] < min_val) {
+            min_val = source[i];
+            result_idx = i;
+        }
+    }
+
+    *target = (uint16_t)result_idx;
+}
+
+#endif /*LV_HAVE_NEONV8*/
+
 #ifdef LV_HAVE_RVV
 #include <float.h>
 #include <riscv_vector.h>
@@ -635,3 +369,266 @@ volk_32f_index_min_16u_rvv(uint16_t* target, const float* src0, uint32_t num_poi
 #endif /*LV_HAVE_RVV*/
 
 #endif /*INCLUDED_volk_32f_index_min_16u_u_H*/
+
+
+#ifndef INCLUDED_volk_32f_index_min_16u_a_H
+#define INCLUDED_volk_32f_index_min_16u_a_H
+
+#include <inttypes.h>
+#include <limits.h>
+#include <stdio.h>
+#include <volk/volk_common.h>
+
+#ifdef LV_HAVE_SSE
+
+#include <xmmintrin.h>
+
+static inline void
+volk_32f_index_min_16u_a_sse(uint16_t* target, const float* source, uint32_t num_points)
+{
+    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
+    const uint32_t quarterPoints = num_points / 4;
+
+    const float* inputPtr = source;
+
+    __m128 indexIncrementValues = _mm_set1_ps(4);
+    __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);
+
+    float min = source[0];
+    float index = 0;
+    __m128 minValues = _mm_set1_ps(min);
+    __m128 minValuesIndex = _mm_setzero_ps();
+    __m128 compareResults;
+    __m128 currentValues;
+
+    __VOLK_ATTR_ALIGNED(16) float minValuesBuffer[4];
+    __VOLK_ATTR_ALIGNED(16) float minIndexesBuffer[4];
+
+    for (uint32_t number = 0; number < quarterPoints; number++) {
+
+        currentValues = _mm_load_ps(inputPtr);
+        inputPtr += 4;
+        currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
+
+        compareResults = _mm_cmplt_ps(currentValues, minValues);
+
+        minValuesIndex = _mm_or_ps(_mm_and_ps(compareResults, currentIndexes),
+                                   _mm_andnot_ps(compareResults, minValuesIndex));
+        minValues = _mm_or_ps(_mm_and_ps(compareResults, currentValues),
+                              _mm_andnot_ps(compareResults, minValues));
+    }
+
+    // Calculate the smallest value from the remaining 4 points
+    _mm_store_ps(minValuesBuffer, minValues);
+    _mm_store_ps(minIndexesBuffer, minValuesIndex);
+
+    for (uint32_t number = 0; number < 4; number++) {
+        if (minValuesBuffer[number] < min) {
+            index = minIndexesBuffer[number];
+            min = minValuesBuffer[number];
+        } else if (minValuesBuffer[number] == min) {
+            if (index > minIndexesBuffer[number])
+                index = minIndexesBuffer[number];
+        }
+    }
+
+    for (uint32_t number = quarterPoints * 4; number < num_points; number++) {
+        if (source[number] < min) {
+            index = number;
+            min = source[number];
+        }
+    }
+    target[0] = (uint16_t)index;
+}
+
+#endif /*LV_HAVE_SSE*/
+
+#ifdef LV_HAVE_SSE4_1
+#include <smmintrin.h>
+
+static inline void volk_32f_index_min_16u_a_sse4_1(uint16_t* target,
+                                                   const float* source,
+                                                   uint32_t num_points)
+{
+    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
+    const uint32_t quarterPoints = num_points / 4;
+
+    const float* inputPtr = source;
+
+    __m128 indexIncrementValues = _mm_set1_ps(4);
+    __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);
+
+    float min = source[0];
+    float index = 0;
+    __m128 minValues = _mm_set1_ps(min);
+    __m128 minValuesIndex = _mm_setzero_ps();
+    __m128 compareResults;
+    __m128 currentValues;
+
+    __VOLK_ATTR_ALIGNED(16) float minValuesBuffer[4];
+    __VOLK_ATTR_ALIGNED(16) float minIndexesBuffer[4];
+
+    for (uint32_t number = 0; number < quarterPoints; number++) {
+
+        currentValues = _mm_load_ps(inputPtr);
+        inputPtr += 4;
+        currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
+
+        compareResults = _mm_cmplt_ps(currentValues, minValues);
+
+        minValuesIndex = _mm_blendv_ps(minValuesIndex, currentIndexes, compareResults);
+        minValues = _mm_blendv_ps(minValues, currentValues, compareResults);
+    }
+
+    // Calculate the smallest value from the remaining 4 points
+    _mm_store_ps(minValuesBuffer, minValues);
+    _mm_store_ps(minIndexesBuffer, minValuesIndex);
+
+    for (uint32_t number = 0; number < 4; number++) {
+        if (minValuesBuffer[number] < min) {
+            index = minIndexesBuffer[number];
+            min = minValuesBuffer[number];
+        } else if (minValuesBuffer[number] == min) {
+            if (index > minIndexesBuffer[number])
+                index = minIndexesBuffer[number];
+        }
+    }
+
+    for (uint32_t number = quarterPoints * 4; number < num_points; number++) {
+        if (source[number] < min) {
+            index = number;
+            min = source[number];
+        }
+    }
+    target[0] = (uint16_t)index;
+}
+
+#endif /*LV_HAVE_SSE4_1*/
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void
+volk_32f_index_min_16u_a_avx(uint16_t* target, const float* source, uint32_t num_points)
+{
+    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
+    const uint32_t eighthPoints = num_points / 8;
+
+    const float* inputPtr = source;
+
+    __m256 indexIncrementValues = _mm256_set1_ps(8);
+    __m256 currentIndexes = _mm256_set_ps(-1, -2, -3, -4, -5, -6, -7, -8);
+
+    float min = source[0];
+    float index = 0;
+    __m256 minValues = _mm256_set1_ps(min);
+    __m256 minValuesIndex = _mm256_setzero_ps();
+    __m256 compareResults;
+    __m256 currentValues;
+
+    __VOLK_ATTR_ALIGNED(32) float minValuesBuffer[8];
+    __VOLK_ATTR_ALIGNED(32) float minIndexesBuffer[8];
+
+    for (uint32_t number = 0; number < eighthPoints; number++) {
+
+        currentValues = _mm256_load_ps(inputPtr);
+        inputPtr += 8;
+        currentIndexes = _mm256_add_ps(currentIndexes, indexIncrementValues);
+
+        compareResults = _mm256_cmp_ps(currentValues, minValues, _CMP_LT_OS);
+
+        minValuesIndex = _mm256_blendv_ps(minValuesIndex, currentIndexes, compareResults);
+        minValues = _mm256_blendv_ps(minValues, currentValues, compareResults);
+    }
+
+    // Calculate the smallest value from the remaining 4 points
+    _mm256_store_ps(minValuesBuffer, minValues);
+    _mm256_store_ps(minIndexesBuffer, minValuesIndex);
+
+    for (uint32_t number = 0; number < 8; number++) {
+        if (minValuesBuffer[number] < min) {
+            index = minIndexesBuffer[number];
+            min = minValuesBuffer[number];
+        } else if (minValuesBuffer[number] == min) {
+            if (index > minIndexesBuffer[number])
+                index = minIndexesBuffer[number];
+        }
+    }
+
+    for (uint32_t number = eighthPoints * 8; number < num_points; number++) {
+        if (source[number] < min) {
+            index = number;
+            min = source[number];
+        }
+    }
+    target[0] = (uint16_t)index;
+}
+
+#endif /*LV_HAVE_AVX*/
+
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+#include <limits.h>
+
+static inline void volk_32f_index_min_16u_a_avx512f(uint16_t* target,
+                                                    const float* source,
+                                                    uint32_t num_points)
+{
+    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
+
+    uint32_t number = 0;
+    const uint32_t sixteenthPoints = num_points / 16;
+
+    const float* inputPtr = source;
+
+    __m512 indexIncrementValues = _mm512_set1_ps(16);
+    __m512 currentIndexes = _mm512_set_ps(
+        -1, -2, -3, -4, -5, -6, -7, -8, -9, -10, -11, -12, -13, -14, -15, -16);
+
+    float min = source[0];
+    float index = 0;
+    __m512 minValues = _mm512_set1_ps(min);
+    __m512 minValuesIndex = _mm512_setzero_ps();
+    __mmask16 compareResults;
+    __m512 currentValues;
+
+    __VOLK_ATTR_ALIGNED(64) float minValuesBuffer[16];
+    __VOLK_ATTR_ALIGNED(64) float minIndexesBuffer[16];
+
+    for (; number < sixteenthPoints; number++) {
+        currentValues = _mm512_load_ps(inputPtr);
+        inputPtr += 16;
+        currentIndexes = _mm512_add_ps(currentIndexes, indexIncrementValues);
+        compareResults = _mm512_cmp_ps_mask(currentValues, minValues, _CMP_LT_OS);
+        minValuesIndex =
+            _mm512_mask_blend_ps(compareResults, minValuesIndex, currentIndexes);
+        minValues = _mm512_mask_blend_ps(compareResults, minValues, currentValues);
+    }
+
+    // Calculate the smallest value from the remaining 16 points
+    _mm512_store_ps(minValuesBuffer, minValues);
+    _mm512_store_ps(minIndexesBuffer, minValuesIndex);
+
+    for (number = 0; number < 16; number++) {
+        if (minValuesBuffer[number] < min) {
+            index = minIndexesBuffer[number];
+            min = minValuesBuffer[number];
+        } else if (minValuesBuffer[number] == min) {
+            if (index > minIndexesBuffer[number])
+                index = minIndexesBuffer[number];
+        }
+    }
+
+    number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        if (source[number] < min) {
+            index = number;
+            min = source[number];
+        }
+    }
+    target[0] = (uint16_t)index;
+}
+
+#endif /*LV_HAVE_AVX512F*/
+
+#endif /*INCLUDED_volk_32f_index_min_16u_a_H*/

--- a/kernels/volk/volk_32f_index_min_32u.h
+++ b/kernels/volk/volk_32f_index_min_32u.h
@@ -65,7 +65,7 @@ static inline void volk_32f_index_min_32u_a_sse4_1(uint32_t* target,
 {
     const uint32_t quarterPoints = num_points / 4;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
 
     __m128 indexIncrementValues = _mm_set1_ps(4);
     __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);
@@ -127,7 +127,7 @@ volk_32f_index_min_32u_a_sse(uint32_t* target, const float* source, uint32_t num
 {
     const uint32_t quarterPoints = num_points / 4;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
 
     __m128 indexIncrementValues = _mm_set1_ps(4);
     __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);
@@ -191,7 +191,7 @@ volk_32f_index_min_32u_a_avx(uint32_t* target, const float* source, uint32_t num
 {
     const uint32_t quarterPoints = num_points / 8;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
 
     __m256 indexIncrementValues = _mm256_set1_ps(8);
     __m256 currentIndexes = _mm256_set_ps(-1, -2, -3, -4, -5, -6, -7, -8);
@@ -249,7 +249,7 @@ volk_32f_index_min_32u_neon(uint32_t* target, const float* source, uint32_t num_
 {
     const uint32_t quarterPoints = num_points / 4;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
     float32x4_t indexIncrementValues = vdupq_n_f32(4);
     __VOLK_ATTR_ALIGNED(16)
     float currentIndexes_float[4] = { -4.0f, -3.0f, -2.0f, -1.0f };
@@ -460,7 +460,7 @@ volk_32f_index_min_32u_u_avx(uint32_t* target, const float* source, uint32_t num
 {
     const uint32_t quarterPoints = num_points / 8;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
 
     __m256 indexIncrementValues = _mm256_set1_ps(8);
     __m256 currentIndexes = _mm256_set_ps(-1, -2, -3, -4, -5, -6, -7, -8);
@@ -519,7 +519,7 @@ static inline void volk_32f_index_min_32u_u_sse4_1(uint32_t* target,
 {
     const uint32_t quarterPoints = num_points / 4;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
 
     __m128 indexIncrementValues = _mm_set1_ps(4);
     __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);
@@ -576,7 +576,7 @@ volk_32f_index_min_32u_u_sse(uint32_t* target, const float* source, uint32_t num
 {
     const uint32_t quarterPoints = num_points / 4;
 
-    float* inputPtr = (float*)source;
+    const float* inputPtr = source;
 
     __m128 indexIncrementValues = _mm_set1_ps(4);
     __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);

--- a/kernels/volk/volk_32f_index_min_32u.h
+++ b/kernels/volk/volk_32f_index_min_32u.h
@@ -49,81 +49,38 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32f_index_min_32u_a_H
-#define INCLUDED_volk_32f_index_min_32u_a_H
+#ifndef INCLUDED_volk_32f_index_min_32u_u_H
+#define INCLUDED_volk_32f_index_min_32u_u_H
 
 #include <inttypes.h>
 #include <stdio.h>
 #include <volk/volk_common.h>
 
-#ifdef LV_HAVE_SSE4_1
-#include <smmintrin.h>
+#ifdef LV_HAVE_GENERIC
 
-static inline void volk_32f_index_min_32u_a_sse4_1(uint32_t* target,
-                                                   const float* source,
-                                                   uint32_t num_points)
+static inline void
+volk_32f_index_min_32u_generic(uint32_t* target, const float* source, uint32_t num_points)
 {
-    const uint32_t quarterPoints = num_points / 4;
-
-    const float* inputPtr = source;
-
-    __m128 indexIncrementValues = _mm_set1_ps(4);
-    __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);
-
     float min = source[0];
-    float index = 0;
-    __m128 minValues = _mm_set1_ps(min);
-    __m128 minValuesIndex = _mm_setzero_ps();
-    __m128 compareResults;
-    __m128 currentValues;
+    uint32_t index = 0;
 
-    __VOLK_ATTR_ALIGNED(16) float minValuesBuffer[4];
-    __VOLK_ATTR_ALIGNED(16) float minIndexesBuffer[4];
-
-    for (uint32_t number = 0; number < quarterPoints; number++) {
-
-        currentValues = _mm_load_ps(inputPtr);
-        inputPtr += 4;
-        currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
-
-        compareResults = _mm_cmplt_ps(currentValues, minValues);
-
-        minValuesIndex = _mm_blendv_ps(minValuesIndex, currentIndexes, compareResults);
-        minValues = _mm_blendv_ps(minValues, currentValues, compareResults);
-    }
-
-    // Calculate the smallest value from the remaining 4 points
-    _mm_store_ps(minValuesBuffer, minValues);
-    _mm_store_ps(minIndexesBuffer, minValuesIndex);
-
-    for (uint32_t number = 0; number < 4; number++) {
-        if (minValuesBuffer[number] < min) {
-            index = minIndexesBuffer[number];
-            min = minValuesBuffer[number];
-        } else if (minValuesBuffer[number] == min) {
-            if (index > minIndexesBuffer[number])
-                index = minIndexesBuffer[number];
+    for (uint32_t i = 1; i < num_points; ++i) {
+        if (source[i] < min) {
+            index = i;
+            min = source[i];
         }
     }
-
-    for (uint32_t number = quarterPoints * 4; number < num_points; number++) {
-        if (source[number] < min) {
-            index = number;
-            min = source[number];
-        }
-    }
-    target[0] = (uint32_t)index;
+    target[0] = index;
 }
 
-#endif /*LV_HAVE_SSE4_1*/
+#endif /*LV_HAVE_GENERIC*/
 
 
 #ifdef LV_HAVE_SSE
-
 #include <xmmintrin.h>
 
 static inline void
-volk_32f_index_min_32u_a_sse(uint32_t* target, const float* source, uint32_t num_points)
+volk_32f_index_min_32u_u_sse(uint32_t* target, const float* source, uint32_t num_points)
 {
     const uint32_t quarterPoints = num_points / 4;
 
@@ -143,16 +100,12 @@ volk_32f_index_min_32u_a_sse(uint32_t* target, const float* source, uint32_t num
     __VOLK_ATTR_ALIGNED(16) float minIndexesBuffer[4];
 
     for (uint32_t number = 0; number < quarterPoints; number++) {
-
-        currentValues = _mm_load_ps(inputPtr);
+        currentValues = _mm_loadu_ps(inputPtr);
         inputPtr += 4;
         currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
-
         compareResults = _mm_cmplt_ps(currentValues, minValues);
-
         minValuesIndex = _mm_or_ps(_mm_and_ps(compareResults, currentIndexes),
                                    _mm_andnot_ps(compareResults, minValuesIndex));
-
         minValues = _mm_or_ps(_mm_and_ps(compareResults, currentValues),
                               _mm_andnot_ps(compareResults, minValues));
     }
@@ -183,11 +136,70 @@ volk_32f_index_min_32u_a_sse(uint32_t* target, const float* source, uint32_t num
 #endif /*LV_HAVE_SSE*/
 
 
+#ifdef LV_HAVE_SSE4_1
+#include <smmintrin.h>
+
+static inline void volk_32f_index_min_32u_u_sse4_1(uint32_t* target,
+                                                   const float* source,
+                                                   uint32_t num_points)
+{
+    const uint32_t quarterPoints = num_points / 4;
+
+    const float* inputPtr = source;
+
+    __m128 indexIncrementValues = _mm_set1_ps(4);
+    __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);
+
+    float min = source[0];
+    float index = 0;
+    __m128 minValues = _mm_set1_ps(min);
+    __m128 minValuesIndex = _mm_setzero_ps();
+    __m128 compareResults;
+    __m128 currentValues;
+
+    __VOLK_ATTR_ALIGNED(16) float minValuesBuffer[4];
+    __VOLK_ATTR_ALIGNED(16) float minIndexesBuffer[4];
+
+    for (uint32_t number = 0; number < quarterPoints; number++) {
+        currentValues = _mm_loadu_ps(inputPtr);
+        inputPtr += 4;
+        currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
+        compareResults = _mm_cmplt_ps(currentValues, minValues);
+        minValuesIndex = _mm_blendv_ps(minValuesIndex, currentIndexes, compareResults);
+        minValues = _mm_blendv_ps(minValues, currentValues, compareResults);
+    }
+
+    // Calculate the smallest value from the remaining 4 points
+    _mm_store_ps(minValuesBuffer, minValues);
+    _mm_store_ps(minIndexesBuffer, minValuesIndex);
+
+    for (uint32_t number = 0; number < 4; number++) {
+        if (minValuesBuffer[number] < min) {
+            index = minIndexesBuffer[number];
+            min = minValuesBuffer[number];
+        } else if (minValuesBuffer[number] == min) {
+            if (index > minIndexesBuffer[number])
+                index = minIndexesBuffer[number];
+        }
+    }
+
+    for (uint32_t number = quarterPoints * 4; number < num_points; number++) {
+        if (source[number] < min) {
+            index = number;
+            min = source[number];
+        }
+    }
+    target[0] = (uint32_t)index;
+}
+
+#endif /*LV_HAVE_SSE4_1*/
+
+
 #ifdef LV_HAVE_AVX
 #include <immintrin.h>
 
 static inline void
-volk_32f_index_min_32u_a_avx(uint32_t* target, const float* source, uint32_t num_points)
+volk_32f_index_min_32u_u_avx(uint32_t* target, const float* source, uint32_t num_points)
 {
     const uint32_t quarterPoints = num_points / 8;
 
@@ -207,7 +219,7 @@ volk_32f_index_min_32u_a_avx(uint32_t* target, const float* source, uint32_t num
     __VOLK_ATTR_ALIGNED(32) float minIndexesBuffer[8];
 
     for (uint32_t number = 0; number < quarterPoints; number++) {
-        currentValues = _mm256_load_ps(inputPtr);
+        currentValues = _mm256_loadu_ps(inputPtr);
         inputPtr += 8;
         currentIndexes = _mm256_add_ps(currentIndexes, indexIncrementValues);
         compareResults = _mm256_cmp_ps(currentValues, minValues, _CMP_LT_OS);
@@ -215,7 +227,7 @@ volk_32f_index_min_32u_a_avx(uint32_t* target, const float* source, uint32_t num
         minValues = _mm256_blendv_ps(minValues, currentValues, compareResults);
     }
 
-    // Calculate the smallest value from the remaining 8 points
+    // Calculate the smalles value from the remaining 8 points
     _mm256_store_ps(minValuesBuffer, minValues);
     _mm256_store_ps(minIndexesBuffer, minValuesIndex);
 
@@ -239,6 +251,71 @@ volk_32f_index_min_32u_a_avx(uint32_t* target, const float* source, uint32_t num
 }
 
 #endif /*LV_HAVE_AVX*/
+
+
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+
+static inline void volk_32f_index_min_32u_u_avx512f(uint32_t* target,
+                                                    const float* source,
+                                                    uint32_t num_points)
+{
+    if (num_points > 0) {
+        uint32_t number = 0;
+        const uint32_t sixteenthPoints = num_points / 16;
+
+        const float* inputPtr = source;
+
+        __m512 indexIncrementValues = _mm512_set1_ps(16);
+        __m512 currentIndexes = _mm512_set_ps(
+            -1, -2, -3, -4, -5, -6, -7, -8, -9, -10, -11, -12, -13, -14, -15, -16);
+
+        float min = source[0];
+        float index = 0;
+        __m512 minValues = _mm512_set1_ps(min);
+        __m512 minValuesIndex = _mm512_setzero_ps();
+        __mmask16 compareResults;
+        __m512 currentValues;
+
+        __VOLK_ATTR_ALIGNED(64) float minValuesBuffer[16];
+        __VOLK_ATTR_ALIGNED(64) float minIndexesBuffer[16];
+
+        for (; number < sixteenthPoints; number++) {
+            currentValues = _mm512_loadu_ps(inputPtr);
+            inputPtr += 16;
+            currentIndexes = _mm512_add_ps(currentIndexes, indexIncrementValues);
+            compareResults = _mm512_cmp_ps_mask(currentValues, minValues, _CMP_LT_OS);
+            minValuesIndex =
+                _mm512_mask_blend_ps(compareResults, minValuesIndex, currentIndexes);
+            minValues = _mm512_mask_blend_ps(compareResults, minValues, currentValues);
+        }
+
+        // Calculate the smallest value from the remaining 16 points
+        _mm512_store_ps(minValuesBuffer, minValues);
+        _mm512_store_ps(minIndexesBuffer, minValuesIndex);
+
+        for (number = 0; number < 16; number++) {
+            if (minValuesBuffer[number] < min) {
+                index = minIndexesBuffer[number];
+                min = minValuesBuffer[number];
+            } else if (minValuesBuffer[number] == min) {
+                if (index > minIndexesBuffer[number])
+                    index = minIndexesBuffer[number];
+            }
+        }
+
+        number = sixteenthPoints * 16;
+        for (; number < num_points; number++) {
+            if (source[number] < min) {
+                index = number;
+                min = source[number];
+            }
+        }
+        target[0] = (uint32_t)index;
+    }
+}
+
+#endif /*LV_HAVE_AVX512F*/
 
 
 #ifdef LV_HAVE_NEON
@@ -358,24 +435,233 @@ volk_32f_index_min_32u_neonv8(uint32_t* target, const float* source, uint32_t nu
 #endif /*LV_HAVE_NEONV8*/
 
 
-#ifdef LV_HAVE_GENERIC
+#ifdef LV_HAVE_RVV
+#include <float.h>
+#include <riscv_vector.h>
 
 static inline void
-volk_32f_index_min_32u_generic(uint32_t* target, const float* source, uint32_t num_points)
+volk_32f_index_min_32u_rvv(uint32_t* target, const float* src0, uint32_t num_points)
 {
-    float min = source[0];
-    uint32_t index = 0;
+    vfloat32m4_t vmin = __riscv_vfmv_v_f_f32m4(FLT_MAX, __riscv_vsetvlmax_e32m4());
+    vuint32m4_t vmini = __riscv_vmv_v_x_u32m4(0, __riscv_vsetvlmax_e32m4());
+    vuint32m4_t vidx = __riscv_vid_v_u32m4(__riscv_vsetvlmax_e32m4());
+    size_t n = num_points;
+    for (size_t vl; n > 0; n -= vl, src0 += vl) {
+        vl = __riscv_vsetvl_e32m4(n);
+        vfloat32m4_t v = __riscv_vle32_v_f32m4(src0, vl);
+        vbool8_t m = __riscv_vmflt(v, vmin, vl);
+        vmin = __riscv_vfmin_tu(vmin, vmin, v, vl);
+        vmini = __riscv_vmerge_tu(vmini, vmini, vidx, m, vl);
+        vidx = __riscv_vadd(vidx, vl, __riscv_vsetvlmax_e32m4());
+    }
+    size_t vl = __riscv_vsetvlmax_e32m4();
+    float min = __riscv_vfmv_f(__riscv_vfredmin(RISCV_SHRINK4(vfmin, f, 32, vmin),
+                                                __riscv_vfmv_v_f_f32m1(FLT_MAX, 1),
+                                                __riscv_vsetvlmax_e32m1()));
+    // Find lanes with min value, set others to UINT32_MAX
+    vbool8_t m = __riscv_vmfeq(vmin, min, vl);
+    vuint32m4_t idx_masked =
+        __riscv_vmerge(__riscv_vmv_v_x_u32m4(UINT32_MAX, vl), vmini, m, vl);
+    // Find minimum index among lanes with min value
+    *target = __riscv_vmv_x(__riscv_vredminu(RISCV_SHRINK4(vminu, u, 32, idx_masked),
+                                             __riscv_vmv_v_x_u32m1(UINT32_MAX, 1),
+                                             __riscv_vsetvlmax_e32m1()));
+}
+#endif /*LV_HAVE_RVV*/
 
-    for (uint32_t i = 1; i < num_points; ++i) {
-        if (source[i] < min) {
-            index = i;
-            min = source[i];
+#endif /*INCLUDED_volk_32f_index_min_32u_u_H*/
+
+
+#ifndef INCLUDED_volk_32f_index_min_32u_a_H
+#define INCLUDED_volk_32f_index_min_32u_a_H
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <volk/volk_common.h>
+
+#ifdef LV_HAVE_SSE
+#include <xmmintrin.h>
+
+static inline void
+volk_32f_index_min_32u_a_sse(uint32_t* target, const float* source, uint32_t num_points)
+{
+    const uint32_t quarterPoints = num_points / 4;
+
+    const float* inputPtr = source;
+
+    __m128 indexIncrementValues = _mm_set1_ps(4);
+    __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);
+
+    float min = source[0];
+    float index = 0;
+    __m128 minValues = _mm_set1_ps(min);
+    __m128 minValuesIndex = _mm_setzero_ps();
+    __m128 compareResults;
+    __m128 currentValues;
+
+    __VOLK_ATTR_ALIGNED(16) float minValuesBuffer[4];
+    __VOLK_ATTR_ALIGNED(16) float minIndexesBuffer[4];
+
+    for (uint32_t number = 0; number < quarterPoints; number++) {
+
+        currentValues = _mm_load_ps(inputPtr);
+        inputPtr += 4;
+        currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
+
+        compareResults = _mm_cmplt_ps(currentValues, minValues);
+
+        minValuesIndex = _mm_or_ps(_mm_and_ps(compareResults, currentIndexes),
+                                   _mm_andnot_ps(compareResults, minValuesIndex));
+
+        minValues = _mm_or_ps(_mm_and_ps(compareResults, currentValues),
+                              _mm_andnot_ps(compareResults, minValues));
+    }
+
+    // Calculate the smallest value from the remaining 4 points
+    _mm_store_ps(minValuesBuffer, minValues);
+    _mm_store_ps(minIndexesBuffer, minValuesIndex);
+
+    for (uint32_t number = 0; number < 4; number++) {
+        if (minValuesBuffer[number] < min) {
+            index = minIndexesBuffer[number];
+            min = minValuesBuffer[number];
+        } else if (minValuesBuffer[number] == min) {
+            if (index > minIndexesBuffer[number])
+                index = minIndexesBuffer[number];
         }
     }
-    target[0] = index;
+
+    for (uint32_t number = quarterPoints * 4; number < num_points; number++) {
+        if (source[number] < min) {
+            index = number;
+            min = source[number];
+        }
+    }
+    target[0] = (uint32_t)index;
 }
 
-#endif /*LV_HAVE_GENERIC*/
+#endif /*LV_HAVE_SSE*/
+
+
+#ifdef LV_HAVE_SSE4_1
+#include <smmintrin.h>
+
+static inline void volk_32f_index_min_32u_a_sse4_1(uint32_t* target,
+                                                   const float* source,
+                                                   uint32_t num_points)
+{
+    const uint32_t quarterPoints = num_points / 4;
+
+    const float* inputPtr = source;
+
+    __m128 indexIncrementValues = _mm_set1_ps(4);
+    __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);
+
+    float min = source[0];
+    float index = 0;
+    __m128 minValues = _mm_set1_ps(min);
+    __m128 minValuesIndex = _mm_setzero_ps();
+    __m128 compareResults;
+    __m128 currentValues;
+
+    __VOLK_ATTR_ALIGNED(16) float minValuesBuffer[4];
+    __VOLK_ATTR_ALIGNED(16) float minIndexesBuffer[4];
+
+    for (uint32_t number = 0; number < quarterPoints; number++) {
+
+        currentValues = _mm_load_ps(inputPtr);
+        inputPtr += 4;
+        currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
+
+        compareResults = _mm_cmplt_ps(currentValues, minValues);
+
+        minValuesIndex = _mm_blendv_ps(minValuesIndex, currentIndexes, compareResults);
+        minValues = _mm_blendv_ps(minValues, currentValues, compareResults);
+    }
+
+    // Calculate the smallest value from the remaining 4 points
+    _mm_store_ps(minValuesBuffer, minValues);
+    _mm_store_ps(minIndexesBuffer, minValuesIndex);
+
+    for (uint32_t number = 0; number < 4; number++) {
+        if (minValuesBuffer[number] < min) {
+            index = minIndexesBuffer[number];
+            min = minValuesBuffer[number];
+        } else if (minValuesBuffer[number] == min) {
+            if (index > minIndexesBuffer[number])
+                index = minIndexesBuffer[number];
+        }
+    }
+
+    for (uint32_t number = quarterPoints * 4; number < num_points; number++) {
+        if (source[number] < min) {
+            index = number;
+            min = source[number];
+        }
+    }
+    target[0] = (uint32_t)index;
+}
+
+#endif /*LV_HAVE_SSE4_1*/
+
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void
+volk_32f_index_min_32u_a_avx(uint32_t* target, const float* source, uint32_t num_points)
+{
+    const uint32_t quarterPoints = num_points / 8;
+
+    const float* inputPtr = source;
+
+    __m256 indexIncrementValues = _mm256_set1_ps(8);
+    __m256 currentIndexes = _mm256_set_ps(-1, -2, -3, -4, -5, -6, -7, -8);
+
+    float min = source[0];
+    float index = 0;
+    __m256 minValues = _mm256_set1_ps(min);
+    __m256 minValuesIndex = _mm256_setzero_ps();
+    __m256 compareResults;
+    __m256 currentValues;
+
+    __VOLK_ATTR_ALIGNED(32) float minValuesBuffer[8];
+    __VOLK_ATTR_ALIGNED(32) float minIndexesBuffer[8];
+
+    for (uint32_t number = 0; number < quarterPoints; number++) {
+        currentValues = _mm256_load_ps(inputPtr);
+        inputPtr += 8;
+        currentIndexes = _mm256_add_ps(currentIndexes, indexIncrementValues);
+        compareResults = _mm256_cmp_ps(currentValues, minValues, _CMP_LT_OS);
+        minValuesIndex = _mm256_blendv_ps(minValuesIndex, currentIndexes, compareResults);
+        minValues = _mm256_blendv_ps(minValues, currentValues, compareResults);
+    }
+
+    // Calculate the smallest value from the remaining 8 points
+    _mm256_store_ps(minValuesBuffer, minValues);
+    _mm256_store_ps(minIndexesBuffer, minValuesIndex);
+
+    for (uint32_t number = 0; number < 8; number++) {
+        if (minValuesBuffer[number] < min) {
+            index = minIndexesBuffer[number];
+            min = minValuesBuffer[number];
+        } else if (minValuesBuffer[number] == min) {
+            if (index > minIndexesBuffer[number])
+                index = minIndexesBuffer[number];
+        }
+    }
+
+    for (uint32_t number = quarterPoints * 8; number < num_points; number++) {
+        if (source[number] < min) {
+            index = number;
+            min = source[number];
+        }
+    }
+    target[0] = (uint32_t)index;
+}
+
+#endif /*LV_HAVE_AVX*/
+
 
 #ifdef LV_HAVE_AVX512F
 #include <immintrin.h>
@@ -442,287 +728,3 @@ static inline void volk_32f_index_min_32u_a_avx512f(uint32_t* target,
 #endif /*LV_HAVE_AVX512F*/
 
 #endif /*INCLUDED_volk_32f_index_min_32u_a_H*/
-
-
-#ifndef INCLUDED_volk_32f_index_min_32u_u_H
-#define INCLUDED_volk_32f_index_min_32u_u_H
-
-#include <inttypes.h>
-#include <stdio.h>
-#include <volk/volk_common.h>
-
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-
-static inline void
-volk_32f_index_min_32u_u_avx(uint32_t* target, const float* source, uint32_t num_points)
-{
-    const uint32_t quarterPoints = num_points / 8;
-
-    const float* inputPtr = source;
-
-    __m256 indexIncrementValues = _mm256_set1_ps(8);
-    __m256 currentIndexes = _mm256_set_ps(-1, -2, -3, -4, -5, -6, -7, -8);
-
-    float min = source[0];
-    float index = 0;
-    __m256 minValues = _mm256_set1_ps(min);
-    __m256 minValuesIndex = _mm256_setzero_ps();
-    __m256 compareResults;
-    __m256 currentValues;
-
-    __VOLK_ATTR_ALIGNED(32) float minValuesBuffer[8];
-    __VOLK_ATTR_ALIGNED(32) float minIndexesBuffer[8];
-
-    for (uint32_t number = 0; number < quarterPoints; number++) {
-        currentValues = _mm256_loadu_ps(inputPtr);
-        inputPtr += 8;
-        currentIndexes = _mm256_add_ps(currentIndexes, indexIncrementValues);
-        compareResults = _mm256_cmp_ps(currentValues, minValues, _CMP_LT_OS);
-        minValuesIndex = _mm256_blendv_ps(minValuesIndex, currentIndexes, compareResults);
-        minValues = _mm256_blendv_ps(minValues, currentValues, compareResults);
-    }
-
-    // Calculate the smalles value from the remaining 8 points
-    _mm256_store_ps(minValuesBuffer, minValues);
-    _mm256_store_ps(minIndexesBuffer, minValuesIndex);
-
-    for (uint32_t number = 0; number < 8; number++) {
-        if (minValuesBuffer[number] < min) {
-            index = minIndexesBuffer[number];
-            min = minValuesBuffer[number];
-        } else if (minValuesBuffer[number] == min) {
-            if (index > minIndexesBuffer[number])
-                index = minIndexesBuffer[number];
-        }
-    }
-
-    for (uint32_t number = quarterPoints * 8; number < num_points; number++) {
-        if (source[number] < min) {
-            index = number;
-            min = source[number];
-        }
-    }
-    target[0] = (uint32_t)index;
-}
-
-#endif /*LV_HAVE_AVX*/
-
-
-#ifdef LV_HAVE_SSE4_1
-#include <smmintrin.h>
-
-static inline void volk_32f_index_min_32u_u_sse4_1(uint32_t* target,
-                                                   const float* source,
-                                                   uint32_t num_points)
-{
-    const uint32_t quarterPoints = num_points / 4;
-
-    const float* inputPtr = source;
-
-    __m128 indexIncrementValues = _mm_set1_ps(4);
-    __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);
-
-    float min = source[0];
-    float index = 0;
-    __m128 minValues = _mm_set1_ps(min);
-    __m128 minValuesIndex = _mm_setzero_ps();
-    __m128 compareResults;
-    __m128 currentValues;
-
-    __VOLK_ATTR_ALIGNED(16) float minValuesBuffer[4];
-    __VOLK_ATTR_ALIGNED(16) float minIndexesBuffer[4];
-
-    for (uint32_t number = 0; number < quarterPoints; number++) {
-        currentValues = _mm_loadu_ps(inputPtr);
-        inputPtr += 4;
-        currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
-        compareResults = _mm_cmplt_ps(currentValues, minValues);
-        minValuesIndex = _mm_blendv_ps(minValuesIndex, currentIndexes, compareResults);
-        minValues = _mm_blendv_ps(minValues, currentValues, compareResults);
-    }
-
-    // Calculate the smallest value from the remaining 4 points
-    _mm_store_ps(minValuesBuffer, minValues);
-    _mm_store_ps(minIndexesBuffer, minValuesIndex);
-
-    for (uint32_t number = 0; number < 4; number++) {
-        if (minValuesBuffer[number] < min) {
-            index = minIndexesBuffer[number];
-            min = minValuesBuffer[number];
-        } else if (minValuesBuffer[number] == min) {
-            if (index > minIndexesBuffer[number])
-                index = minIndexesBuffer[number];
-        }
-    }
-
-    for (uint32_t number = quarterPoints * 4; number < num_points; number++) {
-        if (source[number] < min) {
-            index = number;
-            min = source[number];
-        }
-    }
-    target[0] = (uint32_t)index;
-}
-
-#endif /*LV_HAVE_SSE4_1*/
-
-#ifdef LV_HAVE_SSE
-#include <xmmintrin.h>
-
-static inline void
-volk_32f_index_min_32u_u_sse(uint32_t* target, const float* source, uint32_t num_points)
-{
-    const uint32_t quarterPoints = num_points / 4;
-
-    const float* inputPtr = source;
-
-    __m128 indexIncrementValues = _mm_set1_ps(4);
-    __m128 currentIndexes = _mm_set_ps(-1, -2, -3, -4);
-
-    float min = source[0];
-    float index = 0;
-    __m128 minValues = _mm_set1_ps(min);
-    __m128 minValuesIndex = _mm_setzero_ps();
-    __m128 compareResults;
-    __m128 currentValues;
-
-    __VOLK_ATTR_ALIGNED(16) float minValuesBuffer[4];
-    __VOLK_ATTR_ALIGNED(16) float minIndexesBuffer[4];
-
-    for (uint32_t number = 0; number < quarterPoints; number++) {
-        currentValues = _mm_loadu_ps(inputPtr);
-        inputPtr += 4;
-        currentIndexes = _mm_add_ps(currentIndexes, indexIncrementValues);
-        compareResults = _mm_cmplt_ps(currentValues, minValues);
-        minValuesIndex = _mm_or_ps(_mm_and_ps(compareResults, currentIndexes),
-                                   _mm_andnot_ps(compareResults, minValuesIndex));
-        minValues = _mm_or_ps(_mm_and_ps(compareResults, currentValues),
-                              _mm_andnot_ps(compareResults, minValues));
-    }
-
-    // Calculate the smallest value from the remaining 4 points
-    _mm_store_ps(minValuesBuffer, minValues);
-    _mm_store_ps(minIndexesBuffer, minValuesIndex);
-
-    for (uint32_t number = 0; number < 4; number++) {
-        if (minValuesBuffer[number] < min) {
-            index = minIndexesBuffer[number];
-            min = minValuesBuffer[number];
-        } else if (minValuesBuffer[number] == min) {
-            if (index > minIndexesBuffer[number])
-                index = minIndexesBuffer[number];
-        }
-    }
-
-    for (uint32_t number = quarterPoints * 4; number < num_points; number++) {
-        if (source[number] < min) {
-            index = number;
-            min = source[number];
-        }
-    }
-    target[0] = (uint32_t)index;
-}
-
-#endif /*LV_HAVE_SSE*/
-
-#ifdef LV_HAVE_AVX512F
-#include <immintrin.h>
-
-static inline void volk_32f_index_min_32u_u_avx512f(uint32_t* target,
-                                                    const float* source,
-                                                    uint32_t num_points)
-{
-    if (num_points > 0) {
-        uint32_t number = 0;
-        const uint32_t sixteenthPoints = num_points / 16;
-
-        const float* inputPtr = source;
-
-        __m512 indexIncrementValues = _mm512_set1_ps(16);
-        __m512 currentIndexes = _mm512_set_ps(
-            -1, -2, -3, -4, -5, -6, -7, -8, -9, -10, -11, -12, -13, -14, -15, -16);
-
-        float min = source[0];
-        float index = 0;
-        __m512 minValues = _mm512_set1_ps(min);
-        __m512 minValuesIndex = _mm512_setzero_ps();
-        __mmask16 compareResults;
-        __m512 currentValues;
-
-        __VOLK_ATTR_ALIGNED(64) float minValuesBuffer[16];
-        __VOLK_ATTR_ALIGNED(64) float minIndexesBuffer[16];
-
-        for (; number < sixteenthPoints; number++) {
-            currentValues = _mm512_loadu_ps(inputPtr);
-            inputPtr += 16;
-            currentIndexes = _mm512_add_ps(currentIndexes, indexIncrementValues);
-            compareResults = _mm512_cmp_ps_mask(currentValues, minValues, _CMP_LT_OS);
-            minValuesIndex =
-                _mm512_mask_blend_ps(compareResults, minValuesIndex, currentIndexes);
-            minValues = _mm512_mask_blend_ps(compareResults, minValues, currentValues);
-        }
-
-        // Calculate the smallest value from the remaining 16 points
-        _mm512_store_ps(minValuesBuffer, minValues);
-        _mm512_store_ps(minIndexesBuffer, minValuesIndex);
-
-        for (number = 0; number < 16; number++) {
-            if (minValuesBuffer[number] < min) {
-                index = minIndexesBuffer[number];
-                min = minValuesBuffer[number];
-            } else if (minValuesBuffer[number] == min) {
-                if (index > minIndexesBuffer[number])
-                    index = minIndexesBuffer[number];
-            }
-        }
-
-        number = sixteenthPoints * 16;
-        for (; number < num_points; number++) {
-            if (source[number] < min) {
-                index = number;
-                min = source[number];
-            }
-        }
-        target[0] = (uint32_t)index;
-    }
-}
-
-#endif /*LV_HAVE_AVX512F*/
-
-#ifdef LV_HAVE_RVV
-#include <float.h>
-#include <riscv_vector.h>
-
-static inline void
-volk_32f_index_min_32u_rvv(uint32_t* target, const float* src0, uint32_t num_points)
-{
-    vfloat32m4_t vmin = __riscv_vfmv_v_f_f32m4(FLT_MAX, __riscv_vsetvlmax_e32m4());
-    vuint32m4_t vmini = __riscv_vmv_v_x_u32m4(0, __riscv_vsetvlmax_e32m4());
-    vuint32m4_t vidx = __riscv_vid_v_u32m4(__riscv_vsetvlmax_e32m4());
-    size_t n = num_points;
-    for (size_t vl; n > 0; n -= vl, src0 += vl) {
-        vl = __riscv_vsetvl_e32m4(n);
-        vfloat32m4_t v = __riscv_vle32_v_f32m4(src0, vl);
-        vbool8_t m = __riscv_vmflt(v, vmin, vl);
-        vmin = __riscv_vfmin_tu(vmin, vmin, v, vl);
-        vmini = __riscv_vmerge_tu(vmini, vmini, vidx, m, vl);
-        vidx = __riscv_vadd(vidx, vl, __riscv_vsetvlmax_e32m4());
-    }
-    size_t vl = __riscv_vsetvlmax_e32m4();
-    float min = __riscv_vfmv_f(__riscv_vfredmin(RISCV_SHRINK4(vfmin, f, 32, vmin),
-                                                __riscv_vfmv_v_f_f32m1(FLT_MAX, 1),
-                                                __riscv_vsetvlmax_e32m1()));
-    // Find lanes with min value, set others to UINT32_MAX
-    vbool8_t m = __riscv_vmfeq(vmin, min, vl);
-    vuint32m4_t idx_masked =
-        __riscv_vmerge(__riscv_vmv_v_x_u32m4(UINT32_MAX, vl), vmini, m, vl);
-    // Find minimum index among lanes with min value
-    *target = __riscv_vmv_x(__riscv_vredminu(RISCV_SHRINK4(vminu, u, 32, idx_masked),
-                                             __riscv_vmv_v_x_u32m1(UINT32_MAX, 1),
-                                             __riscv_vsetvlmax_e32m1()));
-}
-#endif /*LV_HAVE_RVV*/
-
-#endif /*INCLUDED_volk_32f_index_min_32u_u_H*/

--- a/kernels/volk/volk_32f_s32f_32f_fm_detect_32f.h
+++ b/kernels/volk/volk_32f_s32f_32f_fm_detect_32f.h
@@ -41,16 +41,54 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32f_s32f_32f_fm_detect_32f_a_H
-#define INCLUDED_volk_32f_s32f_32f_fm_detect_32f_a_H
+#ifndef INCLUDED_volk_32f_s32f_32f_fm_detect_32f_u_H
+#define INCLUDED_volk_32f_s32f_32f_fm_detect_32f_u_H
 
 #include <inttypes.h>
 #include <stdio.h>
 
+#ifdef LV_HAVE_GENERIC
+
+static inline void volk_32f_s32f_32f_fm_detect_32f_generic(float* outputVector,
+                                                           const float* inputVector,
+                                                           const float bound,
+                                                           float* saveValue,
+                                                           unsigned int num_points)
+{
+    if (num_points < 1) {
+        return;
+    }
+    unsigned int number = 0;
+    float* outPtr = outputVector;
+    const float* inPtr = inputVector;
+
+    // Do the first 1 by hand since we're going in from the saveValue:
+    *outPtr = *inPtr - *saveValue;
+    if (*outPtr > bound)
+        *outPtr -= 2 * bound;
+    if (*outPtr < -bound)
+        *outPtr += 2 * bound;
+    inPtr++;
+    outPtr++;
+
+    for (number = 1; number < num_points; number++) {
+        *outPtr = *(inPtr) - *(inPtr - 1);
+        if (*outPtr > bound)
+            *outPtr -= 2 * bound;
+        if (*outPtr < -bound)
+            *outPtr += 2 * bound;
+        inPtr++;
+        outPtr++;
+    }
+
+    *saveValue = inputVector[num_points - 1];
+}
+#endif /* LV_HAVE_GENERIC */
+
 #ifdef LV_HAVE_AVX
 #include <immintrin.h>
 
-static inline void volk_32f_s32f_32f_fm_detect_32f_a_avx(float* outputVector,
+static inline void volk_32f_s32f_32f_fm_detect_32f_u_avx(float* outputVector,
                                                          const float* inputVector,
                                                          const float bound,
                                                          float* saveValue,
@@ -95,7 +133,7 @@ static inline void volk_32f_s32f_32f_fm_detect_32f_a_avx(float* outputVector,
     for (; number < eighthPoints; number++) {
         // Load data
         next3old1 = _mm256_loadu_ps((const float*)(inPtr - 1));
-        next4 = _mm256_load_ps(inPtr);
+        next4 = _mm256_loadu_ps(inPtr);
         inPtr += 8;
         // Subtract and store:
         next3old1 = _mm256_sub_ps(next4, next3old1);
@@ -107,7 +145,7 @@ static inline void volk_32f_s32f_32f_fm_detect_32f_a_avx(float* outputVector,
         boundAdjust = _mm256_or_ps(next4, boundAdjust);
         // Make sure we're in the bounding interval:
         next3old1 = _mm256_add_ps(next3old1, boundAdjust);
-        _mm256_store_ps(outPtr, next3old1); // Store the results back into the output
+        _mm256_storeu_ps(outPtr, next3old1); // Store the results back into the output
         outPtr += 8;
     }
 
@@ -125,125 +163,6 @@ static inline void volk_32f_s32f_32f_fm_detect_32f_a_avx(float* outputVector,
     *saveValue = inputVector[num_points - 1];
 }
 #endif /* LV_HAVE_AVX */
-
-
-#ifdef LV_HAVE_SSE
-#include <xmmintrin.h>
-
-static inline void volk_32f_s32f_32f_fm_detect_32f_a_sse(float* outputVector,
-                                                         const float* inputVector,
-                                                         const float bound,
-                                                         float* saveValue,
-                                                         unsigned int num_points)
-{
-    if (num_points < 1) {
-        return;
-    }
-    unsigned int number = 1;
-    unsigned int j = 0;
-    // num_points-1 keeps Fedora 7's gcc from crashing...
-    // num_points won't work.  :(
-    const unsigned int quarterPoints = (num_points - 1) / 4;
-
-    float* outPtr = outputVector;
-    const float* inPtr = inputVector;
-    __m128 upperBound = _mm_set_ps1(bound);
-    __m128 lowerBound = _mm_set_ps1(-bound);
-    __m128 next3old1;
-    __m128 next4;
-    __m128 boundAdjust;
-    __m128 posBoundAdjust = _mm_set_ps1(-2 * bound); // Subtract when we're above.
-    __m128 negBoundAdjust = _mm_set_ps1(2 * bound);  // Add when we're below.
-    // Do the first 4 by hand since we're going in from the saveValue:
-    *outPtr = *inPtr - *saveValue;
-    if (*outPtr > bound)
-        *outPtr -= 2 * bound;
-    if (*outPtr < -bound)
-        *outPtr += 2 * bound;
-    inPtr++;
-    outPtr++;
-    for (j = 1; j < ((4 < num_points) ? 4 : num_points); j++) {
-        *outPtr = *(inPtr) - *(inPtr - 1);
-        if (*outPtr > bound)
-            *outPtr -= 2 * bound;
-        if (*outPtr < -bound)
-            *outPtr += 2 * bound;
-        inPtr++;
-        outPtr++;
-    }
-
-    for (; number < quarterPoints; number++) {
-        // Load data
-        next3old1 = _mm_loadu_ps((const float*)(inPtr - 1));
-        next4 = _mm_load_ps(inPtr);
-        inPtr += 4;
-        // Subtract and store:
-        next3old1 = _mm_sub_ps(next4, next3old1);
-        // Bound:
-        boundAdjust = _mm_cmpgt_ps(next3old1, upperBound);
-        boundAdjust = _mm_and_ps(boundAdjust, posBoundAdjust);
-        next4 = _mm_cmplt_ps(next3old1, lowerBound);
-        next4 = _mm_and_ps(next4, negBoundAdjust);
-        boundAdjust = _mm_or_ps(next4, boundAdjust);
-        // Make sure we're in the bounding interval:
-        next3old1 = _mm_add_ps(next3old1, boundAdjust);
-        _mm_store_ps(outPtr, next3old1); // Store the results back into the output
-        outPtr += 4;
-    }
-
-    for (number = (4 > (quarterPoints * 4) ? 4 : (4 * quarterPoints));
-         number < num_points;
-         number++) {
-        *outPtr = *(inPtr) - *(inPtr - 1);
-        if (*outPtr > bound)
-            *outPtr -= 2 * bound;
-        if (*outPtr < -bound)
-            *outPtr += 2 * bound;
-        inPtr++;
-        outPtr++;
-    }
-
-    *saveValue = inputVector[num_points - 1];
-}
-#endif /* LV_HAVE_SSE */
-
-#ifdef LV_HAVE_GENERIC
-
-static inline void volk_32f_s32f_32f_fm_detect_32f_generic(float* outputVector,
-                                                           const float* inputVector,
-                                                           const float bound,
-                                                           float* saveValue,
-                                                           unsigned int num_points)
-{
-    if (num_points < 1) {
-        return;
-    }
-    unsigned int number = 0;
-    float* outPtr = outputVector;
-    const float* inPtr = inputVector;
-
-    // Do the first 1 by hand since we're going in from the saveValue:
-    *outPtr = *inPtr - *saveValue;
-    if (*outPtr > bound)
-        *outPtr -= 2 * bound;
-    if (*outPtr < -bound)
-        *outPtr += 2 * bound;
-    inPtr++;
-    outPtr++;
-
-    for (number = 1; number < num_points; number++) {
-        *outPtr = *(inPtr) - *(inPtr - 1);
-        if (*outPtr > bound)
-            *outPtr -= 2 * bound;
-        if (*outPtr < -bound)
-            *outPtr += 2 * bound;
-        inPtr++;
-        outPtr++;
-    }
-
-    *saveValue = inputVector[num_points - 1];
-}
-#endif /* LV_HAVE_GENERIC */
 
 
 #ifdef LV_HAVE_NEON
@@ -421,19 +340,137 @@ static inline void volk_32f_s32f_32f_fm_detect_32f_neonv8(float* outputVector,
 }
 #endif /* LV_HAVE_NEONV8 */
 
-#endif /* INCLUDED_volk_32f_s32f_32f_fm_detect_32f_a_H */
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_32f_s32f_32f_fm_detect_32f_rvv(float* outputVector,
+                                                       const float* inputVector,
+                                                       const float bound,
+                                                       float* saveValue,
+                                                       unsigned int num_points)
+{
+    if (num_points < 1)
+        return;
+
+    *outputVector = *inputVector - *saveValue;
+    if (*outputVector > bound)
+        *outputVector -= 2 * bound;
+    if (*outputVector < -bound)
+        *outputVector += 2 * bound;
+    ++inputVector;
+    ++outputVector;
+
+    vfloat32m8_t v2bound = __riscv_vfmv_v_f_f32m8(bound * 2, __riscv_vsetvlmax_e32m8());
+
+    size_t n = num_points - 1;
+    for (size_t vl; n > 0; n -= vl, inputVector += vl, outputVector += vl) {
+        vl = __riscv_vsetvl_e32m8(n);
+        vfloat32m8_t va = __riscv_vle32_v_f32m8(inputVector, vl);
+        vfloat32m8_t vb = __riscv_vle32_v_f32m8(inputVector - 1, vl);
+        vfloat32m8_t v = __riscv_vfsub(va, vb, vl);
+        v = __riscv_vfsub_mu(__riscv_vmfgt(v, bound, vl), v, v, v2bound, vl);
+        v = __riscv_vfadd_mu(__riscv_vmflt(v, -bound, vl), v, v, v2bound, vl);
+        __riscv_vse32(outputVector, v, vl);
+    }
+
+    *saveValue = inputVector[-1];
+}
+#endif /* LV_HAVE_RVV */
+
+#endif /* INCLUDED_volk_32f_s32f_32f_fm_detect_32f_u_H */
 
 
-#ifndef INCLUDED_volk_32f_s32f_32f_fm_detect_32f_u_H
-#define INCLUDED_volk_32f_s32f_32f_fm_detect_32f_u_H
+#ifndef INCLUDED_volk_32f_s32f_32f_fm_detect_32f_a_H
+#define INCLUDED_volk_32f_s32f_32f_fm_detect_32f_a_H
 
 #include <inttypes.h>
 #include <stdio.h>
 
+#ifdef LV_HAVE_SSE
+#include <xmmintrin.h>
+
+static inline void volk_32f_s32f_32f_fm_detect_32f_a_sse(float* outputVector,
+                                                         const float* inputVector,
+                                                         const float bound,
+                                                         float* saveValue,
+                                                         unsigned int num_points)
+{
+    if (num_points < 1) {
+        return;
+    }
+    unsigned int number = 1;
+    unsigned int j = 0;
+    // num_points-1 keeps Fedora 7's gcc from crashing...
+    // num_points won't work.  :(
+    const unsigned int quarterPoints = (num_points - 1) / 4;
+
+    float* outPtr = outputVector;
+    const float* inPtr = inputVector;
+    __m128 upperBound = _mm_set_ps1(bound);
+    __m128 lowerBound = _mm_set_ps1(-bound);
+    __m128 next3old1;
+    __m128 next4;
+    __m128 boundAdjust;
+    __m128 posBoundAdjust = _mm_set_ps1(-2 * bound); // Subtract when we're above.
+    __m128 negBoundAdjust = _mm_set_ps1(2 * bound);  // Add when we're below.
+    // Do the first 4 by hand since we're going in from the saveValue:
+    *outPtr = *inPtr - *saveValue;
+    if (*outPtr > bound)
+        *outPtr -= 2 * bound;
+    if (*outPtr < -bound)
+        *outPtr += 2 * bound;
+    inPtr++;
+    outPtr++;
+    for (j = 1; j < ((4 < num_points) ? 4 : num_points); j++) {
+        *outPtr = *(inPtr) - *(inPtr - 1);
+        if (*outPtr > bound)
+            *outPtr -= 2 * bound;
+        if (*outPtr < -bound)
+            *outPtr += 2 * bound;
+        inPtr++;
+        outPtr++;
+    }
+
+    for (; number < quarterPoints; number++) {
+        // Load data
+        next3old1 = _mm_loadu_ps((const float*)(inPtr - 1));
+        next4 = _mm_load_ps(inPtr);
+        inPtr += 4;
+        // Subtract and store:
+        next3old1 = _mm_sub_ps(next4, next3old1);
+        // Bound:
+        boundAdjust = _mm_cmpgt_ps(next3old1, upperBound);
+        boundAdjust = _mm_and_ps(boundAdjust, posBoundAdjust);
+        next4 = _mm_cmplt_ps(next3old1, lowerBound);
+        next4 = _mm_and_ps(next4, negBoundAdjust);
+        boundAdjust = _mm_or_ps(next4, boundAdjust);
+        // Make sure we're in the bounding interval:
+        next3old1 = _mm_add_ps(next3old1, boundAdjust);
+        _mm_store_ps(outPtr, next3old1); // Store the results back into the output
+        outPtr += 4;
+    }
+
+    for (number = (4 > (quarterPoints * 4) ? 4 : (4 * quarterPoints));
+         number < num_points;
+         number++) {
+        *outPtr = *(inPtr) - *(inPtr - 1);
+        if (*outPtr > bound)
+            *outPtr -= 2 * bound;
+        if (*outPtr < -bound)
+            *outPtr += 2 * bound;
+        inPtr++;
+        outPtr++;
+    }
+
+    *saveValue = inputVector[num_points - 1];
+}
+#endif /* LV_HAVE_SSE */
+
 #ifdef LV_HAVE_AVX
 #include <immintrin.h>
 
-static inline void volk_32f_s32f_32f_fm_detect_32f_u_avx(float* outputVector,
+static inline void volk_32f_s32f_32f_fm_detect_32f_a_avx(float* outputVector,
                                                          const float* inputVector,
                                                          const float bound,
                                                          float* saveValue,
@@ -478,7 +515,7 @@ static inline void volk_32f_s32f_32f_fm_detect_32f_u_avx(float* outputVector,
     for (; number < eighthPoints; number++) {
         // Load data
         next3old1 = _mm256_loadu_ps((const float*)(inPtr - 1));
-        next4 = _mm256_loadu_ps(inPtr);
+        next4 = _mm256_load_ps(inPtr);
         inPtr += 8;
         // Subtract and store:
         next3old1 = _mm256_sub_ps(next4, next3old1);
@@ -490,7 +527,7 @@ static inline void volk_32f_s32f_32f_fm_detect_32f_u_avx(float* outputVector,
         boundAdjust = _mm256_or_ps(next4, boundAdjust);
         // Make sure we're in the bounding interval:
         next3old1 = _mm256_add_ps(next3old1, boundAdjust);
-        _mm256_storeu_ps(outPtr, next3old1); // Store the results back into the output
+        _mm256_store_ps(outPtr, next3old1); // Store the results back into the output
         outPtr += 8;
     }
 
@@ -509,42 +546,4 @@ static inline void volk_32f_s32f_32f_fm_detect_32f_u_avx(float* outputVector,
 }
 #endif /* LV_HAVE_AVX */
 
-
-#ifdef LV_HAVE_RVV
-#include <riscv_vector.h>
-
-static inline void volk_32f_s32f_32f_fm_detect_32f_rvv(float* outputVector,
-                                                       const float* inputVector,
-                                                       const float bound,
-                                                       float* saveValue,
-                                                       unsigned int num_points)
-{
-    if (num_points < 1)
-        return;
-
-    *outputVector = *inputVector - *saveValue;
-    if (*outputVector > bound)
-        *outputVector -= 2 * bound;
-    if (*outputVector < -bound)
-        *outputVector += 2 * bound;
-    ++inputVector;
-    ++outputVector;
-
-    vfloat32m8_t v2bound = __riscv_vfmv_v_f_f32m8(bound * 2, __riscv_vsetvlmax_e32m8());
-
-    size_t n = num_points - 1;
-    for (size_t vl; n > 0; n -= vl, inputVector += vl, outputVector += vl) {
-        vl = __riscv_vsetvl_e32m8(n);
-        vfloat32m8_t va = __riscv_vle32_v_f32m8(inputVector, vl);
-        vfloat32m8_t vb = __riscv_vle32_v_f32m8(inputVector - 1, vl);
-        vfloat32m8_t v = __riscv_vfsub(va, vb, vl);
-        v = __riscv_vfsub_mu(__riscv_vmfgt(v, bound, vl), v, v, v2bound, vl);
-        v = __riscv_vfadd_mu(__riscv_vmflt(v, -bound, vl), v, v, v2bound, vl);
-        __riscv_vse32(outputVector, v, vl);
-    }
-
-    *saveValue = inputVector[-1];
-}
-#endif /*LV_HAVE_RVV*/
-
-#endif /* INCLUDED_volk_32f_s32f_32f_fm_detect_32f_u_H */
+#endif /* INCLUDED_volk_32f_s32f_32f_fm_detect_32f_a_H */

--- a/kernels/volk/volk_32f_s32f_32f_fm_detect_32f.h
+++ b/kernels/volk/volk_32f_s32f_32f_fm_detect_32f.h
@@ -94,7 +94,7 @@ static inline void volk_32f_s32f_32f_fm_detect_32f_a_avx(float* outputVector,
 
     for (; number < eighthPoints; number++) {
         // Load data
-        next3old1 = _mm256_loadu_ps((float*)(inPtr - 1));
+        next3old1 = _mm256_loadu_ps((const float*)(inPtr - 1));
         next4 = _mm256_load_ps(inPtr);
         inPtr += 8;
         // Subtract and store:
@@ -174,7 +174,7 @@ static inline void volk_32f_s32f_32f_fm_detect_32f_a_sse(float* outputVector,
 
     for (; number < quarterPoints; number++) {
         // Load data
-        next3old1 = _mm_loadu_ps((float*)(inPtr - 1));
+        next3old1 = _mm_loadu_ps((const float*)(inPtr - 1));
         next4 = _mm_load_ps(inPtr);
         inPtr += 4;
         // Subtract and store:
@@ -477,7 +477,7 @@ static inline void volk_32f_s32f_32f_fm_detect_32f_u_avx(float* outputVector,
 
     for (; number < eighthPoints; number++) {
         // Load data
-        next3old1 = _mm256_loadu_ps((float*)(inPtr - 1));
+        next3old1 = _mm256_loadu_ps((const float*)(inPtr - 1));
         next4 = _mm256_loadu_ps(inPtr);
         inPtr += 8;
         // Subtract and store:

--- a/kernels/volk/volk_32f_x3_sum_of_poly_32f.h
+++ b/kernels/volk/volk_32f_x3_sum_of_poly_32f.h
@@ -84,9 +84,9 @@
 #include <xmmintrin.h>
 
 static inline void volk_32f_x3_sum_of_poly_32f_a_sse3(float* target,
-                                                      float* src0,
-                                                      float* center_point_array,
-                                                      float* cutoff,
+                                                      const float* src0,
+                                                      const float* center_point_array,
+                                                      const float* cutoff,
                                                       unsigned int num_points)
 {
     float result = 0.0f;
@@ -175,9 +175,9 @@ static inline void volk_32f_x3_sum_of_poly_32f_a_sse3(float* target,
 #include <immintrin.h>
 
 static inline void volk_32f_x3_sum_of_poly_32f_a_avx2_fma(float* target,
-                                                          float* src0,
-                                                          float* center_point_array,
-                                                          float* cutoff,
+                                                          const float* src0,
+                                                          const float* center_point_array,
+                                                          const float* cutoff,
                                                           unsigned int num_points)
 {
     const unsigned int eighth_points = num_points / 8;
@@ -244,9 +244,9 @@ static inline void volk_32f_x3_sum_of_poly_32f_a_avx2_fma(float* target,
 #include <immintrin.h>
 
 static inline void volk_32f_x3_sum_of_poly_32f_a_avx(float* target,
-                                                     float* src0,
-                                                     float* center_point_array,
-                                                     float* cutoff,
+                                                     const float* src0,
+                                                     const float* center_point_array,
+                                                     const float* cutoff,
                                                      unsigned int num_points)
 {
     const unsigned int eighth_points = num_points / 8;
@@ -315,9 +315,9 @@ static inline void volk_32f_x3_sum_of_poly_32f_a_avx(float* target,
 #ifdef LV_HAVE_GENERIC
 
 static inline void volk_32f_x3_sum_of_poly_32f_generic(float* target,
-                                                       float* src0,
-                                                       float* center_point_array,
-                                                       float* cutoff,
+                                                       const float* src0,
+                                                       const float* center_point_array,
+                                                       const float* cutoff,
                                                        unsigned int num_points)
 {
     const unsigned int eighth_points = num_points / 8;
@@ -365,9 +365,9 @@ static inline void volk_32f_x3_sum_of_poly_32f_generic(float* target,
 #include <arm_neon.h>
 
 static inline void volk_32f_x3_sum_of_poly_32f_neon(float* __restrict target,
-                                                    float* __restrict src0,
-                                                    float* __restrict center_point_array,
-                                                    float* __restrict cutoff,
+                                                    const float* __restrict src0,
+                                                    const float* __restrict center_point_array,
+                                                    const float* __restrict cutoff,
                                                     unsigned int num_points)
 {
     unsigned int i;
@@ -460,9 +460,9 @@ static inline void volk_32f_x3_sum_of_poly_32f_neon(float* __restrict target,
 #include <immintrin.h>
 
 static inline void volk_32f_x3_sum_of_poly_32f_u_avx_fma(float* target,
-                                                         float* src0,
-                                                         float* center_point_array,
-                                                         float* cutoff,
+                                                         const float* src0,
+                                                         const float* center_point_array,
+                                                         const float* cutoff,
                                                          unsigned int num_points)
 {
     const unsigned int eighth_points = num_points / 8;
@@ -530,9 +530,9 @@ static inline void volk_32f_x3_sum_of_poly_32f_u_avx_fma(float* target,
 #include <immintrin.h>
 
 static inline void volk_32f_x3_sum_of_poly_32f_u_avx(float* target,
-                                                     float* src0,
-                                                     float* center_point_array,
-                                                     float* cutoff,
+                                                     const float* src0,
+                                                     const float* center_point_array,
+                                                     const float* cutoff,
                                                      unsigned int num_points)
 {
     const unsigned int eighth_points = num_points / 8;
@@ -604,9 +604,9 @@ static inline void volk_32f_x3_sum_of_poly_32f_u_avx(float* target,
 #include <volk/volk_rvv_intrinsics.h>
 
 static inline void volk_32f_x3_sum_of_poly_32f_rvv(float* target,
-                                                   float* src0,
-                                                   float* center_point_array,
-                                                   float* cutoff,
+                                                   const float* src0,
+                                                   const float* center_point_array,
+                                                   const float* cutoff,
                                                    unsigned int num_points)
 {
     size_t vlmax = __riscv_vsetvlmax_e32m4();

--- a/kernels/volk/volk_32f_x3_sum_of_poly_32f.h
+++ b/kernels/volk/volk_32f_x3_sum_of_poly_32f.h
@@ -68,6 +68,334 @@
  * \endcode
  */
 
+#ifndef INCLUDED_volk_32f_x3_sum_of_poly_32f_u_H
+#define INCLUDED_volk_32f_x3_sum_of_poly_32f_u_H
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <volk/volk_complex.h>
+
+#ifndef MAX
+#define MAX(X, Y) ((X) > (Y) ? (X) : (Y))
+#endif
+
+#ifdef LV_HAVE_GENERIC
+
+static inline void volk_32f_x3_sum_of_poly_32f_generic(float* target,
+                                                       const float* src0,
+                                                       const float* center_point_array,
+                                                       const float* cutoff,
+                                                       unsigned int num_points)
+{
+    const unsigned int eighth_points = num_points / 8;
+
+    float result[8] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
+    float fst = 0.0f;
+    float sq = 0.0f;
+    float thrd = 0.0f;
+    float frth = 0.0f;
+
+    unsigned int i = 0;
+    unsigned int k = 0;
+    for (i = 0; i < eighth_points; ++i) {
+        for (k = 0; k < 8; ++k) {
+            fst = *src0++;
+            fst = MAX(fst, *cutoff);
+            sq = fst * fst;
+            thrd = fst * sq;
+            frth = fst * thrd;
+            result[k] += center_point_array[0] * fst + center_point_array[1] * sq;
+            result[k] += center_point_array[2] * thrd + center_point_array[3] * frth;
+        }
+    }
+    for (k = 0; k < 8; k += 2) {
+        result[k] = result[k] + result[k + 1];
+    }
+
+    *target = result[0] + result[2] + result[4] + result[6];
+
+    for (i = eighth_points * 8; i < num_points; ++i) {
+        fst = *src0++;
+        fst = MAX(fst, *cutoff);
+        sq = fst * fst;
+        thrd = fst * sq;
+        frth = fst * thrd;
+        *target += (center_point_array[0] * fst + center_point_array[1] * sq +
+                    center_point_array[2] * thrd + center_point_array[3] * frth);
+    }
+    *target += (float)(num_points)*center_point_array[4];
+}
+
+#endif /*LV_HAVE_GENERIC*/
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void volk_32f_x3_sum_of_poly_32f_u_avx(float* target,
+                                                     const float* src0,
+                                                     const float* center_point_array,
+                                                     const float* cutoff,
+                                                     unsigned int num_points)
+{
+    const unsigned int eighth_points = num_points / 8;
+    float fst = 0.0;
+    float sq = 0.0;
+    float thrd = 0.0;
+    float frth = 0.0;
+
+    __m256 cpa0, cpa1, cpa2, cpa3, cutoff_vec;
+    __m256 target_vec;
+    __m256 x_to_1, x_to_2, x_to_3, x_to_4;
+
+    cpa0 = _mm256_set1_ps(center_point_array[0]);
+    cpa1 = _mm256_set1_ps(center_point_array[1]);
+    cpa2 = _mm256_set1_ps(center_point_array[2]);
+    cpa3 = _mm256_set1_ps(center_point_array[3]);
+    cutoff_vec = _mm256_set1_ps(*cutoff);
+    target_vec = _mm256_setzero_ps();
+
+    unsigned int i;
+
+    for (i = 0; i < eighth_points; ++i) {
+        x_to_1 = _mm256_loadu_ps(src0);
+        x_to_1 = _mm256_max_ps(x_to_1, cutoff_vec);
+        x_to_2 = _mm256_mul_ps(x_to_1, x_to_1); // x^2
+        x_to_3 = _mm256_mul_ps(x_to_1, x_to_2); // x^3
+        // x^1 * x^3 is slightly faster than x^2 * x^2
+        x_to_4 = _mm256_mul_ps(x_to_1, x_to_3); // x^4
+
+        x_to_1 = _mm256_mul_ps(x_to_1, cpa0); // cpa[0] * x^1
+        x_to_2 = _mm256_mul_ps(x_to_2, cpa1); // cpa[1] * x^2
+        x_to_3 = _mm256_mul_ps(x_to_3, cpa2); // cpa[2] * x^3
+        x_to_4 = _mm256_mul_ps(x_to_4, cpa3); // cpa[3] * x^4
+
+        x_to_1 = _mm256_add_ps(x_to_1, x_to_2);
+        x_to_3 = _mm256_add_ps(x_to_3, x_to_4);
+        // this is slightly faster than result += (x_to_1 + x_to_3)
+        target_vec = _mm256_add_ps(x_to_1, target_vec);
+        target_vec = _mm256_add_ps(x_to_3, target_vec);
+
+        src0 += 8;
+    }
+
+    // the hadd for vector reduction has very very slight impact @ 50k iters
+    __VOLK_ATTR_ALIGNED(32) float temp_results[8];
+    target_vec = _mm256_hadd_ps(
+        target_vec,
+        target_vec); // x0+x1 | x2+x3 | x0+x1 | x2+x3 || x4+x5 | x6+x7 | x4+x5 | x6+x7
+    _mm256_storeu_ps(temp_results, target_vec);
+    *target = temp_results[0] + temp_results[1] + temp_results[4] + temp_results[5];
+
+    for (i = eighth_points * 8; i < num_points; ++i) {
+        fst = *src0++;
+        fst = MAX(fst, *cutoff);
+        sq = fst * fst;
+        thrd = fst * sq;
+        frth = sq * sq;
+
+        *target += (center_point_array[0] * fst + center_point_array[1] * sq +
+                    center_point_array[2] * thrd + center_point_array[3] * frth);
+    }
+
+    *target += (float)(num_points)*center_point_array[4];
+}
+#endif /* LV_HAVE_AVX */
+
+#if LV_HAVE_AVX && LV_HAVE_FMA
+#include <immintrin.h>
+
+static inline void volk_32f_x3_sum_of_poly_32f_u_avx_fma(float* target,
+                                                         const float* src0,
+                                                         const float* center_point_array,
+                                                         const float* cutoff,
+                                                         unsigned int num_points)
+{
+    const unsigned int eighth_points = num_points / 8;
+    float fst = 0.0;
+    float sq = 0.0;
+    float thrd = 0.0;
+    float frth = 0.0;
+
+    __m256 cpa0, cpa1, cpa2, cpa3, cutoff_vec;
+    __m256 target_vec;
+    __m256 x_to_1, x_to_2, x_to_3, x_to_4;
+
+    cpa0 = _mm256_set1_ps(center_point_array[0]);
+    cpa1 = _mm256_set1_ps(center_point_array[1]);
+    cpa2 = _mm256_set1_ps(center_point_array[2]);
+    cpa3 = _mm256_set1_ps(center_point_array[3]);
+    cutoff_vec = _mm256_set1_ps(*cutoff);
+    target_vec = _mm256_setzero_ps();
+
+    unsigned int i;
+
+    for (i = 0; i < eighth_points; ++i) {
+        x_to_1 = _mm256_loadu_ps(src0);
+        x_to_1 = _mm256_max_ps(x_to_1, cutoff_vec);
+        x_to_2 = _mm256_mul_ps(x_to_1, x_to_1); // x^2
+        x_to_3 = _mm256_mul_ps(x_to_1, x_to_2); // x^3
+        // x^1 * x^3 is slightly faster than x^2 * x^2
+        x_to_4 = _mm256_mul_ps(x_to_1, x_to_3); // x^4
+
+        x_to_2 = _mm256_mul_ps(x_to_2, cpa1); // cpa[1] * x^2
+        x_to_4 = _mm256_mul_ps(x_to_4, cpa3); // cpa[3] * x^4
+
+        x_to_1 = _mm256_fmadd_ps(x_to_1, cpa0, x_to_2);
+        x_to_3 = _mm256_fmadd_ps(x_to_3, cpa2, x_to_4);
+        // this is slightly faster than result += (x_to_1 + x_to_3)
+        target_vec = _mm256_add_ps(x_to_1, target_vec);
+        target_vec = _mm256_add_ps(x_to_3, target_vec);
+
+        src0 += 8;
+    }
+
+    // the hadd for vector reduction has very very slight impact @ 50k iters
+    __VOLK_ATTR_ALIGNED(32) float temp_results[8];
+    target_vec = _mm256_hadd_ps(
+        target_vec,
+        target_vec); // x0+x1 | x2+x3 | x0+x1 | x2+x3 || x4+x5 | x6+x7 | x4+x5 | x6+x7
+    _mm256_storeu_ps(temp_results, target_vec);
+    *target = temp_results[0] + temp_results[1] + temp_results[4] + temp_results[5];
+
+    for (i = eighth_points * 8; i < num_points; ++i) {
+        fst = *src0++;
+        fst = MAX(fst, *cutoff);
+        sq = fst * fst;
+        thrd = fst * sq;
+        frth = sq * sq;
+        *target += (center_point_array[0] * fst + center_point_array[1] * sq +
+                    center_point_array[2] * thrd + center_point_array[3] * frth);
+    }
+
+    *target += (float)(num_points)*center_point_array[4];
+}
+#endif /* LV_HAVE_AVX && LV_HAVE_FMA */
+
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+
+static inline void volk_32f_x3_sum_of_poly_32f_neon(float* __restrict target,
+                                                    const float* __restrict src0,
+                                                    const float* __restrict center_point_array,
+                                                    const float* __restrict cutoff,
+                                                    unsigned int num_points)
+{
+    unsigned int i;
+    float zero[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+
+    float accumulator;
+
+    float32x4_t accumulator1_vec, accumulator2_vec, accumulator3_vec, accumulator4_vec;
+    accumulator1_vec = vld1q_f32(zero);
+    accumulator2_vec = vld1q_f32(zero);
+    accumulator3_vec = vld1q_f32(zero);
+    accumulator4_vec = vld1q_f32(zero);
+    float32x4_t x_to_1, x_to_2, x_to_3, x_to_4;
+    float32x4_t cutoff_vector, cpa_0, cpa_1, cpa_2, cpa_3;
+
+    // load the cutoff in to a vector
+    cutoff_vector = vdupq_n_f32(*cutoff);
+    // ... center point array
+    cpa_0 = vdupq_n_f32(center_point_array[0]);
+    cpa_1 = vdupq_n_f32(center_point_array[1]);
+    cpa_2 = vdupq_n_f32(center_point_array[2]);
+    cpa_3 = vdupq_n_f32(center_point_array[3]);
+
+    for (i = 0; i < num_points / 4; ++i) {
+        // load x
+        x_to_1 = vld1q_f32(src0);
+
+        // Get a vector of max(src0, cutoff)
+        x_to_1 = vmaxq_f32(x_to_1, cutoff_vector); // x^1
+        x_to_2 = vmulq_f32(x_to_1, x_to_1);        // x^2
+        x_to_3 = vmulq_f32(x_to_2, x_to_1);        // x^3
+        x_to_4 = vmulq_f32(x_to_3, x_to_1);        // x^4
+        x_to_1 = vmulq_f32(x_to_1, cpa_0);
+        x_to_2 = vmulq_f32(x_to_2, cpa_1);
+        x_to_3 = vmulq_f32(x_to_3, cpa_2);
+        x_to_4 = vmulq_f32(x_to_4, cpa_3);
+        accumulator1_vec = vaddq_f32(accumulator1_vec, x_to_1);
+        accumulator2_vec = vaddq_f32(accumulator2_vec, x_to_2);
+        accumulator3_vec = vaddq_f32(accumulator3_vec, x_to_3);
+        accumulator4_vec = vaddq_f32(accumulator4_vec, x_to_4);
+
+        src0 += 4;
+    }
+    accumulator1_vec = vaddq_f32(accumulator1_vec, accumulator2_vec);
+    accumulator3_vec = vaddq_f32(accumulator3_vec, accumulator4_vec);
+    accumulator1_vec = vaddq_f32(accumulator1_vec, accumulator3_vec);
+
+    __VOLK_ATTR_ALIGNED(32) float res_accumulators[4];
+    vst1q_f32(res_accumulators, accumulator1_vec);
+    accumulator = res_accumulators[0] + res_accumulators[1] + res_accumulators[2] +
+                  res_accumulators[3];
+
+    float fst = 0.0;
+    float sq = 0.0;
+    float thrd = 0.0;
+    float frth = 0.0;
+
+    for (i = 4 * (num_points / 4); i < num_points; ++i) {
+        fst = *src0++;
+        fst = MAX(fst, *cutoff);
+
+        sq = fst * fst;
+        thrd = fst * sq;
+        frth = sq * sq;
+        // fith = sq * thrd;
+
+        accumulator += (center_point_array[0] * fst + center_point_array[1] * sq +
+                        center_point_array[2] * thrd + center_point_array[3] * frth); //+
+    }
+
+    *target = accumulator + (float)num_points * center_point_array[4];
+}
+
+#endif /* LV_HAVE_NEON */
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+#include <volk/volk_rvv_intrinsics.h>
+
+static inline void volk_32f_x3_sum_of_poly_32f_rvv(float* target,
+                                                   const float* src0,
+                                                   const float* center_point_array,
+                                                   const float* cutoff,
+                                                   unsigned int num_points)
+{
+    size_t vlmax = __riscv_vsetvlmax_e32m4();
+    vfloat32m4_t vsum = __riscv_vfmv_v_f_f32m4(0, vlmax);
+    float mul1 = center_point_array[0]; // scalar to avoid register spills
+    float mul2 = center_point_array[1];
+    vfloat32m4_t vmul3 = __riscv_vfmv_v_f_f32m4(center_point_array[2], vlmax);
+    vfloat32m4_t vmul4 = __riscv_vfmv_v_f_f32m4(center_point_array[3], vlmax);
+    vfloat32m4_t vmax = __riscv_vfmv_v_f_f32m4(*cutoff, vlmax);
+
+    size_t n = num_points;
+    for (size_t vl; n > 0; n -= vl, src0 += vl) {
+        vl = __riscv_vsetvl_e32m4(n);
+        vfloat32m4_t v = __riscv_vle32_v_f32m4(src0, vl);
+        vfloat32m4_t v1 = __riscv_vfmax(v, vmax, vl);
+        vfloat32m4_t v2 = __riscv_vfmul(v1, v1, vl);
+        vfloat32m4_t v3 = __riscv_vfmul(v1, v2, vl);
+        vfloat32m4_t v4 = __riscv_vfmul(v2, v2, vl);
+        v2 = __riscv_vfmul(v2, mul2, vl);
+        v4 = __riscv_vfmul(v4, vmul4, vl);
+        v1 = __riscv_vfmadd(v1, mul1, v2, vl);
+        v3 = __riscv_vfmadd(v3, vmul3, v4, vl);
+        v1 = __riscv_vfadd(v1, v3, vl);
+        vsum = __riscv_vfadd_tu(vsum, vsum, v1, vl);
+    }
+    size_t vl = __riscv_vsetvlmax_e32m1();
+    vfloat32m1_t v = RISCV_SHRINK4(vfadd, f, 32, vsum);
+    vfloat32m1_t z = __riscv_vfmv_s_f_f32m1(0, vl);
+    float sum = __riscv_vfmv_f(__riscv_vfredusum(v, z, vl));
+    *target = sum + num_points * center_point_array[4];
+}
+#endif /*LV_HAVE_RVV*/
+
+#endif /*INCLUDED_volk_32f_x3_sum_of_poly_32f_u_H*/
+
 #ifndef INCLUDED_volk_32f_x3_sum_of_poly_32f_a_H
 #define INCLUDED_volk_32f_x3_sum_of_poly_32f_a_H
 
@@ -171,75 +499,6 @@ static inline void volk_32f_x3_sum_of_poly_32f_a_sse3(float* target,
 
 #endif /*LV_HAVE_SSE3*/
 
-#if LV_HAVE_AVX && LV_HAVE_FMA
-#include <immintrin.h>
-
-static inline void volk_32f_x3_sum_of_poly_32f_a_avx2_fma(float* target,
-                                                          const float* src0,
-                                                          const float* center_point_array,
-                                                          const float* cutoff,
-                                                          unsigned int num_points)
-{
-    const unsigned int eighth_points = num_points / 8;
-    float fst = 0.0;
-    float sq = 0.0;
-    float thrd = 0.0;
-    float frth = 0.0;
-
-    __m256 cpa0, cpa1, cpa2, cpa3, cutoff_vec;
-    __m256 target_vec;
-    __m256 x_to_1, x_to_2, x_to_3, x_to_4;
-
-    cpa0 = _mm256_set1_ps(center_point_array[0]);
-    cpa1 = _mm256_set1_ps(center_point_array[1]);
-    cpa2 = _mm256_set1_ps(center_point_array[2]);
-    cpa3 = _mm256_set1_ps(center_point_array[3]);
-    cutoff_vec = _mm256_set1_ps(*cutoff);
-    target_vec = _mm256_setzero_ps();
-
-    unsigned int i;
-
-    for (i = 0; i < eighth_points; ++i) {
-        x_to_1 = _mm256_load_ps(src0);
-        x_to_1 = _mm256_max_ps(x_to_1, cutoff_vec);
-        x_to_2 = _mm256_mul_ps(x_to_1, x_to_1); // x^2
-        x_to_3 = _mm256_mul_ps(x_to_1, x_to_2); // x^3
-        // x^1 * x^3 is slightly faster than x^2 * x^2
-        x_to_4 = _mm256_mul_ps(x_to_1, x_to_3); // x^4
-
-        x_to_2 = _mm256_mul_ps(x_to_2, cpa1); // cpa[1] * x^2
-        x_to_4 = _mm256_mul_ps(x_to_4, cpa3); // cpa[3] * x^4
-
-        x_to_1 = _mm256_fmadd_ps(x_to_1, cpa0, x_to_2);
-        x_to_3 = _mm256_fmadd_ps(x_to_3, cpa2, x_to_4);
-        // this is slightly faster than result += (x_to_1 + x_to_3)
-        target_vec = _mm256_add_ps(x_to_1, target_vec);
-        target_vec = _mm256_add_ps(x_to_3, target_vec);
-
-        src0 += 8;
-    }
-
-    // the hadd for vector reduction has very very slight impact @ 50k iters
-    __VOLK_ATTR_ALIGNED(32) float temp_results[8];
-    target_vec = _mm256_hadd_ps(
-        target_vec,
-        target_vec); // x0+x1 | x2+x3 | x0+x1 | x2+x3 || x4+x5 | x6+x7 | x4+x5 | x6+x7
-    _mm256_store_ps(temp_results, target_vec);
-    *target = temp_results[0] + temp_results[1] + temp_results[4] + temp_results[5];
-
-    for (i = eighth_points * 8; i < num_points; ++i) {
-        fst = *src0++;
-        fst = MAX(fst, *cutoff);
-        sq = fst * fst;
-        thrd = fst * sq;
-        frth = sq * sq;
-        *target += (center_point_array[0] * fst + center_point_array[1] * sq +
-                    center_point_array[2] * thrd + center_point_array[3] * frth);
-    }
-    *target += (float)(num_points)*center_point_array[4];
-}
-#endif // LV_HAVE_AVX && LV_HAVE_FMA
-
 #ifdef LV_HAVE_AVX
 #include <immintrin.h>
 
@@ -309,161 +568,16 @@ static inline void volk_32f_x3_sum_of_poly_32f_a_avx(float* target,
     }
     *target += (float)(num_points)*center_point_array[4];
 }
-#endif // LV_HAVE_AVX
-
-
-#ifdef LV_HAVE_GENERIC
-
-static inline void volk_32f_x3_sum_of_poly_32f_generic(float* target,
-                                                       const float* src0,
-                                                       const float* center_point_array,
-                                                       const float* cutoff,
-                                                       unsigned int num_points)
-{
-    const unsigned int eighth_points = num_points / 8;
-
-    float result[8] = { 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f };
-    float fst = 0.0f;
-    float sq = 0.0f;
-    float thrd = 0.0f;
-    float frth = 0.0f;
-
-    unsigned int i = 0;
-    unsigned int k = 0;
-    for (i = 0; i < eighth_points; ++i) {
-        for (k = 0; k < 8; ++k) {
-            fst = *src0++;
-            fst = MAX(fst, *cutoff);
-            sq = fst * fst;
-            thrd = fst * sq;
-            frth = fst * thrd;
-            result[k] += center_point_array[0] * fst + center_point_array[1] * sq;
-            result[k] += center_point_array[2] * thrd + center_point_array[3] * frth;
-        }
-    }
-    for (k = 0; k < 8; k += 2) {
-        result[k] = result[k] + result[k + 1];
-    }
-
-    *target = result[0] + result[2] + result[4] + result[6];
-
-    for (i = eighth_points * 8; i < num_points; ++i) {
-        fst = *src0++;
-        fst = MAX(fst, *cutoff);
-        sq = fst * fst;
-        thrd = fst * sq;
-        frth = fst * thrd;
-        *target += (center_point_array[0] * fst + center_point_array[1] * sq +
-                    center_point_array[2] * thrd + center_point_array[3] * frth);
-    }
-    *target += (float)(num_points)*center_point_array[4];
-}
-
-#endif /*LV_HAVE_GENERIC*/
-
-#ifdef LV_HAVE_NEON
-#include <arm_neon.h>
-
-static inline void volk_32f_x3_sum_of_poly_32f_neon(float* __restrict target,
-                                                    const float* __restrict src0,
-                                                    const float* __restrict center_point_array,
-                                                    const float* __restrict cutoff,
-                                                    unsigned int num_points)
-{
-    unsigned int i;
-    float zero[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
-
-    float accumulator;
-
-    float32x4_t accumulator1_vec, accumulator2_vec, accumulator3_vec, accumulator4_vec;
-    accumulator1_vec = vld1q_f32(zero);
-    accumulator2_vec = vld1q_f32(zero);
-    accumulator3_vec = vld1q_f32(zero);
-    accumulator4_vec = vld1q_f32(zero);
-    float32x4_t x_to_1, x_to_2, x_to_3, x_to_4;
-    float32x4_t cutoff_vector, cpa_0, cpa_1, cpa_2, cpa_3;
-
-    // load the cutoff in to a vector
-    cutoff_vector = vdupq_n_f32(*cutoff);
-    // ... center point array
-    cpa_0 = vdupq_n_f32(center_point_array[0]);
-    cpa_1 = vdupq_n_f32(center_point_array[1]);
-    cpa_2 = vdupq_n_f32(center_point_array[2]);
-    cpa_3 = vdupq_n_f32(center_point_array[3]);
-
-    for (i = 0; i < num_points / 4; ++i) {
-        // load x
-        x_to_1 = vld1q_f32(src0);
-
-        // Get a vector of max(src0, cutoff)
-        x_to_1 = vmaxq_f32(x_to_1, cutoff_vector); // x^1
-        x_to_2 = vmulq_f32(x_to_1, x_to_1);        // x^2
-        x_to_3 = vmulq_f32(x_to_2, x_to_1);        // x^3
-        x_to_4 = vmulq_f32(x_to_3, x_to_1);        // x^4
-        x_to_1 = vmulq_f32(x_to_1, cpa_0);
-        x_to_2 = vmulq_f32(x_to_2, cpa_1);
-        x_to_3 = vmulq_f32(x_to_3, cpa_2);
-        x_to_4 = vmulq_f32(x_to_4, cpa_3);
-        accumulator1_vec = vaddq_f32(accumulator1_vec, x_to_1);
-        accumulator2_vec = vaddq_f32(accumulator2_vec, x_to_2);
-        accumulator3_vec = vaddq_f32(accumulator3_vec, x_to_3);
-        accumulator4_vec = vaddq_f32(accumulator4_vec, x_to_4);
-
-        src0 += 4;
-    }
-    accumulator1_vec = vaddq_f32(accumulator1_vec, accumulator2_vec);
-    accumulator3_vec = vaddq_f32(accumulator3_vec, accumulator4_vec);
-    accumulator1_vec = vaddq_f32(accumulator1_vec, accumulator3_vec);
-
-    __VOLK_ATTR_ALIGNED(32) float res_accumulators[4];
-    vst1q_f32(res_accumulators, accumulator1_vec);
-    accumulator = res_accumulators[0] + res_accumulators[1] + res_accumulators[2] +
-                  res_accumulators[3];
-
-    float fst = 0.0;
-    float sq = 0.0;
-    float thrd = 0.0;
-    float frth = 0.0;
-
-    for (i = 4 * (num_points / 4); i < num_points; ++i) {
-        fst = *src0++;
-        fst = MAX(fst, *cutoff);
-
-        sq = fst * fst;
-        thrd = fst * sq;
-        frth = sq * sq;
-        // fith = sq * thrd;
-
-        accumulator += (center_point_array[0] * fst + center_point_array[1] * sq +
-                        center_point_array[2] * thrd + center_point_array[3] * frth); //+
-    }
-
-    *target = accumulator + (float)num_points * center_point_array[4];
-}
-
-#endif /* LV_HAVE_NEON */
-
-#endif /*INCLUDED_volk_32f_x3_sum_of_poly_32f_a_H*/
-
-#ifndef INCLUDED_volk_32f_x3_sum_of_poly_32f_u_H
-#define INCLUDED_volk_32f_x3_sum_of_poly_32f_u_H
-
-#include <inttypes.h>
-#include <stdio.h>
-#include <volk/volk_complex.h>
-
-#ifndef MAX
-#define MAX(X, Y) ((X) > (Y) ? (X) : (Y))
-#endif
+#endif /* LV_HAVE_AVX */
 
 #if LV_HAVE_AVX && LV_HAVE_FMA
 #include <immintrin.h>
 
-static inline void volk_32f_x3_sum_of_poly_32f_u_avx_fma(float* target,
-                                                         const float* src0,
-                                                         const float* center_point_array,
-                                                         const float* cutoff,
-                                                         unsigned int num_points)
+static inline void volk_32f_x3_sum_of_poly_32f_a_avx2_fma(float* target,
+                                                          const float* src0,
+                                                          const float* center_point_array,
+                                                          const float* cutoff,
+                                                          unsigned int num_points)
 {
     const unsigned int eighth_points = num_points / 8;
     float fst = 0.0;
@@ -485,7 +599,7 @@ static inline void volk_32f_x3_sum_of_poly_32f_u_avx_fma(float* target,
     unsigned int i;
 
     for (i = 0; i < eighth_points; ++i) {
-        x_to_1 = _mm256_loadu_ps(src0);
+        x_to_1 = _mm256_load_ps(src0);
         x_to_1 = _mm256_max_ps(x_to_1, cutoff_vec);
         x_to_2 = _mm256_mul_ps(x_to_1, x_to_1); // x^2
         x_to_3 = _mm256_mul_ps(x_to_1, x_to_2); // x^3
@@ -509,7 +623,7 @@ static inline void volk_32f_x3_sum_of_poly_32f_u_avx_fma(float* target,
     target_vec = _mm256_hadd_ps(
         target_vec,
         target_vec); // x0+x1 | x2+x3 | x0+x1 | x2+x3 || x4+x5 | x6+x7 | x4+x5 | x6+x7
-    _mm256_storeu_ps(temp_results, target_vec);
+    _mm256_store_ps(temp_results, target_vec);
     *target = temp_results[0] + temp_results[1] + temp_results[4] + temp_results[5];
 
     for (i = eighth_points * 8; i < num_points; ++i) {
@@ -521,123 +635,8 @@ static inline void volk_32f_x3_sum_of_poly_32f_u_avx_fma(float* target,
         *target += (center_point_array[0] * fst + center_point_array[1] * sq +
                     center_point_array[2] * thrd + center_point_array[3] * frth);
     }
-
     *target += (float)(num_points)*center_point_array[4];
 }
-#endif // LV_HAVE_AVX && LV_HAVE_FMA
+#endif /* LV_HAVE_AVX && LV_HAVE_FMA */
 
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-
-static inline void volk_32f_x3_sum_of_poly_32f_u_avx(float* target,
-                                                     const float* src0,
-                                                     const float* center_point_array,
-                                                     const float* cutoff,
-                                                     unsigned int num_points)
-{
-    const unsigned int eighth_points = num_points / 8;
-    float fst = 0.0;
-    float sq = 0.0;
-    float thrd = 0.0;
-    float frth = 0.0;
-
-    __m256 cpa0, cpa1, cpa2, cpa3, cutoff_vec;
-    __m256 target_vec;
-    __m256 x_to_1, x_to_2, x_to_3, x_to_4;
-
-    cpa0 = _mm256_set1_ps(center_point_array[0]);
-    cpa1 = _mm256_set1_ps(center_point_array[1]);
-    cpa2 = _mm256_set1_ps(center_point_array[2]);
-    cpa3 = _mm256_set1_ps(center_point_array[3]);
-    cutoff_vec = _mm256_set1_ps(*cutoff);
-    target_vec = _mm256_setzero_ps();
-
-    unsigned int i;
-
-    for (i = 0; i < eighth_points; ++i) {
-        x_to_1 = _mm256_loadu_ps(src0);
-        x_to_1 = _mm256_max_ps(x_to_1, cutoff_vec);
-        x_to_2 = _mm256_mul_ps(x_to_1, x_to_1); // x^2
-        x_to_3 = _mm256_mul_ps(x_to_1, x_to_2); // x^3
-        // x^1 * x^3 is slightly faster than x^2 * x^2
-        x_to_4 = _mm256_mul_ps(x_to_1, x_to_3); // x^4
-
-        x_to_1 = _mm256_mul_ps(x_to_1, cpa0); // cpa[0] * x^1
-        x_to_2 = _mm256_mul_ps(x_to_2, cpa1); // cpa[1] * x^2
-        x_to_3 = _mm256_mul_ps(x_to_3, cpa2); // cpa[2] * x^3
-        x_to_4 = _mm256_mul_ps(x_to_4, cpa3); // cpa[3] * x^4
-
-        x_to_1 = _mm256_add_ps(x_to_1, x_to_2);
-        x_to_3 = _mm256_add_ps(x_to_3, x_to_4);
-        // this is slightly faster than result += (x_to_1 + x_to_3)
-        target_vec = _mm256_add_ps(x_to_1, target_vec);
-        target_vec = _mm256_add_ps(x_to_3, target_vec);
-
-        src0 += 8;
-    }
-
-    // the hadd for vector reduction has very very slight impact @ 50k iters
-    __VOLK_ATTR_ALIGNED(32) float temp_results[8];
-    target_vec = _mm256_hadd_ps(
-        target_vec,
-        target_vec); // x0+x1 | x2+x3 | x0+x1 | x2+x3 || x4+x5 | x6+x7 | x4+x5 | x6+x7
-    _mm256_storeu_ps(temp_results, target_vec);
-    *target = temp_results[0] + temp_results[1] + temp_results[4] + temp_results[5];
-
-    for (i = eighth_points * 8; i < num_points; ++i) {
-        fst = *src0++;
-        fst = MAX(fst, *cutoff);
-        sq = fst * fst;
-        thrd = fst * sq;
-        frth = sq * sq;
-
-        *target += (center_point_array[0] * fst + center_point_array[1] * sq +
-                    center_point_array[2] * thrd + center_point_array[3] * frth);
-    }
-
-    *target += (float)(num_points)*center_point_array[4];
-}
-#endif // LV_HAVE_AVX
-
-#ifdef LV_HAVE_RVV
-#include <riscv_vector.h>
-#include <volk/volk_rvv_intrinsics.h>
-
-static inline void volk_32f_x3_sum_of_poly_32f_rvv(float* target,
-                                                   const float* src0,
-                                                   const float* center_point_array,
-                                                   const float* cutoff,
-                                                   unsigned int num_points)
-{
-    size_t vlmax = __riscv_vsetvlmax_e32m4();
-    vfloat32m4_t vsum = __riscv_vfmv_v_f_f32m4(0, vlmax);
-    float mul1 = center_point_array[0]; // scalar to avoid register spills
-    float mul2 = center_point_array[1];
-    vfloat32m4_t vmul3 = __riscv_vfmv_v_f_f32m4(center_point_array[2], vlmax);
-    vfloat32m4_t vmul4 = __riscv_vfmv_v_f_f32m4(center_point_array[3], vlmax);
-    vfloat32m4_t vmax = __riscv_vfmv_v_f_f32m4(*cutoff, vlmax);
-
-    size_t n = num_points;
-    for (size_t vl; n > 0; n -= vl, src0 += vl) {
-        vl = __riscv_vsetvl_e32m4(n);
-        vfloat32m4_t v = __riscv_vle32_v_f32m4(src0, vl);
-        vfloat32m4_t v1 = __riscv_vfmax(v, vmax, vl);
-        vfloat32m4_t v2 = __riscv_vfmul(v1, v1, vl);
-        vfloat32m4_t v3 = __riscv_vfmul(v1, v2, vl);
-        vfloat32m4_t v4 = __riscv_vfmul(v2, v2, vl);
-        v2 = __riscv_vfmul(v2, mul2, vl);
-        v4 = __riscv_vfmul(v4, vmul4, vl);
-        v1 = __riscv_vfmadd(v1, mul1, v2, vl);
-        v3 = __riscv_vfmadd(v3, vmul3, v4, vl);
-        v1 = __riscv_vfadd(v1, v3, vl);
-        vsum = __riscv_vfadd_tu(vsum, vsum, v1, vl);
-    }
-    size_t vl = __riscv_vsetvlmax_e32m1();
-    vfloat32m1_t v = RISCV_SHRINK4(vfadd, f, 32, vsum);
-    vfloat32m1_t z = __riscv_vfmv_s_f_f32m1(0, vl);
-    float sum = __riscv_vfmv_f(__riscv_vfredusum(v, z, vl));
-    *target = sum + num_points * center_point_array[4];
-}
-#endif /*LV_HAVE_RVV*/
-
-#endif /*INCLUDED_volk_32f_x3_sum_of_poly_32f_u_H*/
+#endif /*INCLUDED_volk_32f_x3_sum_of_poly_32f_a_H*/

--- a/kernels/volk/volk_32fc_32f_add_32fc.h
+++ b/kernels/volk/volk_32fc_32f_add_32fc.h
@@ -102,8 +102,8 @@ static inline void volk_32fc_32f_add_32fc_u_avx(lv_32fc_t* cVector,
     __m256 tmp1, tmp2;
     for (; number < eighthPoints; number++) {
 
-        aVal1 = _mm256_loadu_ps((float*)aPtr);
-        aVal2 = _mm256_loadu_ps((float*)(aPtr + 4));
+        aVal1 = _mm256_loadu_ps((const float*)aPtr);
+        aVal2 = _mm256_loadu_ps((const float*)(aPtr + 4));
         bVal = _mm256_loadu_ps(bPtr);
         cpx_b1 = _mm256_unpacklo_ps(bVal, zero); // b0, 0, b1, 0, b4, 0, b5, 0
         cpx_b2 = _mm256_unpackhi_ps(bVal, zero); // b2, 0, b3, 0, b6, 0, b7, 0
@@ -153,8 +153,8 @@ static inline void volk_32fc_32f_add_32fc_a_avx(lv_32fc_t* cVector,
     __m256 tmp1, tmp2;
     for (; number < eighthPoints; number++) {
 
-        aVal1 = _mm256_load_ps((float*)aPtr);
-        aVal2 = _mm256_load_ps((float*)(aPtr + 4));
+        aVal1 = _mm256_load_ps((const float*)aPtr);
+        aVal2 = _mm256_load_ps((const float*)(aPtr + 4));
         bVal = _mm256_load_ps(bPtr);
         cpx_b1 = _mm256_unpacklo_ps(bVal, zero); // b0, 0, b1, 0, b4, 0, b5, 0
         cpx_b2 = _mm256_unpackhi_ps(bVal, zero); // b2, 0, b3, 0, b6, 0, b7, 0

--- a/kernels/volk/volk_32fc_32f_add_32fc.h
+++ b/kernels/volk/volk_32fc_32f_add_32fc.h
@@ -131,57 +131,6 @@ static inline void volk_32fc_32f_add_32fc_u_avx(lv_32fc_t* cVector,
 }
 #endif /* LV_HAVE_AVX */
 
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-
-static inline void volk_32fc_32f_add_32fc_a_avx(lv_32fc_t* cVector,
-                                                const lv_32fc_t* aVector,
-                                                const float* bVector,
-                                                unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int eighthPoints = num_points / 8;
-
-    lv_32fc_t* cPtr = cVector;
-    const lv_32fc_t* aPtr = aVector;
-    const float* bPtr = bVector;
-
-    __m256 aVal1, aVal2, bVal, cVal1, cVal2;
-    __m256 cpx_b1, cpx_b2;
-    __m256 zero;
-    zero = _mm256_setzero_ps();
-    __m256 tmp1, tmp2;
-    for (; number < eighthPoints; number++) {
-
-        aVal1 = _mm256_load_ps((const float*)aPtr);
-        aVal2 = _mm256_load_ps((const float*)(aPtr + 4));
-        bVal = _mm256_load_ps(bPtr);
-        cpx_b1 = _mm256_unpacklo_ps(bVal, zero); // b0, 0, b1, 0, b4, 0, b5, 0
-        cpx_b2 = _mm256_unpackhi_ps(bVal, zero); // b2, 0, b3, 0, b6, 0, b7, 0
-
-        tmp1 = _mm256_permute2f128_ps(cpx_b1, cpx_b2, 0x0 + (0x2 << 4));
-        tmp2 = _mm256_permute2f128_ps(cpx_b1, cpx_b2, 0x1 + (0x3 << 4));
-
-        cVal1 = _mm256_add_ps(aVal1, tmp1);
-        cVal2 = _mm256_add_ps(aVal2, tmp2);
-
-        _mm256_store_ps((float*)cPtr,
-                        cVal1); // Store the results back into the C container
-        _mm256_store_ps((float*)(cPtr + 4),
-                        cVal2); // Store the results back into the C container
-
-        aPtr += 8;
-        bPtr += 8;
-        cPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        *cPtr++ = (*aPtr++) + (*bPtr++);
-    }
-}
-#endif /* LV_HAVE_AVX */
-
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
 
@@ -297,5 +246,61 @@ static inline void volk_32fc_32f_add_32fc_rvv(lv_32fc_t* cVector,
     }
 }
 #endif /*LV_HAVE_RVV*/
+
+#endif /* INCLUDED_volk_32fc_32f_add_32fc_u_H */
+
+#ifndef INCLUDED_volk_32fc_32f_add_32fc_a_H
+#define INCLUDED_volk_32fc_32f_add_32fc_a_H
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void volk_32fc_32f_add_32fc_a_avx(lv_32fc_t* cVector,
+                                                const lv_32fc_t* aVector,
+                                                const float* bVector,
+                                                unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    lv_32fc_t* cPtr = cVector;
+    const lv_32fc_t* aPtr = aVector;
+    const float* bPtr = bVector;
+
+    __m256 aVal1, aVal2, bVal, cVal1, cVal2;
+    __m256 cpx_b1, cpx_b2;
+    __m256 zero;
+    zero = _mm256_setzero_ps();
+    __m256 tmp1, tmp2;
+    for (; number < eighthPoints; number++) {
+
+        aVal1 = _mm256_load_ps((const float*)aPtr);
+        aVal2 = _mm256_load_ps((const float*)(aPtr + 4));
+        bVal = _mm256_load_ps(bPtr);
+        cpx_b1 = _mm256_unpacklo_ps(bVal, zero); // b0, 0, b1, 0, b4, 0, b5, 0
+        cpx_b2 = _mm256_unpackhi_ps(bVal, zero); // b2, 0, b3, 0, b6, 0, b7, 0
+
+        tmp1 = _mm256_permute2f128_ps(cpx_b1, cpx_b2, 0x0 + (0x2 << 4));
+        tmp2 = _mm256_permute2f128_ps(cpx_b1, cpx_b2, 0x1 + (0x3 << 4));
+
+        cVal1 = _mm256_add_ps(aVal1, tmp1);
+        cVal2 = _mm256_add_ps(aVal2, tmp2);
+
+        _mm256_store_ps((float*)cPtr,
+                        cVal1); // Store the results back into the C container
+        _mm256_store_ps((float*)(cPtr + 4),
+                        cVal2); // Store the results back into the C container
+
+        aPtr += 8;
+        bPtr += 8;
+        cPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *cPtr++ = (*aPtr++) + (*bPtr++);
+    }
+}
+#endif /* LV_HAVE_AVX */
 
 #endif /* INCLUDED_volk_32fc_32f_add_32fc_a_H */

--- a/kernels/volk/volk_32fc_32f_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_32f_dot_prod_32fc.h
@@ -47,8 +47,8 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32fc_32f_dot_prod_32fc_a_H
-#define INCLUDED_volk_32fc_32f_dot_prod_32fc_a_H
+#ifndef INCLUDED_volk_32fc_32f_dot_prod_32fc_u_H
+#define INCLUDED_volk_32fc_32f_dot_prod_32fc_u_H
 
 #include <stdio.h>
 #include <volk/volk_common.h>
@@ -77,15 +77,95 @@ static inline void volk_32fc_32f_dot_prod_32fc_generic(lv_32fc_t* result,
 
 #endif /*LV_HAVE_GENERIC*/
 
-#ifdef LV_HAVE_AVX512F
+#ifdef LV_HAVE_SSE
+
+static inline void volk_32fc_32f_dot_prod_32fc_u_sse(lv_32fc_t* result,
+                                                     const lv_32fc_t* input,
+                                                     const float* taps,
+                                                     unsigned int num_points)
+{
+
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
+    const float* aPtr = (const float*)input;
+    const float* bPtr = taps;
+
+    __m128 a0Val, a1Val, a2Val, a3Val;
+    __m128 b0Val, b1Val, b2Val, b3Val;
+    __m128 x0Val, x1Val, x2Val, x3Val;
+    __m128 c0Val, c1Val, c2Val, c3Val;
+
+    __m128 dotProdVal0 = _mm_setzero_ps();
+    __m128 dotProdVal1 = _mm_setzero_ps();
+    __m128 dotProdVal2 = _mm_setzero_ps();
+    __m128 dotProdVal3 = _mm_setzero_ps();
+
+    for (; number < eighthPoints; number++) {
+
+        a0Val = _mm_loadu_ps(aPtr);
+        a1Val = _mm_loadu_ps(aPtr + 4);
+        a2Val = _mm_loadu_ps(aPtr + 8);
+        a3Val = _mm_loadu_ps(aPtr + 12);
+
+        x0Val = _mm_loadu_ps(bPtr);
+        x1Val = _mm_loadu_ps(bPtr);
+        x2Val = _mm_loadu_ps(bPtr + 4);
+        x3Val = _mm_loadu_ps(bPtr + 4);
+        b0Val = _mm_unpacklo_ps(x0Val, x1Val);
+        b1Val = _mm_unpackhi_ps(x0Val, x1Val);
+        b2Val = _mm_unpacklo_ps(x2Val, x3Val);
+        b3Val = _mm_unpackhi_ps(x2Val, x3Val);
+
+        c0Val = _mm_mul_ps(a0Val, b0Val);
+        c1Val = _mm_mul_ps(a1Val, b1Val);
+        c2Val = _mm_mul_ps(a2Val, b2Val);
+        c3Val = _mm_mul_ps(a3Val, b3Val);
+
+        dotProdVal0 = _mm_add_ps(c0Val, dotProdVal0);
+        dotProdVal1 = _mm_add_ps(c1Val, dotProdVal1);
+        dotProdVal2 = _mm_add_ps(c2Val, dotProdVal2);
+        dotProdVal3 = _mm_add_ps(c3Val, dotProdVal3);
+
+        aPtr += 16;
+        bPtr += 8;
+    }
+
+    dotProdVal0 = _mm_add_ps(dotProdVal0, dotProdVal1);
+    dotProdVal0 = _mm_add_ps(dotProdVal0, dotProdVal2);
+    dotProdVal0 = _mm_add_ps(dotProdVal0, dotProdVal3);
+
+    __VOLK_ATTR_ALIGNED(16) float dotProductVector[4];
+
+    _mm_store_ps(dotProductVector,
+                 dotProdVal0); // Store the results back into the dot product vector
+
+    returnValue += lv_cmake(dotProductVector[0], dotProductVector[1]);
+    returnValue += lv_cmake(dotProductVector[2], dotProductVector[3]);
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        returnValue += lv_cmake(aPtr[0] * bPtr[0], aPtr[1] * bPtr[0]);
+        aPtr += 2;
+        bPtr += 1;
+    }
+
+    *result = returnValue;
+}
+
+#endif /*LV_HAVE_SSE*/
+
+#ifdef LV_HAVE_AVX
 
 #include <immintrin.h>
 
-static inline void volk_32fc_32f_dot_prod_32fc_a_avx512f(lv_32fc_t* result,
-                                                         const lv_32fc_t* input,
-                                                         const float* taps,
-                                                         unsigned int num_points)
+static inline void volk_32fc_32f_dot_prod_32fc_u_avx(lv_32fc_t* result,
+                                                     const lv_32fc_t* input,
+                                                     const float* taps,
+                                                     unsigned int num_points)
 {
+
     unsigned int number = 0;
     const unsigned int sixteenthPoints = num_points / 16;
 
@@ -93,62 +173,80 @@ static inline void volk_32fc_32f_dot_prod_32fc_a_avx512f(lv_32fc_t* result,
     const float* aPtr = (const float*)input;
     const float* bPtr = taps;
 
-    __m512 a0Val, a1Val;
-    __m512 b0Val, b1Val;
-    __m512 xVal;
+    __m256 a0Val, a1Val, a2Val, a3Val;
+    __m256 b0Val, b1Val, b2Val, b3Val;
+    __m256 x0Val, x1Val, x0loVal, x0hiVal, x1loVal, x1hiVal;
+    __m256 c0Val, c1Val, c2Val, c3Val;
 
-    __m512 dotProdVal0 = _mm512_setzero_ps();
-    __m512 dotProdVal1 = _mm512_setzero_ps();
-
-    // Create index patterns for duplication: 0,0,1,1,2,2,3,3,...,15,15
-    const __m512i idx = _mm512_setr_epi32(0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7);
-    const __m512i idx2 =
-        _mm512_setr_epi32(8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15);
+    __m256 dotProdVal0 = _mm256_setzero_ps();
+    __m256 dotProdVal1 = _mm256_setzero_ps();
+    __m256 dotProdVal2 = _mm256_setzero_ps();
+    __m256 dotProdVal3 = _mm256_setzero_ps();
 
     for (; number < sixteenthPoints; number++) {
-        // Load 16 complex numbers (32 floats)
-        a0Val = _mm512_load_ps(aPtr);      // 8 complex (I0,Q0,I1,Q1,...)
-        a1Val = _mm512_load_ps(aPtr + 16); // 8 complex (I8,Q8,I9,Q9,...)
 
-        // Load 16 real taps
-        xVal = _mm512_load_ps(bPtr); // t0|t1|t2|...|t15
+        a0Val = _mm256_loadu_ps(aPtr);
+        a1Val = _mm256_loadu_ps(aPtr + 8);
+        a2Val = _mm256_loadu_ps(aPtr + 16);
+        a3Val = _mm256_loadu_ps(aPtr + 24);
 
-        // Duplicate each tap value to match complex format using permutexvar
-        b0Val = _mm512_permutexvar_ps(idx, xVal);
-        b1Val = _mm512_permutexvar_ps(idx2, xVal);
+        x0Val = _mm256_loadu_ps(bPtr); // t0|t1|t2|t3|t4|t5|t6|t7
+        x1Val = _mm256_loadu_ps(bPtr + 8);
+        x0loVal = _mm256_unpacklo_ps(x0Val, x0Val); // t0|t0|t1|t1|t4|t4|t5|t5
+        x0hiVal = _mm256_unpackhi_ps(x0Val, x0Val); // t2|t2|t3|t3|t6|t6|t7|t7
+        x1loVal = _mm256_unpacklo_ps(x1Val, x1Val);
+        x1hiVal = _mm256_unpackhi_ps(x1Val, x1Val);
 
-        dotProdVal0 = _mm512_fmadd_ps(a0Val, b0Val, dotProdVal0);
-        dotProdVal1 = _mm512_fmadd_ps(a1Val, b1Val, dotProdVal1);
+        // TODO: it may be possible to rearrange swizzling to better pipeline data
+        b0Val = _mm256_permute2f128_ps(x0loVal, x0hiVal, 0x20); // t0|t0|t1|t1|t2|t2|t3|t3
+        b1Val = _mm256_permute2f128_ps(x0loVal, x0hiVal, 0x31); // t4|t4|t5|t5|t6|t6|t7|t7
+        b2Val = _mm256_permute2f128_ps(x1loVal, x1hiVal, 0x20);
+        b3Val = _mm256_permute2f128_ps(x1loVal, x1hiVal, 0x31);
+
+        c0Val = _mm256_mul_ps(a0Val, b0Val);
+        c1Val = _mm256_mul_ps(a1Val, b1Val);
+        c2Val = _mm256_mul_ps(a2Val, b2Val);
+        c3Val = _mm256_mul_ps(a3Val, b3Val);
+
+        dotProdVal0 = _mm256_add_ps(c0Val, dotProdVal0);
+        dotProdVal1 = _mm256_add_ps(c1Val, dotProdVal1);
+        dotProdVal2 = _mm256_add_ps(c2Val, dotProdVal2);
+        dotProdVal3 = _mm256_add_ps(c3Val, dotProdVal3);
 
         aPtr += 32;
         bPtr += 16;
     }
 
-    dotProdVal0 = _mm512_add_ps(dotProdVal0, dotProdVal1);
+    dotProdVal0 = _mm256_add_ps(dotProdVal0, dotProdVal1);
+    dotProdVal0 = _mm256_add_ps(dotProdVal0, dotProdVal2);
+    dotProdVal0 = _mm256_add_ps(dotProdVal0, dotProdVal3);
 
-    __VOLK_ATTR_ALIGNED(64) float dotProductVector[16];
-    _mm512_store_ps(dotProductVector, dotProdVal0);
+    __VOLK_ATTR_ALIGNED(32) float dotProductVector[8];
 
-    for (unsigned int i = 0; i < 16; i += 2) {
-        returnValue += lv_cmake(dotProductVector[i], dotProductVector[i + 1]);
-    }
+    _mm256_store_ps(dotProductVector,
+                    dotProdVal0); // Store the results back into the dot product vector
+
+    returnValue += lv_cmake(dotProductVector[0], dotProductVector[1]);
+    returnValue += lv_cmake(dotProductVector[2], dotProductVector[3]);
+    returnValue += lv_cmake(dotProductVector[4], dotProductVector[5]);
+    returnValue += lv_cmake(dotProductVector[6], dotProductVector[7]);
 
     number = sixteenthPoints * 16;
-    lv_32fc_t returnTail = lv_cmake(0.0f, 0.0f);
-    volk_32fc_32f_dot_prod_32fc_generic(
-        &returnTail, input + number, bPtr, num_points - number);
-    returnValue += returnTail;
+    for (; number < num_points; number++) {
+        returnValue += lv_cmake(aPtr[0] * bPtr[0], aPtr[1] * bPtr[0]);
+        aPtr += 2;
+        bPtr += 1;
+    }
 
     *result = returnValue;
 }
-
-#endif /*LV_HAVE_AVX512F*/
+#endif /*LV_HAVE_AVX*/
 
 #if LV_HAVE_AVX2 && LV_HAVE_FMA
 
 #include <immintrin.h>
 
-static inline void volk_32fc_32f_dot_prod_32fc_a_avx2_fma(lv_32fc_t* result,
+static inline void volk_32fc_32f_dot_prod_32fc_u_avx2_fma(lv_32fc_t* result,
                                                           const lv_32fc_t* input,
                                                           const float* taps,
                                                           unsigned int num_points)
@@ -172,13 +270,13 @@ static inline void volk_32fc_32f_dot_prod_32fc_a_avx2_fma(lv_32fc_t* result,
 
     for (; number < sixteenthPoints; number++) {
 
-        a0Val = _mm256_load_ps(aPtr);
-        a1Val = _mm256_load_ps(aPtr + 8);
-        a2Val = _mm256_load_ps(aPtr + 16);
-        a3Val = _mm256_load_ps(aPtr + 24);
+        a0Val = _mm256_loadu_ps(aPtr);
+        a1Val = _mm256_loadu_ps(aPtr + 8);
+        a2Val = _mm256_loadu_ps(aPtr + 16);
+        a3Val = _mm256_loadu_ps(aPtr + 24);
 
-        x0Val = _mm256_load_ps(bPtr); // t0|t1|t2|t3|t4|t5|t6|t7
-        x1Val = _mm256_load_ps(bPtr + 8);
+        x0Val = _mm256_loadu_ps(bPtr); // t0|t1|t2|t3|t4|t5|t6|t7
+        x1Val = _mm256_loadu_ps(bPtr + 8);
         x0loVal = _mm256_unpacklo_ps(x0Val, x0Val); // t0|t0|t1|t1|t4|t4|t5|t5
         x0hiVal = _mm256_unpackhi_ps(x0Val, x0Val); // t2|t2|t3|t3|t6|t6|t7|t7
         x1loVal = _mm256_unpacklo_ps(x1Val, x1Val);
@@ -214,6 +312,74 @@ static inline void volk_32fc_32f_dot_prod_32fc_a_avx2_fma(lv_32fc_t* result,
     returnValue += lv_cmake(dotProductVector[6], dotProductVector[7]);
 
     number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        returnValue += lv_cmake(aPtr[0] * bPtr[0], aPtr[1] * bPtr[0]);
+        aPtr += 2;
+        bPtr += 1;
+    }
+
+    *result = returnValue;
+}
+
+#endif /*LV_HAVE_AVX2 && LV_HAVE_FMA*/
+
+#ifdef LV_HAVE_AVX512F
+
+#include <immintrin.h>
+
+static inline void volk_32fc_32f_dot_prod_32fc_u_avx512f(lv_32fc_t* result,
+                                                         const lv_32fc_t* input,
+                                                         const float* taps,
+                                                         unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int sixteenthPoints = num_points / 16;
+
+    lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
+    const float* aPtr = (const float*)input;
+    const float* bPtr = taps;
+
+    __m512 a0Val, a1Val;
+    __m512 b0Val, b1Val;
+    __m512 xVal;
+
+    __m512 dotProdVal0 = _mm512_setzero_ps();
+    __m512 dotProdVal1 = _mm512_setzero_ps();
+
+    // Create index patterns for duplication: 0,0,1,1,2,2,3,3,...,15,15
+    const __m512i idx = _mm512_setr_epi32(0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7);
+    const __m512i idx2 =
+        _mm512_setr_epi32(8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15);
+
+    for (; number < sixteenthPoints; number++) {
+        // Load 16 complex numbers (32 floats) - unaligned
+        a0Val = _mm512_loadu_ps(aPtr);      // 8 complex (I0,Q0,I1,Q1,...)
+        a1Val = _mm512_loadu_ps(aPtr + 16); // 8 complex (I8,Q8,I9,Q9,...)
+
+        // Load 16 real taps - unaligned
+        xVal = _mm512_loadu_ps(bPtr); // t0|t1|t2|...|t15
+
+        // Duplicate each tap value to match complex format using permutexvar
+        b0Val = _mm512_permutexvar_ps(idx, xVal);
+        b1Val = _mm512_permutexvar_ps(idx2, xVal);
+
+        dotProdVal0 = _mm512_fmadd_ps(a0Val, b0Val, dotProdVal0);
+        dotProdVal1 = _mm512_fmadd_ps(a1Val, b1Val, dotProdVal1);
+
+        aPtr += 32;
+        bPtr += 16;
+    }
+
+    dotProdVal0 = _mm512_add_ps(dotProdVal0, dotProdVal1);
+
+    __VOLK_ATTR_ALIGNED(64) float dotProductVector[16];
+    _mm512_store_ps(dotProductVector, dotProdVal0);
+
+    for (unsigned int i = 0; i < 16; i += 2) {
+        returnValue += lv_cmake(dotProductVector[i], dotProductVector[i + 1]);
+    }
+
+    number = sixteenthPoints * 16;
     lv_32fc_t returnTail = lv_cmake(0.0f, 0.0f);
     volk_32fc_32f_dot_prod_32fc_generic(
         &returnTail, input + number, bPtr, num_points - number);
@@ -222,7 +388,293 @@ static inline void volk_32fc_32f_dot_prod_32fc_a_avx2_fma(lv_32fc_t* result,
     *result = returnValue;
 }
 
-#endif /*LV_HAVE_AVX2 && LV_HAVE_FMA*/
+#endif /*LV_HAVE_AVX512F*/
+
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+
+static inline void
+volk_32fc_32f_dot_prod_32fc_neon_unroll(lv_32fc_t* __restrict result,
+                                        const lv_32fc_t* __restrict input,
+                                        const float* __restrict taps,
+                                        unsigned int num_points)
+{
+
+    unsigned int number;
+    const unsigned int quarterPoints = num_points / 8;
+
+    lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
+    const float* inputPtr = (const float*)input;
+    const float* tapsPtr = taps;
+    float zero[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+    float accVector_real[4];
+    float accVector_imag[4];
+
+    float32x4x2_t inputVector0, inputVector1;
+    float32x4_t tapsVector0, tapsVector1;
+    float32x4_t tmp_real0, tmp_imag0;
+    float32x4_t tmp_real1, tmp_imag1;
+    float32x4_t real_accumulator0, imag_accumulator0;
+    float32x4_t real_accumulator1, imag_accumulator1;
+
+    // zero out accumulators
+    // take a *float, return float32x4_t
+    real_accumulator0 = vld1q_f32(zero);
+    imag_accumulator0 = vld1q_f32(zero);
+    real_accumulator1 = vld1q_f32(zero);
+    imag_accumulator1 = vld1q_f32(zero);
+
+    for (number = 0; number < quarterPoints; number++) {
+        // load doublewords and duplicate in to second lane
+        tapsVector0 = vld1q_f32(tapsPtr);
+        tapsVector1 = vld1q_f32(tapsPtr + 4);
+
+        // load quadword of complex numbers in to 2 lanes. 1st lane is real, 2dn imag
+        inputVector0 = vld2q_f32(inputPtr);
+        inputVector1 = vld2q_f32(inputPtr + 8);
+        // inputVector is now a struct of two vectors, 0th is real, 1st is imag
+
+        tmp_real0 = vmulq_f32(tapsVector0, inputVector0.val[0]);
+        tmp_imag0 = vmulq_f32(tapsVector0, inputVector0.val[1]);
+
+        tmp_real1 = vmulq_f32(tapsVector1, inputVector1.val[0]);
+        tmp_imag1 = vmulq_f32(tapsVector1, inputVector1.val[1]);
+
+        real_accumulator0 = vaddq_f32(real_accumulator0, tmp_real0);
+        imag_accumulator0 = vaddq_f32(imag_accumulator0, tmp_imag0);
+
+        real_accumulator1 = vaddq_f32(real_accumulator1, tmp_real1);
+        imag_accumulator1 = vaddq_f32(imag_accumulator1, tmp_imag1);
+
+        tapsPtr += 8;
+        inputPtr += 16;
+    }
+
+    real_accumulator0 = vaddq_f32(real_accumulator0, real_accumulator1);
+    imag_accumulator0 = vaddq_f32(imag_accumulator0, imag_accumulator1);
+    // void vst1q_f32( float32_t * ptr, float32x4_t val);
+    // store results back to a complex (array of 2 floats)
+    vst1q_f32(accVector_real, real_accumulator0);
+    vst1q_f32(accVector_imag, imag_accumulator0);
+    returnValue += lv_cmake(
+        accVector_real[0] + accVector_real[1] + accVector_real[2] + accVector_real[3],
+        accVector_imag[0] + accVector_imag[1] + accVector_imag[2] + accVector_imag[3]);
+
+    // clean up the remainder
+    for (number = quarterPoints * 8; number < num_points; number++) {
+        returnValue += lv_cmake(inputPtr[0] * tapsPtr[0], inputPtr[1] * tapsPtr[0]);
+        inputPtr += 2;
+        tapsPtr += 1;
+    }
+
+    *result = returnValue;
+}
+
+#endif /*LV_HAVE_NEON*/
+
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32fc_32f_dot_prod_32fc_neonv8(lv_32fc_t* result,
+                                                      const lv_32fc_t* input,
+                                                      const float* taps,
+                                                      unsigned int num_points)
+{
+    const unsigned int eighthPoints = num_points / 8;
+    const float* inputPtr = (const float*)input;
+    const float* tapsPtr = taps;
+
+    /* Use 2 independent real/imag accumulators for FMA pipelining */
+    float32x4_t real_acc0 = vdupq_n_f32(0);
+    float32x4_t imag_acc0 = vdupq_n_f32(0);
+    float32x4_t real_acc1 = vdupq_n_f32(0);
+    float32x4_t imag_acc1 = vdupq_n_f32(0);
+
+    for (unsigned int number = 0; number < eighthPoints; number++) {
+        /* Load 8 complex values deinterleaved */
+        float32x4x2_t cplx0 = vld2q_f32(inputPtr);
+        float32x4x2_t cplx1 = vld2q_f32(inputPtr + 8);
+
+        /* Load 8 real taps */
+        float32x4_t taps0 = vld1q_f32(tapsPtr);
+        float32x4_t taps1 = vld1q_f32(tapsPtr + 4);
+        __VOLK_PREFETCH(inputPtr + 32);
+        __VOLK_PREFETCH(tapsPtr + 16);
+
+        /* FMA: acc += taps * complex */
+        real_acc0 = vfmaq_f32(real_acc0, taps0, cplx0.val[0]);
+        imag_acc0 = vfmaq_f32(imag_acc0, taps0, cplx0.val[1]);
+        real_acc1 = vfmaq_f32(real_acc1, taps1, cplx1.val[0]);
+        imag_acc1 = vfmaq_f32(imag_acc1, taps1, cplx1.val[1]);
+
+        inputPtr += 16;
+        tapsPtr += 8;
+    }
+
+    /* Combine accumulators */
+    real_acc0 = vaddq_f32(real_acc0, real_acc1);
+    imag_acc0 = vaddq_f32(imag_acc0, imag_acc1);
+
+    /* Horizontal sum */
+    float real_sum = vaddvq_f32(real_acc0);
+    float imag_sum = vaddvq_f32(imag_acc0);
+
+    lv_32fc_t returnValue = lv_cmake(real_sum, imag_sum);
+
+    /* Handle remainder */
+    for (unsigned int number = eighthPoints * 8; number < num_points; number++) {
+        returnValue += lv_cmake(inputPtr[0] * tapsPtr[0], inputPtr[1] * tapsPtr[0]);
+        inputPtr += 2;
+        tapsPtr += 1;
+    }
+
+    *result = returnValue;
+}
+#endif /*LV_HAVE_NEONV8*/
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+#include <volk/volk_rvv_intrinsics.h>
+
+static inline void volk_32fc_32f_dot_prod_32fc_rvv(lv_32fc_t* result,
+                                                   const lv_32fc_t* input,
+                                                   const float* taps,
+                                                   unsigned int num_points)
+{
+    vfloat32m4_t vsumr = __riscv_vfmv_v_f_f32m4(0, __riscv_vsetvlmax_e32m4());
+    vfloat32m4_t vsumi = vsumr;
+    size_t n = num_points;
+    for (size_t vl; n > 0; n -= vl, input += vl, taps += vl) {
+        vl = __riscv_vsetvl_e32m4(n);
+        vuint64m8_t va = __riscv_vle64_v_u64m8((const uint64_t*)input, vl);
+        vfloat32m4_t vbr = __riscv_vle32_v_f32m4(taps, vl), vbi = vbr;
+        vfloat32m4_t var = __riscv_vreinterpret_f32m4(__riscv_vnsrl(va, 0, vl));
+        vfloat32m4_t vai = __riscv_vreinterpret_f32m4(__riscv_vnsrl(va, 32, vl));
+        vsumr = __riscv_vfmacc_tu(vsumr, var, vbr, vl);
+        vsumi = __riscv_vfmacc_tu(vsumi, vai, vbi, vl);
+    }
+    size_t vl = __riscv_vsetvlmax_e32m1();
+    vfloat32m1_t vr = RISCV_SHRINK4(vfadd, f, 32, vsumr);
+    vfloat32m1_t vi = RISCV_SHRINK4(vfadd, f, 32, vsumi);
+    vfloat32m1_t z = __riscv_vfmv_s_f_f32m1(0, vl);
+    *result = lv_cmake(__riscv_vfmv_f(__riscv_vfredusum(vr, z, vl)),
+                       __riscv_vfmv_f(__riscv_vfredusum(vi, z, vl)));
+}
+#endif /*LV_HAVE_RVV*/
+
+#ifdef LV_HAVE_RVVSEG
+#include <riscv_vector.h>
+#include <volk/volk_rvv_intrinsics.h>
+
+static inline void volk_32fc_32f_dot_prod_32fc_rvvseg(lv_32fc_t* result,
+                                                      const lv_32fc_t* input,
+                                                      const float* taps,
+                                                      unsigned int num_points)
+{
+    vfloat32m4_t vsumr = __riscv_vfmv_v_f_f32m4(0, __riscv_vsetvlmax_e32m4());
+    vfloat32m4_t vsumi = vsumr;
+    size_t n = num_points;
+    for (size_t vl; n > 0; n -= vl, input += vl, taps += vl) {
+        vl = __riscv_vsetvl_e32m4(n);
+        vfloat32m4x2_t va = __riscv_vlseg2e32_v_f32m4x2((const float*)input, vl);
+        vfloat32m4_t var = __riscv_vget_f32m4(va, 0), vai = __riscv_vget_f32m4(va, 1);
+        vfloat32m4_t vbr = __riscv_vle32_v_f32m4(taps, vl), vbi = vbr;
+        vsumr = __riscv_vfmacc_tu(vsumr, var, vbr, vl);
+        vsumi = __riscv_vfmacc_tu(vsumi, vai, vbi, vl);
+    }
+    size_t vl = __riscv_vsetvlmax_e32m1();
+    vfloat32m1_t vr = RISCV_SHRINK4(vfadd, f, 32, vsumr);
+    vfloat32m1_t vi = RISCV_SHRINK4(vfadd, f, 32, vsumi);
+    vfloat32m1_t z = __riscv_vfmv_s_f_f32m1(0, vl);
+    *result = lv_cmake(__riscv_vfmv_f(__riscv_vfredusum(vr, z, vl)),
+                       __riscv_vfmv_f(__riscv_vfredusum(vi, z, vl)));
+}
+#endif /*LV_HAVE_RVVSEG*/
+
+#endif /*INCLUDED_volk_32fc_32f_dot_prod_32fc_u_H*/
+
+#ifndef INCLUDED_volk_32fc_32f_dot_prod_32fc_a_H
+#define INCLUDED_volk_32fc_32f_dot_prod_32fc_a_H
+
+#ifdef LV_HAVE_SSE
+
+
+static inline void volk_32fc_32f_dot_prod_32fc_a_sse(lv_32fc_t* result,
+                                                     const lv_32fc_t* input,
+                                                     const float* taps,
+                                                     unsigned int num_points)
+{
+
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
+    const float* aPtr = (const float*)input;
+    const float* bPtr = taps;
+
+    __m128 a0Val, a1Val, a2Val, a3Val;
+    __m128 b0Val, b1Val, b2Val, b3Val;
+    __m128 x0Val, x1Val, x2Val, x3Val;
+    __m128 c0Val, c1Val, c2Val, c3Val;
+
+    __m128 dotProdVal0 = _mm_setzero_ps();
+    __m128 dotProdVal1 = _mm_setzero_ps();
+    __m128 dotProdVal2 = _mm_setzero_ps();
+    __m128 dotProdVal3 = _mm_setzero_ps();
+
+    for (; number < eighthPoints; number++) {
+
+        a0Val = _mm_load_ps(aPtr);
+        a1Val = _mm_load_ps(aPtr + 4);
+        a2Val = _mm_load_ps(aPtr + 8);
+        a3Val = _mm_load_ps(aPtr + 12);
+
+        x0Val = _mm_load_ps(bPtr);
+        x1Val = _mm_load_ps(bPtr);
+        x2Val = _mm_load_ps(bPtr + 4);
+        x3Val = _mm_load_ps(bPtr + 4);
+        b0Val = _mm_unpacklo_ps(x0Val, x1Val);
+        b1Val = _mm_unpackhi_ps(x0Val, x1Val);
+        b2Val = _mm_unpacklo_ps(x2Val, x3Val);
+        b3Val = _mm_unpackhi_ps(x2Val, x3Val);
+
+        c0Val = _mm_mul_ps(a0Val, b0Val);
+        c1Val = _mm_mul_ps(a1Val, b1Val);
+        c2Val = _mm_mul_ps(a2Val, b2Val);
+        c3Val = _mm_mul_ps(a3Val, b3Val);
+
+        dotProdVal0 = _mm_add_ps(c0Val, dotProdVal0);
+        dotProdVal1 = _mm_add_ps(c1Val, dotProdVal1);
+        dotProdVal2 = _mm_add_ps(c2Val, dotProdVal2);
+        dotProdVal3 = _mm_add_ps(c3Val, dotProdVal3);
+
+        aPtr += 16;
+        bPtr += 8;
+    }
+
+    dotProdVal0 = _mm_add_ps(dotProdVal0, dotProdVal1);
+    dotProdVal0 = _mm_add_ps(dotProdVal0, dotProdVal2);
+    dotProdVal0 = _mm_add_ps(dotProdVal0, dotProdVal3);
+
+    __VOLK_ATTR_ALIGNED(16) float dotProductVector[4];
+
+    _mm_store_ps(dotProductVector,
+                 dotProdVal0); // Store the results back into the dot product vector
+
+    returnValue += lv_cmake(dotProductVector[0], dotProductVector[1]);
+    returnValue += lv_cmake(dotProductVector[2], dotProductVector[3]);
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        returnValue += lv_cmake(aPtr[0] * bPtr[0], aPtr[1] * bPtr[0]);
+        aPtr += 2;
+        bPtr += 1;
+    }
+
+    *result = returnValue;
+}
+
+#endif /*LV_HAVE_SSE*/
 
 #ifdef LV_HAVE_AVX
 
@@ -311,159 +763,11 @@ static inline void volk_32fc_32f_dot_prod_32fc_a_avx(lv_32fc_t* result,
 
 #endif /*LV_HAVE_AVX*/
 
-
-#ifdef LV_HAVE_SSE
-
-
-static inline void volk_32fc_32f_dot_prod_32fc_a_sse(lv_32fc_t* result,
-                                                     const lv_32fc_t* input,
-                                                     const float* taps,
-                                                     unsigned int num_points)
-{
-
-    unsigned int number = 0;
-    const unsigned int eighthPoints = num_points / 8;
-
-    lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* aPtr = (const float*)input;
-    const float* bPtr = taps;
-
-    __m128 a0Val, a1Val, a2Val, a3Val;
-    __m128 b0Val, b1Val, b2Val, b3Val;
-    __m128 x0Val, x1Val, x2Val, x3Val;
-    __m128 c0Val, c1Val, c2Val, c3Val;
-
-    __m128 dotProdVal0 = _mm_setzero_ps();
-    __m128 dotProdVal1 = _mm_setzero_ps();
-    __m128 dotProdVal2 = _mm_setzero_ps();
-    __m128 dotProdVal3 = _mm_setzero_ps();
-
-    for (; number < eighthPoints; number++) {
-
-        a0Val = _mm_load_ps(aPtr);
-        a1Val = _mm_load_ps(aPtr + 4);
-        a2Val = _mm_load_ps(aPtr + 8);
-        a3Val = _mm_load_ps(aPtr + 12);
-
-        x0Val = _mm_load_ps(bPtr);
-        x1Val = _mm_load_ps(bPtr);
-        x2Val = _mm_load_ps(bPtr + 4);
-        x3Val = _mm_load_ps(bPtr + 4);
-        b0Val = _mm_unpacklo_ps(x0Val, x1Val);
-        b1Val = _mm_unpackhi_ps(x0Val, x1Val);
-        b2Val = _mm_unpacklo_ps(x2Val, x3Val);
-        b3Val = _mm_unpackhi_ps(x2Val, x3Val);
-
-        c0Val = _mm_mul_ps(a0Val, b0Val);
-        c1Val = _mm_mul_ps(a1Val, b1Val);
-        c2Val = _mm_mul_ps(a2Val, b2Val);
-        c3Val = _mm_mul_ps(a3Val, b3Val);
-
-        dotProdVal0 = _mm_add_ps(c0Val, dotProdVal0);
-        dotProdVal1 = _mm_add_ps(c1Val, dotProdVal1);
-        dotProdVal2 = _mm_add_ps(c2Val, dotProdVal2);
-        dotProdVal3 = _mm_add_ps(c3Val, dotProdVal3);
-
-        aPtr += 16;
-        bPtr += 8;
-    }
-
-    dotProdVal0 = _mm_add_ps(dotProdVal0, dotProdVal1);
-    dotProdVal0 = _mm_add_ps(dotProdVal0, dotProdVal2);
-    dotProdVal0 = _mm_add_ps(dotProdVal0, dotProdVal3);
-
-    __VOLK_ATTR_ALIGNED(16) float dotProductVector[4];
-
-    _mm_store_ps(dotProductVector,
-                 dotProdVal0); // Store the results back into the dot product vector
-
-    returnValue += lv_cmake(dotProductVector[0], dotProductVector[1]);
-    returnValue += lv_cmake(dotProductVector[2], dotProductVector[3]);
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        returnValue += lv_cmake(aPtr[0] * bPtr[0], aPtr[1] * bPtr[0]);
-        aPtr += 2;
-        bPtr += 1;
-    }
-
-    *result = returnValue;
-}
-
-#endif /*LV_HAVE_SSE*/
-
-#ifdef LV_HAVE_AVX512F
-
-#include <immintrin.h>
-
-static inline void volk_32fc_32f_dot_prod_32fc_u_avx512f(lv_32fc_t* result,
-                                                         const lv_32fc_t* input,
-                                                         const float* taps,
-                                                         unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int sixteenthPoints = num_points / 16;
-
-    lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* aPtr = (const float*)input;
-    const float* bPtr = taps;
-
-    __m512 a0Val, a1Val;
-    __m512 b0Val, b1Val;
-    __m512 xVal;
-
-    __m512 dotProdVal0 = _mm512_setzero_ps();
-    __m512 dotProdVal1 = _mm512_setzero_ps();
-
-    // Create index patterns for duplication: 0,0,1,1,2,2,3,3,...,15,15
-    const __m512i idx = _mm512_setr_epi32(0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7);
-    const __m512i idx2 =
-        _mm512_setr_epi32(8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15);
-
-    for (; number < sixteenthPoints; number++) {
-        // Load 16 complex numbers (32 floats) - unaligned
-        a0Val = _mm512_loadu_ps(aPtr);      // 8 complex (I0,Q0,I1,Q1,...)
-        a1Val = _mm512_loadu_ps(aPtr + 16); // 8 complex (I8,Q8,I9,Q9,...)
-
-        // Load 16 real taps - unaligned
-        xVal = _mm512_loadu_ps(bPtr); // t0|t1|t2|...|t15
-
-        // Duplicate each tap value to match complex format using permutexvar
-        b0Val = _mm512_permutexvar_ps(idx, xVal);
-        b1Val = _mm512_permutexvar_ps(idx2, xVal);
-
-        dotProdVal0 = _mm512_fmadd_ps(a0Val, b0Val, dotProdVal0);
-        dotProdVal1 = _mm512_fmadd_ps(a1Val, b1Val, dotProdVal1);
-
-        aPtr += 32;
-        bPtr += 16;
-    }
-
-    dotProdVal0 = _mm512_add_ps(dotProdVal0, dotProdVal1);
-
-    __VOLK_ATTR_ALIGNED(64) float dotProductVector[16];
-    _mm512_store_ps(dotProductVector, dotProdVal0);
-
-    for (unsigned int i = 0; i < 16; i += 2) {
-        returnValue += lv_cmake(dotProductVector[i], dotProductVector[i + 1]);
-    }
-
-    number = sixteenthPoints * 16;
-    lv_32fc_t returnTail = lv_cmake(0.0f, 0.0f);
-    volk_32fc_32f_dot_prod_32fc_generic(
-        &returnTail, input + number, bPtr, num_points - number);
-    returnValue += returnTail;
-
-    *result = returnValue;
-}
-
-#endif /*LV_HAVE_AVX512F*/
-
 #if LV_HAVE_AVX2 && LV_HAVE_FMA
 
 #include <immintrin.h>
 
-static inline void volk_32fc_32f_dot_prod_32fc_u_avx2_fma(lv_32fc_t* result,
+static inline void volk_32fc_32f_dot_prod_32fc_a_avx2_fma(lv_32fc_t* result,
                                                           const lv_32fc_t* input,
                                                           const float* taps,
                                                           unsigned int num_points)
@@ -487,13 +791,13 @@ static inline void volk_32fc_32f_dot_prod_32fc_u_avx2_fma(lv_32fc_t* result,
 
     for (; number < sixteenthPoints; number++) {
 
-        a0Val = _mm256_loadu_ps(aPtr);
-        a1Val = _mm256_loadu_ps(aPtr + 8);
-        a2Val = _mm256_loadu_ps(aPtr + 16);
-        a3Val = _mm256_loadu_ps(aPtr + 24);
+        a0Val = _mm256_load_ps(aPtr);
+        a1Val = _mm256_load_ps(aPtr + 8);
+        a2Val = _mm256_load_ps(aPtr + 16);
+        a3Val = _mm256_load_ps(aPtr + 24);
 
-        x0Val = _mm256_loadu_ps(bPtr); // t0|t1|t2|t3|t4|t5|t6|t7
-        x1Val = _mm256_loadu_ps(bPtr + 8);
+        x0Val = _mm256_load_ps(bPtr); // t0|t1|t2|t3|t4|t5|t6|t7
+        x1Val = _mm256_load_ps(bPtr + 8);
         x0loVal = _mm256_unpacklo_ps(x0Val, x0Val); // t0|t0|t1|t1|t4|t4|t5|t5
         x0hiVal = _mm256_unpackhi_ps(x0Val, x0Val); // t2|t2|t3|t3|t6|t6|t7|t7
         x1loVal = _mm256_unpacklo_ps(x1Val, x1Val);
@@ -529,27 +833,25 @@ static inline void volk_32fc_32f_dot_prod_32fc_u_avx2_fma(lv_32fc_t* result,
     returnValue += lv_cmake(dotProductVector[6], dotProductVector[7]);
 
     number = sixteenthPoints * 16;
-    for (; number < num_points; number++) {
-        returnValue += lv_cmake(aPtr[0] * bPtr[0], aPtr[1] * bPtr[0]);
-        aPtr += 2;
-        bPtr += 1;
-    }
+    lv_32fc_t returnTail = lv_cmake(0.0f, 0.0f);
+    volk_32fc_32f_dot_prod_32fc_generic(
+        &returnTail, input + number, bPtr, num_points - number);
+    returnValue += returnTail;
 
     *result = returnValue;
 }
 
 #endif /*LV_HAVE_AVX2 && LV_HAVE_FMA*/
 
-#ifdef LV_HAVE_AVX
+#ifdef LV_HAVE_AVX512F
 
 #include <immintrin.h>
 
-static inline void volk_32fc_32f_dot_prod_32fc_u_avx(lv_32fc_t* result,
-                                                     const lv_32fc_t* input,
-                                                     const float* taps,
-                                                     unsigned int num_points)
+static inline void volk_32fc_32f_dot_prod_32fc_a_avx512f(lv_32fc_t* result,
+                                                         const lv_32fc_t* input,
+                                                         const float* taps,
+                                                         unsigned int num_points)
 {
-
     unsigned int number = 0;
     const unsigned int sixteenthPoints = num_points / 16;
 
@@ -557,156 +859,56 @@ static inline void volk_32fc_32f_dot_prod_32fc_u_avx(lv_32fc_t* result,
     const float* aPtr = (const float*)input;
     const float* bPtr = taps;
 
-    __m256 a0Val, a1Val, a2Val, a3Val;
-    __m256 b0Val, b1Val, b2Val, b3Val;
-    __m256 x0Val, x1Val, x0loVal, x0hiVal, x1loVal, x1hiVal;
-    __m256 c0Val, c1Val, c2Val, c3Val;
+    __m512 a0Val, a1Val;
+    __m512 b0Val, b1Val;
+    __m512 xVal;
 
-    __m256 dotProdVal0 = _mm256_setzero_ps();
-    __m256 dotProdVal1 = _mm256_setzero_ps();
-    __m256 dotProdVal2 = _mm256_setzero_ps();
-    __m256 dotProdVal3 = _mm256_setzero_ps();
+    __m512 dotProdVal0 = _mm512_setzero_ps();
+    __m512 dotProdVal1 = _mm512_setzero_ps();
+
+    // Create index patterns for duplication: 0,0,1,1,2,2,3,3,...,15,15
+    const __m512i idx = _mm512_setr_epi32(0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7);
+    const __m512i idx2 =
+        _mm512_setr_epi32(8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15);
 
     for (; number < sixteenthPoints; number++) {
+        // Load 16 complex numbers (32 floats)
+        a0Val = _mm512_load_ps(aPtr);      // 8 complex (I0,Q0,I1,Q1,...)
+        a1Val = _mm512_load_ps(aPtr + 16); // 8 complex (I8,Q8,I9,Q9,...)
 
-        a0Val = _mm256_loadu_ps(aPtr);
-        a1Val = _mm256_loadu_ps(aPtr + 8);
-        a2Val = _mm256_loadu_ps(aPtr + 16);
-        a3Val = _mm256_loadu_ps(aPtr + 24);
+        // Load 16 real taps
+        xVal = _mm512_load_ps(bPtr); // t0|t1|t2|...|t15
 
-        x0Val = _mm256_loadu_ps(bPtr); // t0|t1|t2|t3|t4|t5|t6|t7
-        x1Val = _mm256_loadu_ps(bPtr + 8);
-        x0loVal = _mm256_unpacklo_ps(x0Val, x0Val); // t0|t0|t1|t1|t4|t4|t5|t5
-        x0hiVal = _mm256_unpackhi_ps(x0Val, x0Val); // t2|t2|t3|t3|t6|t6|t7|t7
-        x1loVal = _mm256_unpacklo_ps(x1Val, x1Val);
-        x1hiVal = _mm256_unpackhi_ps(x1Val, x1Val);
+        // Duplicate each tap value to match complex format using permutexvar
+        b0Val = _mm512_permutexvar_ps(idx, xVal);
+        b1Val = _mm512_permutexvar_ps(idx2, xVal);
 
-        // TODO: it may be possible to rearrange swizzling to better pipeline data
-        b0Val = _mm256_permute2f128_ps(x0loVal, x0hiVal, 0x20); // t0|t0|t1|t1|t2|t2|t3|t3
-        b1Val = _mm256_permute2f128_ps(x0loVal, x0hiVal, 0x31); // t4|t4|t5|t5|t6|t6|t7|t7
-        b2Val = _mm256_permute2f128_ps(x1loVal, x1hiVal, 0x20);
-        b3Val = _mm256_permute2f128_ps(x1loVal, x1hiVal, 0x31);
-
-        c0Val = _mm256_mul_ps(a0Val, b0Val);
-        c1Val = _mm256_mul_ps(a1Val, b1Val);
-        c2Val = _mm256_mul_ps(a2Val, b2Val);
-        c3Val = _mm256_mul_ps(a3Val, b3Val);
-
-        dotProdVal0 = _mm256_add_ps(c0Val, dotProdVal0);
-        dotProdVal1 = _mm256_add_ps(c1Val, dotProdVal1);
-        dotProdVal2 = _mm256_add_ps(c2Val, dotProdVal2);
-        dotProdVal3 = _mm256_add_ps(c3Val, dotProdVal3);
+        dotProdVal0 = _mm512_fmadd_ps(a0Val, b0Val, dotProdVal0);
+        dotProdVal1 = _mm512_fmadd_ps(a1Val, b1Val, dotProdVal1);
 
         aPtr += 32;
         bPtr += 16;
     }
 
-    dotProdVal0 = _mm256_add_ps(dotProdVal0, dotProdVal1);
-    dotProdVal0 = _mm256_add_ps(dotProdVal0, dotProdVal2);
-    dotProdVal0 = _mm256_add_ps(dotProdVal0, dotProdVal3);
+    dotProdVal0 = _mm512_add_ps(dotProdVal0, dotProdVal1);
 
-    __VOLK_ATTR_ALIGNED(32) float dotProductVector[8];
+    __VOLK_ATTR_ALIGNED(64) float dotProductVector[16];
+    _mm512_store_ps(dotProductVector, dotProdVal0);
 
-    _mm256_store_ps(dotProductVector,
-                    dotProdVal0); // Store the results back into the dot product vector
-
-    returnValue += lv_cmake(dotProductVector[0], dotProductVector[1]);
-    returnValue += lv_cmake(dotProductVector[2], dotProductVector[3]);
-    returnValue += lv_cmake(dotProductVector[4], dotProductVector[5]);
-    returnValue += lv_cmake(dotProductVector[6], dotProductVector[7]);
+    for (unsigned int i = 0; i < 16; i += 2) {
+        returnValue += lv_cmake(dotProductVector[i], dotProductVector[i + 1]);
+    }
 
     number = sixteenthPoints * 16;
-    for (; number < num_points; number++) {
-        returnValue += lv_cmake(aPtr[0] * bPtr[0], aPtr[1] * bPtr[0]);
-        aPtr += 2;
-        bPtr += 1;
-    }
-
-    *result = returnValue;
-}
-#endif /*LV_HAVE_AVX*/
-
-#ifdef LV_HAVE_NEON
-#include <arm_neon.h>
-
-static inline void
-volk_32fc_32f_dot_prod_32fc_neon_unroll(lv_32fc_t* __restrict result,
-                                        const lv_32fc_t* __restrict input,
-                                        const float* __restrict taps,
-                                        unsigned int num_points)
-{
-
-    unsigned int number;
-    const unsigned int quarterPoints = num_points / 8;
-
-    lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* inputPtr = (const float*)input;
-    const float* tapsPtr = taps;
-    float zero[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
-    float accVector_real[4];
-    float accVector_imag[4];
-
-    float32x4x2_t inputVector0, inputVector1;
-    float32x4_t tapsVector0, tapsVector1;
-    float32x4_t tmp_real0, tmp_imag0;
-    float32x4_t tmp_real1, tmp_imag1;
-    float32x4_t real_accumulator0, imag_accumulator0;
-    float32x4_t real_accumulator1, imag_accumulator1;
-
-    // zero out accumulators
-    // take a *float, return float32x4_t
-    real_accumulator0 = vld1q_f32(zero);
-    imag_accumulator0 = vld1q_f32(zero);
-    real_accumulator1 = vld1q_f32(zero);
-    imag_accumulator1 = vld1q_f32(zero);
-
-    for (number = 0; number < quarterPoints; number++) {
-        // load doublewords and duplicate in to second lane
-        tapsVector0 = vld1q_f32(tapsPtr);
-        tapsVector1 = vld1q_f32(tapsPtr + 4);
-
-        // load quadword of complex numbers in to 2 lanes. 1st lane is real, 2dn imag
-        inputVector0 = vld2q_f32(inputPtr);
-        inputVector1 = vld2q_f32(inputPtr + 8);
-        // inputVector is now a struct of two vectors, 0th is real, 1st is imag
-
-        tmp_real0 = vmulq_f32(tapsVector0, inputVector0.val[0]);
-        tmp_imag0 = vmulq_f32(tapsVector0, inputVector0.val[1]);
-
-        tmp_real1 = vmulq_f32(tapsVector1, inputVector1.val[0]);
-        tmp_imag1 = vmulq_f32(tapsVector1, inputVector1.val[1]);
-
-        real_accumulator0 = vaddq_f32(real_accumulator0, tmp_real0);
-        imag_accumulator0 = vaddq_f32(imag_accumulator0, tmp_imag0);
-
-        real_accumulator1 = vaddq_f32(real_accumulator1, tmp_real1);
-        imag_accumulator1 = vaddq_f32(imag_accumulator1, tmp_imag1);
-
-        tapsPtr += 8;
-        inputPtr += 16;
-    }
-
-    real_accumulator0 = vaddq_f32(real_accumulator0, real_accumulator1);
-    imag_accumulator0 = vaddq_f32(imag_accumulator0, imag_accumulator1);
-    // void vst1q_f32( float32_t * ptr, float32x4_t val);
-    // store results back to a complex (array of 2 floats)
-    vst1q_f32(accVector_real, real_accumulator0);
-    vst1q_f32(accVector_imag, imag_accumulator0);
-    returnValue += lv_cmake(
-        accVector_real[0] + accVector_real[1] + accVector_real[2] + accVector_real[3],
-        accVector_imag[0] + accVector_imag[1] + accVector_imag[2] + accVector_imag[3]);
-
-    // clean up the remainder
-    for (number = quarterPoints * 8; number < num_points; number++) {
-        returnValue += lv_cmake(inputPtr[0] * tapsPtr[0], inputPtr[1] * tapsPtr[0]);
-        inputPtr += 2;
-        tapsPtr += 1;
-    }
+    lv_32fc_t returnTail = lv_cmake(0.0f, 0.0f);
+    volk_32fc_32f_dot_prod_32fc_generic(
+        &returnTail, input + number, bPtr, num_points - number);
+    returnValue += returnTail;
 
     *result = returnValue;
 }
 
-#endif /*LV_HAVE_NEON*/
+#endif /*LV_HAVE_AVX512F*/
 
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
@@ -776,66 +978,6 @@ static inline void volk_32fc_32f_dot_prod_32fc_a_neon(lv_32fc_t* __restrict resu
 
 #endif /*LV_HAVE_NEON*/
 
-#ifdef LV_HAVE_NEONV8
-#include <arm_neon.h>
-
-static inline void volk_32fc_32f_dot_prod_32fc_neonv8(lv_32fc_t* result,
-                                                      const lv_32fc_t* input,
-                                                      const float* taps,
-                                                      unsigned int num_points)
-{
-    const unsigned int eighthPoints = num_points / 8;
-    const float* inputPtr = (const float*)input;
-    const float* tapsPtr = taps;
-
-    /* Use 2 independent real/imag accumulators for FMA pipelining */
-    float32x4_t real_acc0 = vdupq_n_f32(0);
-    float32x4_t imag_acc0 = vdupq_n_f32(0);
-    float32x4_t real_acc1 = vdupq_n_f32(0);
-    float32x4_t imag_acc1 = vdupq_n_f32(0);
-
-    for (unsigned int number = 0; number < eighthPoints; number++) {
-        /* Load 8 complex values deinterleaved */
-        float32x4x2_t cplx0 = vld2q_f32(inputPtr);
-        float32x4x2_t cplx1 = vld2q_f32(inputPtr + 8);
-
-        /* Load 8 real taps */
-        float32x4_t taps0 = vld1q_f32(tapsPtr);
-        float32x4_t taps1 = vld1q_f32(tapsPtr + 4);
-        __VOLK_PREFETCH(inputPtr + 32);
-        __VOLK_PREFETCH(tapsPtr + 16);
-
-        /* FMA: acc += taps * complex */
-        real_acc0 = vfmaq_f32(real_acc0, taps0, cplx0.val[0]);
-        imag_acc0 = vfmaq_f32(imag_acc0, taps0, cplx0.val[1]);
-        real_acc1 = vfmaq_f32(real_acc1, taps1, cplx1.val[0]);
-        imag_acc1 = vfmaq_f32(imag_acc1, taps1, cplx1.val[1]);
-
-        inputPtr += 16;
-        tapsPtr += 8;
-    }
-
-    /* Combine accumulators */
-    real_acc0 = vaddq_f32(real_acc0, real_acc1);
-    imag_acc0 = vaddq_f32(imag_acc0, imag_acc1);
-
-    /* Horizontal sum */
-    float real_sum = vaddvq_f32(real_acc0);
-    float imag_sum = vaddvq_f32(imag_acc0);
-
-    lv_32fc_t returnValue = lv_cmake(real_sum, imag_sum);
-
-    /* Handle remainder */
-    for (unsigned int number = eighthPoints * 8; number < num_points; number++) {
-        returnValue += lv_cmake(inputPtr[0] * tapsPtr[0], inputPtr[1] * tapsPtr[0]);
-        inputPtr += 2;
-        tapsPtr += 1;
-    }
-
-    *result = returnValue;
-}
-#endif /*LV_HAVE_NEONV8*/
-
 #ifdef LV_HAVE_NEONV7
 extern void volk_32fc_32f_dot_prod_32fc_a_neonasm(lv_32fc_t* result,
                                                   const lv_32fc_t* input,
@@ -857,142 +999,4 @@ extern void volk_32fc_32f_dot_prod_32fc_a_neonpipeline(lv_32fc_t* result,
                                                        unsigned int num_points);
 #endif /*LV_HAVE_NEONV7*/
 
-#ifdef LV_HAVE_SSE
-
-static inline void volk_32fc_32f_dot_prod_32fc_u_sse(lv_32fc_t* result,
-                                                     const lv_32fc_t* input,
-                                                     const float* taps,
-                                                     unsigned int num_points)
-{
-
-    unsigned int number = 0;
-    const unsigned int eighthPoints = num_points / 8;
-
-    lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* aPtr = (const float*)input;
-    const float* bPtr = taps;
-
-    __m128 a0Val, a1Val, a2Val, a3Val;
-    __m128 b0Val, b1Val, b2Val, b3Val;
-    __m128 x0Val, x1Val, x2Val, x3Val;
-    __m128 c0Val, c1Val, c2Val, c3Val;
-
-    __m128 dotProdVal0 = _mm_setzero_ps();
-    __m128 dotProdVal1 = _mm_setzero_ps();
-    __m128 dotProdVal2 = _mm_setzero_ps();
-    __m128 dotProdVal3 = _mm_setzero_ps();
-
-    for (; number < eighthPoints; number++) {
-
-        a0Val = _mm_loadu_ps(aPtr);
-        a1Val = _mm_loadu_ps(aPtr + 4);
-        a2Val = _mm_loadu_ps(aPtr + 8);
-        a3Val = _mm_loadu_ps(aPtr + 12);
-
-        x0Val = _mm_loadu_ps(bPtr);
-        x1Val = _mm_loadu_ps(bPtr);
-        x2Val = _mm_loadu_ps(bPtr + 4);
-        x3Val = _mm_loadu_ps(bPtr + 4);
-        b0Val = _mm_unpacklo_ps(x0Val, x1Val);
-        b1Val = _mm_unpackhi_ps(x0Val, x1Val);
-        b2Val = _mm_unpacklo_ps(x2Val, x3Val);
-        b3Val = _mm_unpackhi_ps(x2Val, x3Val);
-
-        c0Val = _mm_mul_ps(a0Val, b0Val);
-        c1Val = _mm_mul_ps(a1Val, b1Val);
-        c2Val = _mm_mul_ps(a2Val, b2Val);
-        c3Val = _mm_mul_ps(a3Val, b3Val);
-
-        dotProdVal0 = _mm_add_ps(c0Val, dotProdVal0);
-        dotProdVal1 = _mm_add_ps(c1Val, dotProdVal1);
-        dotProdVal2 = _mm_add_ps(c2Val, dotProdVal2);
-        dotProdVal3 = _mm_add_ps(c3Val, dotProdVal3);
-
-        aPtr += 16;
-        bPtr += 8;
-    }
-
-    dotProdVal0 = _mm_add_ps(dotProdVal0, dotProdVal1);
-    dotProdVal0 = _mm_add_ps(dotProdVal0, dotProdVal2);
-    dotProdVal0 = _mm_add_ps(dotProdVal0, dotProdVal3);
-
-    __VOLK_ATTR_ALIGNED(16) float dotProductVector[4];
-
-    _mm_store_ps(dotProductVector,
-                 dotProdVal0); // Store the results back into the dot product vector
-
-    returnValue += lv_cmake(dotProductVector[0], dotProductVector[1]);
-    returnValue += lv_cmake(dotProductVector[2], dotProductVector[3]);
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        returnValue += lv_cmake(aPtr[0] * bPtr[0], aPtr[1] * bPtr[0]);
-        aPtr += 2;
-        bPtr += 1;
-    }
-
-    *result = returnValue;
-}
-
-#endif /*LV_HAVE_SSE*/
-
-#ifdef LV_HAVE_RVV
-#include <riscv_vector.h>
-#include <volk/volk_rvv_intrinsics.h>
-
-static inline void volk_32fc_32f_dot_prod_32fc_rvv(lv_32fc_t* result,
-                                                   const lv_32fc_t* input,
-                                                   const float* taps,
-                                                   unsigned int num_points)
-{
-    vfloat32m4_t vsumr = __riscv_vfmv_v_f_f32m4(0, __riscv_vsetvlmax_e32m4());
-    vfloat32m4_t vsumi = vsumr;
-    size_t n = num_points;
-    for (size_t vl; n > 0; n -= vl, input += vl, taps += vl) {
-        vl = __riscv_vsetvl_e32m4(n);
-        vuint64m8_t va = __riscv_vle64_v_u64m8((const uint64_t*)input, vl);
-        vfloat32m4_t vbr = __riscv_vle32_v_f32m4(taps, vl), vbi = vbr;
-        vfloat32m4_t var = __riscv_vreinterpret_f32m4(__riscv_vnsrl(va, 0, vl));
-        vfloat32m4_t vai = __riscv_vreinterpret_f32m4(__riscv_vnsrl(va, 32, vl));
-        vsumr = __riscv_vfmacc_tu(vsumr, var, vbr, vl);
-        vsumi = __riscv_vfmacc_tu(vsumi, vai, vbi, vl);
-    }
-    size_t vl = __riscv_vsetvlmax_e32m1();
-    vfloat32m1_t vr = RISCV_SHRINK4(vfadd, f, 32, vsumr);
-    vfloat32m1_t vi = RISCV_SHRINK4(vfadd, f, 32, vsumi);
-    vfloat32m1_t z = __riscv_vfmv_s_f_f32m1(0, vl);
-    *result = lv_cmake(__riscv_vfmv_f(__riscv_vfredusum(vr, z, vl)),
-                       __riscv_vfmv_f(__riscv_vfredusum(vi, z, vl)));
-}
-#endif /*LV_HAVE_RVV*/
-
-#ifdef LV_HAVE_RVVSEG
-#include <riscv_vector.h>
-#include <volk/volk_rvv_intrinsics.h>
-
-static inline void volk_32fc_32f_dot_prod_32fc_rvvseg(lv_32fc_t* result,
-                                                      const lv_32fc_t* input,
-                                                      const float* taps,
-                                                      unsigned int num_points)
-{
-    vfloat32m4_t vsumr = __riscv_vfmv_v_f_f32m4(0, __riscv_vsetvlmax_e32m4());
-    vfloat32m4_t vsumi = vsumr;
-    size_t n = num_points;
-    for (size_t vl; n > 0; n -= vl, input += vl, taps += vl) {
-        vl = __riscv_vsetvl_e32m4(n);
-        vfloat32m4x2_t va = __riscv_vlseg2e32_v_f32m4x2((const float*)input, vl);
-        vfloat32m4_t var = __riscv_vget_f32m4(va, 0), vai = __riscv_vget_f32m4(va, 1);
-        vfloat32m4_t vbr = __riscv_vle32_v_f32m4(taps, vl), vbi = vbr;
-        vsumr = __riscv_vfmacc_tu(vsumr, var, vbr, vl);
-        vsumi = __riscv_vfmacc_tu(vsumi, vai, vbi, vl);
-    }
-    size_t vl = __riscv_vsetvlmax_e32m1();
-    vfloat32m1_t vr = RISCV_SHRINK4(vfadd, f, 32, vsumr);
-    vfloat32m1_t vi = RISCV_SHRINK4(vfadd, f, 32, vsumi);
-    vfloat32m1_t z = __riscv_vfmv_s_f_f32m1(0, vl);
-    *result = lv_cmake(__riscv_vfmv_f(__riscv_vfredusum(vr, z, vl)),
-                       __riscv_vfmv_f(__riscv_vfredusum(vi, z, vl)));
-}
-#endif /*LV_HAVE_RVVSEG*/
-
-#endif /*INCLUDED_volk_32fc_32f_dot_prod_32fc_H*/
+#endif /*INCLUDED_volk_32fc_32f_dot_prod_32fc_a_H*/

--- a/kernels/volk/volk_32fc_32f_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_32f_dot_prod_32fc.h
@@ -62,7 +62,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_generic(lv_32fc_t* result,
 {
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* aPtr = (float*)input;
+    const float* aPtr = (const float*)input;
     const float* bPtr = taps;
     unsigned int number = 0;
 
@@ -90,7 +90,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_a_avx512f(lv_32fc_t* result,
     const unsigned int sixteenthPoints = num_points / 16;
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* aPtr = (float*)input;
+    const float* aPtr = (const float*)input;
     const float* bPtr = taps;
 
     __m512 a0Val, a1Val;
@@ -158,7 +158,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_a_avx2_fma(lv_32fc_t* result,
     const unsigned int sixteenthPoints = num_points / 16;
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* aPtr = (float*)input;
+    const float* aPtr = (const float*)input;
     const float* bPtr = taps;
 
     __m256 a0Val, a1Val, a2Val, a3Val;
@@ -238,7 +238,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_a_avx(lv_32fc_t* result,
     const unsigned int sixteenthPoints = num_points / 16;
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* aPtr = (float*)input;
+    const float* aPtr = (const float*)input;
     const float* bPtr = taps;
 
     __m256 a0Val, a1Val, a2Val, a3Val;
@@ -325,7 +325,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_a_sse(lv_32fc_t* result,
     const unsigned int eighthPoints = num_points / 8;
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* aPtr = (float*)input;
+    const float* aPtr = (const float*)input;
     const float* bPtr = taps;
 
     __m128 a0Val, a1Val, a2Val, a3Val;
@@ -405,7 +405,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_u_avx512f(lv_32fc_t* result,
     const unsigned int sixteenthPoints = num_points / 16;
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* aPtr = (float*)input;
+    const float* aPtr = (const float*)input;
     const float* bPtr = taps;
 
     __m512 a0Val, a1Val;
@@ -473,7 +473,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_u_avx2_fma(lv_32fc_t* result,
     const unsigned int sixteenthPoints = num_points / 16;
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* aPtr = (float*)input;
+    const float* aPtr = (const float*)input;
     const float* bPtr = taps;
 
     __m256 a0Val, a1Val, a2Val, a3Val;
@@ -554,7 +554,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_u_avx(lv_32fc_t* result,
     const unsigned int sixteenthPoints = num_points / 16;
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* aPtr = (float*)input;
+    const float* aPtr = (const float*)input;
     const float* bPtr = taps;
 
     __m256 a0Val, a1Val, a2Val, a3Val;
@@ -640,7 +640,7 @@ volk_32fc_32f_dot_prod_32fc_neon_unroll(lv_32fc_t* __restrict result,
     const unsigned int quarterPoints = num_points / 8;
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* inputPtr = (float*)input;
+    const float* inputPtr = (const float*)input;
     const float* tapsPtr = taps;
     float zero[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
     float accVector_real[4];
@@ -721,7 +721,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_a_neon(lv_32fc_t* __restrict resu
     const unsigned int quarterPoints = num_points / 4;
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* inputPtr = (float*)input;
+    const float* inputPtr = (const float*)input;
     const float* tapsPtr = taps;
     float zero[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
     float accVector_real[4];
@@ -869,7 +869,7 @@ static inline void volk_32fc_32f_dot_prod_32fc_u_sse(lv_32fc_t* result,
     const unsigned int eighthPoints = num_points / 8;
 
     lv_32fc_t returnValue = lv_cmake(0.0f, 0.0f);
-    const float* aPtr = (float*)input;
+    const float* aPtr = (const float*)input;
     const float* bPtr = taps;
 
     __m128 a0Val, a1Val, a2Val, a3Val;

--- a/kernels/volk/volk_32fc_32f_multiply_32fc.h
+++ b/kernels/volk/volk_32fc_32f_multiply_32fc.h
@@ -39,118 +39,11 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32fc_32f_multiply_32fc_a_H
-#define INCLUDED_volk_32fc_32f_multiply_32fc_a_H
+#ifndef INCLUDED_volk_32fc_32f_multiply_32fc_u_H
+#define INCLUDED_volk_32fc_32f_multiply_32fc_u_H
 
 #include <inttypes.h>
 #include <stdio.h>
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-
-static inline void volk_32fc_32f_multiply_32fc_a_avx(lv_32fc_t* cVector,
-                                                     const lv_32fc_t* aVector,
-                                                     const float* bVector,
-                                                     unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int eighthPoints = num_points / 8;
-
-    lv_32fc_t* cPtr = cVector;
-    const lv_32fc_t* aPtr = aVector;
-    const float* bPtr = bVector;
-
-    __m256 aVal1, aVal2, bVal, bVal1, bVal2, cVal1, cVal2;
-
-    __m256i permute_mask = _mm256_set_epi32(3, 3, 2, 2, 1, 1, 0, 0);
-
-    for (; number < eighthPoints; number++) {
-
-        aVal1 = _mm256_load_ps((const float*)aPtr);
-        aPtr += 4;
-
-        aVal2 = _mm256_load_ps((const float*)aPtr);
-        aPtr += 4;
-
-        bVal = _mm256_load_ps(bPtr); // b0|b1|b2|b3|b4|b5|b6|b7
-        bPtr += 8;
-
-        bVal1 = _mm256_permute2f128_ps(bVal, bVal, 0x00); // b0|b1|b2|b3|b0|b1|b2|b3
-        bVal2 = _mm256_permute2f128_ps(bVal, bVal, 0x11); // b4|b5|b6|b7|b4|b5|b6|b7
-
-        bVal1 = _mm256_permutevar_ps(bVal1, permute_mask); // b0|b0|b1|b1|b2|b2|b3|b3
-        bVal2 = _mm256_permutevar_ps(bVal2, permute_mask); // b4|b4|b5|b5|b6|b6|b7|b7
-
-        cVal1 = _mm256_mul_ps(aVal1, bVal1);
-        cVal2 = _mm256_mul_ps(aVal2, bVal2);
-
-        _mm256_store_ps((float*)cPtr,
-                        cVal1); // Store the results back into the C container
-        cPtr += 4;
-
-        _mm256_store_ps((float*)cPtr,
-                        cVal2); // Store the results back into the C container
-        cPtr += 4;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; ++number) {
-        *cPtr++ = (*aPtr++) * (*bPtr++);
-    }
-}
-#endif /* LV_HAVE_AVX */
-
-
-#ifdef LV_HAVE_SSE
-#include <xmmintrin.h>
-
-static inline void volk_32fc_32f_multiply_32fc_a_sse(lv_32fc_t* cVector,
-                                                     const lv_32fc_t* aVector,
-                                                     const float* bVector,
-                                                     unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-
-    lv_32fc_t* cPtr = cVector;
-    const lv_32fc_t* aPtr = aVector;
-    const float* bPtr = bVector;
-
-    __m128 aVal1, aVal2, bVal, bVal1, bVal2, cVal;
-    for (; number < quarterPoints; number++) {
-
-        aVal1 = _mm_load_ps((const float*)aPtr);
-        aPtr += 2;
-
-        aVal2 = _mm_load_ps((const float*)aPtr);
-        aPtr += 2;
-
-        bVal = _mm_load_ps(bPtr);
-        bPtr += 4;
-
-        bVal1 = _mm_shuffle_ps(bVal, bVal, _MM_SHUFFLE(1, 1, 0, 0));
-        bVal2 = _mm_shuffle_ps(bVal, bVal, _MM_SHUFFLE(3, 3, 2, 2));
-
-        cVal = _mm_mul_ps(aVal1, bVal1);
-
-        _mm_store_ps((float*)cPtr, cVal); // Store the results back into the C container
-        cPtr += 2;
-
-        cVal = _mm_mul_ps(aVal2, bVal2);
-
-        _mm_store_ps((float*)cPtr, cVal); // Store the results back into the C container
-
-        cPtr += 2;
-    }
-
-    number = quarterPoints * 4;
-    for (; number < num_points; number++) {
-        *cPtr++ = (*aPtr++) * (*bPtr);
-        bPtr++;
-    }
-}
-#endif /* LV_HAVE_SSE */
-
 
 #ifdef LV_HAVE_GENERIC
 
@@ -284,7 +177,7 @@ static inline void volk_32fc_32f_multiply_32fc_u_orc(lv_32fc_t* cVector,
     volk_32fc_32f_multiply_32fc_a_orc_impl(cVector, aVector, bVector, num_points);
 }
 
-#endif /* LV_HAVE_GENERIC */
+#endif /* LV_HAVE_ORC */
 
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
@@ -304,6 +197,117 @@ static inline void volk_32fc_32f_multiply_32fc_rvv(lv_32fc_t* cVector,
         __riscv_vse32((float*)cVector, __riscv_vfmul(vc, vf, vl * 2), vl * 2);
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
+
+#endif /* INCLUDED_volk_32fc_32f_multiply_32fc_u_H */
+
+#ifndef INCLUDED_volk_32fc_32f_multiply_32fc_a_H
+#define INCLUDED_volk_32fc_32f_multiply_32fc_a_H
+
+#ifdef LV_HAVE_SSE
+#include <xmmintrin.h>
+
+static inline void volk_32fc_32f_multiply_32fc_a_sse(lv_32fc_t* cVector,
+                                                     const lv_32fc_t* aVector,
+                                                     const float* bVector,
+                                                     unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    lv_32fc_t* cPtr = cVector;
+    const lv_32fc_t* aPtr = aVector;
+    const float* bPtr = bVector;
+
+    __m128 aVal1, aVal2, bVal, bVal1, bVal2, cVal;
+    for (; number < quarterPoints; number++) {
+
+        aVal1 = _mm_load_ps((const float*)aPtr);
+        aPtr += 2;
+
+        aVal2 = _mm_load_ps((const float*)aPtr);
+        aPtr += 2;
+
+        bVal = _mm_load_ps(bPtr);
+        bPtr += 4;
+
+        bVal1 = _mm_shuffle_ps(bVal, bVal, _MM_SHUFFLE(1, 1, 0, 0));
+        bVal2 = _mm_shuffle_ps(bVal, bVal, _MM_SHUFFLE(3, 3, 2, 2));
+
+        cVal = _mm_mul_ps(aVal1, bVal1);
+
+        _mm_store_ps((float*)cPtr, cVal); // Store the results back into the C container
+        cPtr += 2;
+
+        cVal = _mm_mul_ps(aVal2, bVal2);
+
+        _mm_store_ps((float*)cPtr, cVal); // Store the results back into the C container
+
+        cPtr += 2;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        *cPtr++ = (*aPtr++) * (*bPtr);
+        bPtr++;
+    }
+}
+#endif /* LV_HAVE_SSE */
+
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void volk_32fc_32f_multiply_32fc_a_avx(lv_32fc_t* cVector,
+                                                     const lv_32fc_t* aVector,
+                                                     const float* bVector,
+                                                     unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    lv_32fc_t* cPtr = cVector;
+    const lv_32fc_t* aPtr = aVector;
+    const float* bPtr = bVector;
+
+    __m256 aVal1, aVal2, bVal, bVal1, bVal2, cVal1, cVal2;
+
+    __m256i permute_mask = _mm256_set_epi32(3, 3, 2, 2, 1, 1, 0, 0);
+
+    for (; number < eighthPoints; number++) {
+
+        aVal1 = _mm256_load_ps((const float*)aPtr);
+        aPtr += 4;
+
+        aVal2 = _mm256_load_ps((const float*)aPtr);
+        aPtr += 4;
+
+        bVal = _mm256_load_ps(bPtr); // b0|b1|b2|b3|b4|b5|b6|b7
+        bPtr += 8;
+
+        bVal1 = _mm256_permute2f128_ps(bVal, bVal, 0x00); // b0|b1|b2|b3|b0|b1|b2|b3
+        bVal2 = _mm256_permute2f128_ps(bVal, bVal, 0x11); // b4|b5|b6|b7|b4|b5|b6|b7
+
+        bVal1 = _mm256_permutevar_ps(bVal1, permute_mask); // b0|b0|b1|b1|b2|b2|b3|b3
+        bVal2 = _mm256_permutevar_ps(bVal2, permute_mask); // b4|b4|b5|b5|b6|b6|b7|b7
+
+        cVal1 = _mm256_mul_ps(aVal1, bVal1);
+        cVal2 = _mm256_mul_ps(aVal2, bVal2);
+
+        _mm256_store_ps((float*)cPtr,
+                        cVal1); // Store the results back into the C container
+        cPtr += 4;
+
+        _mm256_store_ps((float*)cPtr,
+                        cVal2); // Store the results back into the C container
+        cPtr += 4;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; ++number) {
+        *cPtr++ = (*aPtr++) * (*bPtr++);
+    }
+}
+#endif /* LV_HAVE_AVX */
 
 #endif /* INCLUDED_volk_32fc_32f_multiply_32fc_a_H */

--- a/kernels/volk/volk_32fc_32f_multiply_32fc.h
+++ b/kernels/volk/volk_32fc_32f_multiply_32fc.h
@@ -66,10 +66,10 @@ static inline void volk_32fc_32f_multiply_32fc_a_avx(lv_32fc_t* cVector,
 
     for (; number < eighthPoints; number++) {
 
-        aVal1 = _mm256_load_ps((float*)aPtr);
+        aVal1 = _mm256_load_ps((const float*)aPtr);
         aPtr += 4;
 
-        aVal2 = _mm256_load_ps((float*)aPtr);
+        aVal2 = _mm256_load_ps((const float*)aPtr);
         aPtr += 4;
 
         bVal = _mm256_load_ps(bPtr); // b0|b1|b2|b3|b4|b5|b6|b7
@@ -188,7 +188,7 @@ static inline void volk_32fc_32f_multiply_32fc_neon(lv_32fc_t* cVector,
     float32x4x2_t inputVector, outputVector;
     float32x4_t tapsVector;
     for (number = 0; number < quarter_points; number++) {
-        inputVector = vld2q_f32((float*)aPtr);
+        inputVector = vld2q_f32((const float*)aPtr);
         tapsVector = vld1q_f32(bPtr);
 
         outputVector.val[0] = vmulq_f32(inputVector.val[0], tapsVector);

--- a/kernels/volk/volk_32fc_accumulator_s32fc.h
+++ b/kernels/volk/volk_32fc_accumulator_s32fc.h
@@ -48,55 +48,101 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32fc_accumulator_s32fc_a_H
-#define INCLUDED_volk_32fc_accumulator_s32fc_a_H
+#ifndef INCLUDED_volk_32fc_accumulator_s32fc_u_H
+#define INCLUDED_volk_32fc_accumulator_s32fc_u_H
 
 #include <inttypes.h>
 #include <volk/volk_common.h>
 
-#ifdef LV_HAVE_AVX512F
-#include <immintrin.h>
-
-static inline void volk_32fc_accumulator_s32fc_a_avx512f(lv_32fc_t* result,
-                                                         const lv_32fc_t* inputBuffer,
-                                                         unsigned int num_points)
+#ifdef LV_HAVE_GENERIC
+static inline void volk_32fc_accumulator_s32fc_generic(lv_32fc_t* result,
+                                                       const lv_32fc_t* inputBuffer,
+                                                       unsigned int num_points)
 {
-    lv_32fc_t returnValue = lv_cmake(0.f, 0.f);
-    unsigned int number = 0;
-    const unsigned int eighthPoints = num_points / 8;
-
     const lv_32fc_t* aPtr = inputBuffer;
-    __VOLK_ATTR_ALIGNED(64) float tempBuffer[16];
+    unsigned int number = 0;
+    lv_32fc_t returnValue = lv_cmake(0.f, 0.f);
 
-    __m512 accumulator = _mm512_setzero_ps();
-    __m512 aVal = _mm512_setzero_ps();
-
-    for (; number < eighthPoints; number++) {
-        aVal = _mm512_load_ps((const float*)aPtr);
-        accumulator = _mm512_add_ps(accumulator, aVal);
-        aPtr += 8;
-    }
-
-    _mm512_store_ps(tempBuffer, accumulator);
-
-    // Sum pairs as complex numbers
-    returnValue = lv_cmake(tempBuffer[0], tempBuffer[1]);
-    returnValue += lv_cmake(tempBuffer[2], tempBuffer[3]);
-    returnValue += lv_cmake(tempBuffer[4], tempBuffer[5]);
-    returnValue += lv_cmake(tempBuffer[6], tempBuffer[7]);
-    returnValue += lv_cmake(tempBuffer[8], tempBuffer[9]);
-    returnValue += lv_cmake(tempBuffer[10], tempBuffer[11]);
-    returnValue += lv_cmake(tempBuffer[12], tempBuffer[13]);
-    returnValue += lv_cmake(tempBuffer[14], tempBuffer[15]);
-
-    number = eighthPoints * 8;
     for (; number < num_points; number++) {
         returnValue += (*aPtr++);
     }
     *result = returnValue;
 }
-#endif /* LV_HAVE_AVX512F */
+#endif /* LV_HAVE_GENERIC */
 
+#ifdef LV_HAVE_SSE
+#include <xmmintrin.h>
+
+static inline void volk_32fc_accumulator_s32fc_u_sse(lv_32fc_t* result,
+                                                     const lv_32fc_t* inputBuffer,
+                                                     unsigned int num_points)
+{
+    lv_32fc_t returnValue = lv_cmake(0.f, 0.f);
+    unsigned int number = 0;
+    const unsigned int halfPoints = num_points / 2;
+
+    const lv_32fc_t* aPtr = inputBuffer;
+    __VOLK_ATTR_ALIGNED(16) float tempBuffer[4];
+
+    __m128 accumulator = _mm_setzero_ps();
+    __m128 aVal = _mm_setzero_ps();
+
+    for (; number < halfPoints; number++) {
+        aVal = _mm_loadu_ps((const float*)aPtr);
+        accumulator = _mm_add_ps(accumulator, aVal);
+        aPtr += 2;
+    }
+
+    _mm_store_ps(tempBuffer, accumulator);
+
+    returnValue = lv_cmake(tempBuffer[0], tempBuffer[1]);
+    returnValue += lv_cmake(tempBuffer[2], tempBuffer[3]);
+
+    number = halfPoints * 2;
+    for (; number < num_points; number++) {
+        returnValue += (*aPtr++);
+    }
+    *result = returnValue;
+}
+#endif /* LV_HAVE_SSE */
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void volk_32fc_accumulator_s32fc_u_avx(lv_32fc_t* result,
+                                                     const lv_32fc_t* inputBuffer,
+                                                     unsigned int num_points)
+{
+    lv_32fc_t returnValue = lv_cmake(0.f, 0.f);
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    const lv_32fc_t* aPtr = inputBuffer;
+    __VOLK_ATTR_ALIGNED(32) float tempBuffer[8];
+
+    __m256 accumulator = _mm256_setzero_ps();
+    __m256 aVal = _mm256_setzero_ps();
+
+    for (; number < quarterPoints; number++) {
+        aVal = _mm256_loadu_ps((const float*)aPtr);
+        accumulator = _mm256_add_ps(accumulator, aVal);
+        aPtr += 4;
+    }
+
+    _mm256_store_ps(tempBuffer, accumulator);
+
+    returnValue = lv_cmake(tempBuffer[0], tempBuffer[1]);
+    returnValue += lv_cmake(tempBuffer[2], tempBuffer[3]);
+    returnValue += lv_cmake(tempBuffer[4], tempBuffer[5]);
+    returnValue += lv_cmake(tempBuffer[6], tempBuffer[7]);
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        returnValue += (*aPtr++);
+    }
+    *result = returnValue;
+}
+#endif /* LV_HAVE_AVX */
 
 #ifdef LV_HAVE_AVX512F
 #include <immintrin.h>
@@ -140,171 +186,6 @@ static inline void volk_32fc_accumulator_s32fc_u_avx512f(lv_32fc_t* result,
     *result = returnValue;
 }
 #endif /* LV_HAVE_AVX512F */
-
-
-#ifdef LV_HAVE_GENERIC
-static inline void volk_32fc_accumulator_s32fc_generic(lv_32fc_t* result,
-                                                       const lv_32fc_t* inputBuffer,
-                                                       unsigned int num_points)
-{
-    const lv_32fc_t* aPtr = inputBuffer;
-    unsigned int number = 0;
-    lv_32fc_t returnValue = lv_cmake(0.f, 0.f);
-
-    for (; number < num_points; number++) {
-        returnValue += (*aPtr++);
-    }
-    *result = returnValue;
-}
-#endif /* LV_HAVE_GENERIC */
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-
-static inline void volk_32fc_accumulator_s32fc_u_avx(lv_32fc_t* result,
-                                                     const lv_32fc_t* inputBuffer,
-                                                     unsigned int num_points)
-{
-    lv_32fc_t returnValue = lv_cmake(0.f, 0.f);
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-
-    const lv_32fc_t* aPtr = inputBuffer;
-    __VOLK_ATTR_ALIGNED(32) float tempBuffer[8];
-
-    __m256 accumulator = _mm256_setzero_ps();
-    __m256 aVal = _mm256_setzero_ps();
-
-    for (; number < quarterPoints; number++) {
-        aVal = _mm256_loadu_ps((const float*)aPtr);
-        accumulator = _mm256_add_ps(accumulator, aVal);
-        aPtr += 4;
-    }
-
-    _mm256_store_ps(tempBuffer, accumulator);
-
-    returnValue = lv_cmake(tempBuffer[0], tempBuffer[1]);
-    returnValue += lv_cmake(tempBuffer[2], tempBuffer[3]);
-    returnValue += lv_cmake(tempBuffer[4], tempBuffer[5]);
-    returnValue += lv_cmake(tempBuffer[6], tempBuffer[7]);
-
-    number = quarterPoints * 4;
-    for (; number < num_points; number++) {
-        returnValue += (*aPtr++);
-    }
-    *result = returnValue;
-}
-#endif /* LV_HAVE_AVX */
-
-#ifdef LV_HAVE_SSE
-#include <xmmintrin.h>
-
-static inline void volk_32fc_accumulator_s32fc_u_sse(lv_32fc_t* result,
-                                                     const lv_32fc_t* inputBuffer,
-                                                     unsigned int num_points)
-{
-    lv_32fc_t returnValue = lv_cmake(0.f, 0.f);
-    unsigned int number = 0;
-    const unsigned int halfPoints = num_points / 2;
-
-    const lv_32fc_t* aPtr = inputBuffer;
-    __VOLK_ATTR_ALIGNED(16) float tempBuffer[4];
-
-    __m128 accumulator = _mm_setzero_ps();
-    __m128 aVal = _mm_setzero_ps();
-
-    for (; number < halfPoints; number++) {
-        aVal = _mm_loadu_ps((const float*)aPtr);
-        accumulator = _mm_add_ps(accumulator, aVal);
-        aPtr += 2;
-    }
-
-    _mm_store_ps(tempBuffer, accumulator);
-
-    returnValue = lv_cmake(tempBuffer[0], tempBuffer[1]);
-    returnValue += lv_cmake(tempBuffer[2], tempBuffer[3]);
-
-    number = halfPoints * 2;
-    for (; number < num_points; number++) {
-        returnValue += (*aPtr++);
-    }
-    *result = returnValue;
-}
-#endif /* LV_HAVE_SSE */
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-
-static inline void volk_32fc_accumulator_s32fc_a_avx(lv_32fc_t* result,
-                                                     const lv_32fc_t* inputBuffer,
-                                                     unsigned int num_points)
-{
-    lv_32fc_t returnValue = lv_cmake(0.f, 0.f);
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-
-    const lv_32fc_t* aPtr = inputBuffer;
-    __VOLK_ATTR_ALIGNED(32) float tempBuffer[8];
-
-    __m256 accumulator = _mm256_setzero_ps();
-    __m256 aVal = _mm256_setzero_ps();
-
-    for (; number < quarterPoints; number++) {
-        aVal = _mm256_load_ps((const float*)aPtr);
-        accumulator = _mm256_add_ps(accumulator, aVal);
-        aPtr += 4;
-    }
-
-    _mm256_store_ps(tempBuffer, accumulator);
-
-    returnValue = lv_cmake(tempBuffer[0], tempBuffer[1]);
-    returnValue += lv_cmake(tempBuffer[2], tempBuffer[3]);
-    returnValue += lv_cmake(tempBuffer[4], tempBuffer[5]);
-    returnValue += lv_cmake(tempBuffer[6], tempBuffer[7]);
-
-    number = quarterPoints * 4;
-    for (; number < num_points; number++) {
-        returnValue += (*aPtr++);
-    }
-    *result = returnValue;
-}
-#endif /* LV_HAVE_AVX */
-
-#ifdef LV_HAVE_SSE
-#include <xmmintrin.h>
-
-static inline void volk_32fc_accumulator_s32fc_a_sse(lv_32fc_t* result,
-                                                     const lv_32fc_t* inputBuffer,
-                                                     unsigned int num_points)
-{
-    lv_32fc_t returnValue = lv_cmake(0.f, 0.f);
-    unsigned int number = 0;
-    const unsigned int halfPoints = num_points / 2;
-
-    const lv_32fc_t* aPtr = inputBuffer;
-    __VOLK_ATTR_ALIGNED(16) float tempBuffer[4];
-
-    __m128 accumulator = _mm_setzero_ps();
-    __m128 aVal = _mm_setzero_ps();
-
-    for (; number < halfPoints; number++) {
-        aVal = _mm_load_ps((const float*)aPtr);
-        accumulator = _mm_add_ps(accumulator, aVal);
-        aPtr += 2;
-    }
-
-    _mm_store_ps(tempBuffer, accumulator);
-
-    returnValue = lv_cmake(tempBuffer[0], tempBuffer[1]);
-    returnValue += lv_cmake(tempBuffer[2], tempBuffer[3]);
-
-    number = halfPoints * 2;
-    for (; number < num_points; number++) {
-        returnValue += (*aPtr++);
-    }
-    *result = returnValue;
-}
-#endif /* LV_HAVE_SSE */
 
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
@@ -450,6 +331,128 @@ static inline void volk_32fc_accumulator_s32fc_rvv(lv_32fc_t* result,
     *result = lv_cmake(__riscv_vfmv_f(__riscv_vfredusum(vr, z, vlmax)),
                        __riscv_vfmv_f(__riscv_vfredusum(vi, z, vlmax)));
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
+
+#endif /* INCLUDED_volk_32fc_accumulator_s32fc_u_H */
+
+#ifndef INCLUDED_volk_32fc_accumulator_s32fc_a_H
+#define INCLUDED_volk_32fc_accumulator_s32fc_a_H
+
+#ifdef LV_HAVE_SSE
+#include <xmmintrin.h>
+
+static inline void volk_32fc_accumulator_s32fc_a_sse(lv_32fc_t* result,
+                                                     const lv_32fc_t* inputBuffer,
+                                                     unsigned int num_points)
+{
+    lv_32fc_t returnValue = lv_cmake(0.f, 0.f);
+    unsigned int number = 0;
+    const unsigned int halfPoints = num_points / 2;
+
+    const lv_32fc_t* aPtr = inputBuffer;
+    __VOLK_ATTR_ALIGNED(16) float tempBuffer[4];
+
+    __m128 accumulator = _mm_setzero_ps();
+    __m128 aVal = _mm_setzero_ps();
+
+    for (; number < halfPoints; number++) {
+        aVal = _mm_load_ps((const float*)aPtr);
+        accumulator = _mm_add_ps(accumulator, aVal);
+        aPtr += 2;
+    }
+
+    _mm_store_ps(tempBuffer, accumulator);
+
+    returnValue = lv_cmake(tempBuffer[0], tempBuffer[1]);
+    returnValue += lv_cmake(tempBuffer[2], tempBuffer[3]);
+
+    number = halfPoints * 2;
+    for (; number < num_points; number++) {
+        returnValue += (*aPtr++);
+    }
+    *result = returnValue;
+}
+#endif /* LV_HAVE_SSE */
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void volk_32fc_accumulator_s32fc_a_avx(lv_32fc_t* result,
+                                                     const lv_32fc_t* inputBuffer,
+                                                     unsigned int num_points)
+{
+    lv_32fc_t returnValue = lv_cmake(0.f, 0.f);
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    const lv_32fc_t* aPtr = inputBuffer;
+    __VOLK_ATTR_ALIGNED(32) float tempBuffer[8];
+
+    __m256 accumulator = _mm256_setzero_ps();
+    __m256 aVal = _mm256_setzero_ps();
+
+    for (; number < quarterPoints; number++) {
+        aVal = _mm256_load_ps((const float*)aPtr);
+        accumulator = _mm256_add_ps(accumulator, aVal);
+        aPtr += 4;
+    }
+
+    _mm256_store_ps(tempBuffer, accumulator);
+
+    returnValue = lv_cmake(tempBuffer[0], tempBuffer[1]);
+    returnValue += lv_cmake(tempBuffer[2], tempBuffer[3]);
+    returnValue += lv_cmake(tempBuffer[4], tempBuffer[5]);
+    returnValue += lv_cmake(tempBuffer[6], tempBuffer[7]);
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        returnValue += (*aPtr++);
+    }
+    *result = returnValue;
+}
+#endif /* LV_HAVE_AVX */
+
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+
+static inline void volk_32fc_accumulator_s32fc_a_avx512f(lv_32fc_t* result,
+                                                         const lv_32fc_t* inputBuffer,
+                                                         unsigned int num_points)
+{
+    lv_32fc_t returnValue = lv_cmake(0.f, 0.f);
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    const lv_32fc_t* aPtr = inputBuffer;
+    __VOLK_ATTR_ALIGNED(64) float tempBuffer[16];
+
+    __m512 accumulator = _mm512_setzero_ps();
+    __m512 aVal = _mm512_setzero_ps();
+
+    for (; number < eighthPoints; number++) {
+        aVal = _mm512_load_ps((const float*)aPtr);
+        accumulator = _mm512_add_ps(accumulator, aVal);
+        aPtr += 8;
+    }
+
+    _mm512_store_ps(tempBuffer, accumulator);
+
+    // Sum pairs as complex numbers
+    returnValue = lv_cmake(tempBuffer[0], tempBuffer[1]);
+    returnValue += lv_cmake(tempBuffer[2], tempBuffer[3]);
+    returnValue += lv_cmake(tempBuffer[4], tempBuffer[5]);
+    returnValue += lv_cmake(tempBuffer[6], tempBuffer[7]);
+    returnValue += lv_cmake(tempBuffer[8], tempBuffer[9]);
+    returnValue += lv_cmake(tempBuffer[10], tempBuffer[11]);
+    returnValue += lv_cmake(tempBuffer[12], tempBuffer[13]);
+    returnValue += lv_cmake(tempBuffer[14], tempBuffer[15]);
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        returnValue += (*aPtr++);
+    }
+    *result = returnValue;
+}
+#endif /* LV_HAVE_AVX512F */
 
 #endif /* INCLUDED_volk_32fc_accumulator_s32fc_a_H */

--- a/kernels/volk/volk_32fc_accumulator_s32fc.h
+++ b/kernels/volk/volk_32fc_accumulator_s32fc.h
@@ -72,7 +72,7 @@ static inline void volk_32fc_accumulator_s32fc_a_avx512f(lv_32fc_t* result,
     __m512 aVal = _mm512_setzero_ps();
 
     for (; number < eighthPoints; number++) {
-        aVal = _mm512_load_ps((float*)aPtr);
+        aVal = _mm512_load_ps((const float*)aPtr);
         accumulator = _mm512_add_ps(accumulator, aVal);
         aPtr += 8;
     }
@@ -116,7 +116,7 @@ static inline void volk_32fc_accumulator_s32fc_u_avx512f(lv_32fc_t* result,
     __m512 aVal = _mm512_setzero_ps();
 
     for (; number < eighthPoints; number++) {
-        aVal = _mm512_loadu_ps((float*)aPtr);
+        aVal = _mm512_loadu_ps((const float*)aPtr);
         accumulator = _mm512_add_ps(accumulator, aVal);
         aPtr += 8;
     }
@@ -176,7 +176,7 @@ static inline void volk_32fc_accumulator_s32fc_u_avx(lv_32fc_t* result,
     __m256 aVal = _mm256_setzero_ps();
 
     for (; number < quarterPoints; number++) {
-        aVal = _mm256_loadu_ps((float*)aPtr);
+        aVal = _mm256_loadu_ps((const float*)aPtr);
         accumulator = _mm256_add_ps(accumulator, aVal);
         aPtr += 4;
     }
@@ -214,7 +214,7 @@ static inline void volk_32fc_accumulator_s32fc_u_sse(lv_32fc_t* result,
     __m128 aVal = _mm_setzero_ps();
 
     for (; number < halfPoints; number++) {
-        aVal = _mm_loadu_ps((float*)aPtr);
+        aVal = _mm_loadu_ps((const float*)aPtr);
         accumulator = _mm_add_ps(accumulator, aVal);
         aPtr += 2;
     }
@@ -250,7 +250,7 @@ static inline void volk_32fc_accumulator_s32fc_a_avx(lv_32fc_t* result,
     __m256 aVal = _mm256_setzero_ps();
 
     for (; number < quarterPoints; number++) {
-        aVal = _mm256_load_ps((float*)aPtr);
+        aVal = _mm256_load_ps((const float*)aPtr);
         accumulator = _mm256_add_ps(accumulator, aVal);
         aPtr += 4;
     }
@@ -288,7 +288,7 @@ static inline void volk_32fc_accumulator_s32fc_a_sse(lv_32fc_t* result,
     __m128 aVal = _mm_setzero_ps();
 
     for (; number < halfPoints; number++) {
-        aVal = _mm_load_ps((float*)aPtr);
+        aVal = _mm_load_ps((const float*)aPtr);
         accumulator = _mm_add_ps(accumulator, aVal);
         aPtr += 2;
     }
@@ -324,19 +324,19 @@ static inline void volk_32fc_accumulator_s32fc_neon(lv_32fc_t* result,
     __VOLK_ATTR_ALIGNED(32) float tempBuffer[4];
 
     for (; number < eighthPoints; number++) {
-        in_vec = vld1q_f32((float*)aPtr);
+        in_vec = vld1q_f32((const float*)aPtr);
         out_vec0 = vaddq_f32(in_vec, out_vec0);
         aPtr += 2;
 
-        in_vec = vld1q_f32((float*)aPtr);
+        in_vec = vld1q_f32((const float*)aPtr);
         out_vec1 = vaddq_f32(in_vec, out_vec1);
         aPtr += 2;
 
-        in_vec = vld1q_f32((float*)aPtr);
+        in_vec = vld1q_f32((const float*)aPtr);
         out_vec2 = vaddq_f32(in_vec, out_vec2);
         aPtr += 2;
 
-        in_vec = vld1q_f32((float*)aPtr);
+        in_vec = vld1q_f32((const float*)aPtr);
         out_vec3 = vaddq_f32(in_vec, out_vec3);
         aPtr += 2;
     }
@@ -383,19 +383,19 @@ static inline void volk_32fc_accumulator_s32fc_neonv8(lv_32fc_t* result,
     float32x4_t out_vec3 = vdupq_n_f32(0.f);
 
     for (; number < eighthPoints; number++) {
-        in_vec = vld1q_f32((float*)aPtr);
+        in_vec = vld1q_f32((const float*)aPtr);
         out_vec0 = vaddq_f32(in_vec, out_vec0);
         aPtr += 2;
 
-        in_vec = vld1q_f32((float*)aPtr);
+        in_vec = vld1q_f32((const float*)aPtr);
         out_vec1 = vaddq_f32(in_vec, out_vec1);
         aPtr += 2;
 
-        in_vec = vld1q_f32((float*)aPtr);
+        in_vec = vld1q_f32((const float*)aPtr);
         out_vec2 = vaddq_f32(in_vec, out_vec2);
         aPtr += 2;
 
-        in_vec = vld1q_f32((float*)aPtr);
+        in_vec = vld1q_f32((const float*)aPtr);
         out_vec3 = vaddq_f32(in_vec, out_vec3);
         aPtr += 2;
     }

--- a/kernels/volk/volk_32fc_conjugate_32fc.h
+++ b/kernels/volk/volk_32fc_conjugate_32fc.h
@@ -60,41 +60,21 @@
 #include <stdio.h>
 #include <volk/volk_complex.h>
 
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
+#ifdef LV_HAVE_GENERIC
 
-static inline void volk_32fc_conjugate_32fc_u_avx(lv_32fc_t* cVector,
-                                                  const lv_32fc_t* aVector,
-                                                  unsigned int num_points)
+static inline void volk_32fc_conjugate_32fc_generic(lv_32fc_t* cVector,
+                                                    const lv_32fc_t* aVector,
+                                                    unsigned int num_points)
 {
+    lv_32fc_t* cPtr = cVector;
+    const lv_32fc_t* aPtr = aVector;
     unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
 
-    __m256 x;
-    lv_32fc_t* c = cVector;
-    const lv_32fc_t* a = aVector;
-
-    __m256 conjugator = _mm256_setr_ps(0, -0.f, 0, -0.f, 0, -0.f, 0, -0.f);
-
-    for (; number < quarterPoints; number++) {
-
-        x = _mm256_loadu_ps((const float*)a); // Load the complex data as ar,ai,br,bi
-
-        x = _mm256_xor_ps(x, conjugator); // conjugate register
-
-        _mm256_storeu_ps((float*)c, x); // Store the results back into the C container
-
-        a += 4;
-        c += 4;
-    }
-
-    number = quarterPoints * 4;
-
-    for (; number < num_points; number++) {
-        *c++ = lv_conj(*a++);
+    for (number = 0; number < num_points; number++) {
+        *cPtr++ = lv_conj(*aPtr++);
     }
 }
-#endif /* LV_HAVE_AVX */
+#endif /* LV_HAVE_GENERIC */
 
 #ifdef LV_HAVE_SSE3
 #include <pmmintrin.h>
@@ -130,36 +110,10 @@ static inline void volk_32fc_conjugate_32fc_u_sse3(lv_32fc_t* cVector,
 }
 #endif /* LV_HAVE_SSE3 */
 
-#ifdef LV_HAVE_GENERIC
-
-static inline void volk_32fc_conjugate_32fc_generic(lv_32fc_t* cVector,
-                                                    const lv_32fc_t* aVector,
-                                                    unsigned int num_points)
-{
-    lv_32fc_t* cPtr = cVector;
-    const lv_32fc_t* aPtr = aVector;
-    unsigned int number = 0;
-
-    for (number = 0; number < num_points; number++) {
-        *cPtr++ = lv_conj(*aPtr++);
-    }
-}
-#endif /* LV_HAVE_GENERIC */
-
-
-#endif /* INCLUDED_volk_32fc_conjugate_32fc_u_H */
-#ifndef INCLUDED_volk_32fc_conjugate_32fc_a_H
-#define INCLUDED_volk_32fc_conjugate_32fc_a_H
-
-#include <float.h>
-#include <inttypes.h>
-#include <stdio.h>
-#include <volk/volk_complex.h>
-
 #ifdef LV_HAVE_AVX
 #include <immintrin.h>
 
-static inline void volk_32fc_conjugate_32fc_a_avx(lv_32fc_t* cVector,
+static inline void volk_32fc_conjugate_32fc_u_avx(lv_32fc_t* cVector,
                                                   const lv_32fc_t* aVector,
                                                   unsigned int num_points)
 {
@@ -174,11 +128,11 @@ static inline void volk_32fc_conjugate_32fc_a_avx(lv_32fc_t* cVector,
 
     for (; number < quarterPoints; number++) {
 
-        x = _mm256_load_ps((const float*)a); // Load the complex data as ar,ai,br,bi
+        x = _mm256_loadu_ps((const float*)a); // Load the complex data as ar,ai,br,bi
 
         x = _mm256_xor_ps(x, conjugator); // conjugate register
 
-        _mm256_store_ps((float*)c, x); // Store the results back into the C container
+        _mm256_storeu_ps((float*)c, x); // Store the results back into the C container
 
         a += 4;
         c += 4;
@@ -191,74 +145,6 @@ static inline void volk_32fc_conjugate_32fc_a_avx(lv_32fc_t* cVector,
     }
 }
 #endif /* LV_HAVE_AVX */
-
-#ifdef LV_HAVE_SSE3
-#include <pmmintrin.h>
-
-static inline void volk_32fc_conjugate_32fc_a_sse3(lv_32fc_t* cVector,
-                                                   const lv_32fc_t* aVector,
-                                                   unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int halfPoints = num_points / 2;
-
-    __m128 x;
-    lv_32fc_t* c = cVector;
-    const lv_32fc_t* a = aVector;
-
-    __m128 conjugator = _mm_setr_ps(0, -0.f, 0, -0.f);
-
-    for (; number < halfPoints; number++) {
-
-        x = _mm_load_ps((const float*)a); // Load the complex data as ar,ai,br,bi
-
-        x = _mm_xor_ps(x, conjugator); // conjugate register
-
-        _mm_store_ps((float*)c, x); // Store the results back into the C container
-
-        a += 2;
-        c += 2;
-    }
-
-    if ((num_points % 2) != 0) {
-        *c = lv_conj(*a);
-    }
-}
-#endif /* LV_HAVE_SSE3 */
-
-#ifdef LV_HAVE_NEON
-#include <arm_neon.h>
-
-static inline void volk_32fc_conjugate_32fc_a_neon(lv_32fc_t* cVector,
-                                                   const lv_32fc_t* aVector,
-                                                   unsigned int num_points)
-{
-    unsigned int number;
-    const unsigned int quarterPoints = num_points / 4;
-
-    float32x4x2_t x;
-    lv_32fc_t* c = cVector;
-    const lv_32fc_t* a = aVector;
-
-    for (number = 0; number < quarterPoints; number++) {
-        __VOLK_PREFETCH(a + 4);
-        x = vld2q_f32((const float*)a); // Load the complex data as ar,br,cr,dr; ai,bi,ci,di
-
-        // xor the imaginary lane
-        x.val[1] = vnegq_f32(x.val[1]);
-
-        vst2q_f32((float*)c, x); // Store the results back into the C container
-
-        a += 4;
-        c += 4;
-    }
-
-    for (number = quarterPoints * 4; number < num_points; number++) {
-        *c++ = lv_conj(*a++);
-    }
-}
-#endif /* LV_HAVE_NEON */
-
 
 #ifdef LV_HAVE_NEONV8
 #include <arm_neon.h>
@@ -302,7 +188,6 @@ static inline void volk_32fc_conjugate_32fc_neonv8(lv_32fc_t* cVector,
 
 #endif /* LV_HAVE_NEONV8 */
 
-
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 
@@ -318,6 +203,118 @@ static inline void volk_32fc_conjugate_32fc_rvv(lv_32fc_t* cVector,
         __riscv_vse64((uint64_t*)cVector, __riscv_vxor(v, m, vl), vl);
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
+
+#endif /* INCLUDED_volk_32fc_conjugate_32fc_u_H */
+#ifndef INCLUDED_volk_32fc_conjugate_32fc_a_H
+#define INCLUDED_volk_32fc_conjugate_32fc_a_H
+
+#include <float.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <volk/volk_complex.h>
+
+#ifdef LV_HAVE_SSE3
+#include <pmmintrin.h>
+
+static inline void volk_32fc_conjugate_32fc_a_sse3(lv_32fc_t* cVector,
+                                                   const lv_32fc_t* aVector,
+                                                   unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int halfPoints = num_points / 2;
+
+    __m128 x;
+    lv_32fc_t* c = cVector;
+    const lv_32fc_t* a = aVector;
+
+    __m128 conjugator = _mm_setr_ps(0, -0.f, 0, -0.f);
+
+    for (; number < halfPoints; number++) {
+
+        x = _mm_load_ps((const float*)a); // Load the complex data as ar,ai,br,bi
+
+        x = _mm_xor_ps(x, conjugator); // conjugate register
+
+        _mm_store_ps((float*)c, x); // Store the results back into the C container
+
+        a += 2;
+        c += 2;
+    }
+
+    if ((num_points % 2) != 0) {
+        *c = lv_conj(*a);
+    }
+}
+#endif /* LV_HAVE_SSE3 */
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void volk_32fc_conjugate_32fc_a_avx(lv_32fc_t* cVector,
+                                                  const lv_32fc_t* aVector,
+                                                  unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    __m256 x;
+    lv_32fc_t* c = cVector;
+    const lv_32fc_t* a = aVector;
+
+    __m256 conjugator = _mm256_setr_ps(0, -0.f, 0, -0.f, 0, -0.f, 0, -0.f);
+
+    for (; number < quarterPoints; number++) {
+
+        x = _mm256_load_ps((const float*)a); // Load the complex data as ar,ai,br,bi
+
+        x = _mm256_xor_ps(x, conjugator); // conjugate register
+
+        _mm256_store_ps((float*)c, x); // Store the results back into the C container
+
+        a += 4;
+        c += 4;
+    }
+
+    number = quarterPoints * 4;
+
+    for (; number < num_points; number++) {
+        *c++ = lv_conj(*a++);
+    }
+}
+#endif /* LV_HAVE_AVX */
+
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+
+static inline void volk_32fc_conjugate_32fc_a_neon(lv_32fc_t* cVector,
+                                                   const lv_32fc_t* aVector,
+                                                   unsigned int num_points)
+{
+    unsigned int number;
+    const unsigned int quarterPoints = num_points / 4;
+
+    float32x4x2_t x;
+    lv_32fc_t* c = cVector;
+    const lv_32fc_t* a = aVector;
+
+    for (number = 0; number < quarterPoints; number++) {
+        __VOLK_PREFETCH(a + 4);
+        x = vld2q_f32((const float*)a); // Load the complex data as ar,br,cr,dr; ai,bi,ci,di
+
+        // xor the imaginary lane
+        x.val[1] = vnegq_f32(x.val[1]);
+
+        vst2q_f32((float*)c, x); // Store the results back into the C container
+
+        a += 4;
+        c += 4;
+    }
+
+    for (number = quarterPoints * 4; number < num_points; number++) {
+        *c++ = lv_conj(*a++);
+    }
+}
+#endif /* LV_HAVE_NEON */
 
 #endif /* INCLUDED_volk_32fc_conjugate_32fc_a_H */

--- a/kernels/volk/volk_32fc_conjugate_32fc.h
+++ b/kernels/volk/volk_32fc_conjugate_32fc.h
@@ -78,7 +78,7 @@ static inline void volk_32fc_conjugate_32fc_u_avx(lv_32fc_t* cVector,
 
     for (; number < quarterPoints; number++) {
 
-        x = _mm256_loadu_ps((float*)a); // Load the complex data as ar,ai,br,bi
+        x = _mm256_loadu_ps((const float*)a); // Load the complex data as ar,ai,br,bi
 
         x = _mm256_xor_ps(x, conjugator); // conjugate register
 
@@ -114,7 +114,7 @@ static inline void volk_32fc_conjugate_32fc_u_sse3(lv_32fc_t* cVector,
 
     for (; number < halfPoints; number++) {
 
-        x = _mm_loadu_ps((float*)a); // Load the complex data as ar,ai,br,bi
+        x = _mm_loadu_ps((const float*)a); // Load the complex data as ar,ai,br,bi
 
         x = _mm_xor_ps(x, conjugator); // conjugate register
 
@@ -174,7 +174,7 @@ static inline void volk_32fc_conjugate_32fc_a_avx(lv_32fc_t* cVector,
 
     for (; number < quarterPoints; number++) {
 
-        x = _mm256_load_ps((float*)a); // Load the complex data as ar,ai,br,bi
+        x = _mm256_load_ps((const float*)a); // Load the complex data as ar,ai,br,bi
 
         x = _mm256_xor_ps(x, conjugator); // conjugate register
 
@@ -210,7 +210,7 @@ static inline void volk_32fc_conjugate_32fc_a_sse3(lv_32fc_t* cVector,
 
     for (; number < halfPoints; number++) {
 
-        x = _mm_load_ps((float*)a); // Load the complex data as ar,ai,br,bi
+        x = _mm_load_ps((const float*)a); // Load the complex data as ar,ai,br,bi
 
         x = _mm_xor_ps(x, conjugator); // conjugate register
 
@@ -242,7 +242,7 @@ static inline void volk_32fc_conjugate_32fc_a_neon(lv_32fc_t* cVector,
 
     for (number = 0; number < quarterPoints; number++) {
         __VOLK_PREFETCH(a + 4);
-        x = vld2q_f32((float*)a); // Load the complex data as ar,br,cr,dr; ai,bi,ci,di
+        x = vld2q_f32((const float*)a); // Load the complex data as ar,br,cr,dr; ai,bi,ci,di
 
         // xor the imaginary lane
         x.val[1] = vnegq_f32(x.val[1]);

--- a/kernels/volk/volk_32fc_convert_16ic.h
+++ b/kernels/volk/volk_32fc_convert_16ic.h
@@ -46,7 +46,7 @@ static inline void volk_32fc_convert_16ic_a_avx2(lv_16sc_t* outputVector,
 {
     const unsigned int avx_iters = num_points / 8;
 
-    float* inputVectorPtr = (float*)inputVector;
+    const float* inputVectorPtr = (const float*)inputVector;
     int16_t* outputVectorPtr = (int16_t*)outputVector;
     float aux;
 
@@ -61,9 +61,9 @@ static inline void volk_32fc_convert_16ic_a_avx2(lv_16sc_t* outputVector,
     unsigned int i;
 
     for (i = 0; i < avx_iters; i++) {
-        inputVal1 = _mm256_load_ps((float*)inputVectorPtr);
+        inputVal1 = _mm256_load_ps(inputVectorPtr);
         inputVectorPtr += 8;
-        inputVal2 = _mm256_load_ps((float*)inputVectorPtr);
+        inputVal2 = _mm256_load_ps(inputVectorPtr);
         inputVectorPtr += 8;
         __VOLK_PREFETCH(inputVectorPtr + 16);
 
@@ -101,7 +101,7 @@ static inline void volk_32fc_convert_16ic_a_avx512(lv_16sc_t* outputVector,
 {
     const unsigned int avx512_iters = num_points / 8;
 
-    float* inputVectorPtr = (float*)inputVector;
+    const float* inputVectorPtr = (const float*)inputVector;
     int16_t* outputVectorPtr = (int16_t*)outputVector;
     float aux;
 
@@ -116,7 +116,7 @@ static inline void volk_32fc_convert_16ic_a_avx512(lv_16sc_t* outputVector,
     unsigned int i;
 
     for (i = 0; i < avx512_iters; i++) {
-        inputVal1 = _mm512_load_ps((float*)inputVectorPtr);
+        inputVal1 = _mm512_load_ps(inputVectorPtr);
         inputVectorPtr += 16;
         __VOLK_PREFETCH(inputVectorPtr + 16);
 
@@ -150,7 +150,7 @@ static inline void volk_32fc_convert_16ic_a_sse2(lv_16sc_t* outputVector,
 {
     const unsigned int sse_iters = num_points / 4;
 
-    float* inputVectorPtr = (float*)inputVector;
+    const float* inputVectorPtr = (const float*)inputVector;
     int16_t* outputVectorPtr = (int16_t*)outputVector;
     float aux;
 
@@ -165,9 +165,9 @@ static inline void volk_32fc_convert_16ic_a_sse2(lv_16sc_t* outputVector,
     unsigned int i;
 
     for (i = 0; i < sse_iters; i++) {
-        inputVal1 = _mm_load_ps((float*)inputVectorPtr);
+        inputVal1 = _mm_load_ps(inputVectorPtr);
         inputVectorPtr += 4;
-        inputVal2 = _mm_load_ps((float*)inputVectorPtr);
+        inputVal2 = _mm_load_ps(inputVectorPtr);
         inputVectorPtr += 4;
         __VOLK_PREFETCH(inputVectorPtr + 8);
 
@@ -206,7 +206,7 @@ static inline void volk_32fc_convert_16ic_neon(lv_16sc_t* outputVector,
 
     const unsigned int neon_iters = num_points / 4;
 
-    float32_t* inputVectorPtr = (float32_t*)inputVector;
+    const float32_t* inputVectorPtr = (const float32_t*)inputVector;
     int16_t* outputVectorPtr = (int16_t*)outputVector;
 
     const float min_val_f = (float)SHRT_MIN;
@@ -273,7 +273,7 @@ static inline void volk_32fc_convert_16ic_neonv8(lv_16sc_t* outputVector,
 {
     const unsigned int neon_iters = num_points / 4;
 
-    float32_t* inputVectorPtr = (float32_t*)inputVector;
+    const float32_t* inputVectorPtr = (const float32_t*)inputVector;
     int16_t* outputVectorPtr = (int16_t*)outputVector;
 
     const float min_val_f = (float)SHRT_MIN;
@@ -329,7 +329,7 @@ static inline void volk_32fc_convert_16ic_generic(lv_16sc_t* outputVector,
                                                   const lv_32fc_t* inputVector,
                                                   unsigned int num_points)
 {
-    float* inputVectorPtr = (float*)inputVector;
+    const float* inputVectorPtr = (const float*)inputVector;
     int16_t* outputVectorPtr = (int16_t*)outputVector;
     const float min_val = (float)SHRT_MIN;
     const float max_val = (float)SHRT_MAX;
@@ -365,7 +365,7 @@ static inline void volk_32fc_convert_16ic_u_avx2(lv_16sc_t* outputVector,
 {
     const unsigned int avx_iters = num_points / 8;
 
-    float* inputVectorPtr = (float*)inputVector;
+    const float* inputVectorPtr = (const float*)inputVector;
     int16_t* outputVectorPtr = (int16_t*)outputVector;
     float aux;
 
@@ -380,9 +380,9 @@ static inline void volk_32fc_convert_16ic_u_avx2(lv_16sc_t* outputVector,
     unsigned int i;
 
     for (i = 0; i < avx_iters; i++) {
-        inputVal1 = _mm256_loadu_ps((float*)inputVectorPtr);
+        inputVal1 = _mm256_loadu_ps(inputVectorPtr);
         inputVectorPtr += 8;
-        inputVal2 = _mm256_loadu_ps((float*)inputVectorPtr);
+        inputVal2 = _mm256_loadu_ps(inputVectorPtr);
         inputVectorPtr += 8;
         __VOLK_PREFETCH(inputVectorPtr + 16);
 
@@ -420,7 +420,7 @@ static inline void volk_32fc_convert_16ic_u_avx512(lv_16sc_t* outputVector,
 {
     const unsigned int avx512_iters = num_points / 8;
 
-    float* inputVectorPtr = (float*)inputVector;
+    const float* inputVectorPtr = (const float*)inputVector;
     int16_t* outputVectorPtr = (int16_t*)outputVector;
     float aux;
 
@@ -435,7 +435,7 @@ static inline void volk_32fc_convert_16ic_u_avx512(lv_16sc_t* outputVector,
     unsigned int i;
 
     for (i = 0; i < avx512_iters; i++) {
-        inputVal1 = _mm512_loadu_ps((float*)inputVectorPtr);
+        inputVal1 = _mm512_loadu_ps(inputVectorPtr);
         inputVectorPtr += 16;
         __VOLK_PREFETCH(inputVectorPtr + 16);
 
@@ -470,7 +470,7 @@ static inline void volk_32fc_convert_16ic_u_sse2(lv_16sc_t* outputVector,
 {
     const unsigned int sse_iters = num_points / 4;
 
-    float* inputVectorPtr = (float*)inputVector;
+    const float* inputVectorPtr = (const float*)inputVector;
     int16_t* outputVectorPtr = (int16_t*)outputVector;
     float aux;
 
@@ -485,9 +485,9 @@ static inline void volk_32fc_convert_16ic_u_sse2(lv_16sc_t* outputVector,
 
     unsigned int i;
     for (i = 0; i < sse_iters; i++) {
-        inputVal1 = _mm_loadu_ps((float*)inputVectorPtr);
+        inputVal1 = _mm_loadu_ps(inputVectorPtr);
         inputVectorPtr += 4;
-        inputVal2 = _mm_loadu_ps((float*)inputVectorPtr);
+        inputVal2 = _mm_loadu_ps(inputVectorPtr);
         inputVectorPtr += 4;
         __VOLK_PREFETCH(inputVectorPtr + 8);
 
@@ -523,7 +523,7 @@ static inline void volk_32fc_convert_16ic_rvv(lv_16sc_t* outputVector,
                                               unsigned int num_points)
 {
     int16_t* out = (int16_t*)outputVector;
-    float* in = (float*)inputVector;
+    const float* in = (const float*)inputVector;
     size_t n = num_points * 2;
     for (size_t vl; n > 0; n -= vl, in += vl, out += vl) {
         vl = __riscv_vsetvl_e32m8(n);

--- a/kernels/volk/volk_32fc_convert_16ic.h
+++ b/kernels/volk/volk_32fc_convert_16ic.h
@@ -30,17 +30,94 @@
  *
  */
 
-#ifndef INCLUDED_volk_32fc_convert_16ic_a_H
-#define INCLUDED_volk_32fc_convert_16ic_a_H
+#ifndef INCLUDED_volk_32fc_convert_16ic_u_H
+#define INCLUDED_volk_32fc_convert_16ic_u_H
 
 #include "volk/volk_complex.h"
 #include <limits.h>
 #include <math.h>
 
+#ifdef LV_HAVE_GENERIC
+
+static inline void volk_32fc_convert_16ic_generic(lv_16sc_t* outputVector,
+                                                  const lv_32fc_t* inputVector,
+                                                  unsigned int num_points)
+{
+    const float* inputVectorPtr = (const float*)inputVector;
+    int16_t* outputVectorPtr = (int16_t*)outputVector;
+    const float min_val = (float)SHRT_MIN;
+    const float max_val = (float)SHRT_MAX;
+    float aux;
+    unsigned int i;
+    for (i = 0; i < num_points * 2; i++) {
+        aux = *inputVectorPtr++;
+        if (aux > max_val)
+            aux = max_val;
+        else if (aux < min_val)
+            aux = min_val;
+        *outputVectorPtr++ = (int16_t)rintf(aux);
+    }
+}
+#endif /* LV_HAVE_GENERIC */
+
+#ifdef LV_HAVE_SSE2
+#include <emmintrin.h>
+
+static inline void volk_32fc_convert_16ic_u_sse2(lv_16sc_t* outputVector,
+                                                 const lv_32fc_t* inputVector,
+                                                 unsigned int num_points)
+{
+    const unsigned int sse_iters = num_points / 4;
+
+    const float* inputVectorPtr = (const float*)inputVector;
+    int16_t* outputVectorPtr = (int16_t*)outputVector;
+    float aux;
+
+    const float min_val = (float)SHRT_MIN;
+    const float max_val = (float)SHRT_MAX;
+
+    __m128 inputVal1, inputVal2;
+    __m128i intInputVal1, intInputVal2;
+    __m128 ret1, ret2;
+    const __m128 vmin_val = _mm_set_ps1(min_val);
+    const __m128 vmax_val = _mm_set_ps1(max_val);
+
+    unsigned int i;
+    for (i = 0; i < sse_iters; i++) {
+        inputVal1 = _mm_loadu_ps(inputVectorPtr);
+        inputVectorPtr += 4;
+        inputVal2 = _mm_loadu_ps(inputVectorPtr);
+        inputVectorPtr += 4;
+        __VOLK_PREFETCH(inputVectorPtr + 8);
+
+        // Clip
+        ret1 = _mm_max_ps(_mm_min_ps(inputVal1, vmax_val), vmin_val);
+        ret2 = _mm_max_ps(_mm_min_ps(inputVal2, vmax_val), vmin_val);
+
+        intInputVal1 = _mm_cvtps_epi32(ret1);
+        intInputVal2 = _mm_cvtps_epi32(ret2);
+
+        intInputVal1 = _mm_packs_epi32(intInputVal1, intInputVal2);
+
+        _mm_storeu_si128((__m128i*)outputVectorPtr, intInputVal1);
+        outputVectorPtr += 8;
+    }
+
+    for (i = sse_iters * 8; i < num_points * 2; i++) {
+        aux = *inputVectorPtr++;
+        if (aux > max_val)
+            aux = max_val;
+        else if (aux < min_val)
+            aux = min_val;
+        *outputVectorPtr++ = (int16_t)rintf(aux);
+    }
+}
+#endif /* LV_HAVE_SSE2 */
+
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
 
-static inline void volk_32fc_convert_16ic_a_avx2(lv_16sc_t* outputVector,
+static inline void volk_32fc_convert_16ic_u_avx2(lv_16sc_t* outputVector,
                                                  const lv_32fc_t* inputVector,
                                                  unsigned int num_points)
 {
@@ -61,9 +138,9 @@ static inline void volk_32fc_convert_16ic_a_avx2(lv_16sc_t* outputVector,
     unsigned int i;
 
     for (i = 0; i < avx_iters; i++) {
-        inputVal1 = _mm256_load_ps(inputVectorPtr);
+        inputVal1 = _mm256_loadu_ps(inputVectorPtr);
         inputVectorPtr += 8;
-        inputVal2 = _mm256_load_ps(inputVectorPtr);
+        inputVal2 = _mm256_loadu_ps(inputVectorPtr);
         inputVectorPtr += 8;
         __VOLK_PREFETCH(inputVectorPtr + 16);
 
@@ -77,7 +154,7 @@ static inline void volk_32fc_convert_16ic_a_avx2(lv_16sc_t* outputVector,
         intInputVal1 = _mm256_packs_epi32(intInputVal1, intInputVal2);
         intInputVal1 = _mm256_permute4x64_epi64(intInputVal1, 0xd8);
 
-        _mm256_store_si256((__m256i*)outputVectorPtr, intInputVal1);
+        _mm256_storeu_si256((__m256i*)outputVectorPtr, intInputVal1);
         outputVectorPtr += 16;
     }
 
@@ -95,7 +172,7 @@ static inline void volk_32fc_convert_16ic_a_avx2(lv_16sc_t* outputVector,
 #ifdef LV_HAVE_AVX512F
 #include <immintrin.h>
 
-static inline void volk_32fc_convert_16ic_a_avx512(lv_16sc_t* outputVector,
+static inline void volk_32fc_convert_16ic_u_avx512(lv_16sc_t* outputVector,
                                                    const lv_32fc_t* inputVector,
                                                    unsigned int num_points)
 {
@@ -116,7 +193,7 @@ static inline void volk_32fc_convert_16ic_a_avx512(lv_16sc_t* outputVector,
     unsigned int i;
 
     for (i = 0; i < avx512_iters; i++) {
-        inputVal1 = _mm512_load_ps(inputVectorPtr);
+        inputVal1 = _mm512_loadu_ps(inputVectorPtr);
         inputVectorPtr += 16;
         __VOLK_PREFETCH(inputVectorPtr + 16);
 
@@ -126,7 +203,7 @@ static inline void volk_32fc_convert_16ic_a_avx512(lv_16sc_t* outputVector,
         // Convert float to int32, then pack to int16 with saturation
         intInputVal = _mm512_cvtsepi32_epi16(_mm512_cvtps_epi32(ret1));
 
-        _mm256_store_si256((__m256i*)outputVectorPtr, intInputVal);
+        _mm256_storeu_si256((__m256i*)outputVectorPtr, intInputVal);
         outputVectorPtr += 16;
     }
 
@@ -140,61 +217,6 @@ static inline void volk_32fc_convert_16ic_a_avx512(lv_16sc_t* outputVector,
     }
 }
 #endif /* LV_HAVE_AVX512F */
-
-#ifdef LV_HAVE_SSE2
-#include <emmintrin.h>
-
-static inline void volk_32fc_convert_16ic_a_sse2(lv_16sc_t* outputVector,
-                                                 const lv_32fc_t* inputVector,
-                                                 unsigned int num_points)
-{
-    const unsigned int sse_iters = num_points / 4;
-
-    const float* inputVectorPtr = (const float*)inputVector;
-    int16_t* outputVectorPtr = (int16_t*)outputVector;
-    float aux;
-
-    const float min_val = (float)SHRT_MIN;
-    const float max_val = (float)SHRT_MAX;
-
-    __m128 inputVal1, inputVal2;
-    __m128i intInputVal1, intInputVal2;
-    __m128 ret1, ret2;
-    const __m128 vmin_val = _mm_set_ps1(min_val);
-    const __m128 vmax_val = _mm_set_ps1(max_val);
-    unsigned int i;
-
-    for (i = 0; i < sse_iters; i++) {
-        inputVal1 = _mm_load_ps(inputVectorPtr);
-        inputVectorPtr += 4;
-        inputVal2 = _mm_load_ps(inputVectorPtr);
-        inputVectorPtr += 4;
-        __VOLK_PREFETCH(inputVectorPtr + 8);
-
-        // Clip
-        ret1 = _mm_max_ps(_mm_min_ps(inputVal1, vmax_val), vmin_val);
-        ret2 = _mm_max_ps(_mm_min_ps(inputVal2, vmax_val), vmin_val);
-
-        intInputVal1 = _mm_cvtps_epi32(ret1);
-        intInputVal2 = _mm_cvtps_epi32(ret2);
-
-        intInputVal1 = _mm_packs_epi32(intInputVal1, intInputVal2);
-
-        _mm_store_si128((__m128i*)outputVectorPtr, intInputVal1);
-        outputVectorPtr += 8;
-    }
-
-    for (i = sse_iters * 8; i < num_points * 2; i++) {
-        aux = *inputVectorPtr++;
-        if (aux > max_val)
-            aux = max_val;
-        else if (aux < min_val)
-            aux = min_val;
-        *outputVectorPtr++ = (int16_t)rintf(aux);
-    }
-}
-#endif /* LV_HAVE_SSE2 */
-
 
 #if LV_HAVE_NEONV7
 #include <arm_neon.h>
@@ -322,20 +344,77 @@ static inline void volk_32fc_convert_16ic_neonv8(lv_16sc_t* outputVector,
 }
 #endif /* LV_HAVE_NEONV8 */
 
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
 
-#ifdef LV_HAVE_GENERIC
-
-static inline void volk_32fc_convert_16ic_generic(lv_16sc_t* outputVector,
-                                                  const lv_32fc_t* inputVector,
-                                                  unsigned int num_points)
+static inline void volk_32fc_convert_16ic_rvv(lv_16sc_t* outputVector,
+                                              const lv_32fc_t* inputVector,
+                                              unsigned int num_points)
 {
+    int16_t* out = (int16_t*)outputVector;
+    const float* in = (const float*)inputVector;
+    size_t n = num_points * 2;
+    for (size_t vl; n > 0; n -= vl, in += vl, out += vl) {
+        vl = __riscv_vsetvl_e32m8(n);
+        vfloat32m8_t v = __riscv_vle32_v_f32m8(in, vl);
+        __riscv_vse16(out, __riscv_vfncvt_x(v, vl), vl);
+    }
+}
+#endif /* LV_HAVE_RVV */
+
+#endif /* INCLUDED_volk_32fc_convert_16ic_u_H */
+
+#ifndef INCLUDED_volk_32fc_convert_16ic_a_H
+#define INCLUDED_volk_32fc_convert_16ic_a_H
+
+#include "volk/volk_complex.h"
+#include <limits.h>
+#include <math.h>
+
+#ifdef LV_HAVE_SSE2
+#include <emmintrin.h>
+
+static inline void volk_32fc_convert_16ic_a_sse2(lv_16sc_t* outputVector,
+                                                 const lv_32fc_t* inputVector,
+                                                 unsigned int num_points)
+{
+    const unsigned int sse_iters = num_points / 4;
+
     const float* inputVectorPtr = (const float*)inputVector;
     int16_t* outputVectorPtr = (int16_t*)outputVector;
+    float aux;
+
     const float min_val = (float)SHRT_MIN;
     const float max_val = (float)SHRT_MAX;
-    float aux;
+
+    __m128 inputVal1, inputVal2;
+    __m128i intInputVal1, intInputVal2;
+    __m128 ret1, ret2;
+    const __m128 vmin_val = _mm_set_ps1(min_val);
+    const __m128 vmax_val = _mm_set_ps1(max_val);
     unsigned int i;
-    for (i = 0; i < num_points * 2; i++) {
+
+    for (i = 0; i < sse_iters; i++) {
+        inputVal1 = _mm_load_ps(inputVectorPtr);
+        inputVectorPtr += 4;
+        inputVal2 = _mm_load_ps(inputVectorPtr);
+        inputVectorPtr += 4;
+        __VOLK_PREFETCH(inputVectorPtr + 8);
+
+        // Clip
+        ret1 = _mm_max_ps(_mm_min_ps(inputVal1, vmax_val), vmin_val);
+        ret2 = _mm_max_ps(_mm_min_ps(inputVal2, vmax_val), vmin_val);
+
+        intInputVal1 = _mm_cvtps_epi32(ret1);
+        intInputVal2 = _mm_cvtps_epi32(ret2);
+
+        intInputVal1 = _mm_packs_epi32(intInputVal1, intInputVal2);
+
+        _mm_store_si128((__m128i*)outputVectorPtr, intInputVal1);
+        outputVectorPtr += 8;
+    }
+
+    for (i = sse_iters * 8; i < num_points * 2; i++) {
         aux = *inputVectorPtr++;
         if (aux > max_val)
             aux = max_val;
@@ -344,22 +423,12 @@ static inline void volk_32fc_convert_16ic_generic(lv_16sc_t* outputVector,
         *outputVectorPtr++ = (int16_t)rintf(aux);
     }
 }
-#endif /* LV_HAVE_GENERIC */
-
-#endif /* INCLUDED_volk_32fc_convert_16ic_a_H */
-
-#ifndef INCLUDED_volk_32fc_convert_16ic_u_H
-#define INCLUDED_volk_32fc_convert_16ic_u_H
-
-#include "volk/volk_complex.h"
-#include <limits.h>
-#include <math.h>
-
+#endif /* LV_HAVE_SSE2 */
 
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
 
-static inline void volk_32fc_convert_16ic_u_avx2(lv_16sc_t* outputVector,
+static inline void volk_32fc_convert_16ic_a_avx2(lv_16sc_t* outputVector,
                                                  const lv_32fc_t* inputVector,
                                                  unsigned int num_points)
 {
@@ -380,9 +449,9 @@ static inline void volk_32fc_convert_16ic_u_avx2(lv_16sc_t* outputVector,
     unsigned int i;
 
     for (i = 0; i < avx_iters; i++) {
-        inputVal1 = _mm256_loadu_ps(inputVectorPtr);
+        inputVal1 = _mm256_load_ps(inputVectorPtr);
         inputVectorPtr += 8;
-        inputVal2 = _mm256_loadu_ps(inputVectorPtr);
+        inputVal2 = _mm256_load_ps(inputVectorPtr);
         inputVectorPtr += 8;
         __VOLK_PREFETCH(inputVectorPtr + 16);
 
@@ -396,7 +465,7 @@ static inline void volk_32fc_convert_16ic_u_avx2(lv_16sc_t* outputVector,
         intInputVal1 = _mm256_packs_epi32(intInputVal1, intInputVal2);
         intInputVal1 = _mm256_permute4x64_epi64(intInputVal1, 0xd8);
 
-        _mm256_storeu_si256((__m256i*)outputVectorPtr, intInputVal1);
+        _mm256_store_si256((__m256i*)outputVectorPtr, intInputVal1);
         outputVectorPtr += 16;
     }
 
@@ -414,7 +483,7 @@ static inline void volk_32fc_convert_16ic_u_avx2(lv_16sc_t* outputVector,
 #ifdef LV_HAVE_AVX512F
 #include <immintrin.h>
 
-static inline void volk_32fc_convert_16ic_u_avx512(lv_16sc_t* outputVector,
+static inline void volk_32fc_convert_16ic_a_avx512(lv_16sc_t* outputVector,
                                                    const lv_32fc_t* inputVector,
                                                    unsigned int num_points)
 {
@@ -435,7 +504,7 @@ static inline void volk_32fc_convert_16ic_u_avx512(lv_16sc_t* outputVector,
     unsigned int i;
 
     for (i = 0; i < avx512_iters; i++) {
-        inputVal1 = _mm512_loadu_ps(inputVectorPtr);
+        inputVal1 = _mm512_load_ps(inputVectorPtr);
         inputVectorPtr += 16;
         __VOLK_PREFETCH(inputVectorPtr + 16);
 
@@ -445,7 +514,7 @@ static inline void volk_32fc_convert_16ic_u_avx512(lv_16sc_t* outputVector,
         // Convert float to int32, then pack to int16 with saturation
         intInputVal = _mm512_cvtsepi32_epi16(_mm512_cvtps_epi32(ret1));
 
-        _mm256_storeu_si256((__m256i*)outputVectorPtr, intInputVal);
+        _mm256_store_si256((__m256i*)outputVectorPtr, intInputVal);
         outputVectorPtr += 16;
     }
 
@@ -460,77 +529,4 @@ static inline void volk_32fc_convert_16ic_u_avx512(lv_16sc_t* outputVector,
 }
 #endif /* LV_HAVE_AVX512F */
 
-
-#ifdef LV_HAVE_SSE2
-#include <emmintrin.h>
-
-static inline void volk_32fc_convert_16ic_u_sse2(lv_16sc_t* outputVector,
-                                                 const lv_32fc_t* inputVector,
-                                                 unsigned int num_points)
-{
-    const unsigned int sse_iters = num_points / 4;
-
-    const float* inputVectorPtr = (const float*)inputVector;
-    int16_t* outputVectorPtr = (int16_t*)outputVector;
-    float aux;
-
-    const float min_val = (float)SHRT_MIN;
-    const float max_val = (float)SHRT_MAX;
-
-    __m128 inputVal1, inputVal2;
-    __m128i intInputVal1, intInputVal2;
-    __m128 ret1, ret2;
-    const __m128 vmin_val = _mm_set_ps1(min_val);
-    const __m128 vmax_val = _mm_set_ps1(max_val);
-
-    unsigned int i;
-    for (i = 0; i < sse_iters; i++) {
-        inputVal1 = _mm_loadu_ps(inputVectorPtr);
-        inputVectorPtr += 4;
-        inputVal2 = _mm_loadu_ps(inputVectorPtr);
-        inputVectorPtr += 4;
-        __VOLK_PREFETCH(inputVectorPtr + 8);
-
-        // Clip
-        ret1 = _mm_max_ps(_mm_min_ps(inputVal1, vmax_val), vmin_val);
-        ret2 = _mm_max_ps(_mm_min_ps(inputVal2, vmax_val), vmin_val);
-
-        intInputVal1 = _mm_cvtps_epi32(ret1);
-        intInputVal2 = _mm_cvtps_epi32(ret2);
-
-        intInputVal1 = _mm_packs_epi32(intInputVal1, intInputVal2);
-
-        _mm_storeu_si128((__m128i*)outputVectorPtr, intInputVal1);
-        outputVectorPtr += 8;
-    }
-
-    for (i = sse_iters * 8; i < num_points * 2; i++) {
-        aux = *inputVectorPtr++;
-        if (aux > max_val)
-            aux = max_val;
-        else if (aux < min_val)
-            aux = min_val;
-        *outputVectorPtr++ = (int16_t)rintf(aux);
-    }
-}
-#endif /* LV_HAVE_SSE2 */
-
-#ifdef LV_HAVE_RVV
-#include <riscv_vector.h>
-
-static inline void volk_32fc_convert_16ic_rvv(lv_16sc_t* outputVector,
-                                              const lv_32fc_t* inputVector,
-                                              unsigned int num_points)
-{
-    int16_t* out = (int16_t*)outputVector;
-    const float* in = (const float*)inputVector;
-    size_t n = num_points * 2;
-    for (size_t vl; n > 0; n -= vl, in += vl, out += vl) {
-        vl = __riscv_vsetvl_e32m8(n);
-        vfloat32m8_t v = __riscv_vle32_v_f32m8(in, vl);
-        __riscv_vse16(out, __riscv_vfncvt_x(v, vl), vl);
-    }
-}
-#endif /*LV_HAVE_RVV*/
-
-#endif /* INCLUDED_volk_32fc_convert_16ic_u_H */
+#endif /* INCLUDED_volk_32fc_convert_16ic_a_H */

--- a/kernels/volk/volk_32fc_deinterleave_32f_x2.h
+++ b/kernels/volk/volk_32fc_deinterleave_32f_x2.h
@@ -70,7 +70,7 @@ static inline void volk_32fc_deinterleave_32f_x2_generic(float* iBuffer,
                                                          const lv_32fc_t* complexVector,
                                                          unsigned int num_points)
 {
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
     float* qBufferPtr = qBuffer;
     unsigned int number;
@@ -89,7 +89,7 @@ static inline void volk_32fc_deinterleave_32f_x2_a_avx512f(float* iBuffer,
                                                            const lv_32fc_t* complexVector,
                                                            unsigned int num_points)
 {
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
     float* qBufferPtr = qBuffer;
 
@@ -136,7 +136,7 @@ static inline void volk_32fc_deinterleave_32f_x2_a_avx(float* iBuffer,
                                                        const lv_32fc_t* complexVector,
                                                        unsigned int num_points)
 {
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
     float* qBufferPtr = qBuffer;
 
@@ -182,7 +182,7 @@ static inline void volk_32fc_deinterleave_32f_x2_a_sse(float* iBuffer,
                                                        const lv_32fc_t* complexVector,
                                                        unsigned int num_points)
 {
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
     float* qBufferPtr = qBuffer;
 
@@ -227,7 +227,7 @@ static inline void volk_32fc_deinterleave_32f_x2_neon(float* iBuffer,
 {
     unsigned int number = 0;
     unsigned int quarter_points = num_points / 4;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
     float* qBufferPtr = qBuffer;
     float32x4x2_t complexInput;
@@ -257,7 +257,7 @@ static inline void volk_32fc_deinterleave_32f_x2_neonv8(float* iBuffer,
                                                         unsigned int num_points)
 {
     const unsigned int eighthPoints = num_points / 8;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
     float* qBufferPtr = qBuffer;
 
@@ -300,7 +300,7 @@ static inline void volk_32fc_deinterleave_32f_x2_u_avx512f(float* iBuffer,
                                                            const lv_32fc_t* complexVector,
                                                            unsigned int num_points)
 {
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
     float* qBufferPtr = qBuffer;
 
@@ -347,7 +347,7 @@ static inline void volk_32fc_deinterleave_32f_x2_u_avx(float* iBuffer,
                                                        const lv_32fc_t* complexVector,
                                                        unsigned int num_points)
 {
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
     float* qBufferPtr = qBuffer;
 

--- a/kernels/volk/volk_32fc_deinterleave_32f_x2.h
+++ b/kernels/volk/volk_32fc_deinterleave_32f_x2.h
@@ -57,8 +57,8 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32fc_deinterleave_32f_x2_a_H
-#define INCLUDED_volk_32fc_deinterleave_32f_x2_a_H
+#ifndef INCLUDED_volk_32fc_deinterleave_32f_x2_u_H
+#define INCLUDED_volk_32fc_deinterleave_32f_x2_u_H
 
 #include <inttypes.h>
 #include <stdio.h>
@@ -81,10 +81,55 @@ static inline void volk_32fc_deinterleave_32f_x2_generic(float* iBuffer,
 }
 #endif /* LV_HAVE_GENERIC */
 
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+static inline void volk_32fc_deinterleave_32f_x2_u_avx(float* iBuffer,
+                                                       float* qBuffer,
+                                                       const lv_32fc_t* complexVector,
+                                                       unsigned int num_points)
+{
+    const float* complexVectorPtr = (const float*)complexVector;
+    float* iBufferPtr = iBuffer;
+    float* qBufferPtr = qBuffer;
+
+    unsigned int number = 0;
+    // Mask for real and imaginary parts
+    const unsigned int eighthPoints = num_points / 8;
+    __m256 cplxValue1, cplxValue2, complex1, complex2, iValue, qValue;
+    for (; number < eighthPoints; number++) {
+        cplxValue1 = _mm256_loadu_ps(complexVectorPtr);
+        complexVectorPtr += 8;
+
+        cplxValue2 = _mm256_loadu_ps(complexVectorPtr);
+        complexVectorPtr += 8;
+
+        complex1 = _mm256_permute2f128_ps(cplxValue1, cplxValue2, 0x20);
+        complex2 = _mm256_permute2f128_ps(cplxValue1, cplxValue2, 0x31);
+
+        // Arrange in i1i2i3i4 format
+        iValue = _mm256_shuffle_ps(complex1, complex2, 0x88);
+        // Arrange in q1q2q3q4 format
+        qValue = _mm256_shuffle_ps(complex1, complex2, 0xdd);
+
+        _mm256_storeu_ps(iBufferPtr, iValue);
+        _mm256_storeu_ps(qBufferPtr, qValue);
+
+        iBufferPtr += 8;
+        qBufferPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = *complexVectorPtr++;
+        *qBufferPtr++ = *complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_AVX */
+
 #ifdef LV_HAVE_AVX512F
 #include <immintrin.h>
 
-static inline void volk_32fc_deinterleave_32f_x2_a_avx512f(float* iBuffer,
+static inline void volk_32fc_deinterleave_32f_x2_u_avx512f(float* iBuffer,
                                                            float* qBuffer,
                                                            const lv_32fc_t* complexVector,
                                                            unsigned int num_points)
@@ -100,8 +145,8 @@ static inline void volk_32fc_deinterleave_32f_x2_a_avx512f(float* iBuffer,
     __m512 iValue, qValue;
 
     for (; number < eighthPoints; number++) {
-        // Load 8 complex numbers (16 floats): I0,Q0,I1,Q1,...,I7,Q7
-        cplxValue = _mm512_load_ps(complexVectorPtr);
+        // Load 8 complex numbers (16 floats): I0,Q0,I1,Q1,...,I7,Q7 - unaligned
+        cplxValue = _mm512_loadu_ps(complexVectorPtr);
 
         // Deinterleave using permute
         // Extract all I values (even indices: 0,2,4,6,8,10,12,14)
@@ -114,9 +159,9 @@ static inline void volk_32fc_deinterleave_32f_x2_a_avx512f(float* iBuffer,
             _mm512_setr_epi32(1, 3, 5, 7, 9, 11, 13, 15, 0, 0, 0, 0, 0, 0, 0, 0),
             cplxValue);
 
-        // Store only the first 8 results (lower 256 bits)
-        _mm256_store_ps(iBufferPtr, _mm512_castps512_ps256(iValue));
-        _mm256_store_ps(qBufferPtr, _mm512_castps512_ps256(qValue));
+        // Store only the first 8 results (lower 256 bits) - unaligned
+        _mm256_storeu_ps(iBufferPtr, _mm512_castps512_ps256(iValue));
+        _mm256_storeu_ps(qBufferPtr, _mm512_castps512_ps256(qValue));
 
         complexVectorPtr += 16;
         iBufferPtr += 8;
@@ -128,94 +173,6 @@ static inline void volk_32fc_deinterleave_32f_x2_a_avx512f(float* iBuffer,
         iBufferPtr, qBufferPtr, (const lv_32fc_t*)complexVectorPtr, num_points - number);
 }
 #endif /* LV_HAVE_AVX512F */
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-static inline void volk_32fc_deinterleave_32f_x2_a_avx(float* iBuffer,
-                                                       float* qBuffer,
-                                                       const lv_32fc_t* complexVector,
-                                                       unsigned int num_points)
-{
-    const float* complexVectorPtr = (const float*)complexVector;
-    float* iBufferPtr = iBuffer;
-    float* qBufferPtr = qBuffer;
-
-    unsigned int number = 0;
-    // Mask for real and imaginary parts
-    const unsigned int eighthPoints = num_points / 8;
-    __m256 cplxValue1, cplxValue2, complex1, complex2, iValue, qValue;
-    for (; number < eighthPoints; number++) {
-        cplxValue1 = _mm256_load_ps(complexVectorPtr);
-        complexVectorPtr += 8;
-
-        cplxValue2 = _mm256_load_ps(complexVectorPtr);
-        complexVectorPtr += 8;
-
-        complex1 = _mm256_permute2f128_ps(cplxValue1, cplxValue2, 0x20);
-        complex2 = _mm256_permute2f128_ps(cplxValue1, cplxValue2, 0x31);
-
-        // Arrange in i1i2i3i4 format
-        iValue = _mm256_shuffle_ps(complex1, complex2, 0x88);
-        // Arrange in q1q2q3q4 format
-        qValue = _mm256_shuffle_ps(complex1, complex2, 0xdd);
-
-        _mm256_store_ps(iBufferPtr, iValue);
-        _mm256_store_ps(qBufferPtr, qValue);
-
-        iBufferPtr += 8;
-        qBufferPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = *complexVectorPtr++;
-        *qBufferPtr++ = *complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_AVX */
-
-#ifdef LV_HAVE_SSE
-#include <xmmintrin.h>
-
-static inline void volk_32fc_deinterleave_32f_x2_a_sse(float* iBuffer,
-                                                       float* qBuffer,
-                                                       const lv_32fc_t* complexVector,
-                                                       unsigned int num_points)
-{
-    const float* complexVectorPtr = (const float*)complexVector;
-    float* iBufferPtr = iBuffer;
-    float* qBufferPtr = qBuffer;
-
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-    __m128 cplxValue1, cplxValue2, iValue, qValue;
-    for (; number < quarterPoints; number++) {
-        cplxValue1 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        cplxValue2 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        // Arrange in i1i2i3i4 format
-        iValue = _mm_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(2, 0, 2, 0));
-        // Arrange in q1q2q3q4 format
-        qValue = _mm_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(3, 1, 3, 1));
-
-        _mm_store_ps(iBufferPtr, iValue);
-        _mm_store_ps(qBufferPtr, qValue);
-
-        iBufferPtr += 4;
-        qBufferPtr += 4;
-    }
-
-    number = quarterPoints * 4;
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = *complexVectorPtr++;
-        *qBufferPtr++ = *complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_SSE */
-
 
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
@@ -283,108 +240,6 @@ static inline void volk_32fc_deinterleave_32f_x2_neonv8(float* iBuffer,
 }
 #endif /* LV_HAVE_NEONV8 */
 
-#endif /* INCLUDED_volk_32fc_deinterleave_32f_x2_a_H */
-
-
-#ifndef INCLUDED_volk_32fc_deinterleave_32f_x2_u_H
-#define INCLUDED_volk_32fc_deinterleave_32f_x2_u_H
-
-#include <inttypes.h>
-#include <stdio.h>
-
-#ifdef LV_HAVE_AVX512F
-#include <immintrin.h>
-
-static inline void volk_32fc_deinterleave_32f_x2_u_avx512f(float* iBuffer,
-                                                           float* qBuffer,
-                                                           const lv_32fc_t* complexVector,
-                                                           unsigned int num_points)
-{
-    const float* complexVectorPtr = (const float*)complexVector;
-    float* iBufferPtr = iBuffer;
-    float* qBufferPtr = qBuffer;
-
-    unsigned int number = 0;
-    const unsigned int eighthPoints = num_points / 8;
-
-    __m512 cplxValue;
-    __m512 iValue, qValue;
-
-    for (; number < eighthPoints; number++) {
-        // Load 8 complex numbers (16 floats): I0,Q0,I1,Q1,...,I7,Q7 - unaligned
-        cplxValue = _mm512_loadu_ps(complexVectorPtr);
-
-        // Deinterleave using permute
-        // Extract all I values (even indices: 0,2,4,6,8,10,12,14)
-        iValue = _mm512_permutexvar_ps(
-            _mm512_setr_epi32(0, 2, 4, 6, 8, 10, 12, 14, 0, 0, 0, 0, 0, 0, 0, 0),
-            cplxValue);
-
-        // Extract all Q values (odd indices: 1,3,5,7,9,11,13,15)
-        qValue = _mm512_permutexvar_ps(
-            _mm512_setr_epi32(1, 3, 5, 7, 9, 11, 13, 15, 0, 0, 0, 0, 0, 0, 0, 0),
-            cplxValue);
-
-        // Store only the first 8 results (lower 256 bits) - unaligned
-        _mm256_storeu_ps(iBufferPtr, _mm512_castps512_ps256(iValue));
-        _mm256_storeu_ps(qBufferPtr, _mm512_castps512_ps256(qValue));
-
-        complexVectorPtr += 16;
-        iBufferPtr += 8;
-        qBufferPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    volk_32fc_deinterleave_32f_x2_generic(
-        iBufferPtr, qBufferPtr, (const lv_32fc_t*)complexVectorPtr, num_points - number);
-}
-#endif /* LV_HAVE_AVX512F */
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-static inline void volk_32fc_deinterleave_32f_x2_u_avx(float* iBuffer,
-                                                       float* qBuffer,
-                                                       const lv_32fc_t* complexVector,
-                                                       unsigned int num_points)
-{
-    const float* complexVectorPtr = (const float*)complexVector;
-    float* iBufferPtr = iBuffer;
-    float* qBufferPtr = qBuffer;
-
-    unsigned int number = 0;
-    // Mask for real and imaginary parts
-    const unsigned int eighthPoints = num_points / 8;
-    __m256 cplxValue1, cplxValue2, complex1, complex2, iValue, qValue;
-    for (; number < eighthPoints; number++) {
-        cplxValue1 = _mm256_loadu_ps(complexVectorPtr);
-        complexVectorPtr += 8;
-
-        cplxValue2 = _mm256_loadu_ps(complexVectorPtr);
-        complexVectorPtr += 8;
-
-        complex1 = _mm256_permute2f128_ps(cplxValue1, cplxValue2, 0x20);
-        complex2 = _mm256_permute2f128_ps(cplxValue1, cplxValue2, 0x31);
-
-        // Arrange in i1i2i3i4 format
-        iValue = _mm256_shuffle_ps(complex1, complex2, 0x88);
-        // Arrange in q1q2q3q4 format
-        qValue = _mm256_shuffle_ps(complex1, complex2, 0xdd);
-
-        _mm256_storeu_ps(iBufferPtr, iValue);
-        _mm256_storeu_ps(qBufferPtr, qValue);
-
-        iBufferPtr += 8;
-        qBufferPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = *complexVectorPtr++;
-        *qBufferPtr++ = *complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_AVX */
-
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 
@@ -403,7 +258,7 @@ static inline void volk_32fc_deinterleave_32f_x2_rvv(float* iBuffer,
         __riscv_vse32((uint32_t*)qBuffer, vi, vl);
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
 
 #ifdef LV_HAVE_RVVSEG
 #include <riscv_vector.h>
@@ -424,6 +279,150 @@ static inline void volk_32fc_deinterleave_32f_x2_rvvseg(float* iBuffer,
         __riscv_vse32((uint32_t*)qBuffer, vi, vl);
     }
 }
-#endif /*LV_HAVE_RVVSEG*/
+#endif /* LV_HAVE_RVVSEG */
 
 #endif /* INCLUDED_volk_32fc_deinterleave_32f_x2_u_H */
+
+
+#ifndef INCLUDED_volk_32fc_deinterleave_32f_x2_a_H
+#define INCLUDED_volk_32fc_deinterleave_32f_x2_a_H
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#ifdef LV_HAVE_SSE
+#include <xmmintrin.h>
+
+static inline void volk_32fc_deinterleave_32f_x2_a_sse(float* iBuffer,
+                                                       float* qBuffer,
+                                                       const lv_32fc_t* complexVector,
+                                                       unsigned int num_points)
+{
+    const float* complexVectorPtr = (const float*)complexVector;
+    float* iBufferPtr = iBuffer;
+    float* qBufferPtr = qBuffer;
+
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+    __m128 cplxValue1, cplxValue2, iValue, qValue;
+    for (; number < quarterPoints; number++) {
+        cplxValue1 = _mm_load_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        cplxValue2 = _mm_load_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        // Arrange in i1i2i3i4 format
+        iValue = _mm_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(2, 0, 2, 0));
+        // Arrange in q1q2q3q4 format
+        qValue = _mm_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(3, 1, 3, 1));
+
+        _mm_store_ps(iBufferPtr, iValue);
+        _mm_store_ps(qBufferPtr, qValue);
+
+        iBufferPtr += 4;
+        qBufferPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = *complexVectorPtr++;
+        *qBufferPtr++ = *complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_SSE */
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+static inline void volk_32fc_deinterleave_32f_x2_a_avx(float* iBuffer,
+                                                       float* qBuffer,
+                                                       const lv_32fc_t* complexVector,
+                                                       unsigned int num_points)
+{
+    const float* complexVectorPtr = (const float*)complexVector;
+    float* iBufferPtr = iBuffer;
+    float* qBufferPtr = qBuffer;
+
+    unsigned int number = 0;
+    // Mask for real and imaginary parts
+    const unsigned int eighthPoints = num_points / 8;
+    __m256 cplxValue1, cplxValue2, complex1, complex2, iValue, qValue;
+    for (; number < eighthPoints; number++) {
+        cplxValue1 = _mm256_load_ps(complexVectorPtr);
+        complexVectorPtr += 8;
+
+        cplxValue2 = _mm256_load_ps(complexVectorPtr);
+        complexVectorPtr += 8;
+
+        complex1 = _mm256_permute2f128_ps(cplxValue1, cplxValue2, 0x20);
+        complex2 = _mm256_permute2f128_ps(cplxValue1, cplxValue2, 0x31);
+
+        // Arrange in i1i2i3i4 format
+        iValue = _mm256_shuffle_ps(complex1, complex2, 0x88);
+        // Arrange in q1q2q3q4 format
+        qValue = _mm256_shuffle_ps(complex1, complex2, 0xdd);
+
+        _mm256_store_ps(iBufferPtr, iValue);
+        _mm256_store_ps(qBufferPtr, qValue);
+
+        iBufferPtr += 8;
+        qBufferPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = *complexVectorPtr++;
+        *qBufferPtr++ = *complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_AVX */
+
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+
+static inline void volk_32fc_deinterleave_32f_x2_a_avx512f(float* iBuffer,
+                                                           float* qBuffer,
+                                                           const lv_32fc_t* complexVector,
+                                                           unsigned int num_points)
+{
+    const float* complexVectorPtr = (const float*)complexVector;
+    float* iBufferPtr = iBuffer;
+    float* qBufferPtr = qBuffer;
+
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    __m512 cplxValue;
+    __m512 iValue, qValue;
+
+    for (; number < eighthPoints; number++) {
+        // Load 8 complex numbers (16 floats): I0,Q0,I1,Q1,...,I7,Q7
+        cplxValue = _mm512_load_ps(complexVectorPtr);
+
+        // Deinterleave using permute
+        // Extract all I values (even indices: 0,2,4,6,8,10,12,14)
+        iValue = _mm512_permutexvar_ps(
+            _mm512_setr_epi32(0, 2, 4, 6, 8, 10, 12, 14, 0, 0, 0, 0, 0, 0, 0, 0),
+            cplxValue);
+
+        // Extract all Q values (odd indices: 1,3,5,7,9,11,13,15)
+        qValue = _mm512_permutexvar_ps(
+            _mm512_setr_epi32(1, 3, 5, 7, 9, 11, 13, 15, 0, 0, 0, 0, 0, 0, 0, 0),
+            cplxValue);
+
+        // Store only the first 8 results (lower 256 bits)
+        _mm256_store_ps(iBufferPtr, _mm512_castps512_ps256(iValue));
+        _mm256_store_ps(qBufferPtr, _mm512_castps512_ps256(qValue));
+
+        complexVectorPtr += 16;
+        iBufferPtr += 8;
+        qBufferPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    volk_32fc_deinterleave_32f_x2_generic(
+        iBufferPtr, qBufferPtr, (const lv_32fc_t*)complexVectorPtr, num_points - number);
+}
+#endif /* LV_HAVE_AVX512F */
+
+#endif /* INCLUDED_volk_32fc_deinterleave_32f_x2_a_H */

--- a/kernels/volk/volk_32fc_deinterleave_64f_x2.h
+++ b/kernels/volk/volk_32fc_deinterleave_64f_x2.h
@@ -73,7 +73,7 @@ static inline void volk_32fc_deinterleave_64f_x2_u_avx(double* iBuffer,
 {
     unsigned int number = 0;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
     double* qBufferPtr = qBuffer;
 
@@ -122,7 +122,7 @@ static inline void volk_32fc_deinterleave_64f_x2_u_sse2(double* iBuffer,
 {
     unsigned int number = 0;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
     double* qBufferPtr = qBuffer;
 
@@ -165,7 +165,7 @@ static inline void volk_32fc_deinterleave_64f_x2_generic(double* iBuffer,
                                                          unsigned int num_points)
 {
     unsigned int number = 0;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
     double* qBufferPtr = qBuffer;
 
@@ -193,7 +193,7 @@ static inline void volk_32fc_deinterleave_64f_x2_a_avx(double* iBuffer,
 {
     unsigned int number = 0;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
     double* qBufferPtr = qBuffer;
 
@@ -242,7 +242,7 @@ static inline void volk_32fc_deinterleave_64f_x2_a_sse2(double* iBuffer,
 {
     unsigned int number = 0;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
     double* qBufferPtr = qBuffer;
 
@@ -287,7 +287,7 @@ static inline void volk_32fc_deinterleave_64f_x2_neon(double* iBuffer,
 {
     unsigned int number = 0;
     unsigned int half_points = num_points / 2;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
     double* qBufferPtr = qBuffer;
     float32x2x2_t complexInput;

--- a/kernels/volk/volk_32fc_deinterleave_64f_x2.h
+++ b/kernels/volk/volk_32fc_deinterleave_64f_x2.h
@@ -63,13 +63,77 @@
 #include <inttypes.h>
 #include <stdio.h>
 
+#ifdef LV_HAVE_GENERIC
+
+static inline void volk_32fc_deinterleave_64f_x2_generic(double* iBuffer,
+                                                          double* qBuffer,
+                                                          const lv_32fc_t* complexVector,
+                                                          unsigned int num_points)
+{
+    unsigned int number = 0;
+    const float* complexVectorPtr = (const float*)complexVector;
+    double* iBufferPtr = iBuffer;
+    double* qBufferPtr = qBuffer;
+
+    for (number = 0; number < num_points; number++) {
+        *iBufferPtr++ = (double)*complexVectorPtr++;
+        *qBufferPtr++ = (double)*complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_GENERIC */
+
+#ifdef LV_HAVE_SSE2
+#include <emmintrin.h>
+
+static inline void volk_32fc_deinterleave_64f_x2_u_sse2(double* iBuffer,
+                                                         double* qBuffer,
+                                                         const lv_32fc_t* complexVector,
+                                                         unsigned int num_points)
+{
+    unsigned int number = 0;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    double* iBufferPtr = iBuffer;
+    double* qBufferPtr = qBuffer;
+
+    const unsigned int halfPoints = num_points / 2;
+    __m128 cplxValue, fVal;
+    __m128d dVal;
+
+    for (; number < halfPoints; number++) {
+
+        cplxValue = _mm_loadu_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        // Arrange in i1i2i1i2 format
+        fVal = _mm_shuffle_ps(cplxValue, cplxValue, _MM_SHUFFLE(2, 0, 2, 0));
+        dVal = _mm_cvtps_pd(fVal);
+        _mm_storeu_pd(iBufferPtr, dVal);
+
+        // Arrange in q1q2q1q2 format
+        fVal = _mm_shuffle_ps(cplxValue, cplxValue, _MM_SHUFFLE(3, 1, 3, 1));
+        dVal = _mm_cvtps_pd(fVal);
+        _mm_storeu_pd(qBufferPtr, dVal);
+
+        iBufferPtr += 2;
+        qBufferPtr += 2;
+    }
+
+    number = halfPoints * 2;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = *complexVectorPtr++;
+        *qBufferPtr++ = *complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_SSE2 */
+
 #ifdef LV_HAVE_AVX
 #include <immintrin.h>
 
 static inline void volk_32fc_deinterleave_64f_x2_u_avx(double* iBuffer,
-                                                       double* qBuffer,
-                                                       const lv_32fc_t* complexVector,
-                                                       unsigned int num_points)
+                                                        double* qBuffer,
+                                                        const lv_32fc_t* complexVector,
+                                                        unsigned int num_points)
 {
     unsigned int number = 0;
 
@@ -112,13 +176,97 @@ static inline void volk_32fc_deinterleave_64f_x2_u_avx(double* iBuffer,
 }
 #endif /* LV_HAVE_AVX */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32fc_deinterleave_64f_x2_neon(double* iBuffer,
+                                                       double* qBuffer,
+                                                       const lv_32fc_t* complexVector,
+                                                       unsigned int num_points)
+{
+    unsigned int number = 0;
+    unsigned int half_points = num_points / 2;
+    const float* complexVectorPtr = (const float*)complexVector;
+    double* iBufferPtr = iBuffer;
+    double* qBufferPtr = qBuffer;
+    float32x2x2_t complexInput;
+    float64x2_t iVal, qVal;
+
+    for (number = 0; number < half_points; number++) {
+        complexInput = vld2_f32(complexVectorPtr);
+
+        iVal = vcvt_f64_f32(complexInput.val[0]);
+        qVal = vcvt_f64_f32(complexInput.val[1]);
+
+        vst1q_f64(iBufferPtr, iVal);
+        vst1q_f64(qBufferPtr, qVal);
+
+        complexVectorPtr += 4;
+        iBufferPtr += 2;
+        qBufferPtr += 2;
+    }
+
+    for (number = half_points * 2; number < num_points; number++) {
+        *iBufferPtr++ = (double)*complexVectorPtr++;
+        *qBufferPtr++ = (double)*complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_32fc_deinterleave_64f_x2_rvv(double* iBuffer,
+                                                      double* qBuffer,
+                                                      const lv_32fc_t* complexVector,
+                                                      unsigned int num_points)
+{
+    size_t n = num_points;
+    for (size_t vl; n > 0; n -= vl, complexVector += vl, iBuffer += vl, qBuffer += vl) {
+        vl = __riscv_vsetvl_e32m4(n);
+        vuint64m8_t vc = __riscv_vle64_v_u64m8((const uint64_t*)complexVector, vl);
+        vfloat32m4_t vr = __riscv_vreinterpret_f32m4(__riscv_vnsrl(vc, 0, vl));
+        vfloat32m4_t vi = __riscv_vreinterpret_f32m4(__riscv_vnsrl(vc, 32, vl));
+        __riscv_vse64(iBuffer, __riscv_vfwcvt_f(vr, vl), vl);
+        __riscv_vse64(qBuffer, __riscv_vfwcvt_f(vi, vl), vl);
+    }
+}
+#endif /* LV_HAVE_RVV */
+
+#ifdef LV_HAVE_RVVSEG
+#include <riscv_vector.h>
+
+static inline void volk_32fc_deinterleave_64f_x2_rvvseg(double* iBuffer,
+                                                         double* qBuffer,
+                                                         const lv_32fc_t* complexVector,
+                                                         unsigned int num_points)
+{
+    size_t n = num_points;
+    for (size_t vl; n > 0; n -= vl, complexVector += vl, iBuffer += vl, qBuffer += vl) {
+        vl = __riscv_vsetvl_e32m4(n);
+        vfloat32m4x2_t vc = __riscv_vlseg2e32_v_f32m4x2((const float*)complexVector, vl);
+        vfloat32m4_t vr = __riscv_vget_f32m4(vc, 0);
+        vfloat32m4_t vi = __riscv_vget_f32m4(vc, 1);
+        __riscv_vse64(iBuffer, __riscv_vfwcvt_f(vr, vl), vl);
+        __riscv_vse64(qBuffer, __riscv_vfwcvt_f(vi, vl), vl);
+    }
+}
+#endif /* LV_HAVE_RVVSEG */
+
+#endif /* INCLUDED_volk_32fc_deinterleave_64f_x2_u_H */
+#ifndef INCLUDED_volk_32fc_deinterleave_64f_x2_a_H
+#define INCLUDED_volk_32fc_deinterleave_64f_x2_a_H
+
+#include <inttypes.h>
+#include <stdio.h>
+
 #ifdef LV_HAVE_SSE2
 #include <emmintrin.h>
 
-static inline void volk_32fc_deinterleave_64f_x2_u_sse2(double* iBuffer,
-                                                        double* qBuffer,
-                                                        const lv_32fc_t* complexVector,
-                                                        unsigned int num_points)
+static inline void volk_32fc_deinterleave_64f_x2_a_sse2(double* iBuffer,
+                                                         double* qBuffer,
+                                                         const lv_32fc_t* complexVector,
+                                                         unsigned int num_points)
 {
     unsigned int number = 0;
 
@@ -132,18 +280,18 @@ static inline void volk_32fc_deinterleave_64f_x2_u_sse2(double* iBuffer,
 
     for (; number < halfPoints; number++) {
 
-        cplxValue = _mm_loadu_ps(complexVectorPtr);
+        cplxValue = _mm_load_ps(complexVectorPtr);
         complexVectorPtr += 4;
 
         // Arrange in i1i2i1i2 format
         fVal = _mm_shuffle_ps(cplxValue, cplxValue, _MM_SHUFFLE(2, 0, 2, 0));
         dVal = _mm_cvtps_pd(fVal);
-        _mm_storeu_pd(iBufferPtr, dVal);
+        _mm_store_pd(iBufferPtr, dVal);
 
         // Arrange in q1q2q1q2 format
         fVal = _mm_shuffle_ps(cplxValue, cplxValue, _MM_SHUFFLE(3, 1, 3, 1));
         dVal = _mm_cvtps_pd(fVal);
-        _mm_storeu_pd(qBufferPtr, dVal);
+        _mm_store_pd(qBufferPtr, dVal);
 
         iBufferPtr += 2;
         qBufferPtr += 2;
@@ -155,41 +303,15 @@ static inline void volk_32fc_deinterleave_64f_x2_u_sse2(double* iBuffer,
         *qBufferPtr++ = *complexVectorPtr++;
     }
 }
-#endif /* LV_HAVE_SSE */
-
-#ifdef LV_HAVE_GENERIC
-
-static inline void volk_32fc_deinterleave_64f_x2_generic(double* iBuffer,
-                                                         double* qBuffer,
-                                                         const lv_32fc_t* complexVector,
-                                                         unsigned int num_points)
-{
-    unsigned int number = 0;
-    const float* complexVectorPtr = (const float*)complexVector;
-    double* iBufferPtr = iBuffer;
-    double* qBufferPtr = qBuffer;
-
-    for (number = 0; number < num_points; number++) {
-        *iBufferPtr++ = (double)*complexVectorPtr++;
-        *qBufferPtr++ = (double)*complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_GENERIC */
-
-#endif /* INCLUDED_volk_32fc_deinterleave_64f_x2_u_H */
-#ifndef INCLUDED_volk_32fc_deinterleave_64f_x2_a_H
-#define INCLUDED_volk_32fc_deinterleave_64f_x2_a_H
-
-#include <inttypes.h>
-#include <stdio.h>
+#endif /* LV_HAVE_SSE2 */
 
 #ifdef LV_HAVE_AVX
 #include <immintrin.h>
 
 static inline void volk_32fc_deinterleave_64f_x2_a_avx(double* iBuffer,
-                                                       double* qBuffer,
-                                                       const lv_32fc_t* complexVector,
-                                                       unsigned int num_points)
+                                                        double* qBuffer,
+                                                        const lv_32fc_t* complexVector,
+                                                        unsigned int num_points)
 {
     unsigned int number = 0;
 
@@ -231,127 +353,5 @@ static inline void volk_32fc_deinterleave_64f_x2_a_avx(double* iBuffer,
     }
 }
 #endif /* LV_HAVE_AVX */
-
-#ifdef LV_HAVE_SSE2
-#include <emmintrin.h>
-
-static inline void volk_32fc_deinterleave_64f_x2_a_sse2(double* iBuffer,
-                                                        double* qBuffer,
-                                                        const lv_32fc_t* complexVector,
-                                                        unsigned int num_points)
-{
-    unsigned int number = 0;
-
-    const float* complexVectorPtr = (const float*)complexVector;
-    double* iBufferPtr = iBuffer;
-    double* qBufferPtr = qBuffer;
-
-    const unsigned int halfPoints = num_points / 2;
-    __m128 cplxValue, fVal;
-    __m128d dVal;
-
-    for (; number < halfPoints; number++) {
-
-        cplxValue = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        // Arrange in i1i2i1i2 format
-        fVal = _mm_shuffle_ps(cplxValue, cplxValue, _MM_SHUFFLE(2, 0, 2, 0));
-        dVal = _mm_cvtps_pd(fVal);
-        _mm_store_pd(iBufferPtr, dVal);
-
-        // Arrange in q1q2q1q2 format
-        fVal = _mm_shuffle_ps(cplxValue, cplxValue, _MM_SHUFFLE(3, 1, 3, 1));
-        dVal = _mm_cvtps_pd(fVal);
-        _mm_store_pd(qBufferPtr, dVal);
-
-        iBufferPtr += 2;
-        qBufferPtr += 2;
-    }
-
-    number = halfPoints * 2;
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = *complexVectorPtr++;
-        *qBufferPtr++ = *complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_SSE */
-
-#ifdef LV_HAVE_NEONV8
-#include <arm_neon.h>
-
-static inline void volk_32fc_deinterleave_64f_x2_neon(double* iBuffer,
-                                                      double* qBuffer,
-                                                      const lv_32fc_t* complexVector,
-                                                      unsigned int num_points)
-{
-    unsigned int number = 0;
-    unsigned int half_points = num_points / 2;
-    const float* complexVectorPtr = (const float*)complexVector;
-    double* iBufferPtr = iBuffer;
-    double* qBufferPtr = qBuffer;
-    float32x2x2_t complexInput;
-    float64x2_t iVal, qVal;
-
-    for (number = 0; number < half_points; number++) {
-        complexInput = vld2_f32(complexVectorPtr);
-
-        iVal = vcvt_f64_f32(complexInput.val[0]);
-        qVal = vcvt_f64_f32(complexInput.val[1]);
-
-        vst1q_f64(iBufferPtr, iVal);
-        vst1q_f64(qBufferPtr, qVal);
-
-        complexVectorPtr += 4;
-        iBufferPtr += 2;
-        qBufferPtr += 2;
-    }
-
-    for (number = half_points * 2; number < num_points; number++) {
-        *iBufferPtr++ = (double)*complexVectorPtr++;
-        *qBufferPtr++ = (double)*complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_NEONV8 */
-
-#ifdef LV_HAVE_RVV
-#include <riscv_vector.h>
-
-static inline void volk_32fc_deinterleave_64f_x2_rvv(double* iBuffer,
-                                                     double* qBuffer,
-                                                     const lv_32fc_t* complexVector,
-                                                     unsigned int num_points)
-{
-    size_t n = num_points;
-    for (size_t vl; n > 0; n -= vl, complexVector += vl, iBuffer += vl, qBuffer += vl) {
-        vl = __riscv_vsetvl_e32m4(n);
-        vuint64m8_t vc = __riscv_vle64_v_u64m8((const uint64_t*)complexVector, vl);
-        vfloat32m4_t vr = __riscv_vreinterpret_f32m4(__riscv_vnsrl(vc, 0, vl));
-        vfloat32m4_t vi = __riscv_vreinterpret_f32m4(__riscv_vnsrl(vc, 32, vl));
-        __riscv_vse64(iBuffer, __riscv_vfwcvt_f(vr, vl), vl);
-        __riscv_vse64(qBuffer, __riscv_vfwcvt_f(vi, vl), vl);
-    }
-}
-#endif /*LV_HAVE_RVV*/
-
-#ifdef LV_HAVE_RVVSEG
-#include <riscv_vector.h>
-
-static inline void volk_32fc_deinterleave_64f_x2_rvvseg(double* iBuffer,
-                                                        double* qBuffer,
-                                                        const lv_32fc_t* complexVector,
-                                                        unsigned int num_points)
-{
-    size_t n = num_points;
-    for (size_t vl; n > 0; n -= vl, complexVector += vl, iBuffer += vl, qBuffer += vl) {
-        vl = __riscv_vsetvl_e32m4(n);
-        vfloat32m4x2_t vc = __riscv_vlseg2e32_v_f32m4x2((const float*)complexVector, vl);
-        vfloat32m4_t vr = __riscv_vget_f32m4(vc, 0);
-        vfloat32m4_t vi = __riscv_vget_f32m4(vc, 1);
-        __riscv_vse64(iBuffer, __riscv_vfwcvt_f(vr, vl), vl);
-        __riscv_vse64(qBuffer, __riscv_vfwcvt_f(vi, vl), vl);
-    }
-}
-#endif /*LV_HAVE_RVVSEG*/
 
 #endif /* INCLUDED_volk_32fc_deinterleave_64f_x2_a_H */

--- a/kernels/volk/volk_32fc_deinterleave_imag_32f.h
+++ b/kernels/volk/volk_32fc_deinterleave_imag_32f.h
@@ -54,16 +54,32 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32fc_deinterleave_imag_32f_a_H
-#define INCLUDED_volk_32fc_deinterleave_imag_32f_a_H
+#ifndef INCLUDED_volk_32fc_deinterleave_imag_32f_u_H
+#define INCLUDED_volk_32fc_deinterleave_imag_32f_u_H
 
 #include <inttypes.h>
 #include <stdio.h>
 
+#ifdef LV_HAVE_GENERIC
+
+static inline void volk_32fc_deinterleave_imag_32f_generic(float* qBuffer,
+                                                           const lv_32fc_t* complexVector,
+                                                           unsigned int num_points)
+{
+    unsigned int number = 0;
+    const float* complexVectorPtr = (const float*)complexVector;
+    float* qBufferPtr = qBuffer;
+    for (number = 0; number < num_points; number++) {
+        complexVectorPtr++;
+        *qBufferPtr++ = *complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_GENERIC */
+
 #ifdef LV_HAVE_AVX
 #include <immintrin.h>
 
-static inline void volk_32fc_deinterleave_imag_32f_a_avx(float* qBuffer,
+static inline void volk_32fc_deinterleave_imag_32f_u_avx(float* qBuffer,
                                                          const lv_32fc_t* complexVector,
                                                          unsigned int num_points)
 {
@@ -75,10 +91,10 @@ static inline void volk_32fc_deinterleave_imag_32f_a_avx(float* qBuffer,
     __m256 cplxValue1, cplxValue2, complex1, complex2, qValue;
     for (; number < eighthPoints; number++) {
 
-        cplxValue1 = _mm256_load_ps(complexVectorPtr);
+        cplxValue1 = _mm256_loadu_ps(complexVectorPtr);
         complexVectorPtr += 8;
 
-        cplxValue2 = _mm256_load_ps(complexVectorPtr);
+        cplxValue2 = _mm256_loadu_ps(complexVectorPtr);
         complexVectorPtr += 8;
 
         complex1 = _mm256_permute2f128_ps(cplxValue1, cplxValue2, 0x20);
@@ -87,7 +103,7 @@ static inline void volk_32fc_deinterleave_imag_32f_a_avx(float* qBuffer,
         // Arrange in q1q2q3q4 format
         qValue = _mm256_shuffle_ps(complex1, complex2, 0xdd);
 
-        _mm256_store_ps(qBufferPtr, qValue);
+        _mm256_storeu_ps(qBufferPtr, qValue);
 
         qBufferPtr += 8;
     }
@@ -99,44 +115,6 @@ static inline void volk_32fc_deinterleave_imag_32f_a_avx(float* qBuffer,
     }
 }
 #endif /* LV_HAVE_AVX */
-
-#ifdef LV_HAVE_SSE
-#include <xmmintrin.h>
-
-static inline void volk_32fc_deinterleave_imag_32f_a_sse(float* qBuffer,
-                                                         const lv_32fc_t* complexVector,
-                                                         unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-
-    const float* complexVectorPtr = (const float*)complexVector;
-    float* qBufferPtr = qBuffer;
-
-    __m128 cplxValue1, cplxValue2, iValue;
-    for (; number < quarterPoints; number++) {
-
-        cplxValue1 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        cplxValue2 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        // Arrange in q1q2q3q4 format
-        iValue = _mm_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(3, 1, 3, 1));
-
-        _mm_store_ps(qBufferPtr, iValue);
-
-        qBufferPtr += 4;
-    }
-
-    number = quarterPoints * 4;
-    for (; number < num_points; number++) {
-        complexVectorPtr++;
-        *qBufferPtr++ = *complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_SSE */
 
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
@@ -195,71 +173,6 @@ static inline void volk_32fc_deinterleave_imag_32f_neonv8(float* qBuffer,
 }
 #endif /* LV_HAVE_NEONV8 */
 
-#ifdef LV_HAVE_GENERIC
-
-static inline void volk_32fc_deinterleave_imag_32f_generic(float* qBuffer,
-                                                           const lv_32fc_t* complexVector,
-                                                           unsigned int num_points)
-{
-    unsigned int number = 0;
-    const float* complexVectorPtr = (const float*)complexVector;
-    float* qBufferPtr = qBuffer;
-    for (number = 0; number < num_points; number++) {
-        complexVectorPtr++;
-        *qBufferPtr++ = *complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_GENERIC */
-
-
-#endif /* INCLUDED_volk_32fc_deinterleave_imag_32f_a_H */
-
-#ifndef INCLUDED_volk_32fc_deinterleave_imag_32f_u_H
-#define INCLUDED_volk_32fc_deinterleave_imag_32f_u_H
-
-#include <inttypes.h>
-#include <stdio.h>
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-
-static inline void volk_32fc_deinterleave_imag_32f_u_avx(float* qBuffer,
-                                                         const lv_32fc_t* complexVector,
-                                                         unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int eighthPoints = num_points / 8;
-    const float* complexVectorPtr = (const float*)complexVector;
-    float* qBufferPtr = qBuffer;
-
-    __m256 cplxValue1, cplxValue2, complex1, complex2, qValue;
-    for (; number < eighthPoints; number++) {
-
-        cplxValue1 = _mm256_loadu_ps(complexVectorPtr);
-        complexVectorPtr += 8;
-
-        cplxValue2 = _mm256_loadu_ps(complexVectorPtr);
-        complexVectorPtr += 8;
-
-        complex1 = _mm256_permute2f128_ps(cplxValue1, cplxValue2, 0x20);
-        complex2 = _mm256_permute2f128_ps(cplxValue1, cplxValue2, 0x31);
-
-        // Arrange in q1q2q3q4 format
-        qValue = _mm256_shuffle_ps(complex1, complex2, 0xdd);
-
-        _mm256_storeu_ps(qBufferPtr, qValue);
-
-        qBufferPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        complexVectorPtr++;
-        *qBufferPtr++ = *complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_AVX */
-
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 
@@ -275,6 +188,92 @@ static inline void volk_32fc_deinterleave_imag_32f_rvv(float* qBuffer,
         __riscv_vse32((uint32_t*)qBuffer, __riscv_vnsrl(vc, 32, vl), vl);
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
 
 #endif /* INCLUDED_volk_32fc_deinterleave_imag_32f_u_H */
+
+#ifndef INCLUDED_volk_32fc_deinterleave_imag_32f_a_H
+#define INCLUDED_volk_32fc_deinterleave_imag_32f_a_H
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#ifdef LV_HAVE_SSE
+#include <xmmintrin.h>
+
+static inline void volk_32fc_deinterleave_imag_32f_a_sse(float* qBuffer,
+                                                         const lv_32fc_t* complexVector,
+                                                         unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    float* qBufferPtr = qBuffer;
+
+    __m128 cplxValue1, cplxValue2, iValue;
+    for (; number < quarterPoints; number++) {
+
+        cplxValue1 = _mm_load_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        cplxValue2 = _mm_load_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        // Arrange in q1q2q3q4 format
+        iValue = _mm_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(3, 1, 3, 1));
+
+        _mm_store_ps(qBufferPtr, iValue);
+
+        qBufferPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        complexVectorPtr++;
+        *qBufferPtr++ = *complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_SSE */
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void volk_32fc_deinterleave_imag_32f_a_avx(float* qBuffer,
+                                                         const lv_32fc_t* complexVector,
+                                                         unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+    const float* complexVectorPtr = (const float*)complexVector;
+    float* qBufferPtr = qBuffer;
+
+    __m256 cplxValue1, cplxValue2, complex1, complex2, qValue;
+    for (; number < eighthPoints; number++) {
+
+        cplxValue1 = _mm256_load_ps(complexVectorPtr);
+        complexVectorPtr += 8;
+
+        cplxValue2 = _mm256_load_ps(complexVectorPtr);
+        complexVectorPtr += 8;
+
+        complex1 = _mm256_permute2f128_ps(cplxValue1, cplxValue2, 0x20);
+        complex2 = _mm256_permute2f128_ps(cplxValue1, cplxValue2, 0x31);
+
+        // Arrange in q1q2q3q4 format
+        qValue = _mm256_shuffle_ps(complex1, complex2, 0xdd);
+
+        _mm256_store_ps(qBufferPtr, qValue);
+
+        qBufferPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        complexVectorPtr++;
+        *qBufferPtr++ = *complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_AVX */
+
+#endif /* INCLUDED_volk_32fc_deinterleave_imag_32f_a_H */

--- a/kernels/volk/volk_32fc_deinterleave_imag_32f.h
+++ b/kernels/volk/volk_32fc_deinterleave_imag_32f.h
@@ -147,7 +147,7 @@ static inline void volk_32fc_deinterleave_imag_32f_neon(float* qBuffer,
 {
     unsigned int number = 0;
     unsigned int quarter_points = num_points / 4;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* qBufferPtr = qBuffer;
     float32x4x2_t complexInput;
 
@@ -173,7 +173,7 @@ static inline void volk_32fc_deinterleave_imag_32f_neonv8(float* qBuffer,
                                                           unsigned int num_points)
 {
     const unsigned int eighthPoints = num_points / 8;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* qBufferPtr = qBuffer;
 
     for (unsigned int number = 0; number < eighthPoints; number++) {
@@ -202,7 +202,7 @@ static inline void volk_32fc_deinterleave_imag_32f_generic(float* qBuffer,
                                                            unsigned int num_points)
 {
     unsigned int number = 0;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* qBufferPtr = qBuffer;
     for (number = 0; number < num_points; number++) {
         complexVectorPtr++;

--- a/kernels/volk/volk_32fc_deinterleave_real_32f.h
+++ b/kernels/volk/volk_32fc_deinterleave_real_32f.h
@@ -147,7 +147,7 @@ static inline void volk_32fc_deinterleave_real_32f_generic(float* iBuffer,
                                                            unsigned int num_points)
 {
     unsigned int number = 0;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
     for (number = 0; number < num_points; number++) {
         *iBufferPtr++ = *complexVectorPtr++;
@@ -166,7 +166,7 @@ static inline void volk_32fc_deinterleave_real_32f_neon(float* iBuffer,
 {
     unsigned int number = 0;
     unsigned int quarter_points = num_points / 4;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
     float32x4x2_t complexInput;
 
@@ -192,7 +192,7 @@ static inline void volk_32fc_deinterleave_real_32f_neonv8(float* iBuffer,
                                                           unsigned int num_points)
 {
     const unsigned int eighthPoints = num_points / 8;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* iBufferPtr = iBuffer;
 
     for (unsigned int number = 0; number < eighthPoints; number++) {

--- a/kernels/volk/volk_32fc_deinterleave_real_32f.h
+++ b/kernels/volk/volk_32fc_deinterleave_real_32f.h
@@ -54,91 +54,11 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32fc_deinterleave_real_32f_a_H
-#define INCLUDED_volk_32fc_deinterleave_real_32f_a_H
+#ifndef INCLUDED_volk_32fc_deinterleave_real_32f_u_H
+#define INCLUDED_volk_32fc_deinterleave_real_32f_u_H
 
 #include <inttypes.h>
 #include <stdio.h>
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-
-static inline void volk_32fc_deinterleave_real_32f_a_avx2(float* iBuffer,
-                                                          const lv_32fc_t* complexVector,
-                                                          unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int eighthPoints = num_points / 8;
-
-    const float* complexVectorPtr = (const float*)complexVector;
-    float* iBufferPtr = iBuffer;
-
-    __m256 cplxValue1, cplxValue2;
-    __m256 iValue;
-    __m256i idx = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
-    for (; number < eighthPoints; number++) {
-
-        cplxValue1 = _mm256_load_ps(complexVectorPtr);
-        complexVectorPtr += 8;
-
-        cplxValue2 = _mm256_load_ps(complexVectorPtr);
-        complexVectorPtr += 8;
-
-        // Arrange in i1i2i3i4 format
-        iValue = _mm256_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(2, 0, 2, 0));
-        iValue = _mm256_permutevar8x32_ps(iValue, idx);
-
-        _mm256_store_ps(iBufferPtr, iValue);
-
-        iBufferPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = *complexVectorPtr++;
-        complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_AVX2 */
-
-#ifdef LV_HAVE_SSE
-#include <xmmintrin.h>
-
-static inline void volk_32fc_deinterleave_real_32f_a_sse(float* iBuffer,
-                                                         const lv_32fc_t* complexVector,
-                                                         unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-
-    const float* complexVectorPtr = (const float*)complexVector;
-    float* iBufferPtr = iBuffer;
-
-    __m128 cplxValue1, cplxValue2, iValue;
-    for (; number < quarterPoints; number++) {
-
-        cplxValue1 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        cplxValue2 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        // Arrange in i1i2i3i4 format
-        iValue = _mm_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(2, 0, 2, 0));
-
-        _mm_store_ps(iBufferPtr, iValue);
-
-        iBufferPtr += 4;
-    }
-
-    number = quarterPoints * 4;
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = *complexVectorPtr++;
-        complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_SSE */
-
 
 #ifdef LV_HAVE_GENERIC
 
@@ -156,6 +76,46 @@ static inline void volk_32fc_deinterleave_real_32f_generic(float* iBuffer,
 }
 #endif /* LV_HAVE_GENERIC */
 
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void volk_32fc_deinterleave_real_32f_u_avx2(float* iBuffer,
+                                                          const lv_32fc_t* complexVector,
+                                                          unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    float* iBufferPtr = iBuffer;
+
+    __m256 cplxValue1, cplxValue2;
+    __m256 iValue;
+    __m256i idx = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
+    for (; number < eighthPoints; number++) {
+
+        cplxValue1 = _mm256_loadu_ps(complexVectorPtr);
+        complexVectorPtr += 8;
+
+        cplxValue2 = _mm256_loadu_ps(complexVectorPtr);
+        complexVectorPtr += 8;
+
+        // Arrange in i1i2i3i4 format
+        iValue = _mm256_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(2, 0, 2, 0));
+        iValue = _mm256_permutevar8x32_ps(iValue, idx);
+
+        _mm256_storeu_ps(iBufferPtr, iValue);
+
+        iBufferPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = *complexVectorPtr++;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_AVX2 */
 
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
@@ -214,56 +174,6 @@ static inline void volk_32fc_deinterleave_real_32f_neonv8(float* iBuffer,
 }
 #endif /* LV_HAVE_NEONV8 */
 
-#endif /* INCLUDED_volk_32fc_deinterleave_real_32f_a_H */
-
-
-#ifndef INCLUDED_volk_32fc_deinterleave_real_32f_u_H
-#define INCLUDED_volk_32fc_deinterleave_real_32f_u_H
-
-#include <inttypes.h>
-#include <stdio.h>
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-
-static inline void volk_32fc_deinterleave_real_32f_u_avx2(float* iBuffer,
-                                                          const lv_32fc_t* complexVector,
-                                                          unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int eighthPoints = num_points / 8;
-
-    const float* complexVectorPtr = (const float*)complexVector;
-    float* iBufferPtr = iBuffer;
-
-    __m256 cplxValue1, cplxValue2;
-    __m256 iValue;
-    __m256i idx = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
-    for (; number < eighthPoints; number++) {
-
-        cplxValue1 = _mm256_loadu_ps(complexVectorPtr);
-        complexVectorPtr += 8;
-
-        cplxValue2 = _mm256_loadu_ps(complexVectorPtr);
-        complexVectorPtr += 8;
-
-        // Arrange in i1i2i3i4 format
-        iValue = _mm256_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(2, 0, 2, 0));
-        iValue = _mm256_permutevar8x32_ps(iValue, idx);
-
-        _mm256_storeu_ps(iBufferPtr, iValue);
-
-        iBufferPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = *complexVectorPtr++;
-        complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_AVX2 */
-
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 
@@ -279,6 +189,94 @@ static inline void volk_32fc_deinterleave_real_32f_rvv(float* iBuffer,
         __riscv_vse32((uint32_t*)iBuffer, __riscv_vnsrl(vc, 0, vl), vl);
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
 
 #endif /* INCLUDED_volk_32fc_deinterleave_real_32f_u_H */
+
+
+#ifndef INCLUDED_volk_32fc_deinterleave_real_32f_a_H
+#define INCLUDED_volk_32fc_deinterleave_real_32f_a_H
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#ifdef LV_HAVE_SSE
+#include <xmmintrin.h>
+
+static inline void volk_32fc_deinterleave_real_32f_a_sse(float* iBuffer,
+                                                         const lv_32fc_t* complexVector,
+                                                         unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    float* iBufferPtr = iBuffer;
+
+    __m128 cplxValue1, cplxValue2, iValue;
+    for (; number < quarterPoints; number++) {
+
+        cplxValue1 = _mm_load_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        cplxValue2 = _mm_load_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        // Arrange in i1i2i3i4 format
+        iValue = _mm_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(2, 0, 2, 0));
+
+        _mm_store_ps(iBufferPtr, iValue);
+
+        iBufferPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = *complexVectorPtr++;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_SSE */
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void volk_32fc_deinterleave_real_32f_a_avx2(float* iBuffer,
+                                                          const lv_32fc_t* complexVector,
+                                                          unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    float* iBufferPtr = iBuffer;
+
+    __m256 cplxValue1, cplxValue2;
+    __m256 iValue;
+    __m256i idx = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
+    for (; number < eighthPoints; number++) {
+
+        cplxValue1 = _mm256_load_ps(complexVectorPtr);
+        complexVectorPtr += 8;
+
+        cplxValue2 = _mm256_load_ps(complexVectorPtr);
+        complexVectorPtr += 8;
+
+        // Arrange in i1i2i3i4 format
+        iValue = _mm256_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(2, 0, 2, 0));
+        iValue = _mm256_permutevar8x32_ps(iValue, idx);
+
+        _mm256_store_ps(iBufferPtr, iValue);
+
+        iBufferPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = *complexVectorPtr++;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_AVX2 */
+
+#endif /* INCLUDED_volk_32fc_deinterleave_real_32f_a_H */

--- a/kernels/volk/volk_32fc_deinterleave_real_64f.h
+++ b/kernels/volk/volk_32fc_deinterleave_real_64f.h
@@ -55,86 +55,11 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32fc_deinterleave_real_64f_a_H
-#define INCLUDED_volk_32fc_deinterleave_real_64f_a_H
+#ifndef INCLUDED_volk_32fc_deinterleave_real_64f_u_H
+#define INCLUDED_volk_32fc_deinterleave_real_64f_u_H
 
 #include <inttypes.h>
 #include <stdio.h>
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-
-static inline void volk_32fc_deinterleave_real_64f_a_avx2(double* iBuffer,
-                                                          const lv_32fc_t* complexVector,
-                                                          unsigned int num_points)
-{
-    unsigned int number = 0;
-
-    const float* complexVectorPtr = (const float*)complexVector;
-    double* iBufferPtr = iBuffer;
-
-    const unsigned int quarterPoints = num_points / 4;
-    __m256 cplxValue;
-    __m128 fVal;
-    __m256d dVal;
-    __m256i idx = _mm256_set_epi32(0, 0, 0, 0, 6, 4, 2, 0);
-    for (; number < quarterPoints; number++) {
-
-        cplxValue = _mm256_load_ps(complexVectorPtr);
-        complexVectorPtr += 8;
-
-        // Arrange in i1i2i1i2 format
-        cplxValue = _mm256_permutevar8x32_ps(cplxValue, idx);
-        fVal = _mm256_extractf128_ps(cplxValue, 0);
-        dVal = _mm256_cvtps_pd(fVal);
-        _mm256_store_pd(iBufferPtr, dVal);
-
-        iBufferPtr += 4;
-    }
-
-    number = quarterPoints * 4;
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = (double)*complexVectorPtr++;
-        complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_AVX2 */
-
-#ifdef LV_HAVE_SSE2
-#include <emmintrin.h>
-
-static inline void volk_32fc_deinterleave_real_64f_a_sse2(double* iBuffer,
-                                                          const lv_32fc_t* complexVector,
-                                                          unsigned int num_points)
-{
-    unsigned int number = 0;
-
-    const float* complexVectorPtr = (const float*)complexVector;
-    double* iBufferPtr = iBuffer;
-
-    const unsigned int halfPoints = num_points / 2;
-    __m128 cplxValue, fVal;
-    __m128d dVal;
-    for (; number < halfPoints; number++) {
-
-        cplxValue = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        // Arrange in i1i2i1i2 format
-        fVal = _mm_shuffle_ps(cplxValue, cplxValue, _MM_SHUFFLE(2, 0, 2, 0));
-        dVal = _mm_cvtps_pd(fVal);
-        _mm_store_pd(iBufferPtr, dVal);
-
-        iBufferPtr += 2;
-    }
-
-    number = halfPoints * 2;
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = (double)*complexVectorPtr++;
-        complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_SSE */
 
 #ifdef LV_HAVE_GENERIC
 
@@ -151,55 +76,6 @@ static inline void volk_32fc_deinterleave_real_64f_generic(double* iBuffer,
     }
 }
 #endif /* LV_HAVE_GENERIC */
-
-#ifdef LV_HAVE_NEONV8
-#include <arm_neon.h>
-
-static inline void volk_32fc_deinterleave_real_64f_neon(double* iBuffer,
-                                                        const lv_32fc_t* complexVector,
-                                                        unsigned int num_points)
-{
-    unsigned int number = 0;
-    unsigned int quarter_points = num_points / 4;
-    const float* complexVectorPtr = (const float*)complexVector;
-    double* iBufferPtr = iBuffer;
-    float32x2x4_t complexInput;
-    float64x2_t iVal1;
-    float64x2_t iVal2;
-    float64x2x2_t iVal;
-
-    for (number = 0; number < quarter_points; number++) {
-        // Load data into register
-        complexInput = vld4_f32(complexVectorPtr);
-
-        // Perform single to double precision conversion
-        iVal1 = vcvt_f64_f32(complexInput.val[0]);
-        iVal2 = vcvt_f64_f32(complexInput.val[2]);
-        iVal.val[0] = iVal1;
-        iVal.val[1] = iVal2;
-
-        // Store results into memory buffer
-        vst2q_f64(iBufferPtr, iVal);
-
-        // Update pointers
-        iBufferPtr += 4;
-        complexVectorPtr += 8;
-    }
-
-    for (number = quarter_points * 4; number < num_points; number++) {
-        *iBufferPtr++ = (double)*complexVectorPtr++;
-        complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_NEON */
-
-#endif /* INCLUDED_volk_32fc_deinterleave_real_64f_a_H */
-
-#ifndef INCLUDED_volk_32fc_deinterleave_real_64f_u_H
-#define INCLUDED_volk_32fc_deinterleave_real_64f_u_H
-
-#include <inttypes.h>
-#include <stdio.h>
 
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
@@ -240,6 +116,47 @@ static inline void volk_32fc_deinterleave_real_64f_u_avx2(double* iBuffer,
 }
 #endif /* LV_HAVE_AVX2 */
 
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32fc_deinterleave_real_64f_neon(double* iBuffer,
+                                                        const lv_32fc_t* complexVector,
+                                                        unsigned int num_points)
+{
+    unsigned int number = 0;
+    unsigned int quarter_points = num_points / 4;
+    const float* complexVectorPtr = (const float*)complexVector;
+    double* iBufferPtr = iBuffer;
+    float32x2x4_t complexInput;
+    float64x2_t iVal1;
+    float64x2_t iVal2;
+    float64x2x2_t iVal;
+
+    for (number = 0; number < quarter_points; number++) {
+        // Load data into register
+        complexInput = vld4_f32(complexVectorPtr);
+
+        // Perform single to double precision conversion
+        iVal1 = vcvt_f64_f32(complexInput.val[0]);
+        iVal2 = vcvt_f64_f32(complexInput.val[2]);
+        iVal.val[0] = iVal1;
+        iVal.val[1] = iVal2;
+
+        // Store results into memory buffer
+        vst2q_f64(iBufferPtr, iVal);
+
+        // Update pointers
+        iBufferPtr += 4;
+        complexVectorPtr += 8;
+    }
+
+    for (number = quarter_points * 4; number < num_points; number++) {
+        *iBufferPtr++ = (double)*complexVectorPtr++;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 
@@ -255,6 +172,89 @@ static inline void volk_32fc_deinterleave_real_64f_rvv(double* iBuffer,
         __riscv_vse64(iBuffer, __riscv_vfwcvt_f(__riscv_vreinterpret_f32m4(vi), vl), vl);
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
 
 #endif /* INCLUDED_volk_32fc_deinterleave_real_64f_u_H */
+
+#ifndef INCLUDED_volk_32fc_deinterleave_real_64f_a_H
+#define INCLUDED_volk_32fc_deinterleave_real_64f_a_H
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#ifdef LV_HAVE_SSE2
+#include <emmintrin.h>
+
+static inline void volk_32fc_deinterleave_real_64f_a_sse2(double* iBuffer,
+                                                          const lv_32fc_t* complexVector,
+                                                          unsigned int num_points)
+{
+    unsigned int number = 0;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    double* iBufferPtr = iBuffer;
+
+    const unsigned int halfPoints = num_points / 2;
+    __m128 cplxValue, fVal;
+    __m128d dVal;
+    for (; number < halfPoints; number++) {
+
+        cplxValue = _mm_load_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        // Arrange in i1i2i1i2 format
+        fVal = _mm_shuffle_ps(cplxValue, cplxValue, _MM_SHUFFLE(2, 0, 2, 0));
+        dVal = _mm_cvtps_pd(fVal);
+        _mm_store_pd(iBufferPtr, dVal);
+
+        iBufferPtr += 2;
+    }
+
+    number = halfPoints * 2;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = (double)*complexVectorPtr++;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_SSE2 */
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void volk_32fc_deinterleave_real_64f_a_avx2(double* iBuffer,
+                                                          const lv_32fc_t* complexVector,
+                                                          unsigned int num_points)
+{
+    unsigned int number = 0;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    double* iBufferPtr = iBuffer;
+
+    const unsigned int quarterPoints = num_points / 4;
+    __m256 cplxValue;
+    __m128 fVal;
+    __m256d dVal;
+    __m256i idx = _mm256_set_epi32(0, 0, 0, 0, 6, 4, 2, 0);
+    for (; number < quarterPoints; number++) {
+
+        cplxValue = _mm256_load_ps(complexVectorPtr);
+        complexVectorPtr += 8;
+
+        // Arrange in i1i2i1i2 format
+        cplxValue = _mm256_permutevar8x32_ps(cplxValue, idx);
+        fVal = _mm256_extractf128_ps(cplxValue, 0);
+        dVal = _mm256_cvtps_pd(fVal);
+        _mm256_store_pd(iBufferPtr, dVal);
+
+        iBufferPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = (double)*complexVectorPtr++;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_AVX2 */
+
+#endif /* INCLUDED_volk_32fc_deinterleave_real_64f_a_H */

--- a/kernels/volk/volk_32fc_deinterleave_real_64f.h
+++ b/kernels/volk/volk_32fc_deinterleave_real_64f.h
@@ -70,7 +70,7 @@ static inline void volk_32fc_deinterleave_real_64f_a_avx2(double* iBuffer,
 {
     unsigned int number = 0;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
 
     const unsigned int quarterPoints = num_points / 4;
@@ -109,7 +109,7 @@ static inline void volk_32fc_deinterleave_real_64f_a_sse2(double* iBuffer,
 {
     unsigned int number = 0;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
 
     const unsigned int halfPoints = num_points / 2;
@@ -143,7 +143,7 @@ static inline void volk_32fc_deinterleave_real_64f_generic(double* iBuffer,
                                                            unsigned int num_points)
 {
     unsigned int number = 0;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
     for (number = 0; number < num_points; number++) {
         *iBufferPtr++ = (double)*complexVectorPtr++;
@@ -161,7 +161,7 @@ static inline void volk_32fc_deinterleave_real_64f_neon(double* iBuffer,
 {
     unsigned int number = 0;
     unsigned int quarter_points = num_points / 4;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
     float32x2x4_t complexInput;
     float64x2_t iVal1;
@@ -210,7 +210,7 @@ static inline void volk_32fc_deinterleave_real_64f_u_avx2(double* iBuffer,
 {
     unsigned int number = 0;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     double* iBufferPtr = iBuffer;
 
     const unsigned int quarterPoints = num_points / 4;

--- a/kernels/volk/volk_32fc_index_max_16u.h
+++ b/kernels/volk/volk_32fc_index_max_16u.h
@@ -60,397 +60,14 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32fc_index_max_16u_a_H
-#define INCLUDED_volk_32fc_index_max_16u_a_H
+#ifndef INCLUDED_volk_32fc_index_max_16u_u_H
+#define INCLUDED_volk_32fc_index_max_16u_u_H
 
 #include <inttypes.h>
 #include <limits.h>
 #include <stdio.h>
 #include <volk/volk_common.h>
 #include <volk/volk_complex.h>
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-#include <volk/volk_avx2_intrinsics.h>
-
-static inline void volk_32fc_index_max_16u_a_avx2_variant_0(uint16_t* target,
-                                                            const lv_32fc_t* src0,
-                                                            uint32_t num_points)
-{
-    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
-
-    const __m256i indices_increment = _mm256_set1_epi32(8);
-    /*
-     * At the start of each loop iteration current_indices holds the indices of
-     * the complex numbers loaded from memory. Explanation for odd order is given
-     * in implementation of vector_32fc_index_max_variant0().
-     */
-    __m256i current_indices = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
-
-    __m256 max_values = _mm256_setzero_ps();
-    __m256i max_indices = _mm256_setzero_si256();
-
-    for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((const float*)src0);
-        __m256 in1 = _mm256_load_ps((const float*)(src0 + 4));
-        vector_32fc_index_max_variant0(
-            in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
-        src0 += 8;
-    }
-
-    // determine maximum value and index in the result of the vectorized loop
-    __VOLK_ATTR_ALIGNED(32) float max_values_buffer[8];
-    __VOLK_ATTR_ALIGNED(32) uint32_t max_indices_buffer[8];
-    _mm256_store_ps(max_values_buffer, max_values);
-    _mm256_store_si256((__m256i*)max_indices_buffer, max_indices);
-
-    float max = 0.f;
-    uint32_t index = 0;
-    for (unsigned i = 0; i < 8; i++) {
-        if (max_values_buffer[i] > max) {
-            max = max_values_buffer[i];
-            index = max_indices_buffer[i];
-        }
-    }
-
-    // handle tail not processed by the vectorized loop
-    for (unsigned i = num_points & (~7u); i < num_points; ++i) {
-        const float abs_squared =
-            lv_creal(*src0) * lv_creal(*src0) + lv_cimag(*src0) * lv_cimag(*src0);
-        if (abs_squared > max) {
-            max = abs_squared;
-            index = i;
-        }
-        ++src0;
-    }
-
-    *target = index;
-}
-
-#endif /*LV_HAVE_AVX2*/
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-#include <volk/volk_avx2_intrinsics.h>
-
-static inline void volk_32fc_index_max_16u_a_avx2_variant_1(uint16_t* target,
-                                                            const lv_32fc_t* src0,
-                                                            uint32_t num_points)
-{
-    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
-
-    const __m256i indices_increment = _mm256_set1_epi32(8);
-    /*
-     * At the start of each loop iteration current_indices holds the indices of
-     * the complex numbers loaded from memory. Explanation for odd order is given
-     * in implementation of vector_32fc_index_max_variant0().
-     */
-    __m256i current_indices = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
-
-    __m256 max_values = _mm256_setzero_ps();
-    __m256i max_indices = _mm256_setzero_si256();
-
-    for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((const float*)src0);
-        __m256 in1 = _mm256_load_ps((const float*)(src0 + 4));
-        vector_32fc_index_max_variant1(
-            in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
-        src0 += 8;
-    }
-
-    // determine maximum value and index in the result of the vectorized loop
-    __VOLK_ATTR_ALIGNED(32) float max_values_buffer[8];
-    __VOLK_ATTR_ALIGNED(32) uint32_t max_indices_buffer[8];
-    _mm256_store_ps(max_values_buffer, max_values);
-    _mm256_store_si256((__m256i*)max_indices_buffer, max_indices);
-
-    float max = 0.f;
-    uint32_t index = 0;
-    for (unsigned i = 0; i < 8; i++) {
-        if (max_values_buffer[i] > max) {
-            max = max_values_buffer[i];
-            index = max_indices_buffer[i];
-        }
-    }
-
-    // handle tail not processed by the vectorized loop
-    for (unsigned i = num_points & (~7u); i < num_points; ++i) {
-        const float abs_squared =
-            lv_creal(*src0) * lv_creal(*src0) + lv_cimag(*src0) * lv_cimag(*src0);
-        if (abs_squared > max) {
-            max = abs_squared;
-            index = i;
-        }
-        ++src0;
-    }
-
-    *target = index;
-}
-
-#endif /*LV_HAVE_AVX2*/
-
-#ifdef LV_HAVE_SSE3
-#include <pmmintrin.h>
-#include <xmmintrin.h>
-
-static inline void volk_32fc_index_max_16u_a_sse3(uint16_t* target,
-                                                  const lv_32fc_t* src0,
-                                                  uint32_t num_points)
-{
-    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
-    const uint32_t num_bytes = num_points * 8;
-
-    union bit128 holderf;
-    union bit128 holderi;
-    float sq_dist = 0.0;
-
-    union bit128 xmm5, xmm4;
-    __m128 xmm1, xmm2, xmm3;
-    __m128i xmm8, xmm11, xmm12, xmm9, xmm10;
-
-    xmm5.int_vec = _mm_setzero_si128();
-    xmm4.int_vec = _mm_setzero_si128();
-    holderf.int_vec = _mm_setzero_si128();
-    holderi.int_vec = _mm_setzero_si128();
-
-    int bound = num_bytes >> 5;
-    int i = 0;
-
-    xmm8 = _mm_setr_epi32(0, 1, 2, 3);
-    xmm9 = _mm_setzero_si128();
-    xmm10 = _mm_setr_epi32(4, 4, 4, 4);
-    xmm3 = _mm_setzero_ps();
-
-    for (; i < bound; ++i) {
-        xmm1 = _mm_load_ps((const float*)src0);
-        xmm2 = _mm_load_ps((const float*)&src0[2]);
-
-        src0 += 4;
-
-        xmm1 = _mm_mul_ps(xmm1, xmm1);
-        xmm2 = _mm_mul_ps(xmm2, xmm2);
-
-        xmm1 = _mm_hadd_ps(xmm1, xmm2);
-
-        xmm3 = _mm_max_ps(xmm1, xmm3);
-
-        xmm4.float_vec = _mm_cmplt_ps(xmm1, xmm3);
-        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
-
-        xmm11 = _mm_and_si128(xmm8, xmm5.int_vec);
-        xmm12 = _mm_and_si128(xmm9, xmm4.int_vec);
-
-        xmm9 = _mm_add_epi32(xmm11, xmm12);
-
-        xmm8 = _mm_add_epi32(xmm8, xmm10);
-    }
-
-    if (num_bytes >> 4 & 1) {
-        xmm2 = _mm_load_ps((const float*)src0);
-
-        xmm1 = _mm_movelh_ps(bit128_p(&xmm8)->float_vec, bit128_p(&xmm8)->float_vec);
-        xmm8 = bit128_p(&xmm1)->int_vec;
-
-        xmm2 = _mm_mul_ps(xmm2, xmm2);
-
-        src0 += 2;
-
-        xmm1 = _mm_hadd_ps(xmm2, xmm2);
-
-        xmm3 = _mm_max_ps(xmm1, xmm3);
-
-        xmm10 = _mm_setr_epi32(2, 2, 2, 2);
-
-        xmm4.float_vec = _mm_cmplt_ps(xmm1, xmm3);
-        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
-
-        xmm11 = _mm_and_si128(xmm8, xmm5.int_vec);
-        xmm12 = _mm_and_si128(xmm9, xmm4.int_vec);
-
-        xmm9 = _mm_add_epi32(xmm11, xmm12);
-
-        xmm8 = _mm_add_epi32(xmm8, xmm10);
-    }
-
-    if (num_bytes >> 3 & 1) {
-        sq_dist =
-            lv_creal(src0[0]) * lv_creal(src0[0]) + lv_cimag(src0[0]) * lv_cimag(src0[0]);
-
-        xmm2 = _mm_load1_ps(&sq_dist);
-
-        xmm1 = xmm3;
-
-        xmm3 = _mm_max_ss(xmm3, xmm2);
-
-        xmm4.float_vec = _mm_cmplt_ps(xmm1, xmm3);
-        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
-
-        xmm8 = _mm_shuffle_epi32(xmm8, 0x00);
-
-        xmm11 = _mm_and_si128(xmm8, xmm4.int_vec);
-        xmm12 = _mm_and_si128(xmm9, xmm5.int_vec);
-
-        xmm9 = _mm_add_epi32(xmm11, xmm12);
-    }
-
-    _mm_store_ps((float*)&(holderf.f), xmm3);
-    _mm_store_si128(&(holderi.int_vec), xmm9);
-
-    target[0] = holderi.i[0];
-    sq_dist = holderf.f[0];
-    target[0] = (holderf.f[1] > sq_dist) ? holderi.i[1] : target[0];
-    sq_dist = (holderf.f[1] > sq_dist) ? holderf.f[1] : sq_dist;
-    target[0] = (holderf.f[2] > sq_dist) ? holderi.i[2] : target[0];
-    sq_dist = (holderf.f[2] > sq_dist) ? holderf.f[2] : sq_dist;
-    target[0] = (holderf.f[3] > sq_dist) ? holderi.i[3] : target[0];
-    sq_dist = (holderf.f[3] > sq_dist) ? holderf.f[3] : sq_dist;
-}
-
-#endif /*LV_HAVE_SSE3*/
-
-
-#ifdef LV_HAVE_NEON
-#include <arm_neon.h>
-#include <float.h>
-#include <limits.h>
-#include <volk/volk_neon_intrinsics.h>
-
-static inline void
-volk_32fc_index_max_16u_neon(uint16_t* target, const lv_32fc_t* src0, uint32_t num_points)
-{
-    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
-
-    if (num_points == 0)
-        return;
-
-    const uint32_t quarter_points = num_points / 4;
-    const lv_32fc_t* inputPtr = src0;
-
-    // Use integer indices directly
-    uint32x4_t vec_indices = { 0, 1, 2, 3 };
-    const uint32x4_t vec_incr = vdupq_n_u32(4);
-
-    float32x4_t vec_max = vdupq_n_f32(0.0f);
-    uint32x4_t vec_max_idx = vdupq_n_u32(0);
-
-    for (uint32_t i = 0; i < quarter_points; i++) {
-        // Load and deinterleave complex values
-        float32x4x2_t cplx = vld2q_f32((const float*)inputPtr);
-        inputPtr += 4;
-
-        // Magnitude squared: re*re + im*im
-        float32x4_t mag2 =
-            vmlaq_f32(vmulq_f32(cplx.val[0], cplx.val[0]), cplx.val[1], cplx.val[1]);
-
-        // Compare BEFORE max update to know which lanes change
-        uint32x4_t gt_mask = vcgtq_f32(mag2, vec_max);
-        vec_max_idx = vbslq_u32(gt_mask, vec_indices, vec_max_idx);
-
-        // vmaxq_f32 is single-cycle, no dependency on comparison result
-        vec_max = vmaxq_f32(mag2, vec_max);
-
-        vec_indices = vaddq_u32(vec_indices, vec_incr);
-    }
-
-    // Scalar reduction
-    __VOLK_ATTR_ALIGNED(16) float max_buf[4];
-    __VOLK_ATTR_ALIGNED(16) uint32_t idx_buf[4];
-    vst1q_f32(max_buf, vec_max);
-    vst1q_u32(idx_buf, vec_max_idx);
-
-    float max_val = max_buf[0];
-    uint32_t result_idx = idx_buf[0];
-    for (int i = 1; i < 4; i++) {
-        if (max_buf[i] > max_val) {
-            max_val = max_buf[i];
-            result_idx = idx_buf[i];
-        } else if (max_buf[i] == max_val && idx_buf[i] < result_idx) {
-            result_idx = idx_buf[i];
-        }
-    }
-
-    // Handle tail
-    for (uint32_t i = quarter_points * 4; i < num_points; i++) {
-        float re = lv_creal(src0[i]);
-        float im = lv_cimag(src0[i]);
-        float mag2 = re * re + im * im;
-        if (mag2 > max_val) {
-            max_val = mag2;
-            result_idx = i;
-        }
-    }
-
-    *target = (uint16_t)result_idx;
-}
-
-#endif /*LV_HAVE_NEON*/
-
-
-#ifdef LV_HAVE_NEONV8
-#include <arm_neon.h>
-#include <float.h>
-#include <limits.h>
-
-static inline void volk_32fc_index_max_16u_neonv8(uint16_t* target,
-                                                  const lv_32fc_t* src0,
-                                                  uint32_t num_points)
-{
-    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
-
-    if (num_points == 0)
-        return;
-
-    const uint32_t quarter_points = num_points / 4;
-    const lv_32fc_t* inputPtr = src0;
-
-    // Use integer indices directly (no float conversion overhead)
-    uint32x4_t vec_indices = { 0, 1, 2, 3 };
-    const uint32x4_t vec_incr = vdupq_n_u32(4);
-
-    float32x4_t vec_max = vdupq_n_f32(0.0f);
-    uint32x4_t vec_max_idx = vdupq_n_u32(0);
-
-    for (uint32_t i = 0; i < quarter_points; i++) {
-        // Load and deinterleave complex values
-        float32x4x2_t cplx = vld2q_f32((const float*)inputPtr);
-        inputPtr += 4;
-
-        // Magnitude squared using FMA: re*re + im*im
-        float32x4_t mag2 =
-            vfmaq_f32(vmulq_f32(cplx.val[0], cplx.val[0]), cplx.val[1], cplx.val[1]);
-
-        // Compare BEFORE max update to know which lanes change
-        uint32x4_t gt_mask = vcgtq_f32(mag2, vec_max);
-        vec_max_idx = vbslq_u32(gt_mask, vec_indices, vec_max_idx);
-
-        // vmaxq_f32 is single-cycle, no dependency on comparison result
-        vec_max = vmaxq_f32(mag2, vec_max);
-
-        vec_indices = vaddq_u32(vec_indices, vec_incr);
-    }
-
-    // ARMv8 horizontal reduction
-    float max_val = vmaxvq_f32(vec_max);
-    uint32x4_t max_mask = vceqq_f32(vec_max, vdupq_n_f32(max_val));
-    uint32x4_t idx_masked = vbslq_u32(max_mask, vec_max_idx, vdupq_n_u32(UINT32_MAX));
-    uint32_t result_idx = vminvq_u32(idx_masked);
-
-    // Handle tail
-    for (uint32_t i = quarter_points * 4; i < num_points; i++) {
-        float re = lv_creal(src0[i]);
-        float im = lv_cimag(src0[i]);
-        float mag2 = re * re + im * im;
-        if (mag2 > max_val) {
-            max_val = mag2;
-            result_idx = i;
-        }
-    }
-
-    *target = (uint16_t)result_idx;
-}
-
-#endif /*LV_HAVE_NEONV8*/
-
 
 #ifdef LV_HAVE_GENERIC
 static inline void volk_32fc_index_max_16u_generic(uint16_t* target,
@@ -480,101 +97,6 @@ static inline void volk_32fc_index_max_16u_generic(uint16_t* target,
 }
 
 #endif /*LV_HAVE_GENERIC*/
-
-#ifdef LV_HAVE_AVX512F
-#include <immintrin.h>
-#include <limits.h>
-
-static inline void volk_32fc_index_max_16u_a_avx512f(uint16_t* target,
-                                                     const lv_32fc_t* src0,
-                                                     uint32_t num_points)
-{
-    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
-
-    const lv_32fc_t* src0Ptr = src0;
-    const uint32_t sixteenthPoints = num_points / 16;
-
-    // Index ordering after shuffle: [0,1,8,9, 2,3,10,11, 4,5,12,13, 6,7,14,15]
-    __m512 currentIndexes =
-        _mm512_setr_ps(0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15);
-    const __m512 indexIncrement = _mm512_set1_ps(16);
-
-    __m512 maxValues = _mm512_setzero_ps();
-    __m512 maxIndices = _mm512_setzero_ps();
-
-    for (uint32_t number = 0; number < sixteenthPoints; number++) {
-        // Load 16 complex values (32 floats)
-        __m512 in0 = _mm512_load_ps((const float*)src0Ptr);
-        __m512 in1 = _mm512_load_ps((const float*)(src0Ptr + 8));
-        src0Ptr += 16;
-
-        // Square all values
-        in0 = _mm512_mul_ps(in0, in0);
-        in1 = _mm512_mul_ps(in1, in1);
-
-        // Add adjacent pairs (re² + im²) using within-lane shuffle
-        // 0xB1 = _MM_SHUFFLE(2,3,0,1) swaps adjacent elements
-        __m512 sw0 = _mm512_shuffle_ps(in0, in0, 0xB1);
-        __m512 sw1 = _mm512_shuffle_ps(in1, in1, 0xB1);
-        __m512 sum0 = _mm512_add_ps(in0, sw0);
-        __m512 sum1 = _mm512_add_ps(in1, sw1);
-
-        // Compact: pick elements 0,2 from sum0 and sum1 per 128-bit lane
-        // 0x88 = _MM_SHUFFLE(2,0,2,0)
-        __m512 mag_sq = _mm512_shuffle_ps(sum0, sum1, 0x88);
-
-        // Compare and update maximums
-        __mmask16 cmpMask = _mm512_cmp_ps_mask(mag_sq, maxValues, _CMP_GT_OS);
-        maxIndices = _mm512_mask_blend_ps(cmpMask, maxIndices, currentIndexes);
-        maxValues = _mm512_max_ps(mag_sq, maxValues);
-
-        currentIndexes = _mm512_add_ps(currentIndexes, indexIncrement);
-    }
-
-    // Reduce 16 values to find maximum
-    __VOLK_ATTR_ALIGNED(64) float maxValuesBuffer[16];
-    __VOLK_ATTR_ALIGNED(64) float maxIndexesBuffer[16];
-    _mm512_store_ps(maxValuesBuffer, maxValues);
-    _mm512_store_ps(maxIndexesBuffer, maxIndices);
-
-    float max = 0.0f;
-    uint32_t index = 0;
-    for (uint32_t i = 0; i < 16; i++) {
-        if (maxValuesBuffer[i] > max) {
-            max = maxValuesBuffer[i];
-            index = (uint32_t)maxIndexesBuffer[i];
-        } else if (maxValuesBuffer[i] == max) {
-            if ((uint32_t)maxIndexesBuffer[i] < index)
-                index = (uint32_t)maxIndexesBuffer[i];
-        }
-    }
-
-    // Handle tail
-    for (uint32_t number = sixteenthPoints * 16; number < num_points; number++) {
-        const float re = lv_creal(*src0Ptr);
-        const float im = lv_cimag(*src0Ptr);
-        const float sq_dist = re * re + im * im;
-        if (sq_dist > max) {
-            max = sq_dist;
-            index = number;
-        }
-        src0Ptr++;
-    }
-    *target = (uint16_t)index;
-}
-
-#endif /*LV_HAVE_AVX512F*/
-
-#endif /*INCLUDED_volk_32fc_index_max_16u_a_H*/
-
-#ifndef INCLUDED_volk_32fc_index_max_16u_u_H
-#define INCLUDED_volk_32fc_index_max_16u_u_H
-
-#include <inttypes.h>
-#include <limits.h>
-#include <stdio.h>
-#include <volk/volk_common.h>
-#include <volk/volk_complex.h>
 
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
@@ -780,6 +302,148 @@ static inline void volk_32fc_index_max_16u_u_avx512f(uint16_t* target,
 
 #endif /*LV_HAVE_AVX512F*/
 
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+#include <float.h>
+#include <limits.h>
+#include <volk/volk_neon_intrinsics.h>
+
+static inline void
+volk_32fc_index_max_16u_neon(uint16_t* target, const lv_32fc_t* src0, uint32_t num_points)
+{
+    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
+
+    if (num_points == 0)
+        return;
+
+    const uint32_t quarter_points = num_points / 4;
+    const lv_32fc_t* inputPtr = src0;
+
+    // Use integer indices directly
+    uint32x4_t vec_indices = { 0, 1, 2, 3 };
+    const uint32x4_t vec_incr = vdupq_n_u32(4);
+
+    float32x4_t vec_max = vdupq_n_f32(0.0f);
+    uint32x4_t vec_max_idx = vdupq_n_u32(0);
+
+    for (uint32_t i = 0; i < quarter_points; i++) {
+        // Load and deinterleave complex values
+        float32x4x2_t cplx = vld2q_f32((const float*)inputPtr);
+        inputPtr += 4;
+
+        // Magnitude squared: re*re + im*im
+        float32x4_t mag2 =
+            vmlaq_f32(vmulq_f32(cplx.val[0], cplx.val[0]), cplx.val[1], cplx.val[1]);
+
+        // Compare BEFORE max update to know which lanes change
+        uint32x4_t gt_mask = vcgtq_f32(mag2, vec_max);
+        vec_max_idx = vbslq_u32(gt_mask, vec_indices, vec_max_idx);
+
+        // vmaxq_f32 is single-cycle, no dependency on comparison result
+        vec_max = vmaxq_f32(mag2, vec_max);
+
+        vec_indices = vaddq_u32(vec_indices, vec_incr);
+    }
+
+    // Scalar reduction
+    __VOLK_ATTR_ALIGNED(16) float max_buf[4];
+    __VOLK_ATTR_ALIGNED(16) uint32_t idx_buf[4];
+    vst1q_f32(max_buf, vec_max);
+    vst1q_u32(idx_buf, vec_max_idx);
+
+    float max_val = max_buf[0];
+    uint32_t result_idx = idx_buf[0];
+    for (int i = 1; i < 4; i++) {
+        if (max_buf[i] > max_val) {
+            max_val = max_buf[i];
+            result_idx = idx_buf[i];
+        } else if (max_buf[i] == max_val && idx_buf[i] < result_idx) {
+            result_idx = idx_buf[i];
+        }
+    }
+
+    // Handle tail
+    for (uint32_t i = quarter_points * 4; i < num_points; i++) {
+        float re = lv_creal(src0[i]);
+        float im = lv_cimag(src0[i]);
+        float mag2 = re * re + im * im;
+        if (mag2 > max_val) {
+            max_val = mag2;
+            result_idx = i;
+        }
+    }
+
+    *target = (uint16_t)result_idx;
+}
+
+#endif /*LV_HAVE_NEON*/
+
+
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+#include <float.h>
+#include <limits.h>
+
+static inline void volk_32fc_index_max_16u_neonv8(uint16_t* target,
+                                                  const lv_32fc_t* src0,
+                                                  uint32_t num_points)
+{
+    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
+
+    if (num_points == 0)
+        return;
+
+    const uint32_t quarter_points = num_points / 4;
+    const lv_32fc_t* inputPtr = src0;
+
+    // Use integer indices directly (no float conversion overhead)
+    uint32x4_t vec_indices = { 0, 1, 2, 3 };
+    const uint32x4_t vec_incr = vdupq_n_u32(4);
+
+    float32x4_t vec_max = vdupq_n_f32(0.0f);
+    uint32x4_t vec_max_idx = vdupq_n_u32(0);
+
+    for (uint32_t i = 0; i < quarter_points; i++) {
+        // Load and deinterleave complex values
+        float32x4x2_t cplx = vld2q_f32((const float*)inputPtr);
+        inputPtr += 4;
+
+        // Magnitude squared using FMA: re*re + im*im
+        float32x4_t mag2 =
+            vfmaq_f32(vmulq_f32(cplx.val[0], cplx.val[0]), cplx.val[1], cplx.val[1]);
+
+        // Compare BEFORE max update to know which lanes change
+        uint32x4_t gt_mask = vcgtq_f32(mag2, vec_max);
+        vec_max_idx = vbslq_u32(gt_mask, vec_indices, vec_max_idx);
+
+        // vmaxq_f32 is single-cycle, no dependency on comparison result
+        vec_max = vmaxq_f32(mag2, vec_max);
+
+        vec_indices = vaddq_u32(vec_indices, vec_incr);
+    }
+
+    // ARMv8 horizontal reduction
+    float max_val = vmaxvq_f32(vec_max);
+    uint32x4_t max_mask = vceqq_f32(vec_max, vdupq_n_f32(max_val));
+    uint32x4_t idx_masked = vbslq_u32(max_mask, vec_max_idx, vdupq_n_u32(UINT32_MAX));
+    uint32_t result_idx = vminvq_u32(idx_masked);
+
+    // Handle tail
+    for (uint32_t i = quarter_points * 4; i < num_points; i++) {
+        float re = lv_creal(src0[i]);
+        float im = lv_cimag(src0[i]);
+        float mag2 = re * re + im * im;
+        if (mag2 > max_val) {
+            max_val = mag2;
+            result_idx = i;
+        }
+    }
+
+    *target = (uint16_t)result_idx;
+}
+
+#endif /*LV_HAVE_NEONV8*/
+
 #ifdef LV_HAVE_RVV
 #include <float.h>
 #include <riscv_vector.h>
@@ -865,3 +529,337 @@ static inline void volk_32fc_index_max_16u_rvvseg(uint16_t* target,
 #endif /*LV_HAVE_RVVSEG*/
 
 #endif /*INCLUDED_volk_32fc_index_max_16u_u_H*/
+
+#ifndef INCLUDED_volk_32fc_index_max_16u_a_H
+#define INCLUDED_volk_32fc_index_max_16u_a_H
+
+#include <inttypes.h>
+#include <limits.h>
+#include <stdio.h>
+#include <volk/volk_common.h>
+#include <volk/volk_complex.h>
+
+#ifdef LV_HAVE_SSE3
+#include <pmmintrin.h>
+#include <xmmintrin.h>
+
+static inline void volk_32fc_index_max_16u_a_sse3(uint16_t* target,
+                                                  const lv_32fc_t* src0,
+                                                  uint32_t num_points)
+{
+    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
+    const uint32_t num_bytes = num_points * 8;
+
+    union bit128 holderf;
+    union bit128 holderi;
+    float sq_dist = 0.0;
+
+    union bit128 xmm5, xmm4;
+    __m128 xmm1, xmm2, xmm3;
+    __m128i xmm8, xmm11, xmm12, xmm9, xmm10;
+
+    xmm5.int_vec = _mm_setzero_si128();
+    xmm4.int_vec = _mm_setzero_si128();
+    holderf.int_vec = _mm_setzero_si128();
+    holderi.int_vec = _mm_setzero_si128();
+
+    int bound = num_bytes >> 5;
+    int i = 0;
+
+    xmm8 = _mm_setr_epi32(0, 1, 2, 3);
+    xmm9 = _mm_setzero_si128();
+    xmm10 = _mm_setr_epi32(4, 4, 4, 4);
+    xmm3 = _mm_setzero_ps();
+
+    for (; i < bound; ++i) {
+        xmm1 = _mm_load_ps((const float*)src0);
+        xmm2 = _mm_load_ps((const float*)&src0[2]);
+
+        src0 += 4;
+
+        xmm1 = _mm_mul_ps(xmm1, xmm1);
+        xmm2 = _mm_mul_ps(xmm2, xmm2);
+
+        xmm1 = _mm_hadd_ps(xmm1, xmm2);
+
+        xmm3 = _mm_max_ps(xmm1, xmm3);
+
+        xmm4.float_vec = _mm_cmplt_ps(xmm1, xmm3);
+        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
+
+        xmm11 = _mm_and_si128(xmm8, xmm5.int_vec);
+        xmm12 = _mm_and_si128(xmm9, xmm4.int_vec);
+
+        xmm9 = _mm_add_epi32(xmm11, xmm12);
+
+        xmm8 = _mm_add_epi32(xmm8, xmm10);
+    }
+
+    if (num_bytes >> 4 & 1) {
+        xmm2 = _mm_load_ps((const float*)src0);
+
+        xmm1 = _mm_movelh_ps(bit128_p(&xmm8)->float_vec, bit128_p(&xmm8)->float_vec);
+        xmm8 = bit128_p(&xmm1)->int_vec;
+
+        xmm2 = _mm_mul_ps(xmm2, xmm2);
+
+        src0 += 2;
+
+        xmm1 = _mm_hadd_ps(xmm2, xmm2);
+
+        xmm3 = _mm_max_ps(xmm1, xmm3);
+
+        xmm10 = _mm_setr_epi32(2, 2, 2, 2);
+
+        xmm4.float_vec = _mm_cmplt_ps(xmm1, xmm3);
+        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
+
+        xmm11 = _mm_and_si128(xmm8, xmm5.int_vec);
+        xmm12 = _mm_and_si128(xmm9, xmm4.int_vec);
+
+        xmm9 = _mm_add_epi32(xmm11, xmm12);
+
+        xmm8 = _mm_add_epi32(xmm8, xmm10);
+    }
+
+    if (num_bytes >> 3 & 1) {
+        sq_dist =
+            lv_creal(src0[0]) * lv_creal(src0[0]) + lv_cimag(src0[0]) * lv_cimag(src0[0]);
+
+        xmm2 = _mm_load1_ps(&sq_dist);
+
+        xmm1 = xmm3;
+
+        xmm3 = _mm_max_ss(xmm3, xmm2);
+
+        xmm4.float_vec = _mm_cmplt_ps(xmm1, xmm3);
+        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
+
+        xmm8 = _mm_shuffle_epi32(xmm8, 0x00);
+
+        xmm11 = _mm_and_si128(xmm8, xmm4.int_vec);
+        xmm12 = _mm_and_si128(xmm9, xmm5.int_vec);
+
+        xmm9 = _mm_add_epi32(xmm11, xmm12);
+    }
+
+    _mm_store_ps((float*)&(holderf.f), xmm3);
+    _mm_store_si128(&(holderi.int_vec), xmm9);
+
+    target[0] = holderi.i[0];
+    sq_dist = holderf.f[0];
+    target[0] = (holderf.f[1] > sq_dist) ? holderi.i[1] : target[0];
+    sq_dist = (holderf.f[1] > sq_dist) ? holderf.f[1] : sq_dist;
+    target[0] = (holderf.f[2] > sq_dist) ? holderi.i[2] : target[0];
+    sq_dist = (holderf.f[2] > sq_dist) ? holderf.f[2] : sq_dist;
+    target[0] = (holderf.f[3] > sq_dist) ? holderi.i[3] : target[0];
+    sq_dist = (holderf.f[3] > sq_dist) ? holderf.f[3] : sq_dist;
+}
+
+#endif /*LV_HAVE_SSE3*/
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+#include <volk/volk_avx2_intrinsics.h>
+
+static inline void volk_32fc_index_max_16u_a_avx2_variant_0(uint16_t* target,
+                                                            const lv_32fc_t* src0,
+                                                            uint32_t num_points)
+{
+    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
+
+    const __m256i indices_increment = _mm256_set1_epi32(8);
+    /*
+     * At the start of each loop iteration current_indices holds the indices of
+     * the complex numbers loaded from memory. Explanation for odd order is given
+     * in implementation of vector_32fc_index_max_variant0().
+     */
+    __m256i current_indices = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
+
+    __m256 max_values = _mm256_setzero_ps();
+    __m256i max_indices = _mm256_setzero_si256();
+
+    for (unsigned i = 0; i < num_points / 8u; ++i) {
+        __m256 in0 = _mm256_load_ps((const float*)src0);
+        __m256 in1 = _mm256_load_ps((const float*)(src0 + 4));
+        vector_32fc_index_max_variant0(
+            in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
+        src0 += 8;
+    }
+
+    // determine maximum value and index in the result of the vectorized loop
+    __VOLK_ATTR_ALIGNED(32) float max_values_buffer[8];
+    __VOLK_ATTR_ALIGNED(32) uint32_t max_indices_buffer[8];
+    _mm256_store_ps(max_values_buffer, max_values);
+    _mm256_store_si256((__m256i*)max_indices_buffer, max_indices);
+
+    float max = 0.f;
+    uint32_t index = 0;
+    for (unsigned i = 0; i < 8; i++) {
+        if (max_values_buffer[i] > max) {
+            max = max_values_buffer[i];
+            index = max_indices_buffer[i];
+        }
+    }
+
+    // handle tail not processed by the vectorized loop
+    for (unsigned i = num_points & (~7u); i < num_points; ++i) {
+        const float abs_squared =
+            lv_creal(*src0) * lv_creal(*src0) + lv_cimag(*src0) * lv_cimag(*src0);
+        if (abs_squared > max) {
+            max = abs_squared;
+            index = i;
+        }
+        ++src0;
+    }
+
+    *target = index;
+}
+
+#endif /*LV_HAVE_AVX2*/
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+#include <volk/volk_avx2_intrinsics.h>
+
+static inline void volk_32fc_index_max_16u_a_avx2_variant_1(uint16_t* target,
+                                                            const lv_32fc_t* src0,
+                                                            uint32_t num_points)
+{
+    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
+
+    const __m256i indices_increment = _mm256_set1_epi32(8);
+    /*
+     * At the start of each loop iteration current_indices holds the indices of
+     * the complex numbers loaded from memory. Explanation for odd order is given
+     * in implementation of vector_32fc_index_max_variant0().
+     */
+    __m256i current_indices = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
+
+    __m256 max_values = _mm256_setzero_ps();
+    __m256i max_indices = _mm256_setzero_si256();
+
+    for (unsigned i = 0; i < num_points / 8u; ++i) {
+        __m256 in0 = _mm256_load_ps((const float*)src0);
+        __m256 in1 = _mm256_load_ps((const float*)(src0 + 4));
+        vector_32fc_index_max_variant1(
+            in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
+        src0 += 8;
+    }
+
+    // determine maximum value and index in the result of the vectorized loop
+    __VOLK_ATTR_ALIGNED(32) float max_values_buffer[8];
+    __VOLK_ATTR_ALIGNED(32) uint32_t max_indices_buffer[8];
+    _mm256_store_ps(max_values_buffer, max_values);
+    _mm256_store_si256((__m256i*)max_indices_buffer, max_indices);
+
+    float max = 0.f;
+    uint32_t index = 0;
+    for (unsigned i = 0; i < 8; i++) {
+        if (max_values_buffer[i] > max) {
+            max = max_values_buffer[i];
+            index = max_indices_buffer[i];
+        }
+    }
+
+    // handle tail not processed by the vectorized loop
+    for (unsigned i = num_points & (~7u); i < num_points; ++i) {
+        const float abs_squared =
+            lv_creal(*src0) * lv_creal(*src0) + lv_cimag(*src0) * lv_cimag(*src0);
+        if (abs_squared > max) {
+            max = abs_squared;
+            index = i;
+        }
+        ++src0;
+    }
+
+    *target = index;
+}
+
+#endif /*LV_HAVE_AVX2*/
+
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+#include <limits.h>
+
+static inline void volk_32fc_index_max_16u_a_avx512f(uint16_t* target,
+                                                     const lv_32fc_t* src0,
+                                                     uint32_t num_points)
+{
+    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
+
+    const lv_32fc_t* src0Ptr = src0;
+    const uint32_t sixteenthPoints = num_points / 16;
+
+    // Index ordering after shuffle: [0,1,8,9, 2,3,10,11, 4,5,12,13, 6,7,14,15]
+    __m512 currentIndexes =
+        _mm512_setr_ps(0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15);
+    const __m512 indexIncrement = _mm512_set1_ps(16);
+
+    __m512 maxValues = _mm512_setzero_ps();
+    __m512 maxIndices = _mm512_setzero_ps();
+
+    for (uint32_t number = 0; number < sixteenthPoints; number++) {
+        // Load 16 complex values (32 floats)
+        __m512 in0 = _mm512_load_ps((const float*)src0Ptr);
+        __m512 in1 = _mm512_load_ps((const float*)(src0Ptr + 8));
+        src0Ptr += 16;
+
+        // Square all values
+        in0 = _mm512_mul_ps(in0, in0);
+        in1 = _mm512_mul_ps(in1, in1);
+
+        // Add adjacent pairs (re² + im²) using within-lane shuffle
+        // 0xB1 = _MM_SHUFFLE(2,3,0,1) swaps adjacent elements
+        __m512 sw0 = _mm512_shuffle_ps(in0, in0, 0xB1);
+        __m512 sw1 = _mm512_shuffle_ps(in1, in1, 0xB1);
+        __m512 sum0 = _mm512_add_ps(in0, sw0);
+        __m512 sum1 = _mm512_add_ps(in1, sw1);
+
+        // Compact: pick elements 0,2 from sum0 and sum1 per 128-bit lane
+        // 0x88 = _MM_SHUFFLE(2,0,2,0)
+        __m512 mag_sq = _mm512_shuffle_ps(sum0, sum1, 0x88);
+
+        // Compare and update maximums
+        __mmask16 cmpMask = _mm512_cmp_ps_mask(mag_sq, maxValues, _CMP_GT_OS);
+        maxIndices = _mm512_mask_blend_ps(cmpMask, maxIndices, currentIndexes);
+        maxValues = _mm512_max_ps(mag_sq, maxValues);
+
+        currentIndexes = _mm512_add_ps(currentIndexes, indexIncrement);
+    }
+
+    // Reduce 16 values to find maximum
+    __VOLK_ATTR_ALIGNED(64) float maxValuesBuffer[16];
+    __VOLK_ATTR_ALIGNED(64) float maxIndexesBuffer[16];
+    _mm512_store_ps(maxValuesBuffer, maxValues);
+    _mm512_store_ps(maxIndexesBuffer, maxIndices);
+
+    float max = 0.0f;
+    uint32_t index = 0;
+    for (uint32_t i = 0; i < 16; i++) {
+        if (maxValuesBuffer[i] > max) {
+            max = maxValuesBuffer[i];
+            index = (uint32_t)maxIndexesBuffer[i];
+        } else if (maxValuesBuffer[i] == max) {
+            if ((uint32_t)maxIndexesBuffer[i] < index)
+                index = (uint32_t)maxIndexesBuffer[i];
+        }
+    }
+
+    // Handle tail
+    for (uint32_t number = sixteenthPoints * 16; number < num_points; number++) {
+        const float re = lv_creal(*src0Ptr);
+        const float im = lv_cimag(*src0Ptr);
+        const float sq_dist = re * re + im * im;
+        if (sq_dist > max) {
+            max = sq_dist;
+            index = number;
+        }
+        src0Ptr++;
+    }
+    *target = (uint16_t)index;
+}
+
+#endif /*LV_HAVE_AVX512F*/
+
+#endif /*INCLUDED_volk_32fc_index_max_16u_a_H*/

--- a/kernels/volk/volk_32fc_index_max_16u.h
+++ b/kernels/volk/volk_32fc_index_max_16u.h
@@ -91,8 +91,8 @@ static inline void volk_32fc_index_max_16u_a_avx2_variant_0(uint16_t* target,
     __m256i max_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((float*)src0);
-        __m256 in1 = _mm256_load_ps((float*)(src0 + 4));
+        __m256 in0 = _mm256_load_ps((const float*)src0);
+        __m256 in1 = _mm256_load_ps((const float*)(src0 + 4));
         vector_32fc_index_max_variant0(
             in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
         src0 += 8;
@@ -151,8 +151,8 @@ static inline void volk_32fc_index_max_16u_a_avx2_variant_1(uint16_t* target,
     __m256i max_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((float*)src0);
-        __m256 in1 = _mm256_load_ps((float*)(src0 + 4));
+        __m256 in0 = _mm256_load_ps((const float*)src0);
+        __m256 in1 = _mm256_load_ps((const float*)(src0 + 4));
         vector_32fc_index_max_variant1(
             in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
         src0 += 8;
@@ -222,8 +222,8 @@ static inline void volk_32fc_index_max_16u_a_sse3(uint16_t* target,
     xmm3 = _mm_setzero_ps();
 
     for (; i < bound; ++i) {
-        xmm1 = _mm_load_ps((float*)src0);
-        xmm2 = _mm_load_ps((float*)&src0[2]);
+        xmm1 = _mm_load_ps((const float*)src0);
+        xmm2 = _mm_load_ps((const float*)&src0[2]);
 
         src0 += 4;
 
@@ -246,7 +246,7 @@ static inline void volk_32fc_index_max_16u_a_sse3(uint16_t* target,
     }
 
     if (num_bytes >> 4 & 1) {
-        xmm2 = _mm_load_ps((float*)src0);
+        xmm2 = _mm_load_ps((const float*)src0);
 
         xmm1 = _mm_movelh_ps(bit128_p(&xmm8)->float_vec, bit128_p(&xmm8)->float_vec);
         xmm8 = bit128_p(&xmm1)->int_vec;
@@ -598,8 +598,8 @@ static inline void volk_32fc_index_max_16u_u_avx2_variant_0(uint16_t* target,
     __m256i max_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_loadu_ps((float*)src0);
-        __m256 in1 = _mm256_loadu_ps((float*)(src0 + 4));
+        __m256 in0 = _mm256_loadu_ps((const float*)src0);
+        __m256 in1 = _mm256_loadu_ps((const float*)(src0 + 4));
         vector_32fc_index_max_variant0(
             in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
         src0 += 8;
@@ -658,8 +658,8 @@ static inline void volk_32fc_index_max_16u_u_avx2_variant_1(uint16_t* target,
     __m256i max_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_loadu_ps((float*)src0);
-        __m256 in1 = _mm256_loadu_ps((float*)(src0 + 4));
+        __m256 in0 = _mm256_loadu_ps((const float*)src0);
+        __m256 in1 = _mm256_loadu_ps((const float*)(src0 + 4));
         vector_32fc_index_max_variant1(
             in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
         src0 += 8;

--- a/kernels/volk/volk_32fc_index_max_32u.h
+++ b/kernels/volk/volk_32fc_index_max_32u.h
@@ -81,8 +81,8 @@ static inline void volk_32fc_index_max_32u_a_avx2_variant_0(uint32_t* target,
     __m256i max_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((float*)src0);
-        __m256 in1 = _mm256_load_ps((float*)(src0 + 4));
+        __m256 in0 = _mm256_load_ps((const float*)src0);
+        __m256 in1 = _mm256_load_ps((const float*)(src0 + 4));
         vector_32fc_index_max_variant0(
             in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
         src0 += 8;
@@ -139,8 +139,8 @@ static inline void volk_32fc_index_max_32u_a_avx2_variant_1(uint32_t* target,
     __m256i max_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((float*)src0);
-        __m256 in1 = _mm256_load_ps((float*)(src0 + 4));
+        __m256 in0 = _mm256_load_ps((const float*)src0);
+        __m256 in1 = _mm256_load_ps((const float*)(src0 + 4));
         vector_32fc_index_max_variant1(
             in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
         src0 += 8;
@@ -209,8 +209,8 @@ static inline void volk_32fc_index_max_32u_a_sse3(uint32_t* target,
     xmm3 = _mm_setzero_ps();
 
     for (; i < bound; ++i) {
-        xmm1 = _mm_load_ps((float*)src0);
-        xmm2 = _mm_load_ps((float*)&src0[2]);
+        xmm1 = _mm_load_ps((const float*)src0);
+        xmm2 = _mm_load_ps((const float*)&src0[2]);
 
         src0 += 4;
 
@@ -233,7 +233,7 @@ static inline void volk_32fc_index_max_32u_a_sse3(uint32_t* target,
     }
 
     if (num_bytes >> 4 & 1) {
-        xmm2 = _mm_load_ps((float*)src0);
+        xmm2 = _mm_load_ps((const float*)src0);
 
         xmm1 = _mm_movelh_ps(bit128_p(&xmm8)->float_vec, bit128_p(&xmm8)->float_vec);
         xmm8 = bit128_p(&xmm1)->int_vec;
@@ -432,8 +432,8 @@ static inline void volk_32fc_index_max_32u_u_avx2_variant_0(uint32_t* target,
     __m256i max_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_loadu_ps((float*)src0);
-        __m256 in1 = _mm256_loadu_ps((float*)(src0 + 4));
+        __m256 in0 = _mm256_loadu_ps((const float*)src0);
+        __m256 in1 = _mm256_loadu_ps((const float*)(src0 + 4));
         vector_32fc_index_max_variant0(
             in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
         src0 += 8;
@@ -490,8 +490,8 @@ static inline void volk_32fc_index_max_32u_u_avx2_variant_1(uint32_t* target,
     __m256i max_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_loadu_ps((float*)src0);
-        __m256 in1 = _mm256_loadu_ps((float*)(src0 + 4));
+        __m256 in0 = _mm256_loadu_ps((const float*)src0);
+        __m256 in1 = _mm256_loadu_ps((const float*)(src0 + 4));
         vector_32fc_index_max_variant1(
             in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
         src0 += 8;
@@ -553,7 +553,7 @@ volk_32fc_index_max_32u_neon(uint32_t* target, const lv_32fc_t* src0, uint32_t n
         for (; number < quarter_points; number++) {
             // Load complex and compute magnitude squared
             const float32x4_t vec_mag2 =
-                _vmagnitudesquaredq_f32(vld2q_f32((float*)src0Ptr));
+                _vmagnitudesquaredq_f32(vld2q_f32((const float*)src0Ptr));
             __VOLK_PREFETCH(src0Ptr += 4);
             // a > b?
             const uint32x4_t gt_mask = vcgtq_f32(vec_mag2, vec_max);

--- a/kernels/volk/volk_32fc_index_max_32u.h
+++ b/kernels/volk/volk_32fc_index_max_32u.h
@@ -54,246 +54,12 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32fc_index_max_32u_a_H
-#define INCLUDED_volk_32fc_index_max_32u_a_H
+#ifndef INCLUDED_volk_32fc_index_max_32u_u_H
+#define INCLUDED_volk_32fc_index_max_32u_u_H
 
 #include <inttypes.h>
 #include <volk/volk_common.h>
 #include <volk/volk_complex.h>
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-#include <volk/volk_avx2_intrinsics.h>
-
-static inline void volk_32fc_index_max_32u_a_avx2_variant_0(uint32_t* target,
-                                                            const lv_32fc_t* src0,
-                                                            uint32_t num_points)
-{
-    const __m256i indices_increment = _mm256_set1_epi32(8);
-    /*
-     * At the start of each loop iteration current_indices holds the indices of
-     * the complex numbers loaded from memory. Explanation for odd order is given
-     * in implementation of vector_32fc_index_max_variant0().
-     */
-    __m256i current_indices = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
-
-    __m256 max_values = _mm256_setzero_ps();
-    __m256i max_indices = _mm256_setzero_si256();
-
-    for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((const float*)src0);
-        __m256 in1 = _mm256_load_ps((const float*)(src0 + 4));
-        vector_32fc_index_max_variant0(
-            in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
-        src0 += 8;
-    }
-
-    // determine maximum value and index in the result of the vectorized loop
-    __VOLK_ATTR_ALIGNED(32) float max_values_buffer[8];
-    __VOLK_ATTR_ALIGNED(32) uint32_t max_indices_buffer[8];
-    _mm256_store_ps(max_values_buffer, max_values);
-    _mm256_store_si256((__m256i*)max_indices_buffer, max_indices);
-
-    float max = 0.f;
-    uint32_t index = 0;
-    for (unsigned i = 0; i < 8; i++) {
-        if (max_values_buffer[i] > max) {
-            max = max_values_buffer[i];
-            index = max_indices_buffer[i];
-        }
-    }
-
-    // handle tail not processed by the vectorized loop
-    for (unsigned i = num_points & (~7u); i < num_points; ++i) {
-        const float abs_squared =
-            lv_creal(*src0) * lv_creal(*src0) + lv_cimag(*src0) * lv_cimag(*src0);
-        if (abs_squared > max) {
-            max = abs_squared;
-            index = i;
-        }
-        ++src0;
-    }
-
-    *target = index;
-}
-
-#endif /*LV_HAVE_AVX2*/
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-#include <volk/volk_avx2_intrinsics.h>
-
-static inline void volk_32fc_index_max_32u_a_avx2_variant_1(uint32_t* target,
-                                                            const lv_32fc_t* src0,
-                                                            uint32_t num_points)
-{
-    const __m256i indices_increment = _mm256_set1_epi32(8);
-    /*
-     * At the start of each loop iteration current_indices holds the indices of
-     * the complex numbers loaded from memory. Explanation for odd order is given
-     * in implementation of vector_32fc_index_max_variant0().
-     */
-    __m256i current_indices = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
-
-    __m256 max_values = _mm256_setzero_ps();
-    __m256i max_indices = _mm256_setzero_si256();
-
-    for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((const float*)src0);
-        __m256 in1 = _mm256_load_ps((const float*)(src0 + 4));
-        vector_32fc_index_max_variant1(
-            in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
-        src0 += 8;
-    }
-
-    // determine maximum value and index in the result of the vectorized loop
-    __VOLK_ATTR_ALIGNED(32) float max_values_buffer[8];
-    __VOLK_ATTR_ALIGNED(32) uint32_t max_indices_buffer[8];
-    _mm256_store_ps(max_values_buffer, max_values);
-    _mm256_store_si256((__m256i*)max_indices_buffer, max_indices);
-
-    float max = 0.f;
-    uint32_t index = 0;
-    for (unsigned i = 0; i < 8; i++) {
-        if (max_values_buffer[i] > max) {
-            max = max_values_buffer[i];
-            index = max_indices_buffer[i];
-        }
-    }
-
-    // handle tail not processed by the vectorized loop
-    for (unsigned i = num_points & (~7u); i < num_points; ++i) {
-        const float abs_squared =
-            lv_creal(*src0) * lv_creal(*src0) + lv_cimag(*src0) * lv_cimag(*src0);
-        if (abs_squared > max) {
-            max = abs_squared;
-            index = i;
-        }
-        ++src0;
-    }
-
-    *target = index;
-}
-
-#endif /*LV_HAVE_AVX2*/
-
-#ifdef LV_HAVE_SSE3
-#include <pmmintrin.h>
-#include <xmmintrin.h>
-
-static inline void volk_32fc_index_max_32u_a_sse3(uint32_t* target,
-                                                  const lv_32fc_t* src0,
-                                                  uint32_t num_points)
-{
-    const uint32_t num_bytes = num_points * 8;
-
-    union bit128 holderf;
-    union bit128 holderi;
-    float sq_dist = 0.0;
-
-    union bit128 xmm5, xmm4;
-    __m128 xmm1, xmm2, xmm3;
-    __m128i xmm8, xmm11, xmm12, xmm9, xmm10;
-
-    xmm5.int_vec = _mm_setzero_si128();
-    xmm4.int_vec = _mm_setzero_si128();
-    holderf.int_vec = _mm_setzero_si128();
-    holderi.int_vec = _mm_setzero_si128();
-
-    int bound = num_bytes >> 5;
-    int i = 0;
-
-    xmm8 = _mm_setr_epi32(0, 1, 2, 3);
-    xmm9 = _mm_setzero_si128();
-    xmm10 = _mm_setr_epi32(4, 4, 4, 4);
-    xmm3 = _mm_setzero_ps();
-
-    for (; i < bound; ++i) {
-        xmm1 = _mm_load_ps((const float*)src0);
-        xmm2 = _mm_load_ps((const float*)&src0[2]);
-
-        src0 += 4;
-
-        xmm1 = _mm_mul_ps(xmm1, xmm1);
-        xmm2 = _mm_mul_ps(xmm2, xmm2);
-
-        xmm1 = _mm_hadd_ps(xmm1, xmm2);
-
-        xmm3 = _mm_max_ps(xmm1, xmm3);
-
-        xmm4.float_vec = _mm_cmplt_ps(xmm1, xmm3);
-        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
-
-        xmm11 = _mm_and_si128(xmm8, xmm5.int_vec);
-        xmm12 = _mm_and_si128(xmm9, xmm4.int_vec);
-
-        xmm9 = _mm_add_epi32(xmm11, xmm12);
-
-        xmm8 = _mm_add_epi32(xmm8, xmm10);
-    }
-
-    if (num_bytes >> 4 & 1) {
-        xmm2 = _mm_load_ps((const float*)src0);
-
-        xmm1 = _mm_movelh_ps(bit128_p(&xmm8)->float_vec, bit128_p(&xmm8)->float_vec);
-        xmm8 = bit128_p(&xmm1)->int_vec;
-
-        xmm2 = _mm_mul_ps(xmm2, xmm2);
-
-        src0 += 2;
-
-        xmm1 = _mm_hadd_ps(xmm2, xmm2);
-
-        xmm3 = _mm_max_ps(xmm1, xmm3);
-
-        xmm10 = _mm_setr_epi32(2, 2, 2, 2);
-
-        xmm4.float_vec = _mm_cmplt_ps(xmm1, xmm3);
-        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
-
-        xmm11 = _mm_and_si128(xmm8, xmm5.int_vec);
-        xmm12 = _mm_and_si128(xmm9, xmm4.int_vec);
-
-        xmm9 = _mm_add_epi32(xmm11, xmm12);
-
-        xmm8 = _mm_add_epi32(xmm8, xmm10);
-    }
-
-    if (num_bytes >> 3 & 1) {
-        sq_dist =
-            lv_creal(src0[0]) * lv_creal(src0[0]) + lv_cimag(src0[0]) * lv_cimag(src0[0]);
-
-        xmm2 = _mm_load1_ps(&sq_dist);
-
-        xmm1 = xmm3;
-
-        xmm3 = _mm_max_ss(xmm3, xmm2);
-
-        xmm4.float_vec = _mm_cmplt_ps(xmm1, xmm3);
-        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
-
-        xmm8 = _mm_shuffle_epi32(xmm8, 0x00);
-
-        xmm11 = _mm_and_si128(xmm8, xmm4.int_vec);
-        xmm12 = _mm_and_si128(xmm9, xmm5.int_vec);
-
-        xmm9 = _mm_add_epi32(xmm11, xmm12);
-    }
-
-    _mm_store_ps((float*)&(holderf.f), xmm3);
-    _mm_store_si128(&(holderi.int_vec), xmm9);
-
-    target[0] = holderi.i[0];
-    sq_dist = holderf.f[0];
-    target[0] = (holderf.f[1] > sq_dist) ? holderi.i[1] : target[0];
-    sq_dist = (holderf.f[1] > sq_dist) ? holderf.f[1] : sq_dist;
-    target[0] = (holderf.f[2] > sq_dist) ? holderi.i[2] : target[0];
-    sq_dist = (holderf.f[2] > sq_dist) ? holderf.f[2] : sq_dist;
-    target[0] = (holderf.f[3] > sq_dist) ? holderi.i[3] : target[0];
-    sq_dist = (holderf.f[3] > sq_dist) ? holderf.f[3] : sq_dist;
-}
-
-#endif /*LV_HAVE_SSE3*/
 
 #ifdef LV_HAVE_GENERIC
 static inline void volk_32fc_index_max_32u_generic(uint32_t* target,
@@ -321,96 +87,6 @@ static inline void volk_32fc_index_max_32u_generic(uint32_t* target,
 }
 
 #endif /*LV_HAVE_GENERIC*/
-
-#ifdef LV_HAVE_AVX512F
-#include <immintrin.h>
-
-static inline void volk_32fc_index_max_32u_a_avx512f(uint32_t* target,
-                                                     const lv_32fc_t* src0,
-                                                     uint32_t num_points)
-{
-    const lv_32fc_t* src0Ptr = src0;
-    const uint32_t sixteenthPoints = num_points / 16;
-
-    // Index ordering after shuffle: [0,1,8,9, 2,3,10,11, 4,5,12,13, 6,7,14,15]
-    __m512 currentIndexes =
-        _mm512_setr_ps(0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15);
-    const __m512 indexIncrement = _mm512_set1_ps(16);
-
-    __m512 maxValues = _mm512_setzero_ps();
-    __m512 maxIndices = _mm512_setzero_ps();
-
-    for (uint32_t number = 0; number < sixteenthPoints; number++) {
-        // Load 16 complex values (32 floats)
-        __m512 in0 = _mm512_load_ps((const float*)src0Ptr);
-        __m512 in1 = _mm512_load_ps((const float*)(src0Ptr + 8));
-        src0Ptr += 16;
-
-        // Square all values
-        in0 = _mm512_mul_ps(in0, in0);
-        in1 = _mm512_mul_ps(in1, in1);
-
-        // Add adjacent pairs (re² + im²) using within-lane shuffle
-        // 0xB1 = _MM_SHUFFLE(2,3,0,1) swaps adjacent elements
-        __m512 sw0 = _mm512_shuffle_ps(in0, in0, 0xB1);
-        __m512 sw1 = _mm512_shuffle_ps(in1, in1, 0xB1);
-        __m512 sum0 = _mm512_add_ps(in0, sw0);
-        __m512 sum1 = _mm512_add_ps(in1, sw1);
-
-        // Compact: pick elements 0,2 from sum0 and sum1 per 128-bit lane
-        // 0x88 = _MM_SHUFFLE(2,0,2,0)
-        __m512 mag_sq = _mm512_shuffle_ps(sum0, sum1, 0x88);
-
-        // Compare and update maximums
-        __mmask16 cmpMask = _mm512_cmp_ps_mask(mag_sq, maxValues, _CMP_GT_OS);
-        maxIndices = _mm512_mask_blend_ps(cmpMask, maxIndices, currentIndexes);
-        maxValues = _mm512_max_ps(mag_sq, maxValues);
-
-        currentIndexes = _mm512_add_ps(currentIndexes, indexIncrement);
-    }
-
-    // Reduce 16 values to find maximum
-    __VOLK_ATTR_ALIGNED(64) float maxValuesBuffer[16];
-    __VOLK_ATTR_ALIGNED(64) float maxIndexesBuffer[16];
-    _mm512_store_ps(maxValuesBuffer, maxValues);
-    _mm512_store_ps(maxIndexesBuffer, maxIndices);
-
-    float max = 0.0f;
-    uint32_t index = 0;
-    for (uint32_t i = 0; i < 16; i++) {
-        if (maxValuesBuffer[i] > max) {
-            max = maxValuesBuffer[i];
-            index = (uint32_t)maxIndexesBuffer[i];
-        } else if (maxValuesBuffer[i] == max) {
-            if ((uint32_t)maxIndexesBuffer[i] < index)
-                index = (uint32_t)maxIndexesBuffer[i];
-        }
-    }
-
-    // Handle tail
-    for (uint32_t number = sixteenthPoints * 16; number < num_points; number++) {
-        const float re = lv_creal(*src0Ptr);
-        const float im = lv_cimag(*src0Ptr);
-        const float sq_dist = re * re + im * im;
-        if (sq_dist > max) {
-            max = sq_dist;
-            index = number;
-        }
-        src0Ptr++;
-    }
-    *target = index;
-}
-
-#endif /*LV_HAVE_AVX512F*/
-
-#endif /*INCLUDED_volk_32fc_index_max_32u_a_H*/
-
-#ifndef INCLUDED_volk_32fc_index_max_32u_u_H
-#define INCLUDED_volk_32fc_index_max_32u_u_H
-
-#include <inttypes.h>
-#include <volk/volk_common.h>
-#include <volk/volk_complex.h>
 
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
@@ -527,6 +203,87 @@ static inline void volk_32fc_index_max_32u_u_avx2_variant_1(uint32_t* target,
 }
 
 #endif /*LV_HAVE_AVX2*/
+
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+
+static inline void volk_32fc_index_max_32u_u_avx512f(uint32_t* target,
+                                                     const lv_32fc_t* src0,
+                                                     uint32_t num_points)
+{
+    const lv_32fc_t* src0Ptr = src0;
+    const uint32_t sixteenthPoints = num_points / 16;
+
+    // Index ordering after shuffle: [0,1,8,9, 2,3,10,11, 4,5,12,13, 6,7,14,15]
+    __m512 currentIndexes =
+        _mm512_setr_ps(0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15);
+    const __m512 indexIncrement = _mm512_set1_ps(16);
+
+    __m512 maxValues = _mm512_setzero_ps();
+    __m512 maxIndices = _mm512_setzero_ps();
+
+    for (uint32_t number = 0; number < sixteenthPoints; number++) {
+        // Load 16 complex values (32 floats)
+        __m512 in0 = _mm512_loadu_ps((const float*)src0Ptr);
+        __m512 in1 = _mm512_loadu_ps((const float*)(src0Ptr + 8));
+        src0Ptr += 16;
+
+        // Square all values
+        in0 = _mm512_mul_ps(in0, in0);
+        in1 = _mm512_mul_ps(in1, in1);
+
+        // Add adjacent pairs (re² + im²) using within-lane shuffle
+        // 0xB1 = _MM_SHUFFLE(2,3,0,1) swaps adjacent elements
+        __m512 sw0 = _mm512_shuffle_ps(in0, in0, 0xB1);
+        __m512 sw1 = _mm512_shuffle_ps(in1, in1, 0xB1);
+        __m512 sum0 = _mm512_add_ps(in0, sw0);
+        __m512 sum1 = _mm512_add_ps(in1, sw1);
+
+        // Compact: pick elements 0,2 from sum0 and sum1 per 128-bit lane
+        // 0x88 = _MM_SHUFFLE(2,0,2,0)
+        __m512 mag_sq = _mm512_shuffle_ps(sum0, sum1, 0x88);
+
+        // Compare and update maximums
+        __mmask16 cmpMask = _mm512_cmp_ps_mask(mag_sq, maxValues, _CMP_GT_OS);
+        maxIndices = _mm512_mask_blend_ps(cmpMask, maxIndices, currentIndexes);
+        maxValues = _mm512_max_ps(mag_sq, maxValues);
+
+        currentIndexes = _mm512_add_ps(currentIndexes, indexIncrement);
+    }
+
+    // Reduce 16 values to find maximum
+    __VOLK_ATTR_ALIGNED(64) float maxValuesBuffer[16];
+    __VOLK_ATTR_ALIGNED(64) float maxIndexesBuffer[16];
+    _mm512_store_ps(maxValuesBuffer, maxValues);
+    _mm512_store_ps(maxIndexesBuffer, maxIndices);
+
+    float max = 0.0f;
+    uint32_t index = 0;
+    for (uint32_t i = 0; i < 16; i++) {
+        if (maxValuesBuffer[i] > max) {
+            max = maxValuesBuffer[i];
+            index = (uint32_t)maxIndexesBuffer[i];
+        } else if (maxValuesBuffer[i] == max) {
+            if ((uint32_t)maxIndexesBuffer[i] < index)
+                index = (uint32_t)maxIndexesBuffer[i];
+        }
+    }
+
+    // Handle tail
+    for (uint32_t number = sixteenthPoints * 16; number < num_points; number++) {
+        const float re = lv_creal(*src0Ptr);
+        const float im = lv_cimag(*src0Ptr);
+        const float sq_dist = re * re + im * im;
+        if (sq_dist > max) {
+            max = sq_dist;
+            index = number;
+        }
+        src0Ptr++;
+    }
+    *target = index;
+}
+
+#endif /*LV_HAVE_AVX512F*/
 
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
@@ -658,88 +415,6 @@ static inline void volk_32fc_index_max_32u_neonv8(uint32_t* target,
 
 #endif /*LV_HAVE_NEONV8*/
 
-
-#ifdef LV_HAVE_AVX512F
-#include <immintrin.h>
-
-static inline void volk_32fc_index_max_32u_u_avx512f(uint32_t* target,
-                                                     const lv_32fc_t* src0,
-                                                     uint32_t num_points)
-{
-    const lv_32fc_t* src0Ptr = src0;
-    const uint32_t sixteenthPoints = num_points / 16;
-
-    // Index ordering after shuffle: [0,1,8,9, 2,3,10,11, 4,5,12,13, 6,7,14,15]
-    __m512 currentIndexes =
-        _mm512_setr_ps(0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15);
-    const __m512 indexIncrement = _mm512_set1_ps(16);
-
-    __m512 maxValues = _mm512_setzero_ps();
-    __m512 maxIndices = _mm512_setzero_ps();
-
-    for (uint32_t number = 0; number < sixteenthPoints; number++) {
-        // Load 16 complex values (32 floats)
-        __m512 in0 = _mm512_loadu_ps((const float*)src0Ptr);
-        __m512 in1 = _mm512_loadu_ps((const float*)(src0Ptr + 8));
-        src0Ptr += 16;
-
-        // Square all values
-        in0 = _mm512_mul_ps(in0, in0);
-        in1 = _mm512_mul_ps(in1, in1);
-
-        // Add adjacent pairs (re² + im²) using within-lane shuffle
-        // 0xB1 = _MM_SHUFFLE(2,3,0,1) swaps adjacent elements
-        __m512 sw0 = _mm512_shuffle_ps(in0, in0, 0xB1);
-        __m512 sw1 = _mm512_shuffle_ps(in1, in1, 0xB1);
-        __m512 sum0 = _mm512_add_ps(in0, sw0);
-        __m512 sum1 = _mm512_add_ps(in1, sw1);
-
-        // Compact: pick elements 0,2 from sum0 and sum1 per 128-bit lane
-        // 0x88 = _MM_SHUFFLE(2,0,2,0)
-        __m512 mag_sq = _mm512_shuffle_ps(sum0, sum1, 0x88);
-
-        // Compare and update maximums
-        __mmask16 cmpMask = _mm512_cmp_ps_mask(mag_sq, maxValues, _CMP_GT_OS);
-        maxIndices = _mm512_mask_blend_ps(cmpMask, maxIndices, currentIndexes);
-        maxValues = _mm512_max_ps(mag_sq, maxValues);
-
-        currentIndexes = _mm512_add_ps(currentIndexes, indexIncrement);
-    }
-
-    // Reduce 16 values to find maximum
-    __VOLK_ATTR_ALIGNED(64) float maxValuesBuffer[16];
-    __VOLK_ATTR_ALIGNED(64) float maxIndexesBuffer[16];
-    _mm512_store_ps(maxValuesBuffer, maxValues);
-    _mm512_store_ps(maxIndexesBuffer, maxIndices);
-
-    float max = 0.0f;
-    uint32_t index = 0;
-    for (uint32_t i = 0; i < 16; i++) {
-        if (maxValuesBuffer[i] > max) {
-            max = maxValuesBuffer[i];
-            index = (uint32_t)maxIndexesBuffer[i];
-        } else if (maxValuesBuffer[i] == max) {
-            if ((uint32_t)maxIndexesBuffer[i] < index)
-                index = (uint32_t)maxIndexesBuffer[i];
-        }
-    }
-
-    // Handle tail
-    for (uint32_t number = sixteenthPoints * 16; number < num_points; number++) {
-        const float re = lv_creal(*src0Ptr);
-        const float im = lv_cimag(*src0Ptr);
-        const float sq_dist = re * re + im * im;
-        if (sq_dist > max) {
-            max = sq_dist;
-            index = number;
-        }
-        src0Ptr++;
-    }
-    *target = index;
-}
-
-#endif /*LV_HAVE_AVX512F*/
-
 #ifdef LV_HAVE_RVV
 #include <float.h>
 #include <riscv_vector.h>
@@ -815,3 +490,327 @@ static inline void volk_32fc_index_max_32u_rvvseg(uint32_t* target,
 #endif /*LV_HAVE_RVVSEG*/
 
 #endif /*INCLUDED_volk_32fc_index_max_32u_u_H*/
+
+#ifndef INCLUDED_volk_32fc_index_max_32u_a_H
+#define INCLUDED_volk_32fc_index_max_32u_a_H
+
+#include <inttypes.h>
+#include <volk/volk_common.h>
+#include <volk/volk_complex.h>
+
+#ifdef LV_HAVE_SSE3
+#include <pmmintrin.h>
+#include <xmmintrin.h>
+
+static inline void volk_32fc_index_max_32u_a_sse3(uint32_t* target,
+                                                  const lv_32fc_t* src0,
+                                                  uint32_t num_points)
+{
+    const uint32_t num_bytes = num_points * 8;
+
+    union bit128 holderf;
+    union bit128 holderi;
+    float sq_dist = 0.0;
+
+    union bit128 xmm5, xmm4;
+    __m128 xmm1, xmm2, xmm3;
+    __m128i xmm8, xmm11, xmm12, xmm9, xmm10;
+
+    xmm5.int_vec = _mm_setzero_si128();
+    xmm4.int_vec = _mm_setzero_si128();
+    holderf.int_vec = _mm_setzero_si128();
+    holderi.int_vec = _mm_setzero_si128();
+
+    int bound = num_bytes >> 5;
+    int i = 0;
+
+    xmm8 = _mm_setr_epi32(0, 1, 2, 3);
+    xmm9 = _mm_setzero_si128();
+    xmm10 = _mm_setr_epi32(4, 4, 4, 4);
+    xmm3 = _mm_setzero_ps();
+
+    for (; i < bound; ++i) {
+        xmm1 = _mm_load_ps((const float*)src0);
+        xmm2 = _mm_load_ps((const float*)&src0[2]);
+
+        src0 += 4;
+
+        xmm1 = _mm_mul_ps(xmm1, xmm1);
+        xmm2 = _mm_mul_ps(xmm2, xmm2);
+
+        xmm1 = _mm_hadd_ps(xmm1, xmm2);
+
+        xmm3 = _mm_max_ps(xmm1, xmm3);
+
+        xmm4.float_vec = _mm_cmplt_ps(xmm1, xmm3);
+        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
+
+        xmm11 = _mm_and_si128(xmm8, xmm5.int_vec);
+        xmm12 = _mm_and_si128(xmm9, xmm4.int_vec);
+
+        xmm9 = _mm_add_epi32(xmm11, xmm12);
+
+        xmm8 = _mm_add_epi32(xmm8, xmm10);
+    }
+
+    if (num_bytes >> 4 & 1) {
+        xmm2 = _mm_load_ps((const float*)src0);
+
+        xmm1 = _mm_movelh_ps(bit128_p(&xmm8)->float_vec, bit128_p(&xmm8)->float_vec);
+        xmm8 = bit128_p(&xmm1)->int_vec;
+
+        xmm2 = _mm_mul_ps(xmm2, xmm2);
+
+        src0 += 2;
+
+        xmm1 = _mm_hadd_ps(xmm2, xmm2);
+
+        xmm3 = _mm_max_ps(xmm1, xmm3);
+
+        xmm10 = _mm_setr_epi32(2, 2, 2, 2);
+
+        xmm4.float_vec = _mm_cmplt_ps(xmm1, xmm3);
+        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
+
+        xmm11 = _mm_and_si128(xmm8, xmm5.int_vec);
+        xmm12 = _mm_and_si128(xmm9, xmm4.int_vec);
+
+        xmm9 = _mm_add_epi32(xmm11, xmm12);
+
+        xmm8 = _mm_add_epi32(xmm8, xmm10);
+    }
+
+    if (num_bytes >> 3 & 1) {
+        sq_dist =
+            lv_creal(src0[0]) * lv_creal(src0[0]) + lv_cimag(src0[0]) * lv_cimag(src0[0]);
+
+        xmm2 = _mm_load1_ps(&sq_dist);
+
+        xmm1 = xmm3;
+
+        xmm3 = _mm_max_ss(xmm3, xmm2);
+
+        xmm4.float_vec = _mm_cmplt_ps(xmm1, xmm3);
+        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
+
+        xmm8 = _mm_shuffle_epi32(xmm8, 0x00);
+
+        xmm11 = _mm_and_si128(xmm8, xmm4.int_vec);
+        xmm12 = _mm_and_si128(xmm9, xmm5.int_vec);
+
+        xmm9 = _mm_add_epi32(xmm11, xmm12);
+    }
+
+    _mm_store_ps((float*)&(holderf.f), xmm3);
+    _mm_store_si128(&(holderi.int_vec), xmm9);
+
+    target[0] = holderi.i[0];
+    sq_dist = holderf.f[0];
+    target[0] = (holderf.f[1] > sq_dist) ? holderi.i[1] : target[0];
+    sq_dist = (holderf.f[1] > sq_dist) ? holderf.f[1] : sq_dist;
+    target[0] = (holderf.f[2] > sq_dist) ? holderi.i[2] : target[0];
+    sq_dist = (holderf.f[2] > sq_dist) ? holderf.f[2] : sq_dist;
+    target[0] = (holderf.f[3] > sq_dist) ? holderi.i[3] : target[0];
+    sq_dist = (holderf.f[3] > sq_dist) ? holderf.f[3] : sq_dist;
+}
+
+#endif /*LV_HAVE_SSE3*/
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+#include <volk/volk_avx2_intrinsics.h>
+
+static inline void volk_32fc_index_max_32u_a_avx2_variant_0(uint32_t* target,
+                                                            const lv_32fc_t* src0,
+                                                            uint32_t num_points)
+{
+    const __m256i indices_increment = _mm256_set1_epi32(8);
+    /*
+     * At the start of each loop iteration current_indices holds the indices of
+     * the complex numbers loaded from memory. Explanation for odd order is given
+     * in implementation of vector_32fc_index_max_variant0().
+     */
+    __m256i current_indices = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
+
+    __m256 max_values = _mm256_setzero_ps();
+    __m256i max_indices = _mm256_setzero_si256();
+
+    for (unsigned i = 0; i < num_points / 8u; ++i) {
+        __m256 in0 = _mm256_load_ps((const float*)src0);
+        __m256 in1 = _mm256_load_ps((const float*)(src0 + 4));
+        vector_32fc_index_max_variant0(
+            in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
+        src0 += 8;
+    }
+
+    // determine maximum value and index in the result of the vectorized loop
+    __VOLK_ATTR_ALIGNED(32) float max_values_buffer[8];
+    __VOLK_ATTR_ALIGNED(32) uint32_t max_indices_buffer[8];
+    _mm256_store_ps(max_values_buffer, max_values);
+    _mm256_store_si256((__m256i*)max_indices_buffer, max_indices);
+
+    float max = 0.f;
+    uint32_t index = 0;
+    for (unsigned i = 0; i < 8; i++) {
+        if (max_values_buffer[i] > max) {
+            max = max_values_buffer[i];
+            index = max_indices_buffer[i];
+        }
+    }
+
+    // handle tail not processed by the vectorized loop
+    for (unsigned i = num_points & (~7u); i < num_points; ++i) {
+        const float abs_squared =
+            lv_creal(*src0) * lv_creal(*src0) + lv_cimag(*src0) * lv_cimag(*src0);
+        if (abs_squared > max) {
+            max = abs_squared;
+            index = i;
+        }
+        ++src0;
+    }
+
+    *target = index;
+}
+
+#endif /*LV_HAVE_AVX2*/
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+#include <volk/volk_avx2_intrinsics.h>
+
+static inline void volk_32fc_index_max_32u_a_avx2_variant_1(uint32_t* target,
+                                                            const lv_32fc_t* src0,
+                                                            uint32_t num_points)
+{
+    const __m256i indices_increment = _mm256_set1_epi32(8);
+    /*
+     * At the start of each loop iteration current_indices holds the indices of
+     * the complex numbers loaded from memory. Explanation for odd order is given
+     * in implementation of vector_32fc_index_max_variant0().
+     */
+    __m256i current_indices = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
+
+    __m256 max_values = _mm256_setzero_ps();
+    __m256i max_indices = _mm256_setzero_si256();
+
+    for (unsigned i = 0; i < num_points / 8u; ++i) {
+        __m256 in0 = _mm256_load_ps((const float*)src0);
+        __m256 in1 = _mm256_load_ps((const float*)(src0 + 4));
+        vector_32fc_index_max_variant1(
+            in0, in1, &max_values, &max_indices, &current_indices, indices_increment);
+        src0 += 8;
+    }
+
+    // determine maximum value and index in the result of the vectorized loop
+    __VOLK_ATTR_ALIGNED(32) float max_values_buffer[8];
+    __VOLK_ATTR_ALIGNED(32) uint32_t max_indices_buffer[8];
+    _mm256_store_ps(max_values_buffer, max_values);
+    _mm256_store_si256((__m256i*)max_indices_buffer, max_indices);
+
+    float max = 0.f;
+    uint32_t index = 0;
+    for (unsigned i = 0; i < 8; i++) {
+        if (max_values_buffer[i] > max) {
+            max = max_values_buffer[i];
+            index = max_indices_buffer[i];
+        }
+    }
+
+    // handle tail not processed by the vectorized loop
+    for (unsigned i = num_points & (~7u); i < num_points; ++i) {
+        const float abs_squared =
+            lv_creal(*src0) * lv_creal(*src0) + lv_cimag(*src0) * lv_cimag(*src0);
+        if (abs_squared > max) {
+            max = abs_squared;
+            index = i;
+        }
+        ++src0;
+    }
+
+    *target = index;
+}
+
+#endif /*LV_HAVE_AVX2*/
+
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+
+static inline void volk_32fc_index_max_32u_a_avx512f(uint32_t* target,
+                                                     const lv_32fc_t* src0,
+                                                     uint32_t num_points)
+{
+    const lv_32fc_t* src0Ptr = src0;
+    const uint32_t sixteenthPoints = num_points / 16;
+
+    // Index ordering after shuffle: [0,1,8,9, 2,3,10,11, 4,5,12,13, 6,7,14,15]
+    __m512 currentIndexes =
+        _mm512_setr_ps(0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15);
+    const __m512 indexIncrement = _mm512_set1_ps(16);
+
+    __m512 maxValues = _mm512_setzero_ps();
+    __m512 maxIndices = _mm512_setzero_ps();
+
+    for (uint32_t number = 0; number < sixteenthPoints; number++) {
+        // Load 16 complex values (32 floats)
+        __m512 in0 = _mm512_load_ps((const float*)src0Ptr);
+        __m512 in1 = _mm512_load_ps((const float*)(src0Ptr + 8));
+        src0Ptr += 16;
+
+        // Square all values
+        in0 = _mm512_mul_ps(in0, in0);
+        in1 = _mm512_mul_ps(in1, in1);
+
+        // Add adjacent pairs (re² + im²) using within-lane shuffle
+        // 0xB1 = _MM_SHUFFLE(2,3,0,1) swaps adjacent elements
+        __m512 sw0 = _mm512_shuffle_ps(in0, in0, 0xB1);
+        __m512 sw1 = _mm512_shuffle_ps(in1, in1, 0xB1);
+        __m512 sum0 = _mm512_add_ps(in0, sw0);
+        __m512 sum1 = _mm512_add_ps(in1, sw1);
+
+        // Compact: pick elements 0,2 from sum0 and sum1 per 128-bit lane
+        // 0x88 = _MM_SHUFFLE(2,0,2,0)
+        __m512 mag_sq = _mm512_shuffle_ps(sum0, sum1, 0x88);
+
+        // Compare and update maximums
+        __mmask16 cmpMask = _mm512_cmp_ps_mask(mag_sq, maxValues, _CMP_GT_OS);
+        maxIndices = _mm512_mask_blend_ps(cmpMask, maxIndices, currentIndexes);
+        maxValues = _mm512_max_ps(mag_sq, maxValues);
+
+        currentIndexes = _mm512_add_ps(currentIndexes, indexIncrement);
+    }
+
+    // Reduce 16 values to find maximum
+    __VOLK_ATTR_ALIGNED(64) float maxValuesBuffer[16];
+    __VOLK_ATTR_ALIGNED(64) float maxIndexesBuffer[16];
+    _mm512_store_ps(maxValuesBuffer, maxValues);
+    _mm512_store_ps(maxIndexesBuffer, maxIndices);
+
+    float max = 0.0f;
+    uint32_t index = 0;
+    for (uint32_t i = 0; i < 16; i++) {
+        if (maxValuesBuffer[i] > max) {
+            max = maxValuesBuffer[i];
+            index = (uint32_t)maxIndexesBuffer[i];
+        } else if (maxValuesBuffer[i] == max) {
+            if ((uint32_t)maxIndexesBuffer[i] < index)
+                index = (uint32_t)maxIndexesBuffer[i];
+        }
+    }
+
+    // Handle tail
+    for (uint32_t number = sixteenthPoints * 16; number < num_points; number++) {
+        const float re = lv_creal(*src0Ptr);
+        const float im = lv_cimag(*src0Ptr);
+        const float sq_dist = re * re + im * im;
+        if (sq_dist > max) {
+            max = sq_dist;
+            index = number;
+        }
+        src0Ptr++;
+    }
+    *target = index;
+}
+
+#endif /*LV_HAVE_AVX512F*/
+
+#endif /*INCLUDED_volk_32fc_index_max_32u_a_H*/

--- a/kernels/volk/volk_32fc_index_min_16u.h
+++ b/kernels/volk/volk_32fc_index_min_16u.h
@@ -91,8 +91,8 @@ static inline void volk_32fc_index_min_16u_a_avx2_variant_0(uint16_t* target,
     __m256i min_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((float*)source);
-        __m256 in1 = _mm256_load_ps((float*)(source + 4));
+        __m256 in0 = _mm256_load_ps((const float*)source);
+        __m256 in1 = _mm256_load_ps((const float*)(source + 4));
         vector_32fc_index_min_variant0(
             in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
         source += 8;
@@ -151,8 +151,8 @@ static inline void volk_32fc_index_min_16u_a_avx2_variant_1(uint16_t* target,
     __m256i min_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((float*)source);
-        __m256 in1 = _mm256_load_ps((float*)(source + 4));
+        __m256 in0 = _mm256_load_ps((const float*)source);
+        __m256 in1 = _mm256_load_ps((const float*)(source + 4));
         vector_32fc_index_min_variant1(
             in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
         source += 8;
@@ -220,8 +220,8 @@ static inline void volk_32fc_index_min_16u_a_sse3(uint16_t* target,
     int bound = num_points >> 2;
 
     for (int i = 0; i < bound; ++i) {
-        xmm1 = _mm_load_ps((float*)source);
-        xmm2 = _mm_load_ps((float*)&source[2]);
+        xmm1 = _mm_load_ps((const float*)source);
+        xmm2 = _mm_load_ps((const float*)&source[2]);
 
         source += 4;
 
@@ -244,7 +244,7 @@ static inline void volk_32fc_index_min_16u_a_sse3(uint16_t* target,
     }
 
     if (num_points >> 1 & 1) {
-        xmm2 = _mm_load_ps((float*)source);
+        xmm2 = _mm_load_ps((const float*)source);
 
         xmm1 = _mm_movelh_ps(bit128_p(&xmm8)->float_vec, bit128_p(&xmm8)->float_vec);
         xmm8 = bit128_p(&xmm1)->int_vec;
@@ -594,8 +594,8 @@ static inline void volk_32fc_index_min_16u_u_avx2_variant_0(uint16_t* target,
     __m256i min_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_loadu_ps((float*)source);
-        __m256 in1 = _mm256_loadu_ps((float*)(source + 4));
+        __m256 in0 = _mm256_loadu_ps((const float*)source);
+        __m256 in1 = _mm256_loadu_ps((const float*)(source + 4));
         vector_32fc_index_min_variant0(
             in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
         source += 8;
@@ -654,8 +654,8 @@ static inline void volk_32fc_index_min_16u_u_avx2_variant_1(uint16_t* target,
     __m256i min_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_loadu_ps((float*)source);
-        __m256 in1 = _mm256_loadu_ps((float*)(source + 4));
+        __m256 in0 = _mm256_loadu_ps((const float*)source);
+        __m256 in1 = _mm256_loadu_ps((const float*)(source + 4));
         vector_32fc_index_min_variant1(
             in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
         source += 8;

--- a/kernels/volk/volk_32fc_index_min_16u.h
+++ b/kernels/volk/volk_32fc_index_min_16u.h
@@ -60,396 +60,14 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32fc_index_min_16u_a_H
-#define INCLUDED_volk_32fc_index_min_16u_a_H
+#ifndef INCLUDED_volk_32fc_index_min_16u_u_H
+#define INCLUDED_volk_32fc_index_min_16u_u_H
 
 #include <inttypes.h>
 #include <limits.h>
 #include <stdio.h>
 #include <volk/volk_common.h>
 #include <volk/volk_complex.h>
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-#include <volk/volk_avx2_intrinsics.h>
-
-static inline void volk_32fc_index_min_16u_a_avx2_variant_0(uint16_t* target,
-                                                            const lv_32fc_t* source,
-                                                            uint32_t num_points)
-{
-    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
-
-    const __m256i indices_increment = _mm256_set1_epi32(8);
-    /*
-     * At the start of each loop iteration current_indices holds the indices of
-     * the complex numbers loaded from memory. Explanation for odd order is given
-     * in implementation of vector_32fc_index_min_variant0().
-     */
-    __m256i current_indices = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
-
-    __m256 min_values = _mm256_set1_ps(FLT_MAX);
-    __m256i min_indices = _mm256_setzero_si256();
-
-    for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((const float*)source);
-        __m256 in1 = _mm256_load_ps((const float*)(source + 4));
-        vector_32fc_index_min_variant0(
-            in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
-        source += 8;
-    }
-
-    // determine minimum value and index in the result of the vectorized loop
-    __VOLK_ATTR_ALIGNED(32) float min_values_buffer[8];
-    __VOLK_ATTR_ALIGNED(32) uint32_t min_indices_buffer[8];
-    _mm256_store_ps(min_values_buffer, min_values);
-    _mm256_store_si256((__m256i*)min_indices_buffer, min_indices);
-
-    float min = FLT_MAX;
-    uint32_t index = 0;
-    for (unsigned i = 0; i < 8; i++) {
-        if (min_values_buffer[i] < min) {
-            min = min_values_buffer[i];
-            index = min_indices_buffer[i];
-        }
-    }
-
-    // handle tail not processed by the vectorized loop
-    for (unsigned i = num_points & (~7u); i < num_points; ++i) {
-        const float abs_squared =
-            lv_creal(*source) * lv_creal(*source) + lv_cimag(*source) * lv_cimag(*source);
-        if (abs_squared < min) {
-            min = abs_squared;
-            index = i;
-        }
-        ++source;
-    }
-
-    *target = index;
-}
-
-#endif /*LV_HAVE_AVX2*/
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-#include <volk/volk_avx2_intrinsics.h>
-
-static inline void volk_32fc_index_min_16u_a_avx2_variant_1(uint16_t* target,
-                                                            const lv_32fc_t* source,
-                                                            uint32_t num_points)
-{
-    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
-
-    const __m256i indices_increment = _mm256_set1_epi32(8);
-    /*
-     * At the start of each loop iteration current_indices holds the indices of
-     * the complex numbers loaded from memory. Explanation for odd order is given
-     * in implementation of vector_32fc_index_min_variant0().
-     */
-    __m256i current_indices = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
-
-    __m256 min_values = _mm256_set1_ps(FLT_MAX);
-    __m256i min_indices = _mm256_setzero_si256();
-
-    for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((const float*)source);
-        __m256 in1 = _mm256_load_ps((const float*)(source + 4));
-        vector_32fc_index_min_variant1(
-            in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
-        source += 8;
-    }
-
-    // determine minimum value and index in the result of the vectorized loop
-    __VOLK_ATTR_ALIGNED(32) float min_values_buffer[8];
-    __VOLK_ATTR_ALIGNED(32) uint32_t min_indices_buffer[8];
-    _mm256_store_ps(min_values_buffer, min_values);
-    _mm256_store_si256((__m256i*)min_indices_buffer, min_indices);
-
-    float min = FLT_MAX;
-    uint32_t index = 0;
-    for (unsigned i = 0; i < 8; i++) {
-        if (min_values_buffer[i] < min) {
-            min = min_values_buffer[i];
-            index = min_indices_buffer[i];
-        }
-    }
-
-    // handle tail not processed by the vectorized loop
-    for (unsigned i = num_points & (~7u); i < num_points; ++i) {
-        const float abs_squared =
-            lv_creal(*source) * lv_creal(*source) + lv_cimag(*source) * lv_cimag(*source);
-        if (abs_squared < min) {
-            min = abs_squared;
-            index = i;
-        }
-        ++source;
-    }
-
-    *target = index;
-}
-
-#endif /*LV_HAVE_AVX2*/
-
-#ifdef LV_HAVE_SSE3
-#include <pmmintrin.h>
-#include <xmmintrin.h>
-
-static inline void volk_32fc_index_min_16u_a_sse3(uint16_t* target,
-                                                  const lv_32fc_t* source,
-                                                  uint32_t num_points)
-{
-    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
-
-    union bit128 holderf;
-    union bit128 holderi;
-    float sq_dist = 0.0;
-
-    union bit128 xmm5, xmm4;
-    __m128 xmm1, xmm2, xmm3;
-    __m128i xmm8, xmm11, xmm12, xmm9, xmm10;
-
-    xmm5.int_vec = _mm_setzero_si128();
-    xmm4.int_vec = _mm_setzero_si128();
-    holderf.int_vec = _mm_setzero_si128();
-    holderi.int_vec = _mm_setzero_si128();
-
-    xmm8 = _mm_setr_epi32(0, 1, 2, 3);
-    xmm9 = _mm_setzero_si128();
-    xmm10 = _mm_setr_epi32(4, 4, 4, 4);
-    xmm3 = _mm_set_ps1(FLT_MAX);
-
-    int bound = num_points >> 2;
-
-    for (int i = 0; i < bound; ++i) {
-        xmm1 = _mm_load_ps((const float*)source);
-        xmm2 = _mm_load_ps((const float*)&source[2]);
-
-        source += 4;
-
-        xmm1 = _mm_mul_ps(xmm1, xmm1);
-        xmm2 = _mm_mul_ps(xmm2, xmm2);
-
-        xmm1 = _mm_hadd_ps(xmm1, xmm2);
-
-        xmm3 = _mm_min_ps(xmm1, xmm3);
-
-        xmm4.float_vec = _mm_cmpgt_ps(xmm1, xmm3);
-        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
-
-        xmm11 = _mm_and_si128(xmm8, xmm5.int_vec);
-        xmm12 = _mm_and_si128(xmm9, xmm4.int_vec);
-
-        xmm9 = _mm_add_epi32(xmm11, xmm12);
-
-        xmm8 = _mm_add_epi32(xmm8, xmm10);
-    }
-
-    if (num_points >> 1 & 1) {
-        xmm2 = _mm_load_ps((const float*)source);
-
-        xmm1 = _mm_movelh_ps(bit128_p(&xmm8)->float_vec, bit128_p(&xmm8)->float_vec);
-        xmm8 = bit128_p(&xmm1)->int_vec;
-
-        xmm2 = _mm_mul_ps(xmm2, xmm2);
-
-        source += 2;
-
-        xmm1 = _mm_hadd_ps(xmm2, xmm2);
-
-        xmm3 = _mm_min_ps(xmm1, xmm3);
-
-        xmm10 = _mm_setr_epi32(2, 2, 2, 2);
-
-        xmm4.float_vec = _mm_cmpgt_ps(xmm1, xmm3);
-        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
-
-        xmm11 = _mm_and_si128(xmm8, xmm5.int_vec);
-        xmm12 = _mm_and_si128(xmm9, xmm4.int_vec);
-
-        xmm9 = _mm_add_epi32(xmm11, xmm12);
-
-        xmm8 = _mm_add_epi32(xmm8, xmm10);
-    }
-
-    if (num_points & 1) {
-        sq_dist = lv_creal(source[0]) * lv_creal(source[0]) +
-                  lv_cimag(source[0]) * lv_cimag(source[0]);
-
-        xmm2 = _mm_load1_ps(&sq_dist);
-
-        xmm1 = xmm3;
-
-        xmm3 = _mm_min_ss(xmm3, xmm2);
-
-        xmm4.float_vec = _mm_cmpgt_ps(xmm1, xmm3);
-        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
-
-        xmm8 = _mm_shuffle_epi32(xmm8, 0x00);
-
-        xmm11 = _mm_and_si128(xmm8, xmm4.int_vec);
-        xmm12 = _mm_and_si128(xmm9, xmm5.int_vec);
-
-        xmm9 = _mm_add_epi32(xmm11, xmm12);
-    }
-
-    _mm_store_ps((float*)&(holderf.f), xmm3);
-    _mm_store_si128(&(holderi.int_vec), xmm9);
-
-    target[0] = holderi.i[0];
-    sq_dist = holderf.f[0];
-    target[0] = (holderf.f[1] < sq_dist) ? holderi.i[1] : target[0];
-    sq_dist = (holderf.f[1] < sq_dist) ? holderf.f[1] : sq_dist;
-    target[0] = (holderf.f[2] < sq_dist) ? holderi.i[2] : target[0];
-    sq_dist = (holderf.f[2] < sq_dist) ? holderf.f[2] : sq_dist;
-    target[0] = (holderf.f[3] < sq_dist) ? holderi.i[3] : target[0];
-    sq_dist = (holderf.f[3] < sq_dist) ? holderf.f[3] : sq_dist;
-}
-
-#endif /*LV_HAVE_SSE3*/
-
-
-#ifdef LV_HAVE_NEON
-#include <arm_neon.h>
-#include <float.h>
-#include <limits.h>
-#include <volk/volk_neon_intrinsics.h>
-
-static inline void volk_32fc_index_min_16u_neon(uint16_t* target,
-                                                const lv_32fc_t* source,
-                                                uint32_t num_points)
-{
-    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
-
-    if (num_points == 0)
-        return;
-
-    const uint32_t quarter_points = num_points / 4;
-    const lv_32fc_t* inputPtr = source;
-
-    // Use integer indices directly
-    uint32x4_t vec_indices = { 0, 1, 2, 3 };
-    const uint32x4_t vec_incr = vdupq_n_u32(4);
-
-    float32x4_t vec_min = vdupq_n_f32(FLT_MAX);
-    uint32x4_t vec_min_idx = vdupq_n_u32(0);
-
-    for (uint32_t i = 0; i < quarter_points; i++) {
-        // Load and deinterleave complex values
-        float32x4x2_t cplx = vld2q_f32((const float*)inputPtr);
-        inputPtr += 4;
-
-        // Magnitude squared: re*re + im*im
-        float32x4_t mag2 =
-            vmlaq_f32(vmulq_f32(cplx.val[0], cplx.val[0]), cplx.val[1], cplx.val[1]);
-
-        // Compare BEFORE min update to know which lanes change
-        uint32x4_t lt_mask = vcltq_f32(mag2, vec_min);
-        vec_min_idx = vbslq_u32(lt_mask, vec_indices, vec_min_idx);
-
-        // vminq_f32 is single-cycle, no dependency on comparison result
-        vec_min = vminq_f32(mag2, vec_min);
-
-        vec_indices = vaddq_u32(vec_indices, vec_incr);
-    }
-
-    // Scalar reduction
-    __VOLK_ATTR_ALIGNED(16) float min_buf[4];
-    __VOLK_ATTR_ALIGNED(16) uint32_t idx_buf[4];
-    vst1q_f32(min_buf, vec_min);
-    vst1q_u32(idx_buf, vec_min_idx);
-
-    float min_val = min_buf[0];
-    uint32_t result_idx = idx_buf[0];
-    for (int i = 1; i < 4; i++) {
-        if (min_buf[i] < min_val) {
-            min_val = min_buf[i];
-            result_idx = idx_buf[i];
-        } else if (min_buf[i] == min_val && idx_buf[i] < result_idx) {
-            result_idx = idx_buf[i];
-        }
-    }
-
-    // Handle tail
-    for (uint32_t i = quarter_points * 4; i < num_points; i++) {
-        float re = lv_creal(source[i]);
-        float im = lv_cimag(source[i]);
-        float mag2 = re * re + im * im;
-        if (mag2 < min_val) {
-            min_val = mag2;
-            result_idx = i;
-        }
-    }
-
-    *target = (uint16_t)result_idx;
-}
-
-#endif /*LV_HAVE_NEON*/
-
-
-#ifdef LV_HAVE_NEONV8
-#include <arm_neon.h>
-#include <float.h>
-#include <limits.h>
-
-static inline void volk_32fc_index_min_16u_neonv8(uint16_t* target,
-                                                  const lv_32fc_t* source,
-                                                  uint32_t num_points)
-{
-    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
-
-    if (num_points == 0)
-        return;
-
-    const uint32_t quarter_points = num_points / 4;
-    const lv_32fc_t* inputPtr = source;
-
-    // Use integer indices directly (no float conversion overhead)
-    uint32x4_t vec_indices = { 0, 1, 2, 3 };
-    const uint32x4_t vec_incr = vdupq_n_u32(4);
-
-    float32x4_t vec_min = vdupq_n_f32(FLT_MAX);
-    uint32x4_t vec_min_idx = vdupq_n_u32(0);
-
-    for (uint32_t i = 0; i < quarter_points; i++) {
-        // Load and deinterleave complex values
-        float32x4x2_t cplx = vld2q_f32((const float*)inputPtr);
-        inputPtr += 4;
-
-        // Magnitude squared using FMA: re*re + im*im
-        float32x4_t mag2 =
-            vfmaq_f32(vmulq_f32(cplx.val[0], cplx.val[0]), cplx.val[1], cplx.val[1]);
-
-        // Compare BEFORE min update to know which lanes change
-        uint32x4_t lt_mask = vcltq_f32(mag2, vec_min);
-        vec_min_idx = vbslq_u32(lt_mask, vec_indices, vec_min_idx);
-
-        // vminq_f32 is single-cycle, no dependency on comparison result
-        vec_min = vminq_f32(mag2, vec_min);
-
-        vec_indices = vaddq_u32(vec_indices, vec_incr);
-    }
-
-    // ARMv8 horizontal reduction
-    float min_val = vminvq_f32(vec_min);
-    uint32x4_t min_mask = vceqq_f32(vec_min, vdupq_n_f32(min_val));
-    uint32x4_t idx_masked = vbslq_u32(min_mask, vec_min_idx, vdupq_n_u32(UINT32_MAX));
-    uint32_t result_idx = vminvq_u32(idx_masked);
-
-    // Handle tail
-    for (uint32_t i = quarter_points * 4; i < num_points; i++) {
-        float re = lv_creal(source[i]);
-        float im = lv_cimag(source[i]);
-        float mag2 = re * re + im * im;
-        if (mag2 < min_val) {
-            min_val = mag2;
-            result_idx = i;
-        }
-    }
-
-    *target = (uint16_t)result_idx;
-}
-
-#endif /*LV_HAVE_NEONV8*/
-
 
 #ifdef LV_HAVE_GENERIC
 static inline void volk_32fc_index_min_16u_generic(uint16_t* target,
@@ -475,102 +93,6 @@ static inline void volk_32fc_index_min_16u_generic(uint16_t* target,
 }
 
 #endif /*LV_HAVE_GENERIC*/
-
-#ifdef LV_HAVE_AVX512F
-#include <float.h>
-#include <immintrin.h>
-#include <limits.h>
-
-static inline void volk_32fc_index_min_16u_a_avx512f(uint16_t* target,
-                                                     const lv_32fc_t* src0,
-                                                     uint32_t num_points)
-{
-    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
-
-    const lv_32fc_t* src0Ptr = src0;
-    const uint32_t sixteenthPoints = num_points / 16;
-
-    // Index ordering after shuffle: [0,1,8,9, 2,3,10,11, 4,5,12,13, 6,7,14,15]
-    __m512 currentIndexes =
-        _mm512_setr_ps(0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15);
-    const __m512 indexIncrement = _mm512_set1_ps(16);
-
-    __m512 minValues = _mm512_set1_ps(FLT_MAX);
-    __m512 minIndices = _mm512_setzero_ps();
-
-    for (uint32_t number = 0; number < sixteenthPoints; number++) {
-        // Load 16 complex values (32 floats)
-        __m512 in0 = _mm512_load_ps((const float*)src0Ptr);
-        __m512 in1 = _mm512_load_ps((const float*)(src0Ptr + 8));
-        src0Ptr += 16;
-
-        // Square all values
-        in0 = _mm512_mul_ps(in0, in0);
-        in1 = _mm512_mul_ps(in1, in1);
-
-        // Add adjacent pairs (re² + im²) using within-lane shuffle
-        // 0xB1 = _MM_SHUFFLE(2,3,0,1) swaps adjacent elements
-        __m512 sw0 = _mm512_shuffle_ps(in0, in0, 0xB1);
-        __m512 sw1 = _mm512_shuffle_ps(in1, in1, 0xB1);
-        __m512 sum0 = _mm512_add_ps(in0, sw0);
-        __m512 sum1 = _mm512_add_ps(in1, sw1);
-
-        // Compact: pick elements 0,2 from sum0 and sum1 per 128-bit lane
-        // 0x88 = _MM_SHUFFLE(2,0,2,0)
-        __m512 mag_sq = _mm512_shuffle_ps(sum0, sum1, 0x88);
-
-        // Compare and update minimums
-        __mmask16 cmpMask = _mm512_cmp_ps_mask(mag_sq, minValues, _CMP_LT_OS);
-        minIndices = _mm512_mask_blend_ps(cmpMask, minIndices, currentIndexes);
-        minValues = _mm512_min_ps(mag_sq, minValues);
-
-        currentIndexes = _mm512_add_ps(currentIndexes, indexIncrement);
-    }
-
-    // Reduce 16 values to find minimum
-    __VOLK_ATTR_ALIGNED(64) float minValuesBuffer[16];
-    __VOLK_ATTR_ALIGNED(64) float minIndexesBuffer[16];
-    _mm512_store_ps(minValuesBuffer, minValues);
-    _mm512_store_ps(minIndexesBuffer, minIndices);
-
-    float min = FLT_MAX;
-    uint32_t index = 0;
-    for (uint32_t i = 0; i < 16; i++) {
-        if (minValuesBuffer[i] < min) {
-            min = minValuesBuffer[i];
-            index = (uint32_t)minIndexesBuffer[i];
-        } else if (minValuesBuffer[i] == min) {
-            if ((uint32_t)minIndexesBuffer[i] < index)
-                index = (uint32_t)minIndexesBuffer[i];
-        }
-    }
-
-    // Handle tail
-    for (uint32_t number = sixteenthPoints * 16; number < num_points; number++) {
-        const float re = lv_creal(*src0Ptr);
-        const float im = lv_cimag(*src0Ptr);
-        const float sq_dist = re * re + im * im;
-        if (sq_dist < min) {
-            min = sq_dist;
-            index = number;
-        }
-        src0Ptr++;
-    }
-    *target = (uint16_t)index;
-}
-
-#endif /*LV_HAVE_AVX512F*/
-
-#endif /*INCLUDED_volk_32fc_index_min_16u_a_H*/
-
-#ifndef INCLUDED_volk_32fc_index_min_16u_u_H
-#define INCLUDED_volk_32fc_index_min_16u_u_H
-
-#include <inttypes.h>
-#include <limits.h>
-#include <stdio.h>
-#include <volk/volk_common.h>
-#include <volk/volk_complex.h>
 
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
@@ -777,6 +299,149 @@ static inline void volk_32fc_index_min_16u_u_avx512f(uint16_t* target,
 
 #endif /*LV_HAVE_AVX512F*/
 
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+#include <float.h>
+#include <limits.h>
+#include <volk/volk_neon_intrinsics.h>
+
+static inline void volk_32fc_index_min_16u_neon(uint16_t* target,
+                                                const lv_32fc_t* source,
+                                                uint32_t num_points)
+{
+    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
+
+    if (num_points == 0)
+        return;
+
+    const uint32_t quarter_points = num_points / 4;
+    const lv_32fc_t* inputPtr = source;
+
+    // Use integer indices directly
+    uint32x4_t vec_indices = { 0, 1, 2, 3 };
+    const uint32x4_t vec_incr = vdupq_n_u32(4);
+
+    float32x4_t vec_min = vdupq_n_f32(FLT_MAX);
+    uint32x4_t vec_min_idx = vdupq_n_u32(0);
+
+    for (uint32_t i = 0; i < quarter_points; i++) {
+        // Load and deinterleave complex values
+        float32x4x2_t cplx = vld2q_f32((const float*)inputPtr);
+        inputPtr += 4;
+
+        // Magnitude squared: re*re + im*im
+        float32x4_t mag2 =
+            vmlaq_f32(vmulq_f32(cplx.val[0], cplx.val[0]), cplx.val[1], cplx.val[1]);
+
+        // Compare BEFORE min update to know which lanes change
+        uint32x4_t lt_mask = vcltq_f32(mag2, vec_min);
+        vec_min_idx = vbslq_u32(lt_mask, vec_indices, vec_min_idx);
+
+        // vminq_f32 is single-cycle, no dependency on comparison result
+        vec_min = vminq_f32(mag2, vec_min);
+
+        vec_indices = vaddq_u32(vec_indices, vec_incr);
+    }
+
+    // Scalar reduction
+    __VOLK_ATTR_ALIGNED(16) float min_buf[4];
+    __VOLK_ATTR_ALIGNED(16) uint32_t idx_buf[4];
+    vst1q_f32(min_buf, vec_min);
+    vst1q_u32(idx_buf, vec_min_idx);
+
+    float min_val = min_buf[0];
+    uint32_t result_idx = idx_buf[0];
+    for (int i = 1; i < 4; i++) {
+        if (min_buf[i] < min_val) {
+            min_val = min_buf[i];
+            result_idx = idx_buf[i];
+        } else if (min_buf[i] == min_val && idx_buf[i] < result_idx) {
+            result_idx = idx_buf[i];
+        }
+    }
+
+    // Handle tail
+    for (uint32_t i = quarter_points * 4; i < num_points; i++) {
+        float re = lv_creal(source[i]);
+        float im = lv_cimag(source[i]);
+        float mag2 = re * re + im * im;
+        if (mag2 < min_val) {
+            min_val = mag2;
+            result_idx = i;
+        }
+    }
+
+    *target = (uint16_t)result_idx;
+}
+
+#endif /*LV_HAVE_NEON*/
+
+
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+#include <float.h>
+#include <limits.h>
+
+static inline void volk_32fc_index_min_16u_neonv8(uint16_t* target,
+                                                  const lv_32fc_t* source,
+                                                  uint32_t num_points)
+{
+    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
+
+    if (num_points == 0)
+        return;
+
+    const uint32_t quarter_points = num_points / 4;
+    const lv_32fc_t* inputPtr = source;
+
+    // Use integer indices directly (no float conversion overhead)
+    uint32x4_t vec_indices = { 0, 1, 2, 3 };
+    const uint32x4_t vec_incr = vdupq_n_u32(4);
+
+    float32x4_t vec_min = vdupq_n_f32(FLT_MAX);
+    uint32x4_t vec_min_idx = vdupq_n_u32(0);
+
+    for (uint32_t i = 0; i < quarter_points; i++) {
+        // Load and deinterleave complex values
+        float32x4x2_t cplx = vld2q_f32((const float*)inputPtr);
+        inputPtr += 4;
+
+        // Magnitude squared using FMA: re*re + im*im
+        float32x4_t mag2 =
+            vfmaq_f32(vmulq_f32(cplx.val[0], cplx.val[0]), cplx.val[1], cplx.val[1]);
+
+        // Compare BEFORE min update to know which lanes change
+        uint32x4_t lt_mask = vcltq_f32(mag2, vec_min);
+        vec_min_idx = vbslq_u32(lt_mask, vec_indices, vec_min_idx);
+
+        // vminq_f32 is single-cycle, no dependency on comparison result
+        vec_min = vminq_f32(mag2, vec_min);
+
+        vec_indices = vaddq_u32(vec_indices, vec_incr);
+    }
+
+    // ARMv8 horizontal reduction
+    float min_val = vminvq_f32(vec_min);
+    uint32x4_t min_mask = vceqq_f32(vec_min, vdupq_n_f32(min_val));
+    uint32x4_t idx_masked = vbslq_u32(min_mask, vec_min_idx, vdupq_n_u32(UINT32_MAX));
+    uint32_t result_idx = vminvq_u32(idx_masked);
+
+    // Handle tail
+    for (uint32_t i = quarter_points * 4; i < num_points; i++) {
+        float re = lv_creal(source[i]);
+        float im = lv_cimag(source[i]);
+        float mag2 = re * re + im * im;
+        if (mag2 < min_val) {
+            min_val = mag2;
+            result_idx = i;
+        }
+    }
+
+    *target = (uint16_t)result_idx;
+}
+
+#endif /*LV_HAVE_NEONV8*/
+
 #ifdef LV_HAVE_RVV
 #include <float.h>
 #include <riscv_vector.h>
@@ -861,3 +526,336 @@ static inline void volk_32fc_index_min_16u_rvvseg(uint16_t* target,
 #endif /*LV_HAVE_RVVSEG*/
 
 #endif /*INCLUDED_volk_32fc_index_min_16u_u_H*/
+
+#ifndef INCLUDED_volk_32fc_index_min_16u_a_H
+#define INCLUDED_volk_32fc_index_min_16u_a_H
+
+#include <inttypes.h>
+#include <limits.h>
+#include <stdio.h>
+#include <volk/volk_common.h>
+#include <volk/volk_complex.h>
+
+#ifdef LV_HAVE_SSE3
+#include <pmmintrin.h>
+#include <xmmintrin.h>
+
+static inline void volk_32fc_index_min_16u_a_sse3(uint16_t* target,
+                                                  const lv_32fc_t* source,
+                                                  uint32_t num_points)
+{
+    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
+
+    union bit128 holderf;
+    union bit128 holderi;
+    float sq_dist = 0.0;
+
+    union bit128 xmm5, xmm4;
+    __m128 xmm1, xmm2, xmm3;
+    __m128i xmm8, xmm11, xmm12, xmm9, xmm10;
+
+    xmm5.int_vec = _mm_setzero_si128();
+    xmm4.int_vec = _mm_setzero_si128();
+    holderf.int_vec = _mm_setzero_si128();
+    holderi.int_vec = _mm_setzero_si128();
+
+    xmm8 = _mm_setr_epi32(0, 1, 2, 3);
+    xmm9 = _mm_setzero_si128();
+    xmm10 = _mm_setr_epi32(4, 4, 4, 4);
+    xmm3 = _mm_set_ps1(FLT_MAX);
+
+    int bound = num_points >> 2;
+
+    for (int i = 0; i < bound; ++i) {
+        xmm1 = _mm_load_ps((const float*)source);
+        xmm2 = _mm_load_ps((const float*)&source[2]);
+
+        source += 4;
+
+        xmm1 = _mm_mul_ps(xmm1, xmm1);
+        xmm2 = _mm_mul_ps(xmm2, xmm2);
+
+        xmm1 = _mm_hadd_ps(xmm1, xmm2);
+
+        xmm3 = _mm_min_ps(xmm1, xmm3);
+
+        xmm4.float_vec = _mm_cmpgt_ps(xmm1, xmm3);
+        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
+
+        xmm11 = _mm_and_si128(xmm8, xmm5.int_vec);
+        xmm12 = _mm_and_si128(xmm9, xmm4.int_vec);
+
+        xmm9 = _mm_add_epi32(xmm11, xmm12);
+
+        xmm8 = _mm_add_epi32(xmm8, xmm10);
+    }
+
+    if (num_points >> 1 & 1) {
+        xmm2 = _mm_load_ps((const float*)source);
+
+        xmm1 = _mm_movelh_ps(bit128_p(&xmm8)->float_vec, bit128_p(&xmm8)->float_vec);
+        xmm8 = bit128_p(&xmm1)->int_vec;
+
+        xmm2 = _mm_mul_ps(xmm2, xmm2);
+
+        source += 2;
+
+        xmm1 = _mm_hadd_ps(xmm2, xmm2);
+
+        xmm3 = _mm_min_ps(xmm1, xmm3);
+
+        xmm10 = _mm_setr_epi32(2, 2, 2, 2);
+
+        xmm4.float_vec = _mm_cmpgt_ps(xmm1, xmm3);
+        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
+
+        xmm11 = _mm_and_si128(xmm8, xmm5.int_vec);
+        xmm12 = _mm_and_si128(xmm9, xmm4.int_vec);
+
+        xmm9 = _mm_add_epi32(xmm11, xmm12);
+
+        xmm8 = _mm_add_epi32(xmm8, xmm10);
+    }
+
+    if (num_points & 1) {
+        sq_dist = lv_creal(source[0]) * lv_creal(source[0]) +
+                  lv_cimag(source[0]) * lv_cimag(source[0]);
+
+        xmm2 = _mm_load1_ps(&sq_dist);
+
+        xmm1 = xmm3;
+
+        xmm3 = _mm_min_ss(xmm3, xmm2);
+
+        xmm4.float_vec = _mm_cmpgt_ps(xmm1, xmm3);
+        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
+
+        xmm8 = _mm_shuffle_epi32(xmm8, 0x00);
+
+        xmm11 = _mm_and_si128(xmm8, xmm4.int_vec);
+        xmm12 = _mm_and_si128(xmm9, xmm5.int_vec);
+
+        xmm9 = _mm_add_epi32(xmm11, xmm12);
+    }
+
+    _mm_store_ps((float*)&(holderf.f), xmm3);
+    _mm_store_si128(&(holderi.int_vec), xmm9);
+
+    target[0] = holderi.i[0];
+    sq_dist = holderf.f[0];
+    target[0] = (holderf.f[1] < sq_dist) ? holderi.i[1] : target[0];
+    sq_dist = (holderf.f[1] < sq_dist) ? holderf.f[1] : sq_dist;
+    target[0] = (holderf.f[2] < sq_dist) ? holderi.i[2] : target[0];
+    sq_dist = (holderf.f[2] < sq_dist) ? holderf.f[2] : sq_dist;
+    target[0] = (holderf.f[3] < sq_dist) ? holderi.i[3] : target[0];
+    sq_dist = (holderf.f[3] < sq_dist) ? holderf.f[3] : sq_dist;
+}
+
+#endif /*LV_HAVE_SSE3*/
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+#include <volk/volk_avx2_intrinsics.h>
+
+static inline void volk_32fc_index_min_16u_a_avx2_variant_0(uint16_t* target,
+                                                            const lv_32fc_t* source,
+                                                            uint32_t num_points)
+{
+    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
+
+    const __m256i indices_increment = _mm256_set1_epi32(8);
+    /*
+     * At the start of each loop iteration current_indices holds the indices of
+     * the complex numbers loaded from memory. Explanation for odd order is given
+     * in implementation of vector_32fc_index_min_variant0().
+     */
+    __m256i current_indices = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
+
+    __m256 min_values = _mm256_set1_ps(FLT_MAX);
+    __m256i min_indices = _mm256_setzero_si256();
+
+    for (unsigned i = 0; i < num_points / 8u; ++i) {
+        __m256 in0 = _mm256_load_ps((const float*)source);
+        __m256 in1 = _mm256_load_ps((const float*)(source + 4));
+        vector_32fc_index_min_variant0(
+            in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
+        source += 8;
+    }
+
+    // determine minimum value and index in the result of the vectorized loop
+    __VOLK_ATTR_ALIGNED(32) float min_values_buffer[8];
+    __VOLK_ATTR_ALIGNED(32) uint32_t min_indices_buffer[8];
+    _mm256_store_ps(min_values_buffer, min_values);
+    _mm256_store_si256((__m256i*)min_indices_buffer, min_indices);
+
+    float min = FLT_MAX;
+    uint32_t index = 0;
+    for (unsigned i = 0; i < 8; i++) {
+        if (min_values_buffer[i] < min) {
+            min = min_values_buffer[i];
+            index = min_indices_buffer[i];
+        }
+    }
+
+    // handle tail not processed by the vectorized loop
+    for (unsigned i = num_points & (~7u); i < num_points; ++i) {
+        const float abs_squared =
+            lv_creal(*source) * lv_creal(*source) + lv_cimag(*source) * lv_cimag(*source);
+        if (abs_squared < min) {
+            min = abs_squared;
+            index = i;
+        }
+        ++source;
+    }
+
+    *target = index;
+}
+
+#endif /*LV_HAVE_AVX2*/
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+#include <volk/volk_avx2_intrinsics.h>
+
+static inline void volk_32fc_index_min_16u_a_avx2_variant_1(uint16_t* target,
+                                                            const lv_32fc_t* source,
+                                                            uint32_t num_points)
+{
+    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
+
+    const __m256i indices_increment = _mm256_set1_epi32(8);
+    /*
+     * At the start of each loop iteration current_indices holds the indices of
+     * the complex numbers loaded from memory. Explanation for odd order is given
+     * in implementation of vector_32fc_index_min_variant0().
+     */
+    __m256i current_indices = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
+
+    __m256 min_values = _mm256_set1_ps(FLT_MAX);
+    __m256i min_indices = _mm256_setzero_si256();
+
+    for (unsigned i = 0; i < num_points / 8u; ++i) {
+        __m256 in0 = _mm256_load_ps((const float*)source);
+        __m256 in1 = _mm256_load_ps((const float*)(source + 4));
+        vector_32fc_index_min_variant1(
+            in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
+        source += 8;
+    }
+
+    // determine minimum value and index in the result of the vectorized loop
+    __VOLK_ATTR_ALIGNED(32) float min_values_buffer[8];
+    __VOLK_ATTR_ALIGNED(32) uint32_t min_indices_buffer[8];
+    _mm256_store_ps(min_values_buffer, min_values);
+    _mm256_store_si256((__m256i*)min_indices_buffer, min_indices);
+
+    float min = FLT_MAX;
+    uint32_t index = 0;
+    for (unsigned i = 0; i < 8; i++) {
+        if (min_values_buffer[i] < min) {
+            min = min_values_buffer[i];
+            index = min_indices_buffer[i];
+        }
+    }
+
+    // handle tail not processed by the vectorized loop
+    for (unsigned i = num_points & (~7u); i < num_points; ++i) {
+        const float abs_squared =
+            lv_creal(*source) * lv_creal(*source) + lv_cimag(*source) * lv_cimag(*source);
+        if (abs_squared < min) {
+            min = abs_squared;
+            index = i;
+        }
+        ++source;
+    }
+
+    *target = index;
+}
+
+#endif /*LV_HAVE_AVX2*/
+
+#ifdef LV_HAVE_AVX512F
+#include <float.h>
+#include <immintrin.h>
+#include <limits.h>
+
+static inline void volk_32fc_index_min_16u_a_avx512f(uint16_t* target,
+                                                     const lv_32fc_t* src0,
+                                                     uint32_t num_points)
+{
+    num_points = (num_points > USHRT_MAX) ? USHRT_MAX : num_points;
+
+    const lv_32fc_t* src0Ptr = src0;
+    const uint32_t sixteenthPoints = num_points / 16;
+
+    // Index ordering after shuffle: [0,1,8,9, 2,3,10,11, 4,5,12,13, 6,7,14,15]
+    __m512 currentIndexes =
+        _mm512_setr_ps(0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15);
+    const __m512 indexIncrement = _mm512_set1_ps(16);
+
+    __m512 minValues = _mm512_set1_ps(FLT_MAX);
+    __m512 minIndices = _mm512_setzero_ps();
+
+    for (uint32_t number = 0; number < sixteenthPoints; number++) {
+        // Load 16 complex values (32 floats)
+        __m512 in0 = _mm512_load_ps((const float*)src0Ptr);
+        __m512 in1 = _mm512_load_ps((const float*)(src0Ptr + 8));
+        src0Ptr += 16;
+
+        // Square all values
+        in0 = _mm512_mul_ps(in0, in0);
+        in1 = _mm512_mul_ps(in1, in1);
+
+        // Add adjacent pairs (re² + im²) using within-lane shuffle
+        // 0xB1 = _MM_SHUFFLE(2,3,0,1) swaps adjacent elements
+        __m512 sw0 = _mm512_shuffle_ps(in0, in0, 0xB1);
+        __m512 sw1 = _mm512_shuffle_ps(in1, in1, 0xB1);
+        __m512 sum0 = _mm512_add_ps(in0, sw0);
+        __m512 sum1 = _mm512_add_ps(in1, sw1);
+
+        // Compact: pick elements 0,2 from sum0 and sum1 per 128-bit lane
+        // 0x88 = _MM_SHUFFLE(2,0,2,0)
+        __m512 mag_sq = _mm512_shuffle_ps(sum0, sum1, 0x88);
+
+        // Compare and update minimums
+        __mmask16 cmpMask = _mm512_cmp_ps_mask(mag_sq, minValues, _CMP_LT_OS);
+        minIndices = _mm512_mask_blend_ps(cmpMask, minIndices, currentIndexes);
+        minValues = _mm512_min_ps(mag_sq, minValues);
+
+        currentIndexes = _mm512_add_ps(currentIndexes, indexIncrement);
+    }
+
+    // Reduce 16 values to find minimum
+    __VOLK_ATTR_ALIGNED(64) float minValuesBuffer[16];
+    __VOLK_ATTR_ALIGNED(64) float minIndexesBuffer[16];
+    _mm512_store_ps(minValuesBuffer, minValues);
+    _mm512_store_ps(minIndexesBuffer, minIndices);
+
+    float min = FLT_MAX;
+    uint32_t index = 0;
+    for (uint32_t i = 0; i < 16; i++) {
+        if (minValuesBuffer[i] < min) {
+            min = minValuesBuffer[i];
+            index = (uint32_t)minIndexesBuffer[i];
+        } else if (minValuesBuffer[i] == min) {
+            if ((uint32_t)minIndexesBuffer[i] < index)
+                index = (uint32_t)minIndexesBuffer[i];
+        }
+    }
+
+    // Handle tail
+    for (uint32_t number = sixteenthPoints * 16; number < num_points; number++) {
+        const float re = lv_creal(*src0Ptr);
+        const float im = lv_cimag(*src0Ptr);
+        const float sq_dist = re * re + im * im;
+        if (sq_dist < min) {
+            min = sq_dist;
+            index = number;
+        }
+        src0Ptr++;
+    }
+    *target = (uint16_t)index;
+}
+
+#endif /*LV_HAVE_AVX512F*/
+
+#endif /*INCLUDED_volk_32fc_index_min_16u_a_H*/

--- a/kernels/volk/volk_32fc_index_min_32u.h
+++ b/kernels/volk/volk_32fc_index_min_32u.h
@@ -54,244 +54,13 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32fc_index_min_32u_a_H
-#define INCLUDED_volk_32fc_index_min_32u_a_H
+#ifndef INCLUDED_volk_32fc_index_min_32u_u_H
+#define INCLUDED_volk_32fc_index_min_32u_u_H
 
 #include <inttypes.h>
 #include <stdio.h>
 #include <volk/volk_common.h>
 #include <volk/volk_complex.h>
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-#include <volk/volk_avx2_intrinsics.h>
-
-static inline void volk_32fc_index_min_32u_a_avx2_variant_0(uint32_t* target,
-                                                            const lv_32fc_t* source,
-                                                            uint32_t num_points)
-{
-    const __m256i indices_increment = _mm256_set1_epi32(8);
-    /*
-     * At the start of each loop iteration current_indices holds the indices of
-     * the complex numbers loaded from memory. Explanation for odd order is given
-     * in implementation of vector_32fc_index_min_variant0().
-     */
-    __m256i current_indices = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
-
-    __m256 min_values = _mm256_set1_ps(FLT_MAX);
-    __m256i min_indices = _mm256_setzero_si256();
-
-    for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((const float*)source);
-        __m256 in1 = _mm256_load_ps((const float*)(source + 4));
-        vector_32fc_index_min_variant0(
-            in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
-        source += 8;
-    }
-
-    // determine minimum value and index in the result of the vectorized loop
-    __VOLK_ATTR_ALIGNED(32) float min_values_buffer[8];
-    __VOLK_ATTR_ALIGNED(32) uint32_t min_indices_buffer[8];
-    _mm256_store_ps(min_values_buffer, min_values);
-    _mm256_store_si256((__m256i*)min_indices_buffer, min_indices);
-
-    float min = FLT_MAX;
-    uint32_t index = 0;
-    for (unsigned i = 0; i < 8; i++) {
-        if (min_values_buffer[i] < min) {
-            min = min_values_buffer[i];
-            index = min_indices_buffer[i];
-        }
-    }
-
-    // handle tail not processed by the vectorized loop
-    for (unsigned i = num_points & (~7u); i < num_points; ++i) {
-        const float abs_squared =
-            lv_creal(*source) * lv_creal(*source) + lv_cimag(*source) * lv_cimag(*source);
-        if (abs_squared < min) {
-            min = abs_squared;
-            index = i;
-        }
-        ++source;
-    }
-
-    *target = index;
-}
-
-#endif /*LV_HAVE_AVX2*/
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-#include <volk/volk_avx2_intrinsics.h>
-
-static inline void volk_32fc_index_min_32u_a_avx2_variant_1(uint32_t* target,
-                                                            const lv_32fc_t* source,
-                                                            uint32_t num_points)
-{
-    const __m256i indices_increment = _mm256_set1_epi32(8);
-    /*
-     * At the start of each loop iteration current_indices holds the indices of
-     * the complex numbers loaded from memory. Explanation for odd order is given
-     * in implementation of vector_32fc_index_min_variant0().
-     */
-    __m256i current_indices = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
-
-    __m256 min_values = _mm256_set1_ps(FLT_MAX);
-    __m256i min_indices = _mm256_setzero_si256();
-
-    for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((const float*)source);
-        __m256 in1 = _mm256_load_ps((const float*)(source + 4));
-        vector_32fc_index_min_variant1(
-            in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
-        source += 8;
-    }
-
-    // determine minimum value and index in the result of the vectorized loop
-    __VOLK_ATTR_ALIGNED(32) float min_values_buffer[8];
-    __VOLK_ATTR_ALIGNED(32) uint32_t min_indices_buffer[8];
-    _mm256_store_ps(min_values_buffer, min_values);
-    _mm256_store_si256((__m256i*)min_indices_buffer, min_indices);
-
-    float min = FLT_MAX;
-    uint32_t index = 0;
-    for (unsigned i = 0; i < 8; i++) {
-        if (min_values_buffer[i] < min) {
-            min = min_values_buffer[i];
-            index = min_indices_buffer[i];
-        }
-    }
-
-    // handle tail not processed by the vectorized loop
-    for (unsigned i = num_points & (~7u); i < num_points; ++i) {
-        const float abs_squared =
-            lv_creal(*source) * lv_creal(*source) + lv_cimag(*source) * lv_cimag(*source);
-        if (abs_squared < min) {
-            min = abs_squared;
-            index = i;
-        }
-        ++source;
-    }
-
-    *target = index;
-}
-
-#endif /*LV_HAVE_AVX2*/
-
-#ifdef LV_HAVE_SSE3
-#include <pmmintrin.h>
-#include <xmmintrin.h>
-
-static inline void volk_32fc_index_min_32u_a_sse3(uint32_t* target,
-                                                  const lv_32fc_t* source,
-                                                  uint32_t num_points)
-{
-    union bit128 holderf;
-    union bit128 holderi;
-    float sq_dist = 0.0;
-
-    union bit128 xmm5, xmm4;
-    __m128 xmm1, xmm2, xmm3;
-    __m128i xmm8, xmm11, xmm12, xmm9, xmm10;
-
-    xmm5.int_vec = _mm_setzero_si128();
-    xmm4.int_vec = _mm_setzero_si128();
-    holderf.int_vec = _mm_setzero_si128();
-    holderi.int_vec = _mm_setzero_si128();
-
-    xmm8 = _mm_setr_epi32(0, 1, 2, 3);
-    xmm9 = _mm_setzero_si128();
-    xmm10 = _mm_setr_epi32(4, 4, 4, 4);
-    xmm3 = _mm_set_ps1(FLT_MAX);
-
-    int bound = num_points >> 2;
-
-    for (int i = 0; i < bound; ++i) {
-        xmm1 = _mm_load_ps((const float*)source);
-        xmm2 = _mm_load_ps((const float*)&source[2]);
-
-        source += 4;
-
-        xmm1 = _mm_mul_ps(xmm1, xmm1);
-        xmm2 = _mm_mul_ps(xmm2, xmm2);
-
-        xmm1 = _mm_hadd_ps(xmm1, xmm2);
-
-        xmm3 = _mm_min_ps(xmm1, xmm3);
-
-        xmm4.float_vec = _mm_cmpgt_ps(xmm1, xmm3);
-        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
-
-        xmm11 = _mm_and_si128(xmm8, xmm5.int_vec);
-        xmm12 = _mm_and_si128(xmm9, xmm4.int_vec);
-
-        xmm9 = _mm_add_epi32(xmm11, xmm12);
-
-        xmm8 = _mm_add_epi32(xmm8, xmm10);
-    }
-
-    if (num_points >> 1 & 1) {
-        xmm2 = _mm_load_ps((const float*)source);
-
-        xmm1 = _mm_movelh_ps(bit128_p(&xmm8)->float_vec, bit128_p(&xmm8)->float_vec);
-        xmm8 = bit128_p(&xmm1)->int_vec;
-
-        xmm2 = _mm_mul_ps(xmm2, xmm2);
-
-        source += 2;
-
-        xmm1 = _mm_hadd_ps(xmm2, xmm2);
-
-        xmm3 = _mm_min_ps(xmm1, xmm3);
-
-        xmm10 = _mm_setr_epi32(2, 2, 2, 2);
-
-        xmm4.float_vec = _mm_cmpgt_ps(xmm1, xmm3);
-        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
-
-        xmm11 = _mm_and_si128(xmm8, xmm5.int_vec);
-        xmm12 = _mm_and_si128(xmm9, xmm4.int_vec);
-
-        xmm9 = _mm_add_epi32(xmm11, xmm12);
-
-        xmm8 = _mm_add_epi32(xmm8, xmm10);
-    }
-
-    if (num_points & 1) {
-        sq_dist = lv_creal(source[0]) * lv_creal(source[0]) +
-                  lv_cimag(source[0]) * lv_cimag(source[0]);
-
-        xmm2 = _mm_load1_ps(&sq_dist);
-
-        xmm1 = xmm3;
-
-        xmm3 = _mm_min_ss(xmm3, xmm2);
-
-        xmm4.float_vec = _mm_cmpgt_ps(xmm1, xmm3);
-        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
-
-        xmm8 = _mm_shuffle_epi32(xmm8, 0x00);
-
-        xmm11 = _mm_and_si128(xmm8, xmm4.int_vec);
-        xmm12 = _mm_and_si128(xmm9, xmm5.int_vec);
-
-        xmm9 = _mm_add_epi32(xmm11, xmm12);
-    }
-
-    _mm_store_ps((float*)&(holderf.f), xmm3);
-    _mm_store_si128(&(holderi.int_vec), xmm9);
-
-    target[0] = holderi.i[0];
-    sq_dist = holderf.f[0];
-    target[0] = (holderf.f[1] < sq_dist) ? holderi.i[1] : target[0];
-    sq_dist = (holderf.f[1] < sq_dist) ? holderf.f[1] : sq_dist;
-    target[0] = (holderf.f[2] < sq_dist) ? holderi.i[2] : target[0];
-    sq_dist = (holderf.f[2] < sq_dist) ? holderf.f[2] : sq_dist;
-    target[0] = (holderf.f[3] < sq_dist) ? holderi.i[3] : target[0];
-    sq_dist = (holderf.f[3] < sq_dist) ? holderf.f[3] : sq_dist;
-}
-
-#endif /*LV_HAVE_SSE3*/
 
 #ifdef LV_HAVE_GENERIC
 static inline void volk_32fc_index_min_32u_generic(uint32_t* target,
@@ -315,98 +84,6 @@ static inline void volk_32fc_index_min_32u_generic(uint32_t* target,
 }
 
 #endif /*LV_HAVE_GENERIC*/
-
-#ifdef LV_HAVE_AVX512F
-#include <float.h>
-#include <immintrin.h>
-
-static inline void volk_32fc_index_min_32u_a_avx512f(uint32_t* target,
-                                                     const lv_32fc_t* src0,
-                                                     uint32_t num_points)
-{
-    const lv_32fc_t* src0Ptr = src0;
-    const uint32_t sixteenthPoints = num_points / 16;
-
-    // Index ordering after shuffle: [0,1,8,9, 2,3,10,11, 4,5,12,13, 6,7,14,15]
-    __m512 currentIndexes =
-        _mm512_setr_ps(0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15);
-    const __m512 indexIncrement = _mm512_set1_ps(16);
-
-    __m512 minValues = _mm512_set1_ps(FLT_MAX);
-    __m512 minIndices = _mm512_setzero_ps();
-
-    for (uint32_t number = 0; number < sixteenthPoints; number++) {
-        // Load 16 complex values (32 floats)
-        __m512 in0 = _mm512_load_ps((const float*)src0Ptr);
-        __m512 in1 = _mm512_load_ps((const float*)(src0Ptr + 8));
-        src0Ptr += 16;
-
-        // Square all values
-        in0 = _mm512_mul_ps(in0, in0);
-        in1 = _mm512_mul_ps(in1, in1);
-
-        // Add adjacent pairs (re² + im²) using within-lane shuffle
-        // 0xB1 = _MM_SHUFFLE(2,3,0,1) swaps adjacent elements
-        __m512 sw0 = _mm512_shuffle_ps(in0, in0, 0xB1);
-        __m512 sw1 = _mm512_shuffle_ps(in1, in1, 0xB1);
-        __m512 sum0 = _mm512_add_ps(in0, sw0);
-        __m512 sum1 = _mm512_add_ps(in1, sw1);
-
-        // Compact: pick elements 0,2 from sum0 and sum1 per 128-bit lane
-        // 0x88 = _MM_SHUFFLE(2,0,2,0)
-        __m512 mag_sq = _mm512_shuffle_ps(sum0, sum1, 0x88);
-
-        // Compare and update minimums
-        __mmask16 cmpMask = _mm512_cmp_ps_mask(mag_sq, minValues, _CMP_LT_OS);
-        minIndices = _mm512_mask_blend_ps(cmpMask, minIndices, currentIndexes);
-        minValues = _mm512_min_ps(mag_sq, minValues);
-
-        currentIndexes = _mm512_add_ps(currentIndexes, indexIncrement);
-    }
-
-    // Reduce 16 values to find minimum
-    __VOLK_ATTR_ALIGNED(64) float minValuesBuffer[16];
-    __VOLK_ATTR_ALIGNED(64) float minIndexesBuffer[16];
-    _mm512_store_ps(minValuesBuffer, minValues);
-    _mm512_store_ps(minIndexesBuffer, minIndices);
-
-    float min = FLT_MAX;
-    uint32_t index = 0;
-    for (uint32_t i = 0; i < 16; i++) {
-        if (minValuesBuffer[i] < min) {
-            min = minValuesBuffer[i];
-            index = (uint32_t)minIndexesBuffer[i];
-        } else if (minValuesBuffer[i] == min) {
-            if ((uint32_t)minIndexesBuffer[i] < index)
-                index = (uint32_t)minIndexesBuffer[i];
-        }
-    }
-
-    // Handle tail
-    for (uint32_t number = sixteenthPoints * 16; number < num_points; number++) {
-        const float re = lv_creal(*src0Ptr);
-        const float im = lv_cimag(*src0Ptr);
-        const float sq_dist = re * re + im * im;
-        if (sq_dist < min) {
-            min = sq_dist;
-            index = number;
-        }
-        src0Ptr++;
-    }
-    *target = index;
-}
-
-#endif /*LV_HAVE_AVX512F*/
-
-#endif /*INCLUDED_volk_32fc_index_min_32u_a_H*/
-
-#ifndef INCLUDED_volk_32fc_index_min_32u_u_H
-#define INCLUDED_volk_32fc_index_min_32u_u_H
-
-#include <inttypes.h>
-#include <stdio.h>
-#include <volk/volk_common.h>
-#include <volk/volk_complex.h>
 
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
@@ -523,6 +200,88 @@ static inline void volk_32fc_index_min_32u_u_avx2_variant_1(uint32_t* target,
 }
 
 #endif /*LV_HAVE_AVX2*/
+
+#ifdef LV_HAVE_AVX512F
+#include <float.h>
+#include <immintrin.h>
+
+static inline void volk_32fc_index_min_32u_u_avx512f(uint32_t* target,
+                                                     const lv_32fc_t* src0,
+                                                     uint32_t num_points)
+{
+    const lv_32fc_t* src0Ptr = src0;
+    const uint32_t sixteenthPoints = num_points / 16;
+
+    // Index ordering after shuffle: [0,1,8,9, 2,3,10,11, 4,5,12,13, 6,7,14,15]
+    __m512 currentIndexes =
+        _mm512_setr_ps(0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15);
+    const __m512 indexIncrement = _mm512_set1_ps(16);
+
+    __m512 minValues = _mm512_set1_ps(FLT_MAX);
+    __m512 minIndices = _mm512_setzero_ps();
+
+    for (uint32_t number = 0; number < sixteenthPoints; number++) {
+        // Load 16 complex values (32 floats)
+        __m512 in0 = _mm512_loadu_ps((const float*)src0Ptr);
+        __m512 in1 = _mm512_loadu_ps((const float*)(src0Ptr + 8));
+        src0Ptr += 16;
+
+        // Square all values
+        in0 = _mm512_mul_ps(in0, in0);
+        in1 = _mm512_mul_ps(in1, in1);
+
+        // Add adjacent pairs (re² + im²) using within-lane shuffle
+        // 0xB1 = _MM_SHUFFLE(2,3,0,1) swaps adjacent elements
+        __m512 sw0 = _mm512_shuffle_ps(in0, in0, 0xB1);
+        __m512 sw1 = _mm512_shuffle_ps(in1, in1, 0xB1);
+        __m512 sum0 = _mm512_add_ps(in0, sw0);
+        __m512 sum1 = _mm512_add_ps(in1, sw1);
+
+        // Compact: pick elements 0,2 from sum0 and sum1 per 128-bit lane
+        // 0x88 = _MM_SHUFFLE(2,0,2,0)
+        __m512 mag_sq = _mm512_shuffle_ps(sum0, sum1, 0x88);
+
+        // Compare and update minimums
+        __mmask16 cmpMask = _mm512_cmp_ps_mask(mag_sq, minValues, _CMP_LT_OS);
+        minIndices = _mm512_mask_blend_ps(cmpMask, minIndices, currentIndexes);
+        minValues = _mm512_min_ps(mag_sq, minValues);
+
+        currentIndexes = _mm512_add_ps(currentIndexes, indexIncrement);
+    }
+
+    // Reduce 16 values to find minimum
+    __VOLK_ATTR_ALIGNED(64) float minValuesBuffer[16];
+    __VOLK_ATTR_ALIGNED(64) float minIndexesBuffer[16];
+    _mm512_store_ps(minValuesBuffer, minValues);
+    _mm512_store_ps(minIndexesBuffer, minIndices);
+
+    float min = FLT_MAX;
+    uint32_t index = 0;
+    for (uint32_t i = 0; i < 16; i++) {
+        if (minValuesBuffer[i] < min) {
+            min = minValuesBuffer[i];
+            index = (uint32_t)minIndexesBuffer[i];
+        } else if (minValuesBuffer[i] == min) {
+            if ((uint32_t)minIndexesBuffer[i] < index)
+                index = (uint32_t)minIndexesBuffer[i];
+        }
+    }
+
+    // Handle tail
+    for (uint32_t number = sixteenthPoints * 16; number < num_points; number++) {
+        const float re = lv_creal(*src0Ptr);
+        const float im = lv_cimag(*src0Ptr);
+        const float sq_dist = re * re + im * im;
+        if (sq_dist < min) {
+            min = sq_dist;
+            index = number;
+        }
+        src0Ptr++;
+    }
+    *target = index;
+}
+
+#endif /*LV_HAVE_AVX512F*/
 
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
@@ -654,89 +413,6 @@ static inline void volk_32fc_index_min_32u_neonv8(uint32_t* target,
 
 #endif /*LV_HAVE_NEONV8*/
 
-
-#ifdef LV_HAVE_AVX512F
-#include <float.h>
-#include <immintrin.h>
-
-static inline void volk_32fc_index_min_32u_u_avx512f(uint32_t* target,
-                                                     const lv_32fc_t* src0,
-                                                     uint32_t num_points)
-{
-    const lv_32fc_t* src0Ptr = src0;
-    const uint32_t sixteenthPoints = num_points / 16;
-
-    // Index ordering after shuffle: [0,1,8,9, 2,3,10,11, 4,5,12,13, 6,7,14,15]
-    __m512 currentIndexes =
-        _mm512_setr_ps(0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15);
-    const __m512 indexIncrement = _mm512_set1_ps(16);
-
-    __m512 minValues = _mm512_set1_ps(FLT_MAX);
-    __m512 minIndices = _mm512_setzero_ps();
-
-    for (uint32_t number = 0; number < sixteenthPoints; number++) {
-        // Load 16 complex values (32 floats)
-        __m512 in0 = _mm512_loadu_ps((const float*)src0Ptr);
-        __m512 in1 = _mm512_loadu_ps((const float*)(src0Ptr + 8));
-        src0Ptr += 16;
-
-        // Square all values
-        in0 = _mm512_mul_ps(in0, in0);
-        in1 = _mm512_mul_ps(in1, in1);
-
-        // Add adjacent pairs (re² + im²) using within-lane shuffle
-        // 0xB1 = _MM_SHUFFLE(2,3,0,1) swaps adjacent elements
-        __m512 sw0 = _mm512_shuffle_ps(in0, in0, 0xB1);
-        __m512 sw1 = _mm512_shuffle_ps(in1, in1, 0xB1);
-        __m512 sum0 = _mm512_add_ps(in0, sw0);
-        __m512 sum1 = _mm512_add_ps(in1, sw1);
-
-        // Compact: pick elements 0,2 from sum0 and sum1 per 128-bit lane
-        // 0x88 = _MM_SHUFFLE(2,0,2,0)
-        __m512 mag_sq = _mm512_shuffle_ps(sum0, sum1, 0x88);
-
-        // Compare and update minimums
-        __mmask16 cmpMask = _mm512_cmp_ps_mask(mag_sq, minValues, _CMP_LT_OS);
-        minIndices = _mm512_mask_blend_ps(cmpMask, minIndices, currentIndexes);
-        minValues = _mm512_min_ps(mag_sq, minValues);
-
-        currentIndexes = _mm512_add_ps(currentIndexes, indexIncrement);
-    }
-
-    // Reduce 16 values to find minimum
-    __VOLK_ATTR_ALIGNED(64) float minValuesBuffer[16];
-    __VOLK_ATTR_ALIGNED(64) float minIndexesBuffer[16];
-    _mm512_store_ps(minValuesBuffer, minValues);
-    _mm512_store_ps(minIndexesBuffer, minIndices);
-
-    float min = FLT_MAX;
-    uint32_t index = 0;
-    for (uint32_t i = 0; i < 16; i++) {
-        if (minValuesBuffer[i] < min) {
-            min = minValuesBuffer[i];
-            index = (uint32_t)minIndexesBuffer[i];
-        } else if (minValuesBuffer[i] == min) {
-            if ((uint32_t)minIndexesBuffer[i] < index)
-                index = (uint32_t)minIndexesBuffer[i];
-        }
-    }
-
-    // Handle tail
-    for (uint32_t number = sixteenthPoints * 16; number < num_points; number++) {
-        const float re = lv_creal(*src0Ptr);
-        const float im = lv_cimag(*src0Ptr);
-        const float sq_dist = re * re + im * im;
-        if (sq_dist < min) {
-            min = sq_dist;
-            index = number;
-        }
-        src0Ptr++;
-    }
-    *target = index;
-}
-
-#endif /*LV_HAVE_AVX512F*/
-
 #ifdef LV_HAVE_RVV
 #include <float.h>
 #include <riscv_vector.h>
@@ -813,3 +489,326 @@ static inline void volk_32fc_index_min_32u_rvvseg(uint32_t* target,
 #endif /*LV_HAVE_RVVSEG*/
 
 #endif /*INCLUDED_volk_32fc_index_min_32u_u_H*/
+
+#ifndef INCLUDED_volk_32fc_index_min_32u_a_H
+#define INCLUDED_volk_32fc_index_min_32u_a_H
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <volk/volk_common.h>
+#include <volk/volk_complex.h>
+
+#ifdef LV_HAVE_SSE3
+#include <pmmintrin.h>
+#include <xmmintrin.h>
+
+static inline void volk_32fc_index_min_32u_a_sse3(uint32_t* target,
+                                                  const lv_32fc_t* source,
+                                                  uint32_t num_points)
+{
+    union bit128 holderf;
+    union bit128 holderi;
+    float sq_dist = 0.0;
+
+    union bit128 xmm5, xmm4;
+    __m128 xmm1, xmm2, xmm3;
+    __m128i xmm8, xmm11, xmm12, xmm9, xmm10;
+
+    xmm5.int_vec = _mm_setzero_si128();
+    xmm4.int_vec = _mm_setzero_si128();
+    holderf.int_vec = _mm_setzero_si128();
+    holderi.int_vec = _mm_setzero_si128();
+
+    xmm8 = _mm_setr_epi32(0, 1, 2, 3);
+    xmm9 = _mm_setzero_si128();
+    xmm10 = _mm_setr_epi32(4, 4, 4, 4);
+    xmm3 = _mm_set_ps1(FLT_MAX);
+
+    int bound = num_points >> 2;
+
+    for (int i = 0; i < bound; ++i) {
+        xmm1 = _mm_load_ps((const float*)source);
+        xmm2 = _mm_load_ps((const float*)&source[2]);
+
+        source += 4;
+
+        xmm1 = _mm_mul_ps(xmm1, xmm1);
+        xmm2 = _mm_mul_ps(xmm2, xmm2);
+
+        xmm1 = _mm_hadd_ps(xmm1, xmm2);
+
+        xmm3 = _mm_min_ps(xmm1, xmm3);
+
+        xmm4.float_vec = _mm_cmpgt_ps(xmm1, xmm3);
+        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
+
+        xmm11 = _mm_and_si128(xmm8, xmm5.int_vec);
+        xmm12 = _mm_and_si128(xmm9, xmm4.int_vec);
+
+        xmm9 = _mm_add_epi32(xmm11, xmm12);
+
+        xmm8 = _mm_add_epi32(xmm8, xmm10);
+    }
+
+    if (num_points >> 1 & 1) {
+        xmm2 = _mm_load_ps((const float*)source);
+
+        xmm1 = _mm_movelh_ps(bit128_p(&xmm8)->float_vec, bit128_p(&xmm8)->float_vec);
+        xmm8 = bit128_p(&xmm1)->int_vec;
+
+        xmm2 = _mm_mul_ps(xmm2, xmm2);
+
+        source += 2;
+
+        xmm1 = _mm_hadd_ps(xmm2, xmm2);
+
+        xmm3 = _mm_min_ps(xmm1, xmm3);
+
+        xmm10 = _mm_setr_epi32(2, 2, 2, 2);
+
+        xmm4.float_vec = _mm_cmpgt_ps(xmm1, xmm3);
+        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
+
+        xmm11 = _mm_and_si128(xmm8, xmm5.int_vec);
+        xmm12 = _mm_and_si128(xmm9, xmm4.int_vec);
+
+        xmm9 = _mm_add_epi32(xmm11, xmm12);
+
+        xmm8 = _mm_add_epi32(xmm8, xmm10);
+    }
+
+    if (num_points & 1) {
+        sq_dist = lv_creal(source[0]) * lv_creal(source[0]) +
+                  lv_cimag(source[0]) * lv_cimag(source[0]);
+
+        xmm2 = _mm_load1_ps(&sq_dist);
+
+        xmm1 = xmm3;
+
+        xmm3 = _mm_min_ss(xmm3, xmm2);
+
+        xmm4.float_vec = _mm_cmpgt_ps(xmm1, xmm3);
+        xmm5.float_vec = _mm_cmpeq_ps(xmm1, xmm3);
+
+        xmm8 = _mm_shuffle_epi32(xmm8, 0x00);
+
+        xmm11 = _mm_and_si128(xmm8, xmm4.int_vec);
+        xmm12 = _mm_and_si128(xmm9, xmm5.int_vec);
+
+        xmm9 = _mm_add_epi32(xmm11, xmm12);
+    }
+
+    _mm_store_ps((float*)&(holderf.f), xmm3);
+    _mm_store_si128(&(holderi.int_vec), xmm9);
+
+    target[0] = holderi.i[0];
+    sq_dist = holderf.f[0];
+    target[0] = (holderf.f[1] < sq_dist) ? holderi.i[1] : target[0];
+    sq_dist = (holderf.f[1] < sq_dist) ? holderf.f[1] : sq_dist;
+    target[0] = (holderf.f[2] < sq_dist) ? holderi.i[2] : target[0];
+    sq_dist = (holderf.f[2] < sq_dist) ? holderf.f[2] : sq_dist;
+    target[0] = (holderf.f[3] < sq_dist) ? holderi.i[3] : target[0];
+    sq_dist = (holderf.f[3] < sq_dist) ? holderf.f[3] : sq_dist;
+}
+
+#endif /*LV_HAVE_SSE3*/
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+#include <volk/volk_avx2_intrinsics.h>
+
+static inline void volk_32fc_index_min_32u_a_avx2_variant_0(uint32_t* target,
+                                                            const lv_32fc_t* source,
+                                                            uint32_t num_points)
+{
+    const __m256i indices_increment = _mm256_set1_epi32(8);
+    /*
+     * At the start of each loop iteration current_indices holds the indices of
+     * the complex numbers loaded from memory. Explanation for odd order is given
+     * in implementation of vector_32fc_index_min_variant0().
+     */
+    __m256i current_indices = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
+
+    __m256 min_values = _mm256_set1_ps(FLT_MAX);
+    __m256i min_indices = _mm256_setzero_si256();
+
+    for (unsigned i = 0; i < num_points / 8u; ++i) {
+        __m256 in0 = _mm256_load_ps((const float*)source);
+        __m256 in1 = _mm256_load_ps((const float*)(source + 4));
+        vector_32fc_index_min_variant0(
+            in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
+        source += 8;
+    }
+
+    // determine minimum value and index in the result of the vectorized loop
+    __VOLK_ATTR_ALIGNED(32) float min_values_buffer[8];
+    __VOLK_ATTR_ALIGNED(32) uint32_t min_indices_buffer[8];
+    _mm256_store_ps(min_values_buffer, min_values);
+    _mm256_store_si256((__m256i*)min_indices_buffer, min_indices);
+
+    float min = FLT_MAX;
+    uint32_t index = 0;
+    for (unsigned i = 0; i < 8; i++) {
+        if (min_values_buffer[i] < min) {
+            min = min_values_buffer[i];
+            index = min_indices_buffer[i];
+        }
+    }
+
+    // handle tail not processed by the vectorized loop
+    for (unsigned i = num_points & (~7u); i < num_points; ++i) {
+        const float abs_squared =
+            lv_creal(*source) * lv_creal(*source) + lv_cimag(*source) * lv_cimag(*source);
+        if (abs_squared < min) {
+            min = abs_squared;
+            index = i;
+        }
+        ++source;
+    }
+
+    *target = index;
+}
+
+#endif /*LV_HAVE_AVX2*/
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+#include <volk/volk_avx2_intrinsics.h>
+
+static inline void volk_32fc_index_min_32u_a_avx2_variant_1(uint32_t* target,
+                                                            const lv_32fc_t* source,
+                                                            uint32_t num_points)
+{
+    const __m256i indices_increment = _mm256_set1_epi32(8);
+    /*
+     * At the start of each loop iteration current_indices holds the indices of
+     * the complex numbers loaded from memory. Explanation for odd order is given
+     * in implementation of vector_32fc_index_min_variant0().
+     */
+    __m256i current_indices = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
+
+    __m256 min_values = _mm256_set1_ps(FLT_MAX);
+    __m256i min_indices = _mm256_setzero_si256();
+
+    for (unsigned i = 0; i < num_points / 8u; ++i) {
+        __m256 in0 = _mm256_load_ps((const float*)source);
+        __m256 in1 = _mm256_load_ps((const float*)(source + 4));
+        vector_32fc_index_min_variant1(
+            in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
+        source += 8;
+    }
+
+    // determine minimum value and index in the result of the vectorized loop
+    __VOLK_ATTR_ALIGNED(32) float min_values_buffer[8];
+    __VOLK_ATTR_ALIGNED(32) uint32_t min_indices_buffer[8];
+    _mm256_store_ps(min_values_buffer, min_values);
+    _mm256_store_si256((__m256i*)min_indices_buffer, min_indices);
+
+    float min = FLT_MAX;
+    uint32_t index = 0;
+    for (unsigned i = 0; i < 8; i++) {
+        if (min_values_buffer[i] < min) {
+            min = min_values_buffer[i];
+            index = min_indices_buffer[i];
+        }
+    }
+
+    // handle tail not processed by the vectorized loop
+    for (unsigned i = num_points & (~7u); i < num_points; ++i) {
+        const float abs_squared =
+            lv_creal(*source) * lv_creal(*source) + lv_cimag(*source) * lv_cimag(*source);
+        if (abs_squared < min) {
+            min = abs_squared;
+            index = i;
+        }
+        ++source;
+    }
+
+    *target = index;
+}
+
+#endif /*LV_HAVE_AVX2*/
+
+#ifdef LV_HAVE_AVX512F
+#include <float.h>
+#include <immintrin.h>
+
+static inline void volk_32fc_index_min_32u_a_avx512f(uint32_t* target,
+                                                     const lv_32fc_t* src0,
+                                                     uint32_t num_points)
+{
+    const lv_32fc_t* src0Ptr = src0;
+    const uint32_t sixteenthPoints = num_points / 16;
+
+    // Index ordering after shuffle: [0,1,8,9, 2,3,10,11, 4,5,12,13, 6,7,14,15]
+    __m512 currentIndexes =
+        _mm512_setr_ps(0, 1, 8, 9, 2, 3, 10, 11, 4, 5, 12, 13, 6, 7, 14, 15);
+    const __m512 indexIncrement = _mm512_set1_ps(16);
+
+    __m512 minValues = _mm512_set1_ps(FLT_MAX);
+    __m512 minIndices = _mm512_setzero_ps();
+
+    for (uint32_t number = 0; number < sixteenthPoints; number++) {
+        // Load 16 complex values (32 floats)
+        __m512 in0 = _mm512_load_ps((const float*)src0Ptr);
+        __m512 in1 = _mm512_load_ps((const float*)(src0Ptr + 8));
+        src0Ptr += 16;
+
+        // Square all values
+        in0 = _mm512_mul_ps(in0, in0);
+        in1 = _mm512_mul_ps(in1, in1);
+
+        // Add adjacent pairs (re² + im²) using within-lane shuffle
+        // 0xB1 = _MM_SHUFFLE(2,3,0,1) swaps adjacent elements
+        __m512 sw0 = _mm512_shuffle_ps(in0, in0, 0xB1);
+        __m512 sw1 = _mm512_shuffle_ps(in1, in1, 0xB1);
+        __m512 sum0 = _mm512_add_ps(in0, sw0);
+        __m512 sum1 = _mm512_add_ps(in1, sw1);
+
+        // Compact: pick elements 0,2 from sum0 and sum1 per 128-bit lane
+        // 0x88 = _MM_SHUFFLE(2,0,2,0)
+        __m512 mag_sq = _mm512_shuffle_ps(sum0, sum1, 0x88);
+
+        // Compare and update minimums
+        __mmask16 cmpMask = _mm512_cmp_ps_mask(mag_sq, minValues, _CMP_LT_OS);
+        minIndices = _mm512_mask_blend_ps(cmpMask, minIndices, currentIndexes);
+        minValues = _mm512_min_ps(mag_sq, minValues);
+
+        currentIndexes = _mm512_add_ps(currentIndexes, indexIncrement);
+    }
+
+    // Reduce 16 values to find minimum
+    __VOLK_ATTR_ALIGNED(64) float minValuesBuffer[16];
+    __VOLK_ATTR_ALIGNED(64) float minIndexesBuffer[16];
+    _mm512_store_ps(minValuesBuffer, minValues);
+    _mm512_store_ps(minIndexesBuffer, minIndices);
+
+    float min = FLT_MAX;
+    uint32_t index = 0;
+    for (uint32_t i = 0; i < 16; i++) {
+        if (minValuesBuffer[i] < min) {
+            min = minValuesBuffer[i];
+            index = (uint32_t)minIndexesBuffer[i];
+        } else if (minValuesBuffer[i] == min) {
+            if ((uint32_t)minIndexesBuffer[i] < index)
+                index = (uint32_t)minIndexesBuffer[i];
+        }
+    }
+
+    // Handle tail
+    for (uint32_t number = sixteenthPoints * 16; number < num_points; number++) {
+        const float re = lv_creal(*src0Ptr);
+        const float im = lv_cimag(*src0Ptr);
+        const float sq_dist = re * re + im * im;
+        if (sq_dist < min) {
+            min = sq_dist;
+            index = number;
+        }
+        src0Ptr++;
+    }
+    *target = index;
+}
+
+#endif /*LV_HAVE_AVX512F*/
+
+#endif /*INCLUDED_volk_32fc_index_min_32u_a_H*/

--- a/kernels/volk/volk_32fc_index_min_32u.h
+++ b/kernels/volk/volk_32fc_index_min_32u.h
@@ -82,8 +82,8 @@ static inline void volk_32fc_index_min_32u_a_avx2_variant_0(uint32_t* target,
     __m256i min_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((float*)source);
-        __m256 in1 = _mm256_load_ps((float*)(source + 4));
+        __m256 in0 = _mm256_load_ps((const float*)source);
+        __m256 in1 = _mm256_load_ps((const float*)(source + 4));
         vector_32fc_index_min_variant0(
             in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
         source += 8;
@@ -140,8 +140,8 @@ static inline void volk_32fc_index_min_32u_a_avx2_variant_1(uint32_t* target,
     __m256i min_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_load_ps((float*)source);
-        __m256 in1 = _mm256_load_ps((float*)(source + 4));
+        __m256 in0 = _mm256_load_ps((const float*)source);
+        __m256 in1 = _mm256_load_ps((const float*)(source + 4));
         vector_32fc_index_min_variant1(
             in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
         source += 8;
@@ -207,8 +207,8 @@ static inline void volk_32fc_index_min_32u_a_sse3(uint32_t* target,
     int bound = num_points >> 2;
 
     for (int i = 0; i < bound; ++i) {
-        xmm1 = _mm_load_ps((float*)source);
-        xmm2 = _mm_load_ps((float*)&source[2]);
+        xmm1 = _mm_load_ps((const float*)source);
+        xmm2 = _mm_load_ps((const float*)&source[2]);
 
         source += 4;
 
@@ -231,7 +231,7 @@ static inline void volk_32fc_index_min_32u_a_sse3(uint32_t* target,
     }
 
     if (num_points >> 1 & 1) {
-        xmm2 = _mm_load_ps((float*)source);
+        xmm2 = _mm_load_ps((const float*)source);
 
         xmm1 = _mm_movelh_ps(bit128_p(&xmm8)->float_vec, bit128_p(&xmm8)->float_vec);
         xmm8 = bit128_p(&xmm1)->int_vec;
@@ -428,8 +428,8 @@ static inline void volk_32fc_index_min_32u_u_avx2_variant_0(uint32_t* target,
     __m256i min_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_loadu_ps((float*)source);
-        __m256 in1 = _mm256_loadu_ps((float*)(source + 4));
+        __m256 in0 = _mm256_loadu_ps((const float*)source);
+        __m256 in1 = _mm256_loadu_ps((const float*)(source + 4));
         vector_32fc_index_min_variant0(
             in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
         source += 8;
@@ -486,8 +486,8 @@ static inline void volk_32fc_index_min_32u_u_avx2_variant_1(uint32_t* target,
     __m256i min_indices = _mm256_setzero_si256();
 
     for (unsigned i = 0; i < num_points / 8u; ++i) {
-        __m256 in0 = _mm256_loadu_ps((float*)source);
-        __m256 in1 = _mm256_loadu_ps((float*)(source + 4));
+        __m256 in0 = _mm256_loadu_ps((const float*)source);
+        __m256 in1 = _mm256_loadu_ps((const float*)(source + 4));
         vector_32fc_index_min_variant1(
             in0, in1, &min_values, &min_indices, &current_indices, indices_increment);
         source += 8;
@@ -549,7 +549,7 @@ static inline void volk_32fc_index_min_32u_neon(uint32_t* target,
         for (uint32_t number = 0; number < quarter_points; number++) {
             // Load complex and compute magnitude squared
             const float32x4_t vec_mag2 =
-                _vmagnitudesquaredq_f32(vld2q_f32((float*)sourcePtr));
+                _vmagnitudesquaredq_f32(vld2q_f32((const float*)sourcePtr));
             __VOLK_PREFETCH(sourcePtr += 4);
             // a < b?
             const uint32x4_t lt_mask = vcltq_f32(vec_mag2, vec_min);

--- a/kernels/volk/volk_32fc_magnitude_32f.h
+++ b/kernels/volk/volk_32fc_magnitude_32f.h
@@ -79,6 +79,115 @@ static inline void volk_32fc_magnitude_32f_generic(float* magnitudeVector,
 }
 #endif /* LV_HAVE_GENERIC */
 
+#ifdef LV_HAVE_SSE
+#include <volk/volk_sse_intrinsics.h>
+#include <xmmintrin.h>
+
+static inline void volk_32fc_magnitude_32f_u_sse(float* magnitudeVector,
+                                                 const lv_32fc_t* complexVector,
+                                                 unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    float* magnitudeVectorPtr = magnitudeVector;
+
+    __m128 cplxValue1, cplxValue2, result;
+
+    for (; number < quarterPoints; number++) {
+        cplxValue1 = _mm_loadu_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        cplxValue2 = _mm_loadu_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        result = _mm_magnitude_ps(cplxValue1, cplxValue2);
+        _mm_storeu_ps(magnitudeVectorPtr, result);
+        magnitudeVectorPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        float val1Real = *complexVectorPtr++;
+        float val1Imag = *complexVectorPtr++;
+        *magnitudeVectorPtr++ = sqrtf((val1Real * val1Real) + (val1Imag * val1Imag));
+    }
+}
+#endif /* LV_HAVE_SSE */
+
+#ifdef LV_HAVE_SSE3
+#include <pmmintrin.h>
+#include <volk/volk_sse3_intrinsics.h>
+
+static inline void volk_32fc_magnitude_32f_u_sse3(float* magnitudeVector,
+                                                  const lv_32fc_t* complexVector,
+                                                  unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    float* magnitudeVectorPtr = magnitudeVector;
+
+    __m128 cplxValue1, cplxValue2, result;
+    for (; number < quarterPoints; number++) {
+        cplxValue1 = _mm_loadu_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        cplxValue2 = _mm_loadu_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        result = _mm_magnitude_ps_sse3(cplxValue1, cplxValue2);
+
+        _mm_storeu_ps(magnitudeVectorPtr, result);
+        magnitudeVectorPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        float val1Real = *complexVectorPtr++;
+        float val1Imag = *complexVectorPtr++;
+        *magnitudeVectorPtr++ = sqrtf((val1Real * val1Real) + (val1Imag * val1Imag));
+    }
+}
+#endif /* LV_HAVE_SSE3 */
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
+static inline void volk_32fc_magnitude_32f_u_avx(float* magnitudeVector,
+                                                 const lv_32fc_t* complexVector,
+                                                 unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    float* magnitudeVectorPtr = magnitudeVector;
+
+    __m256 cplxValue1, cplxValue2, result;
+
+    for (; number < eighthPoints; number++) {
+        cplxValue1 = _mm256_loadu_ps(complexVectorPtr);
+        cplxValue2 = _mm256_loadu_ps(complexVectorPtr + 8);
+        result = _mm256_magnitude_ps(cplxValue1, cplxValue2);
+        _mm256_storeu_ps(magnitudeVectorPtr, result);
+
+        complexVectorPtr += 16;
+        magnitudeVectorPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        float val1Real = *complexVectorPtr++;
+        float val1Imag = *complexVectorPtr++;
+        *magnitudeVectorPtr++ = sqrtf((val1Real * val1Real) + (val1Imag * val1Imag));
+    }
+}
+#endif /* LV_HAVE_AVX */
+
 #ifdef LV_HAVE_AVX512F
 #include <immintrin.h>
 
@@ -129,281 +238,6 @@ static inline void volk_32fc_magnitude_32f_u_avx512f(float* magnitudeVector,
 }
 #endif /* LV_HAVE_AVX512F */
 
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-#include <volk/volk_avx_intrinsics.h>
-
-static inline void volk_32fc_magnitude_32f_u_avx(float* magnitudeVector,
-                                                 const lv_32fc_t* complexVector,
-                                                 unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int eighthPoints = num_points / 8;
-
-    const float* complexVectorPtr = (const float*)complexVector;
-    float* magnitudeVectorPtr = magnitudeVector;
-
-    __m256 cplxValue1, cplxValue2, result;
-
-    for (; number < eighthPoints; number++) {
-        cplxValue1 = _mm256_loadu_ps(complexVectorPtr);
-        cplxValue2 = _mm256_loadu_ps(complexVectorPtr + 8);
-        result = _mm256_magnitude_ps(cplxValue1, cplxValue2);
-        _mm256_storeu_ps(magnitudeVectorPtr, result);
-
-        complexVectorPtr += 16;
-        magnitudeVectorPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        float val1Real = *complexVectorPtr++;
-        float val1Imag = *complexVectorPtr++;
-        *magnitudeVectorPtr++ = sqrtf((val1Real * val1Real) + (val1Imag * val1Imag));
-    }
-}
-#endif /* LV_HAVE_AVX */
-
-#ifdef LV_HAVE_SSE3
-#include <pmmintrin.h>
-#include <volk/volk_sse3_intrinsics.h>
-
-static inline void volk_32fc_magnitude_32f_u_sse3(float* magnitudeVector,
-                                                  const lv_32fc_t* complexVector,
-                                                  unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-
-    const float* complexVectorPtr = (const float*)complexVector;
-    float* magnitudeVectorPtr = magnitudeVector;
-
-    __m128 cplxValue1, cplxValue2, result;
-    for (; number < quarterPoints; number++) {
-        cplxValue1 = _mm_loadu_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        cplxValue2 = _mm_loadu_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        result = _mm_magnitude_ps_sse3(cplxValue1, cplxValue2);
-
-        _mm_storeu_ps(magnitudeVectorPtr, result);
-        magnitudeVectorPtr += 4;
-    }
-
-    number = quarterPoints * 4;
-    for (; number < num_points; number++) {
-        float val1Real = *complexVectorPtr++;
-        float val1Imag = *complexVectorPtr++;
-        *magnitudeVectorPtr++ = sqrtf((val1Real * val1Real) + (val1Imag * val1Imag));
-    }
-}
-#endif /* LV_HAVE_SSE3 */
-
-
-#ifdef LV_HAVE_SSE
-#include <volk/volk_sse_intrinsics.h>
-#include <xmmintrin.h>
-
-static inline void volk_32fc_magnitude_32f_u_sse(float* magnitudeVector,
-                                                 const lv_32fc_t* complexVector,
-                                                 unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-
-    const float* complexVectorPtr = (const float*)complexVector;
-    float* magnitudeVectorPtr = magnitudeVector;
-
-    __m128 cplxValue1, cplxValue2, result;
-
-    for (; number < quarterPoints; number++) {
-        cplxValue1 = _mm_loadu_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        cplxValue2 = _mm_loadu_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        result = _mm_magnitude_ps(cplxValue1, cplxValue2);
-        _mm_storeu_ps(magnitudeVectorPtr, result);
-        magnitudeVectorPtr += 4;
-    }
-
-    number = quarterPoints * 4;
-    for (; number < num_points; number++) {
-        float val1Real = *complexVectorPtr++;
-        float val1Imag = *complexVectorPtr++;
-        *magnitudeVectorPtr++ = sqrtf((val1Real * val1Real) + (val1Imag * val1Imag));
-    }
-}
-#endif /* LV_HAVE_SSE */
-
-#endif /* INCLUDED_volk_32fc_magnitude_32f_u_H */
-#ifndef INCLUDED_volk_32fc_magnitude_32f_a_H
-#define INCLUDED_volk_32fc_magnitude_32f_a_H
-
-#include <inttypes.h>
-#include <math.h>
-#include <stdio.h>
-
-#ifdef LV_HAVE_AVX512F
-#include <immintrin.h>
-
-static inline void volk_32fc_magnitude_32f_a_avx512f(float* magnitudeVector,
-                                                     const lv_32fc_t* complexVector,
-                                                     unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int eighthPoints = num_points / 8;
-
-    const float* complexVectorPtr = (const float*)complexVector;
-    float* magnitudeVectorPtr = magnitudeVector;
-
-    __m512 cplxValue;
-    __m512 iValues, qValues;
-    __m512 result;
-
-    for (; number < eighthPoints; number++) {
-        // Load 8 complex numbers (16 floats): I0,Q0,I1,Q1,...,I7,Q7
-        cplxValue = _mm512_load_ps(complexVectorPtr);
-
-        // Separate I and Q values using permute
-        iValues = _mm512_permutexvar_ps(
-            _mm512_setr_epi32(0, 2, 4, 6, 8, 10, 12, 14, 0, 0, 0, 0, 0, 0, 0, 0),
-            cplxValue);
-        qValues = _mm512_permutexvar_ps(
-            _mm512_setr_epi32(1, 3, 5, 7, 9, 11, 13, 15, 0, 0, 0, 0, 0, 0, 0, 0),
-            cplxValue);
-
-        // Square and add: I^2 + Q^2
-        result = _mm512_fmadd_ps(iValues, iValues, _mm512_mul_ps(qValues, qValues));
-
-        // Square root
-        result = _mm512_sqrt_ps(result);
-
-        // Store only first 8 results
-        _mm256_store_ps(magnitudeVectorPtr, _mm512_castps512_ps256(result));
-
-        complexVectorPtr += 16;
-        magnitudeVectorPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    volk_32fc_magnitude_32f_generic(
-        magnitudeVectorPtr, (const lv_32fc_t*)complexVectorPtr, num_points - number);
-}
-#endif /* LV_HAVE_AVX512F */
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-#include <volk/volk_avx_intrinsics.h>
-
-static inline void volk_32fc_magnitude_32f_a_avx(float* magnitudeVector,
-                                                 const lv_32fc_t* complexVector,
-                                                 unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int eighthPoints = num_points / 8;
-
-    const float* complexVectorPtr = (const float*)complexVector;
-    float* magnitudeVectorPtr = magnitudeVector;
-
-    __m256 cplxValue1, cplxValue2, result;
-    for (; number < eighthPoints; number++) {
-        cplxValue1 = _mm256_load_ps(complexVectorPtr);
-        complexVectorPtr += 8;
-
-        cplxValue2 = _mm256_load_ps(complexVectorPtr);
-        complexVectorPtr += 8;
-
-        result = _mm256_magnitude_ps(cplxValue1, cplxValue2);
-        _mm256_store_ps(magnitudeVectorPtr, result);
-        magnitudeVectorPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        float val1Real = *complexVectorPtr++;
-        float val1Imag = *complexVectorPtr++;
-        *magnitudeVectorPtr++ = sqrtf((val1Real * val1Real) + (val1Imag * val1Imag));
-    }
-}
-#endif /* LV_HAVE_AVX */
-
-#ifdef LV_HAVE_SSE3
-#include <pmmintrin.h>
-#include <volk/volk_sse3_intrinsics.h>
-
-static inline void volk_32fc_magnitude_32f_a_sse3(float* magnitudeVector,
-                                                  const lv_32fc_t* complexVector,
-                                                  unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-
-    const float* complexVectorPtr = (const float*)complexVector;
-    float* magnitudeVectorPtr = magnitudeVector;
-
-    __m128 cplxValue1, cplxValue2, result;
-    for (; number < quarterPoints; number++) {
-        cplxValue1 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        cplxValue2 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        result = _mm_magnitude_ps_sse3(cplxValue1, cplxValue2);
-        _mm_store_ps(magnitudeVectorPtr, result);
-        magnitudeVectorPtr += 4;
-    }
-
-    number = quarterPoints * 4;
-    for (; number < num_points; number++) {
-        float val1Real = *complexVectorPtr++;
-        float val1Imag = *complexVectorPtr++;
-        *magnitudeVectorPtr++ = sqrtf((val1Real * val1Real) + (val1Imag * val1Imag));
-    }
-}
-#endif /* LV_HAVE_SSE3 */
-
-#ifdef LV_HAVE_SSE
-#include <volk/volk_sse_intrinsics.h>
-#include <xmmintrin.h>
-
-static inline void volk_32fc_magnitude_32f_a_sse(float* magnitudeVector,
-                                                 const lv_32fc_t* complexVector,
-                                                 unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-
-    const float* complexVectorPtr = (const float*)complexVector;
-    float* magnitudeVectorPtr = magnitudeVector;
-
-    __m128 cplxValue1, cplxValue2, result;
-    for (; number < quarterPoints; number++) {
-        cplxValue1 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        cplxValue2 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        result = _mm_magnitude_ps(cplxValue1, cplxValue2);
-        _mm_store_ps(magnitudeVectorPtr, result);
-        magnitudeVectorPtr += 4;
-    }
-
-    number = quarterPoints * 4;
-    for (; number < num_points; number++) {
-        float val1Real = *complexVectorPtr++;
-        float val1Imag = *complexVectorPtr++;
-        *magnitudeVectorPtr++ = sqrtf((val1Real * val1Real) + (val1Imag * val1Imag));
-    }
-}
-#endif /* LV_HAVE_SSE */
-
-
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
 
@@ -438,7 +272,6 @@ static inline void volk_32fc_magnitude_32f_neon(float* magnitudeVector,
     }
 }
 #endif /* LV_HAVE_NEON */
-
 
 #ifdef LV_HAVE_NEONV8
 #include <arm_neon.h>
@@ -476,7 +309,6 @@ static inline void volk_32fc_magnitude_32f_neonv8(float* magnitudeVector,
     }
 }
 #endif /* LV_HAVE_NEONV8 */
-
 
 #ifdef LV_HAVE_NEON
 /*!
@@ -571,7 +403,7 @@ static inline void volk_32fc_magnitude_32f_rvv(float* magnitudeVector,
         __riscv_vse32(magnitudeVector, __riscv_vfsqrt(v, vl), vl);
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
 
 #ifdef LV_HAVE_RVVSEG
 #include <riscv_vector.h>
@@ -590,6 +422,170 @@ static inline void volk_32fc_magnitude_32f_rvvseg(float* magnitudeVector,
         __riscv_vse32(magnitudeVector, __riscv_vfsqrt(v, vl), vl);
     }
 }
-#endif /*LV_HAVE_RVVSEG*/
+#endif /* LV_HAVE_RVVSEG */
+
+#endif /* INCLUDED_volk_32fc_magnitude_32f_u_H */
+#ifndef INCLUDED_volk_32fc_magnitude_32f_a_H
+#define INCLUDED_volk_32fc_magnitude_32f_a_H
+
+#include <inttypes.h>
+#include <math.h>
+#include <stdio.h>
+
+#ifdef LV_HAVE_SSE
+#include <volk/volk_sse_intrinsics.h>
+#include <xmmintrin.h>
+
+static inline void volk_32fc_magnitude_32f_a_sse(float* magnitudeVector,
+                                                 const lv_32fc_t* complexVector,
+                                                 unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    float* magnitudeVectorPtr = magnitudeVector;
+
+    __m128 cplxValue1, cplxValue2, result;
+    for (; number < quarterPoints; number++) {
+        cplxValue1 = _mm_load_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        cplxValue2 = _mm_load_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        result = _mm_magnitude_ps(cplxValue1, cplxValue2);
+        _mm_store_ps(magnitudeVectorPtr, result);
+        magnitudeVectorPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        float val1Real = *complexVectorPtr++;
+        float val1Imag = *complexVectorPtr++;
+        *magnitudeVectorPtr++ = sqrtf((val1Real * val1Real) + (val1Imag * val1Imag));
+    }
+}
+#endif /* LV_HAVE_SSE */
+
+#ifdef LV_HAVE_SSE3
+#include <pmmintrin.h>
+#include <volk/volk_sse3_intrinsics.h>
+
+static inline void volk_32fc_magnitude_32f_a_sse3(float* magnitudeVector,
+                                                  const lv_32fc_t* complexVector,
+                                                  unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    float* magnitudeVectorPtr = magnitudeVector;
+
+    __m128 cplxValue1, cplxValue2, result;
+    for (; number < quarterPoints; number++) {
+        cplxValue1 = _mm_load_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        cplxValue2 = _mm_load_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        result = _mm_magnitude_ps_sse3(cplxValue1, cplxValue2);
+        _mm_store_ps(magnitudeVectorPtr, result);
+        magnitudeVectorPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        float val1Real = *complexVectorPtr++;
+        float val1Imag = *complexVectorPtr++;
+        *magnitudeVectorPtr++ = sqrtf((val1Real * val1Real) + (val1Imag * val1Imag));
+    }
+}
+#endif /* LV_HAVE_SSE3 */
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
+static inline void volk_32fc_magnitude_32f_a_avx(float* magnitudeVector,
+                                                 const lv_32fc_t* complexVector,
+                                                 unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    float* magnitudeVectorPtr = magnitudeVector;
+
+    __m256 cplxValue1, cplxValue2, result;
+    for (; number < eighthPoints; number++) {
+        cplxValue1 = _mm256_load_ps(complexVectorPtr);
+        complexVectorPtr += 8;
+
+        cplxValue2 = _mm256_load_ps(complexVectorPtr);
+        complexVectorPtr += 8;
+
+        result = _mm256_magnitude_ps(cplxValue1, cplxValue2);
+        _mm256_store_ps(magnitudeVectorPtr, result);
+        magnitudeVectorPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        float val1Real = *complexVectorPtr++;
+        float val1Imag = *complexVectorPtr++;
+        *magnitudeVectorPtr++ = sqrtf((val1Real * val1Real) + (val1Imag * val1Imag));
+    }
+}
+#endif /* LV_HAVE_AVX */
+
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+
+static inline void volk_32fc_magnitude_32f_a_avx512f(float* magnitudeVector,
+                                                     const lv_32fc_t* complexVector,
+                                                     unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    float* magnitudeVectorPtr = magnitudeVector;
+
+    __m512 cplxValue;
+    __m512 iValues, qValues;
+    __m512 result;
+
+    for (; number < eighthPoints; number++) {
+        // Load 8 complex numbers (16 floats): I0,Q0,I1,Q1,...,I7,Q7
+        cplxValue = _mm512_load_ps(complexVectorPtr);
+
+        // Separate I and Q values using permute
+        iValues = _mm512_permutexvar_ps(
+            _mm512_setr_epi32(0, 2, 4, 6, 8, 10, 12, 14, 0, 0, 0, 0, 0, 0, 0, 0),
+            cplxValue);
+        qValues = _mm512_permutexvar_ps(
+            _mm512_setr_epi32(1, 3, 5, 7, 9, 11, 13, 15, 0, 0, 0, 0, 0, 0, 0, 0),
+            cplxValue);
+
+        // Square and add: I^2 + Q^2
+        result = _mm512_fmadd_ps(iValues, iValues, _mm512_mul_ps(qValues, qValues));
+
+        // Square root
+        result = _mm512_sqrt_ps(result);
+
+        // Store only first 8 results
+        _mm256_store_ps(magnitudeVectorPtr, _mm512_castps512_ps256(result));
+
+        complexVectorPtr += 16;
+        magnitudeVectorPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    volk_32fc_magnitude_32f_generic(
+        magnitudeVectorPtr, (const lv_32fc_t*)complexVectorPtr, num_points - number);
+}
+#endif /* LV_HAVE_AVX512F */
 
 #endif /* INCLUDED_volk_32fc_magnitude_32f_a_H */

--- a/kernels/volk/volk_32fc_magnitude_32f.h
+++ b/kernels/volk/volk_32fc_magnitude_32f.h
@@ -68,7 +68,7 @@ static inline void volk_32fc_magnitude_32f_generic(float* magnitudeVector,
                                                    const lv_32fc_t* complexVector,
                                                    unsigned int num_points)
 {
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
     unsigned int number = 0;
     for (number = 0; number < num_points; number++) {
@@ -89,7 +89,7 @@ static inline void volk_32fc_magnitude_32f_u_avx512f(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int eighthPoints = num_points / 8;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m512 cplxValue;
@@ -140,7 +140,7 @@ static inline void volk_32fc_magnitude_32f_u_avx(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int eighthPoints = num_points / 8;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m256 cplxValue1, cplxValue2, result;
@@ -175,7 +175,7 @@ static inline void volk_32fc_magnitude_32f_u_sse3(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int quarterPoints = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m128 cplxValue1, cplxValue2, result;
@@ -213,7 +213,7 @@ static inline void volk_32fc_magnitude_32f_u_sse(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int quarterPoints = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m128 cplxValue1, cplxValue2, result;
@@ -257,7 +257,7 @@ static inline void volk_32fc_magnitude_32f_a_avx512f(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int eighthPoints = num_points / 8;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m512 cplxValue;
@@ -306,7 +306,7 @@ static inline void volk_32fc_magnitude_32f_a_avx(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int eighthPoints = num_points / 8;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m256 cplxValue1, cplxValue2, result;
@@ -342,7 +342,7 @@ static inline void volk_32fc_magnitude_32f_a_sse3(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int quarterPoints = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m128 cplxValue1, cplxValue2, result;
@@ -378,7 +378,7 @@ static inline void volk_32fc_magnitude_32f_a_sse(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int quarterPoints = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m128 cplxValue1, cplxValue2, result;
@@ -413,7 +413,7 @@ static inline void volk_32fc_magnitude_32f_neon(float* magnitudeVector,
 {
     unsigned int number;
     unsigned int quarter_points = num_points / 4;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     float32x4x2_t complex_vec;
@@ -449,7 +449,7 @@ static inline void volk_32fc_magnitude_32f_neonv8(float* magnitudeVector,
 {
     unsigned int number;
     unsigned int quarter_points = num_points / 4;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     float32x4x2_t complex_vec;
@@ -500,7 +500,7 @@ static inline void volk_32fc_magnitude_32f_neon_fancy_sweet(
 {
     unsigned int number;
     unsigned int quarter_points = num_points / 4;
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     const float threshold = 0.4142135;

--- a/kernels/volk/volk_32fc_magnitude_squared_32f.h
+++ b/kernels/volk/volk_32fc_magnitude_squared_32f.h
@@ -62,77 +62,22 @@
 #include <math.h>
 #include <stdio.h>
 
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-#include <volk/volk_avx_intrinsics.h>
+#ifdef LV_HAVE_GENERIC
 
-static inline void volk_32fc_magnitude_squared_32f_u_avx(float* magnitudeVector,
-                                                         const lv_32fc_t* complexVector,
-                                                         unsigned int num_points)
+static inline void volk_32fc_magnitude_squared_32f_generic(float* magnitudeVector,
+                                                           const lv_32fc_t* complexVector,
+                                                           unsigned int num_points)
 {
-    unsigned int number = 0;
-    const unsigned int eighthPoints = num_points / 8;
-
     const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
-
-    __m256 cplxValue1, cplxValue2, result;
-
-    for (; number < eighthPoints; number++) {
-        cplxValue1 = _mm256_loadu_ps(complexVectorPtr);
-        cplxValue2 = _mm256_loadu_ps(complexVectorPtr + 8);
-        result = _mm256_magnitudesquared_ps(cplxValue1, cplxValue2);
-        _mm256_storeu_ps(magnitudeVectorPtr, result);
-
-        complexVectorPtr += 16;
-        magnitudeVectorPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        float val1Real = *complexVectorPtr++;
-        float val1Imag = *complexVectorPtr++;
-        *magnitudeVectorPtr++ = (val1Real * val1Real) + (val1Imag * val1Imag);
-    }
-}
-#endif /* LV_HAVE_AVX */
-
-
-#ifdef LV_HAVE_SSE3
-#include <pmmintrin.h>
-#include <volk/volk_sse3_intrinsics.h>
-
-static inline void volk_32fc_magnitude_squared_32f_u_sse3(float* magnitudeVector,
-                                                          const lv_32fc_t* complexVector,
-                                                          unsigned int num_points)
-{
     unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-
-    const float* complexVectorPtr = (const float*)complexVector;
-    float* magnitudeVectorPtr = magnitudeVector;
-
-    __m128 cplxValue1, cplxValue2, result;
-    for (; number < quarterPoints; number++) {
-        cplxValue1 = _mm_loadu_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        cplxValue2 = _mm_loadu_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        result = _mm_magnitudesquared_ps_sse3(cplxValue1, cplxValue2);
-        _mm_storeu_ps(magnitudeVectorPtr, result);
-        magnitudeVectorPtr += 4;
-    }
-
-    number = quarterPoints * 4;
-    for (; number < num_points; number++) {
-        float val1Real = *complexVectorPtr++;
-        float val1Imag = *complexVectorPtr++;
-        *magnitudeVectorPtr++ = (val1Real * val1Real) + (val1Imag * val1Imag);
+    for (number = 0; number < num_points; number++) {
+        const float real = *complexVectorPtr++;
+        const float imag = *complexVectorPtr++;
+        *magnitudeVectorPtr++ = (real * real) + (imag * imag);
     }
 }
-#endif /* LV_HAVE_SSE3 */
+#endif /* LV_HAVE_GENERIC */
 
 
 #ifdef LV_HAVE_SSE
@@ -173,74 +118,11 @@ static inline void volk_32fc_magnitude_squared_32f_u_sse(float* magnitudeVector,
 #endif /* LV_HAVE_SSE */
 
 
-#ifdef LV_HAVE_GENERIC
-
-static inline void volk_32fc_magnitude_squared_32f_generic(float* magnitudeVector,
-                                                           const lv_32fc_t* complexVector,
-                                                           unsigned int num_points)
-{
-    const float* complexVectorPtr = (const float*)complexVector;
-    float* magnitudeVectorPtr = magnitudeVector;
-    unsigned int number = 0;
-    for (number = 0; number < num_points; number++) {
-        const float real = *complexVectorPtr++;
-        const float imag = *complexVectorPtr++;
-        *magnitudeVectorPtr++ = (real * real) + (imag * imag);
-    }
-}
-#endif /* LV_HAVE_GENERIC */
-
-
-#endif /* INCLUDED_volk_32fc_magnitude_32f_u_H */
-#ifndef INCLUDED_volk_32fc_magnitude_squared_32f_a_H
-#define INCLUDED_volk_32fc_magnitude_squared_32f_a_H
-
-#include <inttypes.h>
-#include <math.h>
-#include <stdio.h>
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-#include <volk/volk_avx_intrinsics.h>
-
-static inline void volk_32fc_magnitude_squared_32f_a_avx(float* magnitudeVector,
-                                                         const lv_32fc_t* complexVector,
-                                                         unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int eighthPoints = num_points / 8;
-
-    const float* complexVectorPtr = (const float*)complexVector;
-    float* magnitudeVectorPtr = magnitudeVector;
-
-    __m256 cplxValue1, cplxValue2, result;
-    for (; number < eighthPoints; number++) {
-        cplxValue1 = _mm256_load_ps(complexVectorPtr);
-        complexVectorPtr += 8;
-
-        cplxValue2 = _mm256_load_ps(complexVectorPtr);
-        complexVectorPtr += 8;
-
-        result = _mm256_magnitudesquared_ps(cplxValue1, cplxValue2);
-        _mm256_store_ps(magnitudeVectorPtr, result);
-        magnitudeVectorPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        float val1Real = *complexVectorPtr++;
-        float val1Imag = *complexVectorPtr++;
-        *magnitudeVectorPtr++ = (val1Real * val1Real) + (val1Imag * val1Imag);
-    }
-}
-#endif /* LV_HAVE_AVX */
-
-
 #ifdef LV_HAVE_SSE3
 #include <pmmintrin.h>
 #include <volk/volk_sse3_intrinsics.h>
 
-static inline void volk_32fc_magnitude_squared_32f_a_sse3(float* magnitudeVector,
+static inline void volk_32fc_magnitude_squared_32f_u_sse3(float* magnitudeVector,
                                                           const lv_32fc_t* complexVector,
                                                           unsigned int num_points)
 {
@@ -252,14 +134,14 @@ static inline void volk_32fc_magnitude_squared_32f_a_sse3(float* magnitudeVector
 
     __m128 cplxValue1, cplxValue2, result;
     for (; number < quarterPoints; number++) {
-        cplxValue1 = _mm_load_ps(complexVectorPtr);
+        cplxValue1 = _mm_loadu_ps(complexVectorPtr);
         complexVectorPtr += 4;
 
-        cplxValue2 = _mm_load_ps(complexVectorPtr);
+        cplxValue2 = _mm_loadu_ps(complexVectorPtr);
         complexVectorPtr += 4;
 
         result = _mm_magnitudesquared_ps_sse3(cplxValue1, cplxValue2);
-        _mm_store_ps(magnitudeVectorPtr, result);
+        _mm_storeu_ps(magnitudeVectorPtr, result);
         magnitudeVectorPtr += 4;
     }
 
@@ -273,41 +155,40 @@ static inline void volk_32fc_magnitude_squared_32f_a_sse3(float* magnitudeVector
 #endif /* LV_HAVE_SSE3 */
 
 
-#ifdef LV_HAVE_SSE
-#include <volk/volk_sse_intrinsics.h>
-#include <xmmintrin.h>
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
 
-static inline void volk_32fc_magnitude_squared_32f_a_sse(float* magnitudeVector,
+static inline void volk_32fc_magnitude_squared_32f_u_avx(float* magnitudeVector,
                                                          const lv_32fc_t* complexVector,
                                                          unsigned int num_points)
 {
     unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
+    const unsigned int eighthPoints = num_points / 8;
 
     const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
-    __m128 cplxValue1, cplxValue2, result;
-    for (; number < quarterPoints; number++) {
-        cplxValue1 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
+    __m256 cplxValue1, cplxValue2, result;
 
-        cplxValue2 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
+    for (; number < eighthPoints; number++) {
+        cplxValue1 = _mm256_loadu_ps(complexVectorPtr);
+        cplxValue2 = _mm256_loadu_ps(complexVectorPtr + 8);
+        result = _mm256_magnitudesquared_ps(cplxValue1, cplxValue2);
+        _mm256_storeu_ps(magnitudeVectorPtr, result);
 
-        result = _mm_magnitudesquared_ps(cplxValue1, cplxValue2);
-        _mm_store_ps(magnitudeVectorPtr, result);
-        magnitudeVectorPtr += 4;
+        complexVectorPtr += 16;
+        magnitudeVectorPtr += 8;
     }
 
-    number = quarterPoints * 4;
+    number = eighthPoints * 8;
     for (; number < num_points; number++) {
         float val1Real = *complexVectorPtr++;
         float val1Imag = *complexVectorPtr++;
         *magnitudeVectorPtr++ = (val1Real * val1Real) + (val1Imag * val1Imag);
     }
 }
-#endif /* LV_HAVE_SSE */
+#endif /* LV_HAVE_AVX */
 
 
 #ifdef LV_HAVE_NEON
@@ -425,7 +306,7 @@ static inline void volk_32fc_magnitude_squared_32f_rvv(float* magnitudeVector,
         __riscv_vse32(magnitudeVector, v, vl);
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
 
 #ifdef LV_HAVE_RVVSEG
 #include <riscv_vector.h>
@@ -444,6 +325,126 @@ static inline void volk_32fc_magnitude_squared_32f_rvvseg(float* magnitudeVector
         __riscv_vse32(magnitudeVector, v, vl);
     }
 }
-#endif /*LV_HAVE_RVVSEG*/
+#endif /* LV_HAVE_RVVSEG */
 
-#endif /* INCLUDED_volk_32fc_magnitude_32f_a_H */
+#endif /* INCLUDED_volk_32fc_magnitude_squared_32f_u_H */
+
+#ifndef INCLUDED_volk_32fc_magnitude_squared_32f_a_H
+#define INCLUDED_volk_32fc_magnitude_squared_32f_a_H
+
+#include <inttypes.h>
+#include <math.h>
+#include <stdio.h>
+
+#ifdef LV_HAVE_SSE
+#include <volk/volk_sse_intrinsics.h>
+#include <xmmintrin.h>
+
+static inline void volk_32fc_magnitude_squared_32f_a_sse(float* magnitudeVector,
+                                                         const lv_32fc_t* complexVector,
+                                                         unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    float* magnitudeVectorPtr = magnitudeVector;
+
+    __m128 cplxValue1, cplxValue2, result;
+    for (; number < quarterPoints; number++) {
+        cplxValue1 = _mm_load_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        cplxValue2 = _mm_load_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        result = _mm_magnitudesquared_ps(cplxValue1, cplxValue2);
+        _mm_store_ps(magnitudeVectorPtr, result);
+        magnitudeVectorPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        float val1Real = *complexVectorPtr++;
+        float val1Imag = *complexVectorPtr++;
+        *magnitudeVectorPtr++ = (val1Real * val1Real) + (val1Imag * val1Imag);
+    }
+}
+#endif /* LV_HAVE_SSE */
+
+
+#ifdef LV_HAVE_SSE3
+#include <pmmintrin.h>
+#include <volk/volk_sse3_intrinsics.h>
+
+static inline void volk_32fc_magnitude_squared_32f_a_sse3(float* magnitudeVector,
+                                                          const lv_32fc_t* complexVector,
+                                                          unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    float* magnitudeVectorPtr = magnitudeVector;
+
+    __m128 cplxValue1, cplxValue2, result;
+    for (; number < quarterPoints; number++) {
+        cplxValue1 = _mm_load_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        cplxValue2 = _mm_load_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        result = _mm_magnitudesquared_ps_sse3(cplxValue1, cplxValue2);
+        _mm_store_ps(magnitudeVectorPtr, result);
+        magnitudeVectorPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        float val1Real = *complexVectorPtr++;
+        float val1Imag = *complexVectorPtr++;
+        *magnitudeVectorPtr++ = (val1Real * val1Real) + (val1Imag * val1Imag);
+    }
+}
+#endif /* LV_HAVE_SSE3 */
+
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
+static inline void volk_32fc_magnitude_squared_32f_a_avx(float* magnitudeVector,
+                                                         const lv_32fc_t* complexVector,
+                                                         unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    float* magnitudeVectorPtr = magnitudeVector;
+
+    __m256 cplxValue1, cplxValue2, result;
+    for (; number < eighthPoints; number++) {
+        cplxValue1 = _mm256_load_ps(complexVectorPtr);
+        complexVectorPtr += 8;
+
+        cplxValue2 = _mm256_load_ps(complexVectorPtr);
+        complexVectorPtr += 8;
+
+        result = _mm256_magnitudesquared_ps(cplxValue1, cplxValue2);
+        _mm256_store_ps(magnitudeVectorPtr, result);
+        magnitudeVectorPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        float val1Real = *complexVectorPtr++;
+        float val1Imag = *complexVectorPtr++;
+        *magnitudeVectorPtr++ = (val1Real * val1Real) + (val1Imag * val1Imag);
+    }
+}
+#endif /* LV_HAVE_AVX */
+
+
+#endif /* INCLUDED_volk_32fc_magnitude_squared_32f_a_H */

--- a/kernels/volk/volk_32fc_magnitude_squared_32f.h
+++ b/kernels/volk/volk_32fc_magnitude_squared_32f.h
@@ -73,7 +73,7 @@ static inline void volk_32fc_magnitude_squared_32f_u_avx(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int eighthPoints = num_points / 8;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m256 cplxValue1, cplxValue2, result;
@@ -109,7 +109,7 @@ static inline void volk_32fc_magnitude_squared_32f_u_sse3(float* magnitudeVector
     unsigned int number = 0;
     const unsigned int quarterPoints = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m128 cplxValue1, cplxValue2, result;
@@ -146,7 +146,7 @@ static inline void volk_32fc_magnitude_squared_32f_u_sse(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int quarterPoints = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m128 cplxValue1, cplxValue2, result;
@@ -179,7 +179,7 @@ static inline void volk_32fc_magnitude_squared_32f_generic(float* magnitudeVecto
                                                            const lv_32fc_t* complexVector,
                                                            unsigned int num_points)
 {
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
     unsigned int number = 0;
     for (number = 0; number < num_points; number++) {
@@ -210,7 +210,7 @@ static inline void volk_32fc_magnitude_squared_32f_a_avx(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int eighthPoints = num_points / 8;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m256 cplxValue1, cplxValue2, result;
@@ -247,7 +247,7 @@ static inline void volk_32fc_magnitude_squared_32f_a_sse3(float* magnitudeVector
     unsigned int number = 0;
     const unsigned int quarterPoints = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m128 cplxValue1, cplxValue2, result;
@@ -284,7 +284,7 @@ static inline void volk_32fc_magnitude_squared_32f_a_sse(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int quarterPoints = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     __m128 cplxValue1, cplxValue2, result;
@@ -320,7 +320,7 @@ static inline void volk_32fc_magnitude_squared_32f_neon(float* magnitudeVector,
     unsigned int number = 0;
     const unsigned int quarterPoints = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     float* magnitudeVectorPtr = magnitudeVector;
 
     float32x4x2_t cmplx_val;

--- a/kernels/volk/volk_32fc_s32f_atan2_32f.h
+++ b/kernels/volk/volk_32fc_s32f_atan2_32f.h
@@ -58,8 +58,8 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32fc_s32f_atan2_32f_a_H
-#define INCLUDED_volk_32fc_s32f_atan2_32f_a_H
+#ifndef INCLUDED_volk_32fc_s32f_atan2_32f_u_H
+#define INCLUDED_volk_32fc_s32f_atan2_32f_u_H
 
 #include <volk/volk_mathematical_functions.h>
 
@@ -102,114 +102,10 @@ static inline void volk_32fc_s32f_atan2_32f_polynomial(float* outputVector,
 }
 #endif /* LV_HAVE_GENERIC */
 
-#if LV_HAVE_AVX512F && LV_HAVE_AVX512DQ
-#include <immintrin.h>
-#include <volk/volk_avx512_intrinsics.h>
-static inline void volk_32fc_s32f_atan2_32f_a_avx512dq(float* outputVector,
-                                                       const lv_32fc_t* complexVector,
-                                                       const float normalizeFactor,
-                                                       unsigned int num_points)
-{
-    const float* in = (const float*)complexVector;
-    float* out = (float*)outputVector;
-
-    const float invNormalizeFactor = 1.f / normalizeFactor;
-    const __m512 vinvNormalizeFactor = _mm512_set1_ps(invNormalizeFactor);
-    const __m512 pi = _mm512_set1_ps(0x1.921fb6p1f);
-    const __m512 pi_2 = _mm512_set1_ps(0x1.921fb6p0f);
-    const __m512 abs_mask = _mm512_castsi512_ps(_mm512_set1_epi32(0x7FFFFFFF));
-    const __m512 sign_mask = _mm512_castsi512_ps(_mm512_set1_epi32(0x80000000));
-
-    unsigned int number = 0;
-    const unsigned int sixteenth_points = num_points / 16;
-    for (; number < sixteenth_points; number++) {
-        __m512 z1 = _mm512_load_ps(in);
-        in += 16;
-        __m512 z2 = _mm512_load_ps(in);
-        in += 16;
-
-        __m512 x = _mm512_real(z1, z2);
-        __m512 y = _mm512_imag(z1, z2);
-
-        // Detect NaN in original inputs before division
-        __mmask16 input_nan_mask = _mm512_cmp_ps_mask(x, x, _CMP_UNORD_Q) |
-                                   _mm512_cmp_ps_mask(y, y, _CMP_UNORD_Q);
-
-        // Handle infinity cases per IEEE 754
-        const __m512 zero = _mm512_setzero_ps();
-        const __m512 pi_4 = _mm512_set1_ps(0x1.921fb6p-1f);      // π/4
-        const __m512 three_pi_4 = _mm512_set1_ps(0x1.2d97c8p1f); // 3π/4
-
-        __mmask16 y_inf_mask = _mm512_fpclass_ps_mask(y, 0x18); // ±inf
-        __mmask16 x_inf_mask = _mm512_fpclass_ps_mask(x, 0x18); // ±inf
-        __mmask16 x_pos_mask = _mm512_cmp_ps_mask(x, zero, _CMP_GT_OS);
-
-        // Build infinity result
-        __m512 inf_result = zero;
-        // Both infinite: ±π/4 or ±3π/4
-        __mmask16 both_inf = y_inf_mask & x_inf_mask;
-        __m512 both_inf_result = _mm512_mask_blend_ps(x_pos_mask, three_pi_4, pi_4);
-        both_inf_result = _mm512_or_ps(both_inf_result, _mm512_and_ps(y, sign_mask));
-        inf_result = _mm512_mask_blend_ps(both_inf, inf_result, both_inf_result);
-
-        // y infinite, x finite: ±π/2
-        __mmask16 y_inf_only = y_inf_mask & ~x_inf_mask;
-        __m512 y_inf_result = _mm512_or_ps(pi_2, _mm512_and_ps(y, sign_mask));
-        inf_result = _mm512_mask_blend_ps(y_inf_only, inf_result, y_inf_result);
-
-        // x infinite, y finite: 0 or ±π
-        __mmask16 x_inf_only = x_inf_mask & ~y_inf_mask;
-        __m512 x_inf_result =
-            _mm512_mask_blend_ps(x_pos_mask,
-                                 _mm512_or_ps(pi, _mm512_and_ps(y, sign_mask)),
-                                 _mm512_or_ps(zero, _mm512_and_ps(y, sign_mask)));
-        inf_result = _mm512_mask_blend_ps(x_inf_only, inf_result, x_inf_result);
-
-        __mmask16 any_inf_mask = y_inf_mask | x_inf_mask;
-
-        __mmask16 swap_mask = _mm512_cmp_ps_mask(
-            _mm512_and_ps(y, abs_mask), _mm512_and_ps(x, abs_mask), _CMP_GT_OS);
-        __m512 numerator = _mm512_mask_blend_ps(swap_mask, y, x);
-        __m512 denominator = _mm512_mask_blend_ps(swap_mask, x, y);
-        __m512 input = _mm512_div_ps(numerator, denominator);
-
-        // Only handle NaN from division (0/0, inf/inf), not from NaN inputs
-        // Replace with numerator to preserve sign (e.g., atan2(-0, 0) = -0)
-        __mmask16 div_nan_mask =
-            _mm512_cmp_ps_mask(input, input, _CMP_UNORD_Q) & ~input_nan_mask;
-        input = _mm512_mask_blend_ps(div_nan_mask, input, numerator);
-        __m512 result = _mm512_arctan_poly_avx512(input);
-
-        input =
-            _mm512_sub_ps(_mm512_or_ps(pi_2, _mm512_and_ps(input, sign_mask)), result);
-        result = _mm512_mask_blend_ps(swap_mask, result, input);
-
-        __m512 x_sign_mask =
-            _mm512_castsi512_ps(_mm512_srai_epi32(_mm512_castps_si512(x), 31));
-
-        result = _mm512_add_ps(
-            _mm512_and_ps(_mm512_xor_ps(pi, _mm512_and_ps(sign_mask, y)), x_sign_mask),
-            result);
-
-        // Select infinity result or normal result
-        result = _mm512_mask_blend_ps(any_inf_mask, result, inf_result);
-
-        result = _mm512_mul_ps(result, vinvNormalizeFactor);
-
-        _mm512_store_ps(out, result);
-        out += 16;
-    }
-
-    number = sixteenth_points * 16;
-    volk_32fc_s32f_atan2_32f_polynomial(
-        out, complexVector + number, normalizeFactor, num_points - number);
-}
-#endif /* LV_HAVE_AVX512F && LV_HAVE_AVX512DQ for aligned */
-
 #if LV_HAVE_AVX2 && LV_HAVE_FMA
 #include <immintrin.h>
 #include <volk/volk_avx2_fma_intrinsics.h>
-static inline void volk_32fc_s32f_atan2_32f_a_avx2_fma(float* outputVector,
+static inline void volk_32fc_s32f_atan2_32f_u_avx2_fma(float* outputVector,
                                                        const lv_32fc_t* complexVector,
                                                        const float normalizeFactor,
                                                        unsigned int num_points)
@@ -227,9 +123,9 @@ static inline void volk_32fc_s32f_atan2_32f_a_avx2_fma(float* outputVector,
     unsigned int number = 0;
     const unsigned int eighth_points = num_points / 8;
     for (; number < eighth_points; number++) {
-        __m256 z1 = _mm256_load_ps(in);
+        __m256 z1 = _mm256_loadu_ps(in);
         in += 8;
-        __m256 z2 = _mm256_load_ps(in);
+        __m256 z2 = _mm256_loadu_ps(in);
         in += 8;
 
         __m256 x = _mm256_real(z1, z2);
@@ -303,7 +199,7 @@ static inline void volk_32fc_s32f_atan2_32f_a_avx2_fma(float* outputVector,
 
         result = _mm256_mul_ps(result, vinvNormalizeFactor);
 
-        _mm256_store_ps(out, result);
+        _mm256_storeu_ps(out, result);
         out += 8;
     }
 
@@ -311,12 +207,12 @@ static inline void volk_32fc_s32f_atan2_32f_a_avx2_fma(float* outputVector,
     volk_32fc_s32f_atan2_32f_polynomial(
         out, (const lv_32fc_t*)in, normalizeFactor, num_points - number);
 }
-#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA for aligned */
+#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA */
 
 #if LV_HAVE_AVX2
 #include <immintrin.h>
 #include <volk/volk_avx_intrinsics.h>
-static inline void volk_32fc_s32f_atan2_32f_a_avx2(float* outputVector,
+static inline void volk_32fc_s32f_atan2_32f_u_avx2(float* outputVector,
                                                    const lv_32fc_t* complexVector,
                                                    const float normalizeFactor,
                                                    unsigned int num_points)
@@ -334,9 +230,9 @@ static inline void volk_32fc_s32f_atan2_32f_a_avx2(float* outputVector,
     unsigned int number = 0;
     const unsigned int eighth_points = num_points / 8;
     for (; number < eighth_points; number++) {
-        __m256 z1 = _mm256_load_ps(in);
+        __m256 z1 = _mm256_loadu_ps(in);
         in += 8;
-        __m256 z2 = _mm256_load_ps(in);
+        __m256 z2 = _mm256_loadu_ps(in);
         in += 8;
 
         __m256 x = _mm256_real(z1, z2);
@@ -410,7 +306,7 @@ static inline void volk_32fc_s32f_atan2_32f_a_avx2(float* outputVector,
 
         result = _mm256_mul_ps(result, vinvNormalizeFactor);
 
-        _mm256_store_ps(out, result);
+        _mm256_storeu_ps(out, result);
         out += 8;
     }
 
@@ -418,7 +314,111 @@ static inline void volk_32fc_s32f_atan2_32f_a_avx2(float* outputVector,
     volk_32fc_s32f_atan2_32f_polynomial(
         out, (const lv_32fc_t*)in, normalizeFactor, num_points - number);
 }
-#endif /* LV_HAVE_AVX2 for aligned */
+#endif /* LV_HAVE_AVX2 */
+
+#if LV_HAVE_AVX512F && LV_HAVE_AVX512DQ
+#include <immintrin.h>
+#include <volk/volk_avx512_intrinsics.h>
+static inline void volk_32fc_s32f_atan2_32f_u_avx512dq(float* outputVector,
+                                                       const lv_32fc_t* complexVector,
+                                                       const float normalizeFactor,
+                                                       unsigned int num_points)
+{
+    const float* in = (const float*)complexVector;
+    float* out = (float*)outputVector;
+
+    const float invNormalizeFactor = 1.f / normalizeFactor;
+    const __m512 vinvNormalizeFactor = _mm512_set1_ps(invNormalizeFactor);
+    const __m512 pi = _mm512_set1_ps(0x1.921fb6p1f);
+    const __m512 pi_2 = _mm512_set1_ps(0x1.921fb6p0f);
+    const __m512 abs_mask = _mm512_castsi512_ps(_mm512_set1_epi32(0x7FFFFFFF));
+    const __m512 sign_mask = _mm512_castsi512_ps(_mm512_set1_epi32(0x80000000));
+
+    const unsigned int sixteenth_points = num_points / 16;
+
+    for (unsigned int number = 0; number < sixteenth_points; number++) {
+        __m512 z1 = _mm512_loadu_ps(in);
+        in += 16;
+        __m512 z2 = _mm512_loadu_ps(in);
+        in += 16;
+
+        __m512 x = _mm512_real(z1, z2);
+        __m512 y = _mm512_imag(z1, z2);
+
+        // Detect NaN in original inputs before division
+        __mmask16 input_nan_mask = _mm512_cmp_ps_mask(x, x, _CMP_UNORD_Q) |
+                                   _mm512_cmp_ps_mask(y, y, _CMP_UNORD_Q);
+
+        // Handle infinity cases per IEEE 754
+        const __m512 zero = _mm512_setzero_ps();
+        const __m512 pi_4 = _mm512_set1_ps(0x1.921fb6p-1f);      // π/4
+        const __m512 three_pi_4 = _mm512_set1_ps(0x1.2d97c8p1f); // 3π/4
+
+        __mmask16 y_inf_mask = _mm512_fpclass_ps_mask(y, 0x18); // ±inf
+        __mmask16 x_inf_mask = _mm512_fpclass_ps_mask(x, 0x18); // ±inf
+        __mmask16 x_pos_mask = _mm512_cmp_ps_mask(x, zero, _CMP_GT_OS);
+
+        // Build infinity result
+        __m512 inf_result = zero;
+        // Both infinite: ±π/4 or ±3π/4
+        __mmask16 both_inf = y_inf_mask & x_inf_mask;
+        __m512 both_inf_result = _mm512_mask_blend_ps(x_pos_mask, three_pi_4, pi_4);
+        both_inf_result = _mm512_or_ps(both_inf_result, _mm512_and_ps(y, sign_mask));
+        inf_result = _mm512_mask_blend_ps(both_inf, inf_result, both_inf_result);
+
+        // y infinite, x finite: ±π/2
+        __mmask16 y_inf_only = y_inf_mask & ~x_inf_mask;
+        __m512 y_inf_result = _mm512_or_ps(pi_2, _mm512_and_ps(y, sign_mask));
+        inf_result = _mm512_mask_blend_ps(y_inf_only, inf_result, y_inf_result);
+
+        // x infinite, y finite: 0 or ±π
+        __mmask16 x_inf_only = x_inf_mask & ~y_inf_mask;
+        __m512 x_inf_result =
+            _mm512_mask_blend_ps(x_pos_mask,
+                                 _mm512_or_ps(pi, _mm512_and_ps(y, sign_mask)),
+                                 _mm512_or_ps(zero, _mm512_and_ps(y, sign_mask)));
+        inf_result = _mm512_mask_blend_ps(x_inf_only, inf_result, x_inf_result);
+
+        __mmask16 any_inf_mask = y_inf_mask | x_inf_mask;
+
+        __mmask16 swap_mask = _mm512_cmp_ps_mask(
+            _mm512_and_ps(y, abs_mask), _mm512_and_ps(x, abs_mask), _CMP_GT_OS);
+        __m512 numerator = _mm512_mask_blend_ps(swap_mask, y, x);
+        __m512 denominator = _mm512_mask_blend_ps(swap_mask, x, y);
+        __m512 input = _mm512_div_ps(numerator, denominator);
+
+        // Only handle NaN from division (0/0, inf/inf), not from NaN inputs
+        // Replace with numerator to preserve sign (e.g., atan2(-0, 0) = -0)
+        __mmask16 div_nan_mask =
+            _mm512_cmp_ps_mask(input, input, _CMP_UNORD_Q) & ~input_nan_mask;
+        input = _mm512_mask_blend_ps(div_nan_mask, input, numerator);
+        __m512 result = _mm512_arctan_poly_avx512(input);
+
+        input =
+            _mm512_sub_ps(_mm512_or_ps(pi_2, _mm512_and_ps(input, sign_mask)), result);
+        result = _mm512_mask_blend_ps(swap_mask, result, input);
+
+        __m512 x_sign_mask =
+            _mm512_castsi512_ps(_mm512_srai_epi32(_mm512_castps_si512(x), 31));
+
+        result = _mm512_add_ps(
+            _mm512_and_ps(_mm512_xor_ps(pi, _mm512_and_ps(sign_mask, y)), x_sign_mask),
+            result);
+
+        // Select infinity result or normal result
+        result = _mm512_mask_blend_ps(any_inf_mask, result, inf_result);
+
+        result = _mm512_mul_ps(result, vinvNormalizeFactor);
+
+        _mm512_storeu_ps(out, result);
+        out += 16;
+    }
+
+    unsigned int number = sixteenth_points * 16;
+    volk_32fc_s32f_atan2_32f_polynomial(
+        out, complexVector + number, normalizeFactor, num_points - number);
+}
+#endif /* LV_HAVE_AVX512F && LV_HAVE_AVX512DQ */
 
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
@@ -684,329 +684,6 @@ static inline void volk_32fc_s32f_atan2_32f_neonv8(float* outputVector,
 }
 #endif /* LV_HAVE_NEONV8 */
 
-#endif /* INCLUDED_volk_32fc_s32f_atan2_32f_a_H */
-
-#ifndef INCLUDED_volk_32fc_s32f_atan2_32f_u_H
-#define INCLUDED_volk_32fc_s32f_atan2_32f_u_H
-
-#if LV_HAVE_AVX512F && LV_HAVE_AVX512DQ
-#include <immintrin.h>
-#include <volk/volk_avx512_intrinsics.h>
-static inline void volk_32fc_s32f_atan2_32f_u_avx512dq(float* outputVector,
-                                                       const lv_32fc_t* complexVector,
-                                                       const float normalizeFactor,
-                                                       unsigned int num_points)
-{
-    const float* in = (const float*)complexVector;
-    float* out = (float*)outputVector;
-
-    const float invNormalizeFactor = 1.f / normalizeFactor;
-    const __m512 vinvNormalizeFactor = _mm512_set1_ps(invNormalizeFactor);
-    const __m512 pi = _mm512_set1_ps(0x1.921fb6p1f);
-    const __m512 pi_2 = _mm512_set1_ps(0x1.921fb6p0f);
-    const __m512 abs_mask = _mm512_castsi512_ps(_mm512_set1_epi32(0x7FFFFFFF));
-    const __m512 sign_mask = _mm512_castsi512_ps(_mm512_set1_epi32(0x80000000));
-
-    const unsigned int sixteenth_points = num_points / 16;
-
-    for (unsigned int number = 0; number < sixteenth_points; number++) {
-        __m512 z1 = _mm512_loadu_ps(in);
-        in += 16;
-        __m512 z2 = _mm512_loadu_ps(in);
-        in += 16;
-
-        __m512 x = _mm512_real(z1, z2);
-        __m512 y = _mm512_imag(z1, z2);
-
-        // Detect NaN in original inputs before division
-        __mmask16 input_nan_mask = _mm512_cmp_ps_mask(x, x, _CMP_UNORD_Q) |
-                                   _mm512_cmp_ps_mask(y, y, _CMP_UNORD_Q);
-
-        // Handle infinity cases per IEEE 754
-        const __m512 zero = _mm512_setzero_ps();
-        const __m512 pi_4 = _mm512_set1_ps(0x1.921fb6p-1f);      // π/4
-        const __m512 three_pi_4 = _mm512_set1_ps(0x1.2d97c8p1f); // 3π/4
-
-        __mmask16 y_inf_mask = _mm512_fpclass_ps_mask(y, 0x18); // ±inf
-        __mmask16 x_inf_mask = _mm512_fpclass_ps_mask(x, 0x18); // ±inf
-        __mmask16 x_pos_mask = _mm512_cmp_ps_mask(x, zero, _CMP_GT_OS);
-
-        // Build infinity result
-        __m512 inf_result = zero;
-        // Both infinite: ±π/4 or ±3π/4
-        __mmask16 both_inf = y_inf_mask & x_inf_mask;
-        __m512 both_inf_result = _mm512_mask_blend_ps(x_pos_mask, three_pi_4, pi_4);
-        both_inf_result = _mm512_or_ps(both_inf_result, _mm512_and_ps(y, sign_mask));
-        inf_result = _mm512_mask_blend_ps(both_inf, inf_result, both_inf_result);
-
-        // y infinite, x finite: ±π/2
-        __mmask16 y_inf_only = y_inf_mask & ~x_inf_mask;
-        __m512 y_inf_result = _mm512_or_ps(pi_2, _mm512_and_ps(y, sign_mask));
-        inf_result = _mm512_mask_blend_ps(y_inf_only, inf_result, y_inf_result);
-
-        // x infinite, y finite: 0 or ±π
-        __mmask16 x_inf_only = x_inf_mask & ~y_inf_mask;
-        __m512 x_inf_result =
-            _mm512_mask_blend_ps(x_pos_mask,
-                                 _mm512_or_ps(pi, _mm512_and_ps(y, sign_mask)),
-                                 _mm512_or_ps(zero, _mm512_and_ps(y, sign_mask)));
-        inf_result = _mm512_mask_blend_ps(x_inf_only, inf_result, x_inf_result);
-
-        __mmask16 any_inf_mask = y_inf_mask | x_inf_mask;
-
-        __mmask16 swap_mask = _mm512_cmp_ps_mask(
-            _mm512_and_ps(y, abs_mask), _mm512_and_ps(x, abs_mask), _CMP_GT_OS);
-        __m512 numerator = _mm512_mask_blend_ps(swap_mask, y, x);
-        __m512 denominator = _mm512_mask_blend_ps(swap_mask, x, y);
-        __m512 input = _mm512_div_ps(numerator, denominator);
-
-        // Only handle NaN from division (0/0, inf/inf), not from NaN inputs
-        // Replace with numerator to preserve sign (e.g., atan2(-0, 0) = -0)
-        __mmask16 div_nan_mask =
-            _mm512_cmp_ps_mask(input, input, _CMP_UNORD_Q) & ~input_nan_mask;
-        input = _mm512_mask_blend_ps(div_nan_mask, input, numerator);
-        __m512 result = _mm512_arctan_poly_avx512(input);
-
-        input =
-            _mm512_sub_ps(_mm512_or_ps(pi_2, _mm512_and_ps(input, sign_mask)), result);
-        result = _mm512_mask_blend_ps(swap_mask, result, input);
-
-        __m512 x_sign_mask =
-            _mm512_castsi512_ps(_mm512_srai_epi32(_mm512_castps_si512(x), 31));
-
-        result = _mm512_add_ps(
-            _mm512_and_ps(_mm512_xor_ps(pi, _mm512_and_ps(sign_mask, y)), x_sign_mask),
-            result);
-
-        // Select infinity result or normal result
-        result = _mm512_mask_blend_ps(any_inf_mask, result, inf_result);
-
-        result = _mm512_mul_ps(result, vinvNormalizeFactor);
-
-        _mm512_storeu_ps(out, result);
-        out += 16;
-    }
-
-    unsigned int number = sixteenth_points * 16;
-    volk_32fc_s32f_atan2_32f_polynomial(
-        out, complexVector + number, normalizeFactor, num_points - number);
-}
-#endif /* LV_HAVE_AVX512F && LV_HAVE_AVX512DQ for unaligned */
-
-#if LV_HAVE_AVX2 && LV_HAVE_FMA
-#include <immintrin.h>
-#include <volk/volk_avx2_fma_intrinsics.h>
-static inline void volk_32fc_s32f_atan2_32f_u_avx2_fma(float* outputVector,
-                                                       const lv_32fc_t* complexVector,
-                                                       const float normalizeFactor,
-                                                       unsigned int num_points)
-{
-    const float* in = (const float*)complexVector;
-    float* out = (float*)outputVector;
-
-    const float invNormalizeFactor = 1.f / normalizeFactor;
-    const __m256 vinvNormalizeFactor = _mm256_set1_ps(invNormalizeFactor);
-    const __m256 pi = _mm256_set1_ps(0x1.921fb6p1f);
-    const __m256 pi_2 = _mm256_set1_ps(0x1.921fb6p0f);
-    const __m256 abs_mask = _mm256_castsi256_ps(_mm256_set1_epi32(0x7FFFFFFF));
-    const __m256 sign_mask = _mm256_castsi256_ps(_mm256_set1_epi32(0x80000000));
-
-    unsigned int number = 0;
-    const unsigned int eighth_points = num_points / 8;
-    for (; number < eighth_points; number++) {
-        __m256 z1 = _mm256_loadu_ps(in);
-        in += 8;
-        __m256 z2 = _mm256_loadu_ps(in);
-        in += 8;
-
-        __m256 x = _mm256_real(z1, z2);
-        __m256 y = _mm256_imag(z1, z2);
-
-        // Detect NaN in original inputs before division
-        __m256 input_nan_mask = _mm256_or_ps(_mm256_cmp_ps(x, x, _CMP_UNORD_Q),
-                                             _mm256_cmp_ps(y, y, _CMP_UNORD_Q));
-
-        // Handle infinity cases per IEEE 754
-        const __m256 zero = _mm256_setzero_ps();
-        const __m256 inf = _mm256_set1_ps(HUGE_VALF);
-        const __m256 pi_4 = _mm256_set1_ps(0x1.921fb6p-1f);      // π/4
-        const __m256 three_pi_4 = _mm256_set1_ps(0x1.2d97c8p1f); // 3π/4
-
-        __m256 y_abs = _mm256_and_ps(y, abs_mask);
-        __m256 x_abs = _mm256_and_ps(x, abs_mask);
-        __m256 y_inf_mask = _mm256_cmp_ps(y_abs, inf, _CMP_EQ_OQ); // |y| == inf
-        __m256 x_inf_mask = _mm256_cmp_ps(x_abs, inf, _CMP_EQ_OQ); // |x| == inf
-        __m256 x_pos_mask = _mm256_cmp_ps(x, zero, _CMP_GT_OS);
-
-        // Build infinity result
-        __m256 inf_result = zero;
-        // Both infinite: ±π/4 or ±3π/4
-        __m256 both_inf = _mm256_and_ps(y_inf_mask, x_inf_mask);
-        __m256 both_inf_result = _mm256_blendv_ps(three_pi_4, pi_4, x_pos_mask);
-        both_inf_result = _mm256_or_ps(both_inf_result, _mm256_and_ps(y, sign_mask));
-        inf_result = _mm256_blendv_ps(inf_result, both_inf_result, both_inf);
-
-        // y infinite, x finite: ±π/2
-        __m256 y_inf_only = _mm256_andnot_ps(x_inf_mask, y_inf_mask);
-        __m256 y_inf_result = _mm256_or_ps(pi_2, _mm256_and_ps(y, sign_mask));
-        inf_result = _mm256_blendv_ps(inf_result, y_inf_result, y_inf_only);
-
-        // x infinite, y finite: 0 or ±π
-        __m256 x_inf_only = _mm256_andnot_ps(y_inf_mask, x_inf_mask);
-        __m256 x_inf_result =
-            _mm256_blendv_ps(_mm256_or_ps(pi, _mm256_and_ps(y, sign_mask)),
-                             _mm256_or_ps(zero, _mm256_and_ps(y, sign_mask)),
-                             x_pos_mask);
-        inf_result = _mm256_blendv_ps(inf_result, x_inf_result, x_inf_only);
-
-        __m256 any_inf_mask = _mm256_or_ps(y_inf_mask, x_inf_mask);
-
-        __m256 swap_mask = _mm256_cmp_ps(
-            _mm256_and_ps(y, abs_mask), _mm256_and_ps(x, abs_mask), _CMP_GT_OS);
-        __m256 numerator = _mm256_blendv_ps(y, x, swap_mask);
-        __m256 denominator = _mm256_blendv_ps(x, y, swap_mask);
-        __m256 input = _mm256_div_ps(numerator, denominator);
-
-        // Only handle NaN from division (0/0, inf/inf), not from NaN inputs
-        // Replace with numerator to preserve sign (e.g., atan2(-0, 0) = -0)
-        __m256 div_nan_mask =
-            _mm256_andnot_ps(input_nan_mask, _mm256_cmp_ps(input, input, _CMP_UNORD_Q));
-        input = _mm256_blendv_ps(input, numerator, div_nan_mask);
-        __m256 result = _mm256_arctan_poly_avx2_fma(input);
-
-        input =
-            _mm256_sub_ps(_mm256_or_ps(pi_2, _mm256_and_ps(input, sign_mask)), result);
-        result = _mm256_blendv_ps(result, input, swap_mask);
-
-        __m256 x_sign_mask =
-            _mm256_castsi256_ps(_mm256_srai_epi32(_mm256_castps_si256(x), 31));
-
-        result = _mm256_add_ps(
-            _mm256_and_ps(_mm256_xor_ps(pi, _mm256_and_ps(sign_mask, y)), x_sign_mask),
-            result);
-
-        // Select infinity result or normal result
-        result = _mm256_blendv_ps(result, inf_result, any_inf_mask);
-
-        result = _mm256_mul_ps(result, vinvNormalizeFactor);
-
-        _mm256_storeu_ps(out, result);
-        out += 8;
-    }
-
-    number = eighth_points * 8;
-    volk_32fc_s32f_atan2_32f_polynomial(
-        out, (const lv_32fc_t*)in, normalizeFactor, num_points - number);
-}
-#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA for unaligned */
-
-#if LV_HAVE_AVX2
-#include <immintrin.h>
-#include <volk/volk_avx_intrinsics.h>
-static inline void volk_32fc_s32f_atan2_32f_u_avx2(float* outputVector,
-                                                   const lv_32fc_t* complexVector,
-                                                   const float normalizeFactor,
-                                                   unsigned int num_points)
-{
-    const float* in = (const float*)complexVector;
-    float* out = (float*)outputVector;
-
-    const float invNormalizeFactor = 1.f / normalizeFactor;
-    const __m256 vinvNormalizeFactor = _mm256_set1_ps(invNormalizeFactor);
-    const __m256 pi = _mm256_set1_ps(0x1.921fb6p1f);
-    const __m256 pi_2 = _mm256_set1_ps(0x1.921fb6p0f);
-    const __m256 abs_mask = _mm256_castsi256_ps(_mm256_set1_epi32(0x7FFFFFFF));
-    const __m256 sign_mask = _mm256_castsi256_ps(_mm256_set1_epi32(0x80000000));
-
-    unsigned int number = 0;
-    const unsigned int eighth_points = num_points / 8;
-    for (; number < eighth_points; number++) {
-        __m256 z1 = _mm256_loadu_ps(in);
-        in += 8;
-        __m256 z2 = _mm256_loadu_ps(in);
-        in += 8;
-
-        __m256 x = _mm256_real(z1, z2);
-        __m256 y = _mm256_imag(z1, z2);
-
-        // Detect NaN in original inputs before division
-        __m256 input_nan_mask = _mm256_or_ps(_mm256_cmp_ps(x, x, _CMP_UNORD_Q),
-                                             _mm256_cmp_ps(y, y, _CMP_UNORD_Q));
-
-        // Handle infinity cases per IEEE 754
-        const __m256 zero = _mm256_setzero_ps();
-        const __m256 inf = _mm256_set1_ps(HUGE_VALF);
-        const __m256 pi_4 = _mm256_set1_ps(0x1.921fb6p-1f);      // π/4
-        const __m256 three_pi_4 = _mm256_set1_ps(0x1.2d97c8p1f); // 3π/4
-
-        __m256 y_abs = _mm256_and_ps(y, abs_mask);
-        __m256 x_abs = _mm256_and_ps(x, abs_mask);
-        __m256 y_inf_mask = _mm256_cmp_ps(y_abs, inf, _CMP_EQ_OQ); // |y| == inf
-        __m256 x_inf_mask = _mm256_cmp_ps(x_abs, inf, _CMP_EQ_OQ); // |x| == inf
-        __m256 x_pos_mask = _mm256_cmp_ps(x, zero, _CMP_GT_OS);
-
-        // Build infinity result
-        __m256 inf_result = zero;
-        // Both infinite: ±π/4 or ±3π/4
-        __m256 both_inf = _mm256_and_ps(y_inf_mask, x_inf_mask);
-        __m256 both_inf_result = _mm256_blendv_ps(three_pi_4, pi_4, x_pos_mask);
-        both_inf_result = _mm256_or_ps(both_inf_result, _mm256_and_ps(y, sign_mask));
-        inf_result = _mm256_blendv_ps(inf_result, both_inf_result, both_inf);
-
-        // y infinite, x finite: ±π/2
-        __m256 y_inf_only = _mm256_andnot_ps(x_inf_mask, y_inf_mask);
-        __m256 y_inf_result = _mm256_or_ps(pi_2, _mm256_and_ps(y, sign_mask));
-        inf_result = _mm256_blendv_ps(inf_result, y_inf_result, y_inf_only);
-
-        // x infinite, y finite: 0 or ±π
-        __m256 x_inf_only = _mm256_andnot_ps(y_inf_mask, x_inf_mask);
-        __m256 x_inf_result =
-            _mm256_blendv_ps(_mm256_or_ps(pi, _mm256_and_ps(y, sign_mask)),
-                             _mm256_or_ps(zero, _mm256_and_ps(y, sign_mask)),
-                             x_pos_mask);
-        inf_result = _mm256_blendv_ps(inf_result, x_inf_result, x_inf_only);
-
-        __m256 any_inf_mask = _mm256_or_ps(y_inf_mask, x_inf_mask);
-
-        __m256 swap_mask = _mm256_cmp_ps(
-            _mm256_and_ps(y, abs_mask), _mm256_and_ps(x, abs_mask), _CMP_GT_OS);
-        __m256 numerator = _mm256_blendv_ps(y, x, swap_mask);
-        __m256 denominator = _mm256_blendv_ps(x, y, swap_mask);
-        __m256 input = _mm256_div_ps(numerator, denominator);
-
-        // Only handle NaN from division (0/0, inf/inf), not from NaN inputs
-        // Replace with numerator to preserve sign (e.g., atan2(-0, 0) = -0)
-        __m256 div_nan_mask =
-            _mm256_andnot_ps(input_nan_mask, _mm256_cmp_ps(input, input, _CMP_UNORD_Q));
-        input = _mm256_blendv_ps(input, numerator, div_nan_mask);
-        __m256 result = _mm256_arctan_poly_avx(input);
-
-        input =
-            _mm256_sub_ps(_mm256_or_ps(pi_2, _mm256_and_ps(input, sign_mask)), result);
-        result = _mm256_blendv_ps(result, input, swap_mask);
-
-        __m256 x_sign_mask =
-            _mm256_castsi256_ps(_mm256_srai_epi32(_mm256_castps_si256(x), 31));
-
-        result = _mm256_add_ps(
-            _mm256_and_ps(_mm256_xor_ps(pi, _mm256_and_ps(sign_mask, y)), x_sign_mask),
-            result);
-
-        // Select infinity result or normal result
-        result = _mm256_blendv_ps(result, inf_result, any_inf_mask);
-
-        result = _mm256_mul_ps(result, vinvNormalizeFactor);
-
-        _mm256_storeu_ps(out, result);
-        out += 8;
-    }
-
-    number = eighth_points * 8;
-    volk_32fc_s32f_atan2_32f_polynomial(
-        out, (const lv_32fc_t*)in, normalizeFactor, num_points - number);
-}
-#endif /* LV_HAVE_AVX2 for unaligned */
-
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 #include <volk/volk_rvv_intrinsics.h>
@@ -1109,7 +786,7 @@ static inline void volk_32fc_s32f_atan2_32f_rvv(float* outputVector,
         __riscv_vse32(outputVector, __riscv_vfmul(p, norm, vl), vl);
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
 
 #ifdef LV_HAVE_RVVSEG
 #include <riscv_vector.h>
@@ -1212,6 +889,329 @@ static inline void volk_32fc_s32f_atan2_32f_rvvseg(float* outputVector,
         __riscv_vse32(outputVector, __riscv_vfmul(p, norm, vl), vl);
     }
 }
-#endif /*LV_HAVE_RVVSEG*/
+#endif /* LV_HAVE_RVVSEG */
 
 #endif /* INCLUDED_volk_32fc_s32f_atan2_32f_u_H */
+
+#ifndef INCLUDED_volk_32fc_s32f_atan2_32f_a_H
+#define INCLUDED_volk_32fc_s32f_atan2_32f_a_H
+
+#if LV_HAVE_AVX2 && LV_HAVE_FMA
+#include <immintrin.h>
+#include <volk/volk_avx2_fma_intrinsics.h>
+static inline void volk_32fc_s32f_atan2_32f_a_avx2_fma(float* outputVector,
+                                                       const lv_32fc_t* complexVector,
+                                                       const float normalizeFactor,
+                                                       unsigned int num_points)
+{
+    const float* in = (const float*)complexVector;
+    float* out = (float*)outputVector;
+
+    const float invNormalizeFactor = 1.f / normalizeFactor;
+    const __m256 vinvNormalizeFactor = _mm256_set1_ps(invNormalizeFactor);
+    const __m256 pi = _mm256_set1_ps(0x1.921fb6p1f);
+    const __m256 pi_2 = _mm256_set1_ps(0x1.921fb6p0f);
+    const __m256 abs_mask = _mm256_castsi256_ps(_mm256_set1_epi32(0x7FFFFFFF));
+    const __m256 sign_mask = _mm256_castsi256_ps(_mm256_set1_epi32(0x80000000));
+
+    unsigned int number = 0;
+    const unsigned int eighth_points = num_points / 8;
+    for (; number < eighth_points; number++) {
+        __m256 z1 = _mm256_load_ps(in);
+        in += 8;
+        __m256 z2 = _mm256_load_ps(in);
+        in += 8;
+
+        __m256 x = _mm256_real(z1, z2);
+        __m256 y = _mm256_imag(z1, z2);
+
+        // Detect NaN in original inputs before division
+        __m256 input_nan_mask = _mm256_or_ps(_mm256_cmp_ps(x, x, _CMP_UNORD_Q),
+                                             _mm256_cmp_ps(y, y, _CMP_UNORD_Q));
+
+        // Handle infinity cases per IEEE 754
+        const __m256 zero = _mm256_setzero_ps();
+        const __m256 inf = _mm256_set1_ps(HUGE_VALF);
+        const __m256 pi_4 = _mm256_set1_ps(0x1.921fb6p-1f);      // π/4
+        const __m256 three_pi_4 = _mm256_set1_ps(0x1.2d97c8p1f); // 3π/4
+
+        __m256 y_abs = _mm256_and_ps(y, abs_mask);
+        __m256 x_abs = _mm256_and_ps(x, abs_mask);
+        __m256 y_inf_mask = _mm256_cmp_ps(y_abs, inf, _CMP_EQ_OQ); // |y| == inf
+        __m256 x_inf_mask = _mm256_cmp_ps(x_abs, inf, _CMP_EQ_OQ); // |x| == inf
+        __m256 x_pos_mask = _mm256_cmp_ps(x, zero, _CMP_GT_OS);
+
+        // Build infinity result
+        __m256 inf_result = zero;
+        // Both infinite: ±π/4 or ±3π/4
+        __m256 both_inf = _mm256_and_ps(y_inf_mask, x_inf_mask);
+        __m256 both_inf_result = _mm256_blendv_ps(three_pi_4, pi_4, x_pos_mask);
+        both_inf_result = _mm256_or_ps(both_inf_result, _mm256_and_ps(y, sign_mask));
+        inf_result = _mm256_blendv_ps(inf_result, both_inf_result, both_inf);
+
+        // y infinite, x finite: ±π/2
+        __m256 y_inf_only = _mm256_andnot_ps(x_inf_mask, y_inf_mask);
+        __m256 y_inf_result = _mm256_or_ps(pi_2, _mm256_and_ps(y, sign_mask));
+        inf_result = _mm256_blendv_ps(inf_result, y_inf_result, y_inf_only);
+
+        // x infinite, y finite: 0 or ±π
+        __m256 x_inf_only = _mm256_andnot_ps(y_inf_mask, x_inf_mask);
+        __m256 x_inf_result =
+            _mm256_blendv_ps(_mm256_or_ps(pi, _mm256_and_ps(y, sign_mask)),
+                             _mm256_or_ps(zero, _mm256_and_ps(y, sign_mask)),
+                             x_pos_mask);
+        inf_result = _mm256_blendv_ps(inf_result, x_inf_result, x_inf_only);
+
+        __m256 any_inf_mask = _mm256_or_ps(y_inf_mask, x_inf_mask);
+
+        __m256 swap_mask = _mm256_cmp_ps(
+            _mm256_and_ps(y, abs_mask), _mm256_and_ps(x, abs_mask), _CMP_GT_OS);
+        __m256 numerator = _mm256_blendv_ps(y, x, swap_mask);
+        __m256 denominator = _mm256_blendv_ps(x, y, swap_mask);
+        __m256 input = _mm256_div_ps(numerator, denominator);
+
+        // Only handle NaN from division (0/0, inf/inf), not from NaN inputs
+        // Replace with numerator to preserve sign (e.g., atan2(-0, 0) = -0)
+        __m256 div_nan_mask =
+            _mm256_andnot_ps(input_nan_mask, _mm256_cmp_ps(input, input, _CMP_UNORD_Q));
+        input = _mm256_blendv_ps(input, numerator, div_nan_mask);
+        __m256 result = _mm256_arctan_poly_avx2_fma(input);
+
+        input =
+            _mm256_sub_ps(_mm256_or_ps(pi_2, _mm256_and_ps(input, sign_mask)), result);
+        result = _mm256_blendv_ps(result, input, swap_mask);
+
+        __m256 x_sign_mask =
+            _mm256_castsi256_ps(_mm256_srai_epi32(_mm256_castps_si256(x), 31));
+
+        result = _mm256_add_ps(
+            _mm256_and_ps(_mm256_xor_ps(pi, _mm256_and_ps(sign_mask, y)), x_sign_mask),
+            result);
+
+        // Select infinity result or normal result
+        result = _mm256_blendv_ps(result, inf_result, any_inf_mask);
+
+        result = _mm256_mul_ps(result, vinvNormalizeFactor);
+
+        _mm256_store_ps(out, result);
+        out += 8;
+    }
+
+    number = eighth_points * 8;
+    volk_32fc_s32f_atan2_32f_polynomial(
+        out, (const lv_32fc_t*)in, normalizeFactor, num_points - number);
+}
+#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA */
+
+#if LV_HAVE_AVX2
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+static inline void volk_32fc_s32f_atan2_32f_a_avx2(float* outputVector,
+                                                   const lv_32fc_t* complexVector,
+                                                   const float normalizeFactor,
+                                                   unsigned int num_points)
+{
+    const float* in = (const float*)complexVector;
+    float* out = (float*)outputVector;
+
+    const float invNormalizeFactor = 1.f / normalizeFactor;
+    const __m256 vinvNormalizeFactor = _mm256_set1_ps(invNormalizeFactor);
+    const __m256 pi = _mm256_set1_ps(0x1.921fb6p1f);
+    const __m256 pi_2 = _mm256_set1_ps(0x1.921fb6p0f);
+    const __m256 abs_mask = _mm256_castsi256_ps(_mm256_set1_epi32(0x7FFFFFFF));
+    const __m256 sign_mask = _mm256_castsi256_ps(_mm256_set1_epi32(0x80000000));
+
+    unsigned int number = 0;
+    const unsigned int eighth_points = num_points / 8;
+    for (; number < eighth_points; number++) {
+        __m256 z1 = _mm256_load_ps(in);
+        in += 8;
+        __m256 z2 = _mm256_load_ps(in);
+        in += 8;
+
+        __m256 x = _mm256_real(z1, z2);
+        __m256 y = _mm256_imag(z1, z2);
+
+        // Detect NaN in original inputs before division
+        __m256 input_nan_mask = _mm256_or_ps(_mm256_cmp_ps(x, x, _CMP_UNORD_Q),
+                                             _mm256_cmp_ps(y, y, _CMP_UNORD_Q));
+
+        // Handle infinity cases per IEEE 754
+        const __m256 zero = _mm256_setzero_ps();
+        const __m256 inf = _mm256_set1_ps(HUGE_VALF);
+        const __m256 pi_4 = _mm256_set1_ps(0x1.921fb6p-1f);      // π/4
+        const __m256 three_pi_4 = _mm256_set1_ps(0x1.2d97c8p1f); // 3π/4
+
+        __m256 y_abs = _mm256_and_ps(y, abs_mask);
+        __m256 x_abs = _mm256_and_ps(x, abs_mask);
+        __m256 y_inf_mask = _mm256_cmp_ps(y_abs, inf, _CMP_EQ_OQ); // |y| == inf
+        __m256 x_inf_mask = _mm256_cmp_ps(x_abs, inf, _CMP_EQ_OQ); // |x| == inf
+        __m256 x_pos_mask = _mm256_cmp_ps(x, zero, _CMP_GT_OS);
+
+        // Build infinity result
+        __m256 inf_result = zero;
+        // Both infinite: ±π/4 or ±3π/4
+        __m256 both_inf = _mm256_and_ps(y_inf_mask, x_inf_mask);
+        __m256 both_inf_result = _mm256_blendv_ps(three_pi_4, pi_4, x_pos_mask);
+        both_inf_result = _mm256_or_ps(both_inf_result, _mm256_and_ps(y, sign_mask));
+        inf_result = _mm256_blendv_ps(inf_result, both_inf_result, both_inf);
+
+        // y infinite, x finite: ±π/2
+        __m256 y_inf_only = _mm256_andnot_ps(x_inf_mask, y_inf_mask);
+        __m256 y_inf_result = _mm256_or_ps(pi_2, _mm256_and_ps(y, sign_mask));
+        inf_result = _mm256_blendv_ps(inf_result, y_inf_result, y_inf_only);
+
+        // x infinite, y finite: 0 or ±π
+        __m256 x_inf_only = _mm256_andnot_ps(y_inf_mask, x_inf_mask);
+        __m256 x_inf_result =
+            _mm256_blendv_ps(_mm256_or_ps(pi, _mm256_and_ps(y, sign_mask)),
+                             _mm256_or_ps(zero, _mm256_and_ps(y, sign_mask)),
+                             x_pos_mask);
+        inf_result = _mm256_blendv_ps(inf_result, x_inf_result, x_inf_only);
+
+        __m256 any_inf_mask = _mm256_or_ps(y_inf_mask, x_inf_mask);
+
+        __m256 swap_mask = _mm256_cmp_ps(
+            _mm256_and_ps(y, abs_mask), _mm256_and_ps(x, abs_mask), _CMP_GT_OS);
+        __m256 numerator = _mm256_blendv_ps(y, x, swap_mask);
+        __m256 denominator = _mm256_blendv_ps(x, y, swap_mask);
+        __m256 input = _mm256_div_ps(numerator, denominator);
+
+        // Only handle NaN from division (0/0, inf/inf), not from NaN inputs
+        // Replace with numerator to preserve sign (e.g., atan2(-0, 0) = -0)
+        __m256 div_nan_mask =
+            _mm256_andnot_ps(input_nan_mask, _mm256_cmp_ps(input, input, _CMP_UNORD_Q));
+        input = _mm256_blendv_ps(input, numerator, div_nan_mask);
+        __m256 result = _mm256_arctan_poly_avx(input);
+
+        input =
+            _mm256_sub_ps(_mm256_or_ps(pi_2, _mm256_and_ps(input, sign_mask)), result);
+        result = _mm256_blendv_ps(result, input, swap_mask);
+
+        __m256 x_sign_mask =
+            _mm256_castsi256_ps(_mm256_srai_epi32(_mm256_castps_si256(x), 31));
+
+        result = _mm256_add_ps(
+            _mm256_and_ps(_mm256_xor_ps(pi, _mm256_and_ps(sign_mask, y)), x_sign_mask),
+            result);
+
+        // Select infinity result or normal result
+        result = _mm256_blendv_ps(result, inf_result, any_inf_mask);
+
+        result = _mm256_mul_ps(result, vinvNormalizeFactor);
+
+        _mm256_store_ps(out, result);
+        out += 8;
+    }
+
+    number = eighth_points * 8;
+    volk_32fc_s32f_atan2_32f_polynomial(
+        out, (const lv_32fc_t*)in, normalizeFactor, num_points - number);
+}
+#endif /* LV_HAVE_AVX2 */
+
+#if LV_HAVE_AVX512F && LV_HAVE_AVX512DQ
+#include <immintrin.h>
+#include <volk/volk_avx512_intrinsics.h>
+static inline void volk_32fc_s32f_atan2_32f_a_avx512dq(float* outputVector,
+                                                       const lv_32fc_t* complexVector,
+                                                       const float normalizeFactor,
+                                                       unsigned int num_points)
+{
+    const float* in = (const float*)complexVector;
+    float* out = (float*)outputVector;
+
+    const float invNormalizeFactor = 1.f / normalizeFactor;
+    const __m512 vinvNormalizeFactor = _mm512_set1_ps(invNormalizeFactor);
+    const __m512 pi = _mm512_set1_ps(0x1.921fb6p1f);
+    const __m512 pi_2 = _mm512_set1_ps(0x1.921fb6p0f);
+    const __m512 abs_mask = _mm512_castsi512_ps(_mm512_set1_epi32(0x7FFFFFFF));
+    const __m512 sign_mask = _mm512_castsi512_ps(_mm512_set1_epi32(0x80000000));
+
+    unsigned int number = 0;
+    const unsigned int sixteenth_points = num_points / 16;
+    for (; number < sixteenth_points; number++) {
+        __m512 z1 = _mm512_load_ps(in);
+        in += 16;
+        __m512 z2 = _mm512_load_ps(in);
+        in += 16;
+
+        __m512 x = _mm512_real(z1, z2);
+        __m512 y = _mm512_imag(z1, z2);
+
+        // Detect NaN in original inputs before division
+        __mmask16 input_nan_mask = _mm512_cmp_ps_mask(x, x, _CMP_UNORD_Q) |
+                                   _mm512_cmp_ps_mask(y, y, _CMP_UNORD_Q);
+
+        // Handle infinity cases per IEEE 754
+        const __m512 zero = _mm512_setzero_ps();
+        const __m512 pi_4 = _mm512_set1_ps(0x1.921fb6p-1f);      // π/4
+        const __m512 three_pi_4 = _mm512_set1_ps(0x1.2d97c8p1f); // 3π/4
+
+        __mmask16 y_inf_mask = _mm512_fpclass_ps_mask(y, 0x18); // ±inf
+        __mmask16 x_inf_mask = _mm512_fpclass_ps_mask(x, 0x18); // ±inf
+        __mmask16 x_pos_mask = _mm512_cmp_ps_mask(x, zero, _CMP_GT_OS);
+
+        // Build infinity result
+        __m512 inf_result = zero;
+        // Both infinite: ±π/4 or ±3π/4
+        __mmask16 both_inf = y_inf_mask & x_inf_mask;
+        __m512 both_inf_result = _mm512_mask_blend_ps(x_pos_mask, three_pi_4, pi_4);
+        both_inf_result = _mm512_or_ps(both_inf_result, _mm512_and_ps(y, sign_mask));
+        inf_result = _mm512_mask_blend_ps(both_inf, inf_result, both_inf_result);
+
+        // y infinite, x finite: ±π/2
+        __mmask16 y_inf_only = y_inf_mask & ~x_inf_mask;
+        __m512 y_inf_result = _mm512_or_ps(pi_2, _mm512_and_ps(y, sign_mask));
+        inf_result = _mm512_mask_blend_ps(y_inf_only, inf_result, y_inf_result);
+
+        // x infinite, y finite: 0 or ±π
+        __mmask16 x_inf_only = x_inf_mask & ~y_inf_mask;
+        __m512 x_inf_result =
+            _mm512_mask_blend_ps(x_pos_mask,
+                                 _mm512_or_ps(pi, _mm512_and_ps(y, sign_mask)),
+                                 _mm512_or_ps(zero, _mm512_and_ps(y, sign_mask)));
+        inf_result = _mm512_mask_blend_ps(x_inf_only, inf_result, x_inf_result);
+
+        __mmask16 any_inf_mask = y_inf_mask | x_inf_mask;
+
+        __mmask16 swap_mask = _mm512_cmp_ps_mask(
+            _mm512_and_ps(y, abs_mask), _mm512_and_ps(x, abs_mask), _CMP_GT_OS);
+        __m512 numerator = _mm512_mask_blend_ps(swap_mask, y, x);
+        __m512 denominator = _mm512_mask_blend_ps(swap_mask, x, y);
+        __m512 input = _mm512_div_ps(numerator, denominator);
+
+        // Only handle NaN from division (0/0, inf/inf), not from NaN inputs
+        // Replace with numerator to preserve sign (e.g., atan2(-0, 0) = -0)
+        __mmask16 div_nan_mask =
+            _mm512_cmp_ps_mask(input, input, _CMP_UNORD_Q) & ~input_nan_mask;
+        input = _mm512_mask_blend_ps(div_nan_mask, input, numerator);
+        __m512 result = _mm512_arctan_poly_avx512(input);
+
+        input =
+            _mm512_sub_ps(_mm512_or_ps(pi_2, _mm512_and_ps(input, sign_mask)), result);
+        result = _mm512_mask_blend_ps(swap_mask, result, input);
+
+        __m512 x_sign_mask =
+            _mm512_castsi512_ps(_mm512_srai_epi32(_mm512_castps_si512(x), 31));
+
+        result = _mm512_add_ps(
+            _mm512_and_ps(_mm512_xor_ps(pi, _mm512_and_ps(sign_mask, y)), x_sign_mask),
+            result);
+
+        // Select infinity result or normal result
+        result = _mm512_mask_blend_ps(any_inf_mask, result, inf_result);
+
+        result = _mm512_mul_ps(result, vinvNormalizeFactor);
+
+        _mm512_store_ps(out, result);
+        out += 16;
+    }
+
+    number = sixteenth_points * 16;
+    volk_32fc_s32f_atan2_32f_polynomial(
+        out, complexVector + number, normalizeFactor, num_points - number);
+}
+#endif /* LV_HAVE_AVX512F && LV_HAVE_AVX512DQ */
+
+#endif /* INCLUDED_volk_32fc_s32f_atan2_32f_a_H */

--- a/kernels/volk/volk_32fc_s32f_atan2_32f.h
+++ b/kernels/volk/volk_32fc_s32f_atan2_32f.h
@@ -72,7 +72,7 @@ static inline void volk_32fc_s32f_atan2_32f_generic(float* outputVector,
                                                     unsigned int num_points)
 {
     float* outPtr = outputVector;
-    const float* inPtr = (float*)inputVector;
+    const float* inPtr = (const float*)inputVector;
     const float invNormalizeFactor = 1.f / normalizeFactor;
 
     for (unsigned int number = 0; number < num_points; number++) {
@@ -91,7 +91,7 @@ static inline void volk_32fc_s32f_atan2_32f_polynomial(float* outputVector,
                                                        unsigned int num_points)
 {
     float* outPtr = outputVector;
-    const float* inPtr = (float*)inputVector;
+    const float* inPtr = (const float*)inputVector;
     const float invNormalizeFactor = 1.f / normalizeFactor;
 
     for (unsigned int number = 0; number < num_points; number++) {
@@ -110,7 +110,7 @@ static inline void volk_32fc_s32f_atan2_32f_a_avx512dq(float* outputVector,
                                                        const float normalizeFactor,
                                                        unsigned int num_points)
 {
-    const float* in = (float*)complexVector;
+    const float* in = (const float*)complexVector;
     float* out = (float*)outputVector;
 
     const float invNormalizeFactor = 1.f / normalizeFactor;
@@ -214,7 +214,7 @@ static inline void volk_32fc_s32f_atan2_32f_a_avx2_fma(float* outputVector,
                                                        const float normalizeFactor,
                                                        unsigned int num_points)
 {
-    const float* in = (float*)complexVector;
+    const float* in = (const float*)complexVector;
     float* out = (float*)outputVector;
 
     const float invNormalizeFactor = 1.f / normalizeFactor;
@@ -309,7 +309,7 @@ static inline void volk_32fc_s32f_atan2_32f_a_avx2_fma(float* outputVector,
 
     number = eighth_points * 8;
     volk_32fc_s32f_atan2_32f_polynomial(
-        out, (lv_32fc_t*)in, normalizeFactor, num_points - number);
+        out, (const lv_32fc_t*)in, normalizeFactor, num_points - number);
 }
 #endif /* LV_HAVE_AVX2 && LV_HAVE_FMA for aligned */
 
@@ -321,7 +321,7 @@ static inline void volk_32fc_s32f_atan2_32f_a_avx2(float* outputVector,
                                                    const float normalizeFactor,
                                                    unsigned int num_points)
 {
-    const float* in = (float*)complexVector;
+    const float* in = (const float*)complexVector;
     float* out = (float*)outputVector;
 
     const float invNormalizeFactor = 1.f / normalizeFactor;
@@ -416,7 +416,7 @@ static inline void volk_32fc_s32f_atan2_32f_a_avx2(float* outputVector,
 
     number = eighth_points * 8;
     volk_32fc_s32f_atan2_32f_polynomial(
-        out, (lv_32fc_t*)in, normalizeFactor, num_points - number);
+        out, (const lv_32fc_t*)in, normalizeFactor, num_points - number);
 }
 #endif /* LV_HAVE_AVX2 for aligned */
 
@@ -428,7 +428,7 @@ static inline void volk_32fc_s32f_atan2_32f_neon(float* outputVector,
                                                  const float normalizeFactor,
                                                  unsigned int num_points)
 {
-    const float* in = (float*)complexVector;
+    const float* in = (const float*)complexVector;
     float* out = outputVector;
 
     const float invNormalizeFactor = 1.f / normalizeFactor;
@@ -532,7 +532,7 @@ static inline void volk_32fc_s32f_atan2_32f_neonv8(float* outputVector,
                                                    const float normalizeFactor,
                                                    unsigned int num_points)
 {
-    const float* in = (float*)complexVector;
+    const float* in = (const float*)complexVector;
     float* out = outputVector;
 
     const float invNormalizeFactor = 1.f / normalizeFactor;
@@ -697,7 +697,7 @@ static inline void volk_32fc_s32f_atan2_32f_u_avx512dq(float* outputVector,
                                                        const float normalizeFactor,
                                                        unsigned int num_points)
 {
-    const float* in = (float*)complexVector;
+    const float* in = (const float*)complexVector;
     float* out = (float*)outputVector;
 
     const float invNormalizeFactor = 1.f / normalizeFactor;
@@ -801,7 +801,7 @@ static inline void volk_32fc_s32f_atan2_32f_u_avx2_fma(float* outputVector,
                                                        const float normalizeFactor,
                                                        unsigned int num_points)
 {
-    const float* in = (float*)complexVector;
+    const float* in = (const float*)complexVector;
     float* out = (float*)outputVector;
 
     const float invNormalizeFactor = 1.f / normalizeFactor;
@@ -896,7 +896,7 @@ static inline void volk_32fc_s32f_atan2_32f_u_avx2_fma(float* outputVector,
 
     number = eighth_points * 8;
     volk_32fc_s32f_atan2_32f_polynomial(
-        out, (lv_32fc_t*)in, normalizeFactor, num_points - number);
+        out, (const lv_32fc_t*)in, normalizeFactor, num_points - number);
 }
 #endif /* LV_HAVE_AVX2 && LV_HAVE_FMA for unaligned */
 
@@ -908,7 +908,7 @@ static inline void volk_32fc_s32f_atan2_32f_u_avx2(float* outputVector,
                                                    const float normalizeFactor,
                                                    unsigned int num_points)
 {
-    const float* in = (float*)complexVector;
+    const float* in = (const float*)complexVector;
     float* out = (float*)outputVector;
 
     const float invNormalizeFactor = 1.f / normalizeFactor;
@@ -1003,7 +1003,7 @@ static inline void volk_32fc_s32f_atan2_32f_u_avx2(float* outputVector,
 
     number = eighth_points * 8;
     volk_32fc_s32f_atan2_32f_polynomial(
-        out, (lv_32fc_t*)in, normalizeFactor, num_points - number);
+        out, (const lv_32fc_t*)in, normalizeFactor, num_points - number);
 }
 #endif /* LV_HAVE_AVX2 for unaligned */
 

--- a/kernels/volk/volk_32fc_s32f_deinterleave_real_16i.h
+++ b/kernels/volk/volk_32fc_s32f_deinterleave_real_16i.h
@@ -77,7 +77,7 @@ volk_32fc_s32f_deinterleave_real_16i_a_avx2(int16_t* iBuffer,
     unsigned int number = 0;
     const unsigned int eighthPoints = num_points / 8;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     int16_t* iBufferPtr = iBuffer;
 
     __m256 vScalar = _mm256_set1_ps(scalar);
@@ -132,7 +132,7 @@ volk_32fc_s32f_deinterleave_real_16i_a_sse(int16_t* iBuffer,
     unsigned int number = 0;
     const unsigned int quarterPoints = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     int16_t* iBufferPtr = iBuffer;
 
     __m128 vScalar = _mm_set_ps1(scalar);
@@ -179,7 +179,7 @@ volk_32fc_s32f_deinterleave_real_16i_generic(int16_t* iBuffer,
                                              const float scalar,
                                              unsigned int num_points)
 {
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     unsigned int number = 0;
     for (number = 0; number < num_points; number++) {
@@ -211,7 +211,7 @@ volk_32fc_s32f_deinterleave_real_16i_u_avx2(int16_t* iBuffer,
     unsigned int number = 0;
     const unsigned int eighthPoints = num_points / 8;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     int16_t* iBufferPtr = iBuffer;
 
     __m256 vScalar = _mm256_set1_ps(scalar);
@@ -265,7 +265,7 @@ volk_32fc_s32f_deinterleave_real_16i_neon(int16_t* iBuffer,
     unsigned int number = 0;
     const unsigned int quarter_points = num_points / 4;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     float32x4_t vScalar = vdupq_n_f32(scalar);
 
@@ -308,7 +308,7 @@ volk_32fc_s32f_deinterleave_real_16i_neonv8(int16_t* iBuffer,
     unsigned int number = 0;
     const unsigned int eighth_points = num_points / 8;
 
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     float32x4_t vScalar = vdupq_n_f32(scalar);
 

--- a/kernels/volk/volk_32fc_s32f_deinterleave_real_16i.h
+++ b/kernels/volk/volk_32fc_s32f_deinterleave_real_16i.h
@@ -57,118 +57,12 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32fc_s32f_deinterleave_real_16i_a_H
-#define INCLUDED_volk_32fc_s32f_deinterleave_real_16i_a_H
+#ifndef INCLUDED_volk_32fc_s32f_deinterleave_real_16i_u_H
+#define INCLUDED_volk_32fc_s32f_deinterleave_real_16i_u_H
 
 #include <inttypes.h>
 #include <stdio.h>
 #include <volk/volk_common.h>
-
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-
-static inline void
-volk_32fc_s32f_deinterleave_real_16i_a_avx2(int16_t* iBuffer,
-                                            const lv_32fc_t* complexVector,
-                                            const float scalar,
-                                            unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int eighthPoints = num_points / 8;
-
-    const float* complexVectorPtr = (const float*)complexVector;
-    int16_t* iBufferPtr = iBuffer;
-
-    __m256 vScalar = _mm256_set1_ps(scalar);
-
-    __m256 cplxValue1, cplxValue2, iValue;
-    __m256i a;
-    __m128i b;
-
-    __m256i idx = _mm256_set_epi32(3, 3, 3, 3, 5, 1, 4, 0);
-
-    for (; number < eighthPoints; number++) {
-        cplxValue1 = _mm256_load_ps(complexVectorPtr);
-        complexVectorPtr += 8;
-
-        cplxValue2 = _mm256_load_ps(complexVectorPtr);
-        complexVectorPtr += 8;
-
-        // Arrange in i1i2i3i4 format
-        iValue = _mm256_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(2, 0, 2, 0));
-
-        iValue = _mm256_mul_ps(iValue, vScalar);
-
-        a = _mm256_cvtps_epi32(iValue);
-        a = _mm256_packs_epi32(a, a);
-        a = _mm256_permutevar8x32_epi32(a, idx);
-        b = _mm256_extracti128_si256(a, 0);
-
-        _mm_store_si128((__m128i*)iBufferPtr, b);
-        iBufferPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    iBufferPtr = &iBuffer[number];
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = (int16_t)rintf(*complexVectorPtr++ * scalar);
-        complexVectorPtr++;
-    }
-}
-
-
-#endif /* LV_HAVE_AVX2 */
-
-#ifdef LV_HAVE_SSE
-#include <xmmintrin.h>
-
-static inline void
-volk_32fc_s32f_deinterleave_real_16i_a_sse(int16_t* iBuffer,
-                                           const lv_32fc_t* complexVector,
-                                           const float scalar,
-                                           unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-
-    const float* complexVectorPtr = (const float*)complexVector;
-    int16_t* iBufferPtr = iBuffer;
-
-    __m128 vScalar = _mm_set_ps1(scalar);
-
-    __m128 cplxValue1, cplxValue2, iValue;
-
-    __VOLK_ATTR_ALIGNED(16) float floatBuffer[4];
-
-    for (; number < quarterPoints; number++) {
-        cplxValue1 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        cplxValue2 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        // Arrange in i1i2i3i4 format
-        iValue = _mm_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(2, 0, 2, 0));
-
-        iValue = _mm_mul_ps(iValue, vScalar);
-
-        _mm_store_ps(floatBuffer, iValue);
-        *iBufferPtr++ = (int16_t)rintf(floatBuffer[0]);
-        *iBufferPtr++ = (int16_t)rintf(floatBuffer[1]);
-        *iBufferPtr++ = (int16_t)rintf(floatBuffer[2]);
-        *iBufferPtr++ = (int16_t)rintf(floatBuffer[3]);
-    }
-
-    number = quarterPoints * 4;
-    iBufferPtr = &iBuffer[number];
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = (int16_t)rintf(*complexVectorPtr++ * scalar);
-        complexVectorPtr++;
-    }
-}
-
-#endif /* LV_HAVE_SSE */
 
 
 #ifdef LV_HAVE_GENERIC
@@ -189,15 +83,6 @@ volk_32fc_s32f_deinterleave_real_16i_generic(int16_t* iBuffer,
 }
 
 #endif /* LV_HAVE_GENERIC */
-
-#endif /* INCLUDED_volk_32fc_s32f_deinterleave_real_16i_a_H */
-
-#ifndef INCLUDED_volk_32fc_s32f_deinterleave_real_16i_u_H
-#define INCLUDED_volk_32fc_s32f_deinterleave_real_16i_u_H
-
-#include <inttypes.h>
-#include <stdio.h>
-#include <volk/volk_common.h>
 
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
@@ -361,3 +246,117 @@ volk_32fc_s32f_deinterleave_real_16i_rvv(int16_t* iBuffer,
 #endif /*LV_HAVE_RVV*/
 
 #endif /* INCLUDED_volk_32fc_s32f_deinterleave_real_16i_u_H */
+
+#ifndef INCLUDED_volk_32fc_s32f_deinterleave_real_16i_a_H
+#define INCLUDED_volk_32fc_s32f_deinterleave_real_16i_a_H
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <volk/volk_common.h>
+
+#ifdef LV_HAVE_SSE
+#include <xmmintrin.h>
+
+static inline void
+volk_32fc_s32f_deinterleave_real_16i_a_sse(int16_t* iBuffer,
+                                           const lv_32fc_t* complexVector,
+                                           const float scalar,
+                                           unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    int16_t* iBufferPtr = iBuffer;
+
+    __m128 vScalar = _mm_set_ps1(scalar);
+
+    __m128 cplxValue1, cplxValue2, iValue;
+
+    __VOLK_ATTR_ALIGNED(16) float floatBuffer[4];
+
+    for (; number < quarterPoints; number++) {
+        cplxValue1 = _mm_load_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        cplxValue2 = _mm_load_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        // Arrange in i1i2i3i4 format
+        iValue = _mm_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(2, 0, 2, 0));
+
+        iValue = _mm_mul_ps(iValue, vScalar);
+
+        _mm_store_ps(floatBuffer, iValue);
+        *iBufferPtr++ = (int16_t)rintf(floatBuffer[0]);
+        *iBufferPtr++ = (int16_t)rintf(floatBuffer[1]);
+        *iBufferPtr++ = (int16_t)rintf(floatBuffer[2]);
+        *iBufferPtr++ = (int16_t)rintf(floatBuffer[3]);
+    }
+
+    number = quarterPoints * 4;
+    iBufferPtr = &iBuffer[number];
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = (int16_t)rintf(*complexVectorPtr++ * scalar);
+        complexVectorPtr++;
+    }
+}
+
+#endif /* LV_HAVE_SSE */
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void
+volk_32fc_s32f_deinterleave_real_16i_a_avx2(int16_t* iBuffer,
+                                            const lv_32fc_t* complexVector,
+                                            const float scalar,
+                                            unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    int16_t* iBufferPtr = iBuffer;
+
+    __m256 vScalar = _mm256_set1_ps(scalar);
+
+    __m256 cplxValue1, cplxValue2, iValue;
+    __m256i a;
+    __m128i b;
+
+    __m256i idx = _mm256_set_epi32(3, 3, 3, 3, 5, 1, 4, 0);
+
+    for (; number < eighthPoints; number++) {
+        cplxValue1 = _mm256_load_ps(complexVectorPtr);
+        complexVectorPtr += 8;
+
+        cplxValue2 = _mm256_load_ps(complexVectorPtr);
+        complexVectorPtr += 8;
+
+        // Arrange in i1i2i3i4 format
+        iValue = _mm256_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(2, 0, 2, 0));
+
+        iValue = _mm256_mul_ps(iValue, vScalar);
+
+        a = _mm256_cvtps_epi32(iValue);
+        a = _mm256_packs_epi32(a, a);
+        a = _mm256_permutevar8x32_epi32(a, idx);
+        b = _mm256_extracti128_si256(a, 0);
+
+        _mm_store_si128((__m128i*)iBufferPtr, b);
+        iBufferPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    iBufferPtr = &iBuffer[number];
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = (int16_t)rintf(*complexVectorPtr++ * scalar);
+        complexVectorPtr++;
+    }
+}
+
+
+#endif /* LV_HAVE_AVX2 */
+
+#endif /* INCLUDED_volk_32fc_s32f_deinterleave_real_16i_a_H */

--- a/kernels/volk/volk_32fc_s32f_magnitude_16i.h
+++ b/kernels/volk/volk_32fc_s32f_magnitude_16i.h
@@ -57,8 +57,8 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32fc_s32f_magnitude_16i_a_H
-#define INCLUDED_volk_32fc_s32f_magnitude_16i_a_H
+#ifndef INCLUDED_volk_32fc_s32f_magnitude_16i_u_H
+#define INCLUDED_volk_32fc_s32f_magnitude_16i_u_H
 
 #include <inttypes.h>
 #include <math.h>
@@ -83,173 +83,6 @@ static inline void volk_32fc_s32f_magnitude_16i_generic(int16_t* magnitudeVector
     }
 }
 #endif /* LV_HAVE_GENERIC */
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-
-static inline void volk_32fc_s32f_magnitude_16i_a_avx2(int16_t* magnitudeVector,
-                                                       const lv_32fc_t* complexVector,
-                                                       const float scalar,
-                                                       unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int eighthPoints = num_points / 8;
-
-    const float* complexVectorPtr = (const float*)complexVector;
-    int16_t* magnitudeVectorPtr = magnitudeVector;
-
-    __m256 vScalar = _mm256_set1_ps(scalar);
-    __m256i idx = _mm256_set_epi32(0, 0, 0, 0, 5, 1, 4, 0);
-    __m256 cplxValue1, cplxValue2, result;
-    __m256i resultInt;
-    __m128i resultShort;
-
-    for (; number < eighthPoints; number++) {
-        cplxValue1 = _mm256_load_ps(complexVectorPtr);
-        complexVectorPtr += 8;
-
-        cplxValue2 = _mm256_load_ps(complexVectorPtr);
-        complexVectorPtr += 8;
-
-        cplxValue1 = _mm256_mul_ps(cplxValue1, cplxValue1); // Square the values
-        cplxValue2 = _mm256_mul_ps(cplxValue2, cplxValue2); // Square the Values
-
-        result = _mm256_hadd_ps(cplxValue1, cplxValue2); // Add the I2 and Q2 values
-
-        result = _mm256_sqrt_ps(result);
-
-        result = _mm256_mul_ps(result, vScalar);
-
-        resultInt = _mm256_cvtps_epi32(result);
-        resultInt = _mm256_packs_epi32(resultInt, resultInt);
-        resultInt = _mm256_permutevar8x32_epi32(
-            resultInt, idx); // permute to compensate for shuffling in hadd and packs
-        resultShort = _mm256_extracti128_si256(resultInt, 0);
-        _mm_store_si128((__m128i*)magnitudeVectorPtr, resultShort);
-        magnitudeVectorPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    volk_32fc_s32f_magnitude_16i_generic(
-        magnitudeVector + number, complexVector + number, scalar, num_points - number);
-}
-#endif /* LV_HAVE_AVX2 */
-
-#ifdef LV_HAVE_SSE3
-#include <pmmintrin.h>
-
-static inline void volk_32fc_s32f_magnitude_16i_a_sse3(int16_t* magnitudeVector,
-                                                       const lv_32fc_t* complexVector,
-                                                       const float scalar,
-                                                       unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-
-    const float* complexVectorPtr = (const float*)complexVector;
-    int16_t* magnitudeVectorPtr = magnitudeVector;
-
-    __m128 vScalar = _mm_set_ps1(scalar);
-
-    __m128 cplxValue1, cplxValue2, result;
-
-    __VOLK_ATTR_ALIGNED(16) float floatBuffer[4];
-
-    for (; number < quarterPoints; number++) {
-        cplxValue1 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        cplxValue2 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        cplxValue1 = _mm_mul_ps(cplxValue1, cplxValue1); // Square the values
-        cplxValue2 = _mm_mul_ps(cplxValue2, cplxValue2); // Square the Values
-
-        result = _mm_hadd_ps(cplxValue1, cplxValue2); // Add the I2 and Q2 values
-
-        result = _mm_sqrt_ps(result);
-
-        result = _mm_mul_ps(result, vScalar);
-
-        _mm_store_ps(floatBuffer, result);
-        *magnitudeVectorPtr++ = (int16_t)rintf(floatBuffer[0]);
-        *magnitudeVectorPtr++ = (int16_t)rintf(floatBuffer[1]);
-        *magnitudeVectorPtr++ = (int16_t)rintf(floatBuffer[2]);
-        *magnitudeVectorPtr++ = (int16_t)rintf(floatBuffer[3]);
-    }
-
-    number = quarterPoints * 4;
-    volk_32fc_s32f_magnitude_16i_generic(
-        magnitudeVector + number, complexVector + number, scalar, num_points - number);
-}
-#endif /* LV_HAVE_SSE3 */
-
-
-#ifdef LV_HAVE_SSE
-#include <xmmintrin.h>
-
-static inline void volk_32fc_s32f_magnitude_16i_a_sse(int16_t* magnitudeVector,
-                                                      const lv_32fc_t* complexVector,
-                                                      const float scalar,
-                                                      unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-
-    const float* complexVectorPtr = (const float*)complexVector;
-    int16_t* magnitudeVectorPtr = magnitudeVector;
-
-    __m128 vScalar = _mm_set_ps1(scalar);
-
-    __m128 cplxValue1, cplxValue2, result;
-    __m128 iValue, qValue;
-
-    __VOLK_ATTR_ALIGNED(16) float floatBuffer[4];
-
-    for (; number < quarterPoints; number++) {
-        cplxValue1 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        cplxValue2 = _mm_load_ps(complexVectorPtr);
-        complexVectorPtr += 4;
-
-        // Arrange in i1i2i3i4 format
-        iValue = _mm_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(2, 0, 2, 0));
-        // Arrange in q1q2q3q4 format
-        qValue = _mm_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(3, 1, 3, 1));
-
-        __m128 iValue2 = _mm_mul_ps(iValue, iValue); // Square the I values
-        __m128 qValue2 = _mm_mul_ps(qValue, qValue); // Square the Q Values
-
-        result = _mm_add_ps(iValue2, qValue2); // Add the I2 and Q2 values
-
-        result = _mm_sqrt_ps(result);
-
-        result = _mm_mul_ps(result, vScalar);
-
-        _mm_store_ps(floatBuffer, result);
-        *magnitudeVectorPtr++ = (int16_t)rintf(floatBuffer[0]);
-        *magnitudeVectorPtr++ = (int16_t)rintf(floatBuffer[1]);
-        *magnitudeVectorPtr++ = (int16_t)rintf(floatBuffer[2]);
-        *magnitudeVectorPtr++ = (int16_t)rintf(floatBuffer[3]);
-    }
-
-    number = quarterPoints * 4;
-    volk_32fc_s32f_magnitude_16i_generic(
-        magnitudeVector + number, complexVector + number, scalar, num_points - number);
-}
-#endif /* LV_HAVE_SSE */
-
-
-#endif /* INCLUDED_volk_32fc_s32f_magnitude_16i_a_H */
-
-#ifndef INCLUDED_volk_32fc_s32f_magnitude_16i_u_H
-#define INCLUDED_volk_32fc_s32f_magnitude_16i_u_H
-
-#include <inttypes.h>
-#include <math.h>
-#include <stdio.h>
-#include <volk/volk_common.h>
 
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
@@ -452,3 +285,169 @@ static inline void volk_32fc_s32f_magnitude_16i_rvvseg(int16_t* magnitudeVector,
 #endif /*LV_HAVE_RVVSEG*/
 
 #endif /* INCLUDED_volk_32fc_s32f_magnitude_16i_u_H */
+
+#ifndef INCLUDED_volk_32fc_s32f_magnitude_16i_a_H
+#define INCLUDED_volk_32fc_s32f_magnitude_16i_a_H
+
+#include <inttypes.h>
+#include <math.h>
+#include <stdio.h>
+#include <volk/volk_common.h>
+
+#ifdef LV_HAVE_SSE
+#include <xmmintrin.h>
+
+static inline void volk_32fc_s32f_magnitude_16i_a_sse(int16_t* magnitudeVector,
+                                                      const lv_32fc_t* complexVector,
+                                                      const float scalar,
+                                                      unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    int16_t* magnitudeVectorPtr = magnitudeVector;
+
+    __m128 vScalar = _mm_set_ps1(scalar);
+
+    __m128 cplxValue1, cplxValue2, result;
+    __m128 iValue, qValue;
+
+    __VOLK_ATTR_ALIGNED(16) float floatBuffer[4];
+
+    for (; number < quarterPoints; number++) {
+        cplxValue1 = _mm_load_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        cplxValue2 = _mm_load_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        // Arrange in i1i2i3i4 format
+        iValue = _mm_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(2, 0, 2, 0));
+        // Arrange in q1q2q3q4 format
+        qValue = _mm_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(3, 1, 3, 1));
+
+        __m128 iValue2 = _mm_mul_ps(iValue, iValue); // Square the I values
+        __m128 qValue2 = _mm_mul_ps(qValue, qValue); // Square the Q Values
+
+        result = _mm_add_ps(iValue2, qValue2); // Add the I2 and Q2 values
+
+        result = _mm_sqrt_ps(result);
+
+        result = _mm_mul_ps(result, vScalar);
+
+        _mm_store_ps(floatBuffer, result);
+        *magnitudeVectorPtr++ = (int16_t)rintf(floatBuffer[0]);
+        *magnitudeVectorPtr++ = (int16_t)rintf(floatBuffer[1]);
+        *magnitudeVectorPtr++ = (int16_t)rintf(floatBuffer[2]);
+        *magnitudeVectorPtr++ = (int16_t)rintf(floatBuffer[3]);
+    }
+
+    number = quarterPoints * 4;
+    volk_32fc_s32f_magnitude_16i_generic(
+        magnitudeVector + number, complexVector + number, scalar, num_points - number);
+}
+#endif /* LV_HAVE_SSE */
+
+#ifdef LV_HAVE_SSE3
+#include <pmmintrin.h>
+
+static inline void volk_32fc_s32f_magnitude_16i_a_sse3(int16_t* magnitudeVector,
+                                                       const lv_32fc_t* complexVector,
+                                                       const float scalar,
+                                                       unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    int16_t* magnitudeVectorPtr = magnitudeVector;
+
+    __m128 vScalar = _mm_set_ps1(scalar);
+
+    __m128 cplxValue1, cplxValue2, result;
+
+    __VOLK_ATTR_ALIGNED(16) float floatBuffer[4];
+
+    for (; number < quarterPoints; number++) {
+        cplxValue1 = _mm_load_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        cplxValue2 = _mm_load_ps(complexVectorPtr);
+        complexVectorPtr += 4;
+
+        cplxValue1 = _mm_mul_ps(cplxValue1, cplxValue1); // Square the values
+        cplxValue2 = _mm_mul_ps(cplxValue2, cplxValue2); // Square the Values
+
+        result = _mm_hadd_ps(cplxValue1, cplxValue2); // Add the I2 and Q2 values
+
+        result = _mm_sqrt_ps(result);
+
+        result = _mm_mul_ps(result, vScalar);
+
+        _mm_store_ps(floatBuffer, result);
+        *magnitudeVectorPtr++ = (int16_t)rintf(floatBuffer[0]);
+        *magnitudeVectorPtr++ = (int16_t)rintf(floatBuffer[1]);
+        *magnitudeVectorPtr++ = (int16_t)rintf(floatBuffer[2]);
+        *magnitudeVectorPtr++ = (int16_t)rintf(floatBuffer[3]);
+    }
+
+    number = quarterPoints * 4;
+    volk_32fc_s32f_magnitude_16i_generic(
+        magnitudeVector + number, complexVector + number, scalar, num_points - number);
+}
+#endif /* LV_HAVE_SSE3 */
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void volk_32fc_s32f_magnitude_16i_a_avx2(int16_t* magnitudeVector,
+                                                       const lv_32fc_t* complexVector,
+                                                       const float scalar,
+                                                       unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+
+    const float* complexVectorPtr = (const float*)complexVector;
+    int16_t* magnitudeVectorPtr = magnitudeVector;
+
+    __m256 vScalar = _mm256_set1_ps(scalar);
+    __m256i idx = _mm256_set_epi32(0, 0, 0, 0, 5, 1, 4, 0);
+    __m256 cplxValue1, cplxValue2, result;
+    __m256i resultInt;
+    __m128i resultShort;
+
+    for (; number < eighthPoints; number++) {
+        cplxValue1 = _mm256_load_ps(complexVectorPtr);
+        complexVectorPtr += 8;
+
+        cplxValue2 = _mm256_load_ps(complexVectorPtr);
+        complexVectorPtr += 8;
+
+        cplxValue1 = _mm256_mul_ps(cplxValue1, cplxValue1); // Square the values
+        cplxValue2 = _mm256_mul_ps(cplxValue2, cplxValue2); // Square the Values
+
+        result = _mm256_hadd_ps(cplxValue1, cplxValue2); // Add the I2 and Q2 values
+
+        result = _mm256_sqrt_ps(result);
+
+        result = _mm256_mul_ps(result, vScalar);
+
+        resultInt = _mm256_cvtps_epi32(result);
+        resultInt = _mm256_packs_epi32(resultInt, resultInt);
+        resultInt = _mm256_permutevar8x32_epi32(
+            resultInt, idx); // permute to compensate for shuffling in hadd and packs
+        resultShort = _mm256_extracti128_si256(resultInt, 0);
+        _mm_store_si128((__m128i*)magnitudeVectorPtr, resultShort);
+        magnitudeVectorPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    volk_32fc_s32f_magnitude_16i_generic(
+        magnitudeVector + number, complexVector + number, scalar, num_points - number);
+}
+#endif /* LV_HAVE_AVX2 */
+
+
+#endif /* INCLUDED_volk_32fc_s32f_magnitude_16i_a_H */

--- a/kernels/volk/volk_32fc_s32f_magnitude_16i.h
+++ b/kernels/volk/volk_32fc_s32f_magnitude_16i.h
@@ -72,7 +72,7 @@ static inline void volk_32fc_s32f_magnitude_16i_generic(int16_t* magnitudeVector
                                                         const float scalar,
                                                         unsigned int num_points)
 {
-    const float* complexVectorPtr = (float*)complexVector;
+    const float* complexVectorPtr = (const float*)complexVector;
     int16_t* magnitudeVectorPtr = magnitudeVector;
     unsigned int number = 0;
     for (number = 0; number < num_points; number++) {

--- a/kernels/volk/volk_32fc_s32f_power_spectrum_32f.h
+++ b/kernels/volk/volk_32fc_s32f_power_spectrum_32f.h
@@ -37,8 +37,8 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32fc_s32f_power_spectrum_32f_a_H
-#define INCLUDED_volk_32fc_s32f_power_spectrum_32f_a_H
+#ifndef INCLUDED_volk_32fc_s32f_power_spectrum_32f_u_H
+#define INCLUDED_volk_32fc_s32f_power_spectrum_32f_u_H
 
 #include <volk/volk_mathematical_functions.h>
 
@@ -226,7 +226,7 @@ static inline void volk_32fc_s32f_power_spectrum_32f_rvv(float* logPowerOutput,
         __riscv_vse32(logPowerOutput, v, vl);
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
 
 
 #ifdef LV_HAVE_RVVSEG
@@ -313,6 +313,13 @@ volk_32fc_s32f_power_spectrum_32f_rvvseg(float* logPowerOutput,
     }
 }
 
-#endif /*LV_HAVE_RVVSEG*/
+#endif /* LV_HAVE_RVVSEG */
+
+#endif /* INCLUDED_volk_32fc_s32f_power_spectrum_32f_u_H */
+
+#ifndef INCLUDED_volk_32fc_s32f_power_spectrum_32f_a_H
+#define INCLUDED_volk_32fc_s32f_power_spectrum_32f_a_H
+
+/* No aligned-only implementations — all archs are in the unaligned section. */
 
 #endif /* INCLUDED_volk_32fc_s32f_power_spectrum_32f_a_H */

--- a/kernels/volk/volk_32fc_s32f_power_spectrum_32f.h
+++ b/kernels/volk/volk_32fc_s32f_power_spectrum_32f.h
@@ -115,7 +115,7 @@ volk_32fc_s32f_power_spectrum_32f_neon(float* logPowerOutput,
 
     for (number = 0; number < quarter_points; number++) {
         // Load
-        fft_vec = vld2q_f32((float*)complexFFTInputPtr);
+        fft_vec = vld2q_f32((const float*)complexFFTInputPtr);
         // Prefetch next 4
         __VOLK_PREFETCH(complexFFTInputPtr + 4);
         // Normalize

--- a/kernels/volk/volk_32fc_s32fc_multiply2_32fc.h
+++ b/kernels/volk/volk_32fc_s32fc_multiply2_32fc.h
@@ -89,7 +89,7 @@ static inline void volk_32fc_s32fc_multiply2_32fc_u_avx_fma(lv_32fc_t* cVector,
     yh = _mm256_set1_ps(lv_cimag(*scalar));
 
     for (; number < quarterPoints; number++) {
-        x = _mm256_loadu_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        x = _mm256_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
 
         tmp1 = x;
 
@@ -133,7 +133,7 @@ static inline void volk_32fc_s32fc_multiply2_32fc_u_avx(lv_32fc_t* cVector,
     yh = _mm256_set1_ps(lv_cimag(*scalar));
 
     for (; number < quarterPoints; number++) {
-        x = _mm256_loadu_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        x = _mm256_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
 
         tmp1 = _mm256_mul_ps(x, yl); // tmp1 = ar*cr,ai*cr,br*dr,bi*dr
 
@@ -177,7 +177,7 @@ static inline void volk_32fc_s32fc_multiply2_32fc_u_sse3(lv_32fc_t* cVector,
 
     for (; number < halfPoints; number++) {
 
-        x = _mm_loadu_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        x = _mm_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
 
         tmp1 = _mm_mul_ps(x, yl); // tmp1 = ar*cr,ai*cr,br*dr,bi*dr
 
@@ -261,7 +261,7 @@ static inline void volk_32fc_s32fc_multiply2_32fc_a_avx_fma(lv_32fc_t* cVector,
     yh = _mm256_set1_ps(lv_cimag(*scalar));
 
     for (; number < quarterPoints; number++) {
-        x = _mm256_load_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        x = _mm256_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
 
         tmp1 = x;
 
@@ -306,7 +306,7 @@ static inline void volk_32fc_s32fc_multiply2_32fc_a_avx(lv_32fc_t* cVector,
     yh = _mm256_set1_ps(lv_cimag(*scalar));
 
     for (; number < quarterPoints; number++) {
-        x = _mm256_load_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        x = _mm256_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
 
         tmp1 = _mm256_mul_ps(x, yl); // tmp1 = ar*cr,ai*cr,br*dr,bi*dr
 
@@ -350,7 +350,7 @@ static inline void volk_32fc_s32fc_multiply2_32fc_a_sse3(lv_32fc_t* cVector,
 
     for (; number < halfPoints; number++) {
 
-        x = _mm_load_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        x = _mm_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
 
         tmp1 = _mm_mul_ps(x, yl); // tmp1 = ar*cr,ai*cr,br*dr,bi*dr
 
@@ -392,7 +392,7 @@ static inline void volk_32fc_s32fc_multiply2_32fc_neon(lv_32fc_t* cVector,
     scalar_val.val[0] = vld1q_dup_f32((const float*)scalar);
     scalar_val.val[1] = vld1q_dup_f32(((const float*)scalar) + 1);
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld2q_f32((float*)aPtr);
+        a_val = vld2q_f32((const float*)aPtr);
         tmp_imag.val[1] = vmulq_f32(a_val.val[1], scalar_val.val[0]);
         tmp_imag.val[0] = vmulq_f32(a_val.val[0], scalar_val.val[0]);
 

--- a/kernels/volk/volk_32fc_s32fc_multiply2_32fc.h
+++ b/kernels/volk/volk_32fc_s32fc_multiply2_32fc.h
@@ -68,49 +68,79 @@
 #include <stdio.h>
 #include <volk/volk_complex.h>
 
-#if LV_HAVE_AVX && LV_HAVE_FMA
-#include <immintrin.h>
+#ifdef LV_HAVE_GENERIC
 
-static inline void volk_32fc_s32fc_multiply2_32fc_u_avx_fma(lv_32fc_t* cVector,
-                                                            const lv_32fc_t* aVector,
-                                                            const lv_32fc_t* scalar,
-                                                            unsigned int num_points)
+static inline void volk_32fc_s32fc_multiply2_32fc_generic(lv_32fc_t* cVector,
+                                                          const lv_32fc_t* aVector,
+                                                          const lv_32fc_t* scalar,
+                                                          unsigned int num_points)
+{
+    lv_32fc_t* cPtr = cVector;
+    const lv_32fc_t* aPtr = aVector;
+    unsigned int number = num_points;
+
+    // unwrap loop
+    while (number >= 8) {
+        *cPtr++ = (*aPtr++) * (*scalar);
+        *cPtr++ = (*aPtr++) * (*scalar);
+        *cPtr++ = (*aPtr++) * (*scalar);
+        *cPtr++ = (*aPtr++) * (*scalar);
+        *cPtr++ = (*aPtr++) * (*scalar);
+        *cPtr++ = (*aPtr++) * (*scalar);
+        *cPtr++ = (*aPtr++) * (*scalar);
+        *cPtr++ = (*aPtr++) * (*scalar);
+        number -= 8;
+    }
+
+    // clean up any remaining
+    while (number-- > 0)
+        *cPtr++ = *aPtr++ * (*scalar);
+}
+#endif /* LV_HAVE_GENERIC */
+
+#ifdef LV_HAVE_SSE3
+#include <pmmintrin.h>
+
+static inline void volk_32fc_s32fc_multiply2_32fc_u_sse3(lv_32fc_t* cVector,
+                                                         const lv_32fc_t* aVector,
+                                                         const lv_32fc_t* scalar,
+                                                         unsigned int num_points)
 {
     unsigned int number = 0;
-    unsigned int i = 0;
-    const unsigned int quarterPoints = num_points / 4;
-    unsigned int isodd = num_points & 3;
-    __m256 x, yl, yh, z, tmp1, tmp2;
+    const unsigned int halfPoints = num_points / 2;
+
+    __m128 x, yl, yh, z, tmp1, tmp2;
     lv_32fc_t* c = cVector;
     const lv_32fc_t* a = aVector;
 
     // Set up constant scalar vector
-    yl = _mm256_set1_ps(lv_creal(*scalar));
-    yh = _mm256_set1_ps(lv_cimag(*scalar));
+    yl = _mm_set_ps1(lv_creal(*scalar));
+    yh = _mm_set_ps1(lv_cimag(*scalar));
 
-    for (; number < quarterPoints; number++) {
-        x = _mm256_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+    for (; number < halfPoints; number++) {
 
-        tmp1 = x;
+        x = _mm_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
 
-        x = _mm256_shuffle_ps(x, x, 0xB1); // Re-arrange x to be ai,ar,bi,br
+        tmp1 = _mm_mul_ps(x, yl); // tmp1 = ar*cr,ai*cr,br*dr,bi*dr
 
-        tmp2 = _mm256_mul_ps(x, yh); // tmp2 = ai*ci,ar*ci,bi*di,br*di
+        x = _mm_shuffle_ps(x, x, 0xB1); // Re-arrange x to be ai,ar,bi,br
 
-        z = _mm256_fmaddsub_ps(
-            tmp1, yl, tmp2); // ar*cr-ai*ci, ai*cr+ar*ci, br*dr-bi*di, bi*dr+br*di
+        tmp2 = _mm_mul_ps(x, yh); // tmp2 = ai*ci,ar*ci,bi*di,br*di
 
-        _mm256_storeu_ps((float*)c, z); // Store the results back into the C container
+        z = _mm_addsub_ps(tmp1,
+                          tmp2); // ar*cr-ai*ci, ai*cr+ar*ci, br*dr-bi*di, bi*dr+br*di
 
-        a += 4;
-        c += 4;
+        _mm_storeu_ps((float*)c, z); // Store the results back into the C container
+
+        a += 2;
+        c += 2;
     }
 
-    for (i = num_points - isodd; i < num_points; i++) {
-        *c++ = (*a++) * (*scalar);
+    if ((num_points % 2) != 0) {
+        *c = (*a) * (*scalar);
     }
 }
-#endif /* LV_HAVE_AVX && LV_HAVE_FMA */
+#endif /* LV_HAVE_SSE3 */
 
 #ifdef LV_HAVE_AVX
 #include <immintrin.h>
@@ -156,94 +186,10 @@ static inline void volk_32fc_s32fc_multiply2_32fc_u_avx(lv_32fc_t* cVector,
 }
 #endif /* LV_HAVE_AVX */
 
-#ifdef LV_HAVE_SSE3
-#include <pmmintrin.h>
-
-static inline void volk_32fc_s32fc_multiply2_32fc_u_sse3(lv_32fc_t* cVector,
-                                                         const lv_32fc_t* aVector,
-                                                         const lv_32fc_t* scalar,
-                                                         unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int halfPoints = num_points / 2;
-
-    __m128 x, yl, yh, z, tmp1, tmp2;
-    lv_32fc_t* c = cVector;
-    const lv_32fc_t* a = aVector;
-
-    // Set up constant scalar vector
-    yl = _mm_set_ps1(lv_creal(*scalar));
-    yh = _mm_set_ps1(lv_cimag(*scalar));
-
-    for (; number < halfPoints; number++) {
-
-        x = _mm_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
-
-        tmp1 = _mm_mul_ps(x, yl); // tmp1 = ar*cr,ai*cr,br*dr,bi*dr
-
-        x = _mm_shuffle_ps(x, x, 0xB1); // Re-arrange x to be ai,ar,bi,br
-
-        tmp2 = _mm_mul_ps(x, yh); // tmp2 = ai*ci,ar*ci,bi*di,br*di
-
-        z = _mm_addsub_ps(tmp1,
-                          tmp2); // ar*cr-ai*ci, ai*cr+ar*ci, br*dr-bi*di, bi*dr+br*di
-
-        _mm_storeu_ps((float*)c, z); // Store the results back into the C container
-
-        a += 2;
-        c += 2;
-    }
-
-    if ((num_points % 2) != 0) {
-        *c = (*a) * (*scalar);
-    }
-}
-#endif /* LV_HAVE_SSE */
-
-#ifdef LV_HAVE_GENERIC
-
-static inline void volk_32fc_s32fc_multiply2_32fc_generic(lv_32fc_t* cVector,
-                                                          const lv_32fc_t* aVector,
-                                                          const lv_32fc_t* scalar,
-                                                          unsigned int num_points)
-{
-    lv_32fc_t* cPtr = cVector;
-    const lv_32fc_t* aPtr = aVector;
-    unsigned int number = num_points;
-
-    // unwrap loop
-    while (number >= 8) {
-        *cPtr++ = (*aPtr++) * (*scalar);
-        *cPtr++ = (*aPtr++) * (*scalar);
-        *cPtr++ = (*aPtr++) * (*scalar);
-        *cPtr++ = (*aPtr++) * (*scalar);
-        *cPtr++ = (*aPtr++) * (*scalar);
-        *cPtr++ = (*aPtr++) * (*scalar);
-        *cPtr++ = (*aPtr++) * (*scalar);
-        *cPtr++ = (*aPtr++) * (*scalar);
-        number -= 8;
-    }
-
-    // clean up any remaining
-    while (number-- > 0)
-        *cPtr++ = *aPtr++ * (*scalar);
-}
-#endif /* LV_HAVE_GENERIC */
-
-
-#endif /* INCLUDED_volk_32fc_x2_multiply2_32fc_u_H */
-#ifndef INCLUDED_volk_32fc_s32fc_multiply2_32fc_a_H
-#define INCLUDED_volk_32fc_s32fc_multiply2_32fc_a_H
-
-#include <float.h>
-#include <inttypes.h>
-#include <stdio.h>
-#include <volk/volk_complex.h>
-
 #if LV_HAVE_AVX && LV_HAVE_FMA
 #include <immintrin.h>
 
-static inline void volk_32fc_s32fc_multiply2_32fc_a_avx_fma(lv_32fc_t* cVector,
+static inline void volk_32fc_s32fc_multiply2_32fc_u_avx_fma(lv_32fc_t* cVector,
                                                             const lv_32fc_t* aVector,
                                                             const lv_32fc_t* scalar,
                                                             unsigned int num_points)
@@ -261,7 +207,7 @@ static inline void volk_32fc_s32fc_multiply2_32fc_a_avx_fma(lv_32fc_t* cVector,
     yh = _mm256_set1_ps(lv_cimag(*scalar));
 
     for (; number < quarterPoints; number++) {
-        x = _mm256_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        x = _mm256_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
 
         tmp1 = x;
 
@@ -272,7 +218,7 @@ static inline void volk_32fc_s32fc_multiply2_32fc_a_avx_fma(lv_32fc_t* cVector,
         z = _mm256_fmaddsub_ps(
             tmp1, yl, tmp2); // ar*cr-ai*ci, ai*cr+ar*ci, br*dr-bi*di, bi*dr+br*di
 
-        _mm256_store_ps((float*)c, z); // Store the results back into the C container
+        _mm256_storeu_ps((float*)c, z); // Store the results back into the C container
 
         a += 4;
         c += 4;
@@ -283,95 +229,6 @@ static inline void volk_32fc_s32fc_multiply2_32fc_a_avx_fma(lv_32fc_t* cVector,
     }
 }
 #endif /* LV_HAVE_AVX && LV_HAVE_FMA */
-
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-
-static inline void volk_32fc_s32fc_multiply2_32fc_a_avx(lv_32fc_t* cVector,
-                                                        const lv_32fc_t* aVector,
-                                                        const lv_32fc_t* scalar,
-                                                        unsigned int num_points)
-{
-    unsigned int number = 0;
-    unsigned int i = 0;
-    const unsigned int quarterPoints = num_points / 4;
-    unsigned int isodd = num_points & 3;
-    __m256 x, yl, yh, z, tmp1, tmp2;
-    lv_32fc_t* c = cVector;
-    const lv_32fc_t* a = aVector;
-
-    // Set up constant scalar vector
-    yl = _mm256_set1_ps(lv_creal(*scalar));
-    yh = _mm256_set1_ps(lv_cimag(*scalar));
-
-    for (; number < quarterPoints; number++) {
-        x = _mm256_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
-
-        tmp1 = _mm256_mul_ps(x, yl); // tmp1 = ar*cr,ai*cr,br*dr,bi*dr
-
-        x = _mm256_shuffle_ps(x, x, 0xB1); // Re-arrange x to be ai,ar,bi,br
-
-        tmp2 = _mm256_mul_ps(x, yh); // tmp2 = ai*ci,ar*ci,bi*di,br*di
-
-        z = _mm256_addsub_ps(tmp1,
-                             tmp2); // ar*cr-ai*ci, ai*cr+ar*ci, br*dr-bi*di, bi*dr+br*di
-
-        _mm256_store_ps((float*)c, z); // Store the results back into the C container
-
-        a += 4;
-        c += 4;
-    }
-
-    for (i = num_points - isodd; i < num_points; i++) {
-        *c++ = (*a++) * (*scalar);
-    }
-}
-#endif /* LV_HAVE_AVX */
-
-#ifdef LV_HAVE_SSE3
-#include <pmmintrin.h>
-
-static inline void volk_32fc_s32fc_multiply2_32fc_a_sse3(lv_32fc_t* cVector,
-                                                         const lv_32fc_t* aVector,
-                                                         const lv_32fc_t* scalar,
-                                                         unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int halfPoints = num_points / 2;
-
-    __m128 x, yl, yh, z, tmp1, tmp2;
-    lv_32fc_t* c = cVector;
-    const lv_32fc_t* a = aVector;
-
-    // Set up constant scalar vector
-    yl = _mm_set_ps1(lv_creal(*scalar));
-    yh = _mm_set_ps1(lv_cimag(*scalar));
-
-    for (; number < halfPoints; number++) {
-
-        x = _mm_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
-
-        tmp1 = _mm_mul_ps(x, yl); // tmp1 = ar*cr,ai*cr,br*dr,bi*dr
-
-        x = _mm_shuffle_ps(x, x, 0xB1); // Re-arrange x to be ai,ar,bi,br
-
-        tmp2 = _mm_mul_ps(x, yh); // tmp2 = ai*ci,ar*ci,bi*di,br*di
-
-        z = _mm_addsub_ps(tmp1,
-                          tmp2); // ar*cr-ai*ci, ai*cr+ar*ci, br*dr-bi*di, bi*dr+br*di
-
-        _mm_store_ps((float*)c, z); // Store the results back into the C container
-
-        a += 2;
-        c += 2;
-    }
-
-    if ((num_points % 2) != 0) {
-        *c = (*a) * (*scalar);
-    }
-}
-#endif /* LV_HAVE_SSE */
 
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
@@ -472,4 +329,145 @@ static inline void volk_32fc_s32fc_multiply2_32fc_neonv8(lv_32fc_t* cVector,
 
 #endif /* LV_HAVE_NEONV8 */
 
-#endif /* INCLUDED_volk_32fc_x2_multiply2_32fc_a_H */
+#endif /* INCLUDED_volk_32fc_s32fc_multiply2_32fc_u_H */
+#ifndef INCLUDED_volk_32fc_s32fc_multiply2_32fc_a_H
+#define INCLUDED_volk_32fc_s32fc_multiply2_32fc_a_H
+
+#include <float.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <volk/volk_complex.h>
+
+#ifdef LV_HAVE_SSE3
+#include <pmmintrin.h>
+
+static inline void volk_32fc_s32fc_multiply2_32fc_a_sse3(lv_32fc_t* cVector,
+                                                         const lv_32fc_t* aVector,
+                                                         const lv_32fc_t* scalar,
+                                                         unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int halfPoints = num_points / 2;
+
+    __m128 x, yl, yh, z, tmp1, tmp2;
+    lv_32fc_t* c = cVector;
+    const lv_32fc_t* a = aVector;
+
+    // Set up constant scalar vector
+    yl = _mm_set_ps1(lv_creal(*scalar));
+    yh = _mm_set_ps1(lv_cimag(*scalar));
+
+    for (; number < halfPoints; number++) {
+
+        x = _mm_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+
+        tmp1 = _mm_mul_ps(x, yl); // tmp1 = ar*cr,ai*cr,br*dr,bi*dr
+
+        x = _mm_shuffle_ps(x, x, 0xB1); // Re-arrange x to be ai,ar,bi,br
+
+        tmp2 = _mm_mul_ps(x, yh); // tmp2 = ai*ci,ar*ci,bi*di,br*di
+
+        z = _mm_addsub_ps(tmp1,
+                          tmp2); // ar*cr-ai*ci, ai*cr+ar*ci, br*dr-bi*di, bi*dr+br*di
+
+        _mm_store_ps((float*)c, z); // Store the results back into the C container
+
+        a += 2;
+        c += 2;
+    }
+
+    if ((num_points % 2) != 0) {
+        *c = (*a) * (*scalar);
+    }
+}
+#endif /* LV_HAVE_SSE3 */
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void volk_32fc_s32fc_multiply2_32fc_a_avx(lv_32fc_t* cVector,
+                                                        const lv_32fc_t* aVector,
+                                                        const lv_32fc_t* scalar,
+                                                        unsigned int num_points)
+{
+    unsigned int number = 0;
+    unsigned int i = 0;
+    const unsigned int quarterPoints = num_points / 4;
+    unsigned int isodd = num_points & 3;
+    __m256 x, yl, yh, z, tmp1, tmp2;
+    lv_32fc_t* c = cVector;
+    const lv_32fc_t* a = aVector;
+
+    // Set up constant scalar vector
+    yl = _mm256_set1_ps(lv_creal(*scalar));
+    yh = _mm256_set1_ps(lv_cimag(*scalar));
+
+    for (; number < quarterPoints; number++) {
+        x = _mm256_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+
+        tmp1 = _mm256_mul_ps(x, yl); // tmp1 = ar*cr,ai*cr,br*dr,bi*dr
+
+        x = _mm256_shuffle_ps(x, x, 0xB1); // Re-arrange x to be ai,ar,bi,br
+
+        tmp2 = _mm256_mul_ps(x, yh); // tmp2 = ai*ci,ar*ci,bi*di,br*di
+
+        z = _mm256_addsub_ps(tmp1,
+                             tmp2); // ar*cr-ai*ci, ai*cr+ar*ci, br*dr-bi*di, bi*dr+br*di
+
+        _mm256_store_ps((float*)c, z); // Store the results back into the C container
+
+        a += 4;
+        c += 4;
+    }
+
+    for (i = num_points - isodd; i < num_points; i++) {
+        *c++ = (*a++) * (*scalar);
+    }
+}
+#endif /* LV_HAVE_AVX */
+
+#if LV_HAVE_AVX && LV_HAVE_FMA
+#include <immintrin.h>
+
+static inline void volk_32fc_s32fc_multiply2_32fc_a_avx_fma(lv_32fc_t* cVector,
+                                                            const lv_32fc_t* aVector,
+                                                            const lv_32fc_t* scalar,
+                                                            unsigned int num_points)
+{
+    unsigned int number = 0;
+    unsigned int i = 0;
+    const unsigned int quarterPoints = num_points / 4;
+    unsigned int isodd = num_points & 3;
+    __m256 x, yl, yh, z, tmp1, tmp2;
+    lv_32fc_t* c = cVector;
+    const lv_32fc_t* a = aVector;
+
+    // Set up constant scalar vector
+    yl = _mm256_set1_ps(lv_creal(*scalar));
+    yh = _mm256_set1_ps(lv_cimag(*scalar));
+
+    for (; number < quarterPoints; number++) {
+        x = _mm256_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+
+        tmp1 = x;
+
+        x = _mm256_shuffle_ps(x, x, 0xB1); // Re-arrange x to be ai,ar,bi,br
+
+        tmp2 = _mm256_mul_ps(x, yh); // tmp2 = ai*ci,ar*ci,bi*di,br*di
+
+        z = _mm256_fmaddsub_ps(
+            tmp1, yl, tmp2); // ar*cr-ai*ci, ai*cr+ar*ci, br*dr-bi*di, bi*dr+br*di
+
+        _mm256_store_ps((float*)c, z); // Store the results back into the C container
+
+        a += 4;
+        c += 4;
+    }
+
+    for (i = num_points - isodd; i < num_points; i++) {
+        *c++ = (*a++) * (*scalar);
+    }
+}
+#endif /* LV_HAVE_AVX && LV_HAVE_FMA */
+
+#endif /* INCLUDED_volk_32fc_s32fc_multiply2_32fc_a_H */

--- a/kernels/volk/volk_32fc_s32fc_x2_rotator2_32fc.h
+++ b/kernels/volk/volk_32fc_s32fc_x2_rotator2_32fc.h
@@ -65,9 +65,7 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32fc_s32fc_rotator2_32fc_a_H
-#define INCLUDED_volk_32fc_s32fc_rotator2_32fc_a_H
-
+/* TODO: volk_32fc_s32fc_x2_rotator2_32fc_a_avx uses unaligned loads/stores but is named _a_ */
 
 #include <math.h>
 #include <stdio.h>
@@ -77,6 +75,10 @@
 #define ROTATOR_RELOAD_2 (ROTATOR_RELOAD / 2)
 #define ROTATOR_RELOAD_4 (ROTATOR_RELOAD / 4)
 #define ROTATOR_RELOAD_8 (ROTATOR_RELOAD / 8)
+
+
+#ifndef INCLUDED_volk_32fc_s32fc_x2_rotator2_32fc_u_H
+#define INCLUDED_volk_32fc_s32fc_x2_rotator2_32fc_u_H
 
 
 #ifdef LV_HAVE_GENERIC
@@ -108,6 +110,287 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_generic(lv_32fc_t* outVector
 }
 
 #endif /* LV_HAVE_GENERIC */
+
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+/*!
+ * \brief Unaligned AVX implementation with angle-based resync for numerical stability.
+ *
+ * Uses Kahan summation for angle accumulation and periodic sincos resync
+ * to eliminate accumulated phase error. Suitable for billion-sample stability.
+ */
+static inline void volk_32fc_s32fc_x2_rotator2_32fc_u_avx(lv_32fc_t* outVector,
+                                                          const lv_32fc_t* inVector,
+                                                          const lv_32fc_t* phase_inc,
+                                                          lv_32fc_t* phase,
+                                                          unsigned int num_points)
+{
+    lv_32fc_t* cPtr = outVector;
+    const lv_32fc_t* aPtr = inVector;
+
+    // Extract angles using double precision
+    const double initial_angle =
+        atan2((double)lv_cimag(*phase), (double)lv_creal(*phase));
+    const double delta_angle =
+        atan2((double)lv_cimag(*phase_inc), (double)lv_creal(*phase_inc));
+
+    // Kahan summation state for angle accumulation
+    double angle_sum = initial_angle;
+    double angle_c = 0.0;
+
+    // Precompute block increment
+    const double block_delta = (double)ROTATOR_RELOAD * delta_angle;
+
+    // Compute incr = phase_inc^4 from exact angle
+    const double delta4 = 4.0 * delta_angle;
+    lv_32fc_t incr = lv_cmake((float)cos(delta4), (float)sin(delta4));
+
+    __m256 aVal, phase_Val, z;
+    lv_32fc_t phase_Ptr[4];
+
+    const __m256 inc_Val = _mm256_set_ps(lv_cimag(incr),
+                                         lv_creal(incr),
+                                         lv_cimag(incr),
+                                         lv_creal(incr),
+                                         lv_cimag(incr),
+                                         lv_creal(incr),
+                                         lv_cimag(incr),
+                                         lv_creal(incr));
+
+#define REDUCE_ANGLE(a)              \
+    do {                             \
+        (a) = fmod((a), 2.0 * M_PI); \
+        if ((a) > M_PI)              \
+            (a) -= 2.0 * M_PI;       \
+        else if ((a) < -M_PI)        \
+            (a) += 2.0 * M_PI;       \
+    } while (0)
+
+    // Initialize phase vector from exact angles
+    for (unsigned int k = 0; k < 4; ++k) {
+        double a = angle_sum + (double)k * delta_angle;
+        REDUCE_ANGLE(a);
+        phase_Ptr[k] = lv_cmake((float)cos(a), (float)sin(a));
+    }
+    phase_Val = _mm256_loadu_ps((float*)phase_Ptr);
+
+    unsigned int i, j;
+
+    // Main loop with periodic resync
+    for (i = 0; i < (unsigned int)(num_points / ROTATOR_RELOAD); ++i) {
+        for (j = 0; j < ROTATOR_RELOAD_4; ++j) {
+            aVal = _mm256_loadu_ps((const float*)aPtr);
+            z = _mm256_complexmul_ps(aVal, phase_Val);
+            phase_Val = _mm256_complexmul_ps(phase_Val, inc_Val);
+            _mm256_storeu_ps((float*)cPtr, z);
+            aPtr += 4;
+            cPtr += 4;
+        }
+
+        // Advance angle using Kahan summation
+        {
+            double y = block_delta - angle_c;
+            double t = angle_sum + y;
+            angle_c = (t - angle_sum) - y;
+            angle_sum = t;
+        }
+
+        // Resync: recompute phase from accumulated angle
+        for (unsigned int k = 0; k < 4; ++k) {
+            double a = angle_sum + (double)k * delta_angle;
+            REDUCE_ANGLE(a);
+            phase_Ptr[k] = lv_cmake((float)cos(a), (float)sin(a));
+        }
+        phase_Val = _mm256_loadu_ps((float*)phase_Ptr);
+    }
+
+    // Handle remainder
+    for (i = 0; i < (num_points % ROTATOR_RELOAD) / 4; ++i) {
+        aVal = _mm256_loadu_ps((const float*)aPtr);
+        z = _mm256_complexmul_ps(aVal, phase_Val);
+        phase_Val = _mm256_complexmul_ps(phase_Val, inc_Val);
+        _mm256_storeu_ps((float*)cPtr, z);
+        aPtr += 4;
+        cPtr += 4;
+
+        {
+            double y = (4.0 * delta_angle) - angle_c;
+            double t = angle_sum + y;
+            angle_c = (t - angle_sum) - y;
+            angle_sum = t;
+        }
+    }
+
+    // Final phase output
+    {
+        double a = angle_sum;
+        REDUCE_ANGLE(a);
+        *phase = lv_cmake((float)cos(a), (float)sin(a));
+    }
+
+    // Scalar remainder
+    for (i = 0; i < num_points % 4; ++i) {
+        *cPtr++ = *aPtr++ * (*phase);
+        {
+            double y = delta_angle - angle_c;
+            double t = angle_sum + y;
+            angle_c = (t - angle_sum) - y;
+            angle_sum = t;
+        }
+        double a = angle_sum;
+        REDUCE_ANGLE(a);
+        *phase = lv_cmake((float)cos(a), (float)sin(a));
+    }
+
+#undef REDUCE_ANGLE
+}
+
+#endif /* LV_HAVE_AVX */
+
+
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+#include <volk/volk_avx512_intrinsics.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+/*!
+ * \brief Unaligned AVX512F implementation with angle-based resync for numerical
+ * stability.
+ */
+static inline void volk_32fc_s32fc_x2_rotator2_32fc_u_avx512f(lv_32fc_t* outVector,
+                                                              const lv_32fc_t* inVector,
+                                                              const lv_32fc_t* phase_inc,
+                                                              lv_32fc_t* phase,
+                                                              unsigned int num_points)
+{
+    lv_32fc_t* cPtr = outVector;
+    const lv_32fc_t* aPtr = inVector;
+
+    const double initial_angle =
+        atan2((double)lv_cimag(*phase), (double)lv_creal(*phase));
+    const double delta_angle =
+        atan2((double)lv_cimag(*phase_inc), (double)lv_creal(*phase_inc));
+
+    double angle_sum = initial_angle;
+    double angle_c = 0.0;
+
+    const double block_delta = (double)ROTATOR_RELOAD * delta_angle;
+
+    const double delta8 = 8.0 * delta_angle;
+    lv_32fc_t incr = lv_cmake((float)cos(delta8), (float)sin(delta8));
+
+    __m512 aVal, phase_Val, z;
+    lv_32fc_t phase_Ptr[8];
+
+    const __m512 inc_Val = _mm512_set_ps(lv_cimag(incr),
+                                         lv_creal(incr),
+                                         lv_cimag(incr),
+                                         lv_creal(incr),
+                                         lv_cimag(incr),
+                                         lv_creal(incr),
+                                         lv_cimag(incr),
+                                         lv_creal(incr),
+                                         lv_cimag(incr),
+                                         lv_creal(incr),
+                                         lv_cimag(incr),
+                                         lv_creal(incr),
+                                         lv_cimag(incr),
+                                         lv_creal(incr),
+                                         lv_cimag(incr),
+                                         lv_creal(incr));
+
+#define REDUCE_ANGLE(a)              \
+    do {                             \
+        (a) = fmod((a), 2.0 * M_PI); \
+        if ((a) > M_PI)              \
+            (a) -= 2.0 * M_PI;       \
+        else if ((a) < -M_PI)        \
+            (a) += 2.0 * M_PI;       \
+    } while (0)
+
+    for (unsigned int k = 0; k < 8; ++k) {
+        double a = angle_sum + (double)k * delta_angle;
+        REDUCE_ANGLE(a);
+        phase_Ptr[k] = lv_cmake((float)cos(a), (float)sin(a));
+    }
+    phase_Val = _mm512_loadu_ps((float*)phase_Ptr);
+
+    unsigned int i, j;
+
+    for (i = 0; i < (unsigned int)(num_points / ROTATOR_RELOAD); ++i) {
+        for (j = 0; j < ROTATOR_RELOAD_8; ++j) {
+            aVal = _mm512_loadu_ps((const float*)aPtr);
+            z = _mm512_complexmul_ps(aVal, phase_Val);
+            phase_Val = _mm512_complexmul_ps(phase_Val, inc_Val);
+            _mm512_storeu_ps((float*)cPtr, z);
+            aPtr += 8;
+            cPtr += 8;
+        }
+
+        {
+            double y = block_delta - angle_c;
+            double t = angle_sum + y;
+            angle_c = (t - angle_sum) - y;
+            angle_sum = t;
+        }
+
+        for (unsigned int k = 0; k < 8; ++k) {
+            double a = angle_sum + (double)k * delta_angle;
+            REDUCE_ANGLE(a);
+            phase_Ptr[k] = lv_cmake((float)cos(a), (float)sin(a));
+        }
+        phase_Val = _mm512_loadu_ps((float*)phase_Ptr);
+    }
+
+    for (i = 0; i < (num_points % ROTATOR_RELOAD) / 8; ++i) {
+        aVal = _mm512_loadu_ps((const float*)aPtr);
+        z = _mm512_complexmul_ps(aVal, phase_Val);
+        phase_Val = _mm512_complexmul_ps(phase_Val, inc_Val);
+        _mm512_storeu_ps((float*)cPtr, z);
+        aPtr += 8;
+        cPtr += 8;
+
+        {
+            double y = (8.0 * delta_angle) - angle_c;
+            double t = angle_sum + y;
+            angle_c = (t - angle_sum) - y;
+            angle_sum = t;
+        }
+    }
+
+    {
+        double a = angle_sum;
+        REDUCE_ANGLE(a);
+        *phase = lv_cmake((float)cos(a), (float)sin(a));
+    }
+
+    for (i = 0; i < num_points % 8; ++i) {
+        *cPtr++ = *aPtr++ * (*phase);
+        {
+            double y = delta_angle - angle_c;
+            double t = angle_sum + y;
+            angle_c = (t - angle_sum) - y;
+            angle_sum = t;
+        }
+        double a = angle_sum;
+        REDUCE_ANGLE(a);
+        *phase = lv_cmake((float)cos(a), (float)sin(a));
+    }
+
+#undef REDUCE_ANGLE
+}
+
+#endif /* LV_HAVE_AVX512F */
 
 
 #ifdef LV_HAVE_NEON
@@ -259,6 +542,167 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_neon(lv_32fc_t* outVector,
 }
 
 #endif /* LV_HAVE_NEON */
+
+
+/* Note on the RVV implementation:
+ * The complex multiply was expanded, because we don't care about the corner cases.
+ * Otherwise, without -ffast-math, the compiler would inserts function calls,
+ * which invalidates all vector registers and spills them on each loop iteration. */
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_32fc_s32fc_x2_rotator2_32fc_rvv(lv_32fc_t* outVector,
+                                                        const lv_32fc_t* inVector,
+                                                        const lv_32fc_t* phase_inc,
+                                                        lv_32fc_t* phase,
+                                                        unsigned int num_points)
+{
+    size_t vlmax = __riscv_vsetvlmax_e32m2();
+    vlmax = vlmax < ROTATOR_RELOAD ? vlmax : ROTATOR_RELOAD;
+
+    lv_32fc_t inc = 1.0f;
+    vfloat32m2_t phr = __riscv_vfmv_v_f_f32m2(0, vlmax), phi = phr;
+    for (size_t i = 0; i < vlmax; ++i) {
+        lv_32fc_t ph =
+            lv_cmake(lv_creal(*phase) * lv_creal(inc) - lv_cimag(*phase) * lv_cimag(inc),
+                     lv_creal(*phase) * lv_cimag(inc) + lv_cimag(*phase) * lv_creal(inc));
+        phr = __riscv_vfslide1down(phr, lv_creal(ph), vlmax);
+        phi = __riscv_vfslide1down(phi, lv_cimag(ph), vlmax);
+        inc = lv_cmake(
+            lv_creal(*phase_inc) * lv_creal(inc) - lv_cimag(*phase_inc) * lv_cimag(inc),
+            lv_creal(*phase_inc) * lv_cimag(inc) + lv_cimag(*phase_inc) * lv_creal(inc));
+    }
+    vfloat32m2_t incr = __riscv_vfmv_v_f_f32m2(lv_creal(inc), vlmax);
+    vfloat32m2_t inci = __riscv_vfmv_v_f_f32m2(lv_cimag(inc), vlmax);
+
+    size_t vl = 0;
+    if (num_points > 0)
+        while (1) {
+            size_t n = num_points < ROTATOR_RELOAD ? num_points : ROTATOR_RELOAD;
+            num_points -= n;
+
+            for (; n > 0; n -= vl, inVector += vl, outVector += vl) {
+                // vl<vlmax can only happen on the last iteration of the loops
+                vl = __riscv_vsetvl_e32m2(n < vlmax ? n : vlmax);
+
+                vuint64m4_t va = __riscv_vle64_v_u64m4((const uint64_t*)inVector, vl);
+                vfloat32m2_t var = __riscv_vreinterpret_f32m2(__riscv_vnsrl(va, 0, vl));
+                vfloat32m2_t vai = __riscv_vreinterpret_f32m2(__riscv_vnsrl(va, 32, vl));
+
+                vfloat32m2_t vr =
+                    __riscv_vfnmsac(__riscv_vfmul(var, phr, vl), vai, phi, vl);
+                vfloat32m2_t vi =
+                    __riscv_vfmacc(__riscv_vfmul(var, phi, vl), vai, phr, vl);
+
+                vuint32m2_t vru = __riscv_vreinterpret_u32m2(vr);
+                vuint32m2_t viu = __riscv_vreinterpret_u32m2(vi);
+                vuint64m4_t res =
+                    __riscv_vwmaccu(__riscv_vwaddu_vv(vru, viu, vl), 0xFFFFFFFF, viu, vl);
+                __riscv_vse64((uint64_t*)outVector, res, vl);
+
+                vfloat32m2_t tmp = phr;
+                phr = __riscv_vfnmsac(__riscv_vfmul(tmp, incr, vl), phi, inci, vl);
+                phi = __riscv_vfmacc(__riscv_vfmul(tmp, inci, vl), phi, incr, vl);
+            }
+
+            if (num_points <= 0)
+                break;
+
+            // normalize
+            vfloat32m2_t scale =
+                __riscv_vfmacc(__riscv_vfmul(phr, phr, vl), phi, phi, vl);
+            scale = __riscv_vfsqrt(scale, vl);
+            phr = __riscv_vfdiv(phr, scale, vl);
+            phi = __riscv_vfdiv(phi, scale, vl);
+        }
+
+    lv_32fc_t ph = lv_cmake(__riscv_vfmv_f(phr), __riscv_vfmv_f(phi));
+    for (size_t i = 0; i < vlmax - vl; ++i) {
+        ph /= *phase_inc; // we're going backwards
+    }
+    *phase = ph * 1.0f / hypotf(lv_creal(ph), lv_cimag(ph));
+}
+#endif /* LV_HAVE_RVV */
+
+#ifdef LV_HAVE_RVVSEG
+#include <riscv_vector.h>
+
+static inline void volk_32fc_s32fc_x2_rotator2_32fc_rvvseg(lv_32fc_t* outVector,
+                                                           const lv_32fc_t* inVector,
+                                                           const lv_32fc_t* phase_inc,
+                                                           lv_32fc_t* phase,
+                                                           unsigned int num_points)
+{
+    size_t vlmax = __riscv_vsetvlmax_e32m2();
+    vlmax = vlmax < ROTATOR_RELOAD ? vlmax : ROTATOR_RELOAD;
+
+    lv_32fc_t inc = 1.0f;
+    vfloat32m2_t phr = __riscv_vfmv_v_f_f32m2(0, vlmax), phi = phr;
+    for (size_t i = 0; i < vlmax; ++i) {
+        lv_32fc_t ph =
+            lv_cmake(lv_creal(*phase) * lv_creal(inc) - lv_cimag(*phase) * lv_cimag(inc),
+                     lv_creal(*phase) * lv_cimag(inc) + lv_cimag(*phase) * lv_creal(inc));
+        phr = __riscv_vfslide1down(phr, lv_creal(ph), vlmax);
+        phi = __riscv_vfslide1down(phi, lv_cimag(ph), vlmax);
+        inc = lv_cmake(
+            lv_creal(*phase_inc) * lv_creal(inc) - lv_cimag(*phase_inc) * lv_cimag(inc),
+            lv_creal(*phase_inc) * lv_cimag(inc) + lv_cimag(*phase_inc) * lv_creal(inc));
+    }
+    vfloat32m2_t incr = __riscv_vfmv_v_f_f32m2(lv_creal(inc), vlmax);
+    vfloat32m2_t inci = __riscv_vfmv_v_f_f32m2(lv_cimag(inc), vlmax);
+
+    size_t vl = 0;
+    if (num_points > 0)
+        while (1) {
+            size_t n = num_points < ROTATOR_RELOAD ? num_points : ROTATOR_RELOAD;
+            num_points -= n;
+
+            for (; n > 0; n -= vl, inVector += vl, outVector += vl) {
+                // vl<vlmax can only happen on the last iteration of the loops
+                vl = __riscv_vsetvl_e32m2(n < vlmax ? n : vlmax);
+
+                vfloat32m2x2_t va =
+                    __riscv_vlseg2e32_v_f32m2x2((const float*)inVector, vl);
+                vfloat32m2_t var = __riscv_vget_f32m2(va, 0);
+                vfloat32m2_t vai = __riscv_vget_f32m2(va, 1);
+
+                vfloat32m2_t vr =
+                    __riscv_vfnmsac(__riscv_vfmul(var, phr, vl), vai, phi, vl);
+                vfloat32m2_t vi =
+                    __riscv_vfmacc(__riscv_vfmul(var, phi, vl), vai, phr, vl);
+                vfloat32m2x2_t vc = __riscv_vcreate_v_f32m2x2(vr, vi);
+                __riscv_vsseg2e32_v_f32m2x2((float*)outVector, vc, vl);
+
+                vfloat32m2_t tmp = phr;
+                phr = __riscv_vfnmsac(__riscv_vfmul(tmp, incr, vl), phi, inci, vl);
+                phi = __riscv_vfmacc(__riscv_vfmul(tmp, inci, vl), phi, incr, vl);
+            }
+
+            if (num_points <= 0)
+                break;
+
+            // normalize
+            vfloat32m2_t scale =
+                __riscv_vfmacc(__riscv_vfmul(phr, phr, vl), phi, phi, vl);
+            scale = __riscv_vfsqrt(scale, vl);
+            phr = __riscv_vfdiv(phr, scale, vl);
+            phi = __riscv_vfdiv(phi, scale, vl);
+        }
+
+    lv_32fc_t ph = lv_cmake(__riscv_vfmv_f(phr), __riscv_vfmv_f(phi));
+    for (size_t i = 0; i < vlmax - vl; ++i) {
+        ph /= *phase_inc; // we're going backwards
+    }
+    *phase = ph * 1.0f / hypotf(lv_creal(ph), lv_cimag(ph));
+}
+#endif /* LV_HAVE_RVVSEG */
+
+#endif /* INCLUDED_volk_32fc_s32fc_x2_rotator2_32fc_u_H */
+
+
+#ifndef INCLUDED_volk_32fc_s32fc_x2_rotator2_32fc_a_H
+#define INCLUDED_volk_32fc_s32fc_x2_rotator2_32fc_a_H
 
 
 #ifdef LV_HAVE_AVX
@@ -413,147 +857,13 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_a_avx(lv_32fc_t* outVector,
 #endif /* LV_HAVE_AVX */
 
 
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-
-/*!
- * \brief Unaligned AVX implementation with angle-based resync for numerical stability.
- *
- * Uses Kahan summation for angle accumulation and periodic sincos resync
- * to eliminate accumulated phase error. Suitable for billion-sample stability.
- */
-static inline void volk_32fc_s32fc_x2_rotator2_32fc_u_avx(lv_32fc_t* outVector,
-                                                          const lv_32fc_t* inVector,
-                                                          const lv_32fc_t* phase_inc,
-                                                          lv_32fc_t* phase,
-                                                          unsigned int num_points)
-{
-    lv_32fc_t* cPtr = outVector;
-    const lv_32fc_t* aPtr = inVector;
-
-    // Extract angles using double precision
-    const double initial_angle =
-        atan2((double)lv_cimag(*phase), (double)lv_creal(*phase));
-    const double delta_angle =
-        atan2((double)lv_cimag(*phase_inc), (double)lv_creal(*phase_inc));
-
-    // Kahan summation state for angle accumulation
-    double angle_sum = initial_angle;
-    double angle_c = 0.0;
-
-    // Precompute block increment
-    const double block_delta = (double)ROTATOR_RELOAD * delta_angle;
-
-    // Compute incr = phase_inc^4 from exact angle
-    const double delta4 = 4.0 * delta_angle;
-    lv_32fc_t incr = lv_cmake((float)cos(delta4), (float)sin(delta4));
-
-    __m256 aVal, phase_Val, z;
-    lv_32fc_t phase_Ptr[4];
-
-    const __m256 inc_Val = _mm256_set_ps(lv_cimag(incr),
-                                         lv_creal(incr),
-                                         lv_cimag(incr),
-                                         lv_creal(incr),
-                                         lv_cimag(incr),
-                                         lv_creal(incr),
-                                         lv_cimag(incr),
-                                         lv_creal(incr));
-
-#define REDUCE_ANGLE(a)              \
-    do {                             \
-        (a) = fmod((a), 2.0 * M_PI); \
-        if ((a) > M_PI)              \
-            (a) -= 2.0 * M_PI;       \
-        else if ((a) < -M_PI)        \
-            (a) += 2.0 * M_PI;       \
-    } while (0)
-
-    // Initialize phase vector from exact angles
-    for (unsigned int k = 0; k < 4; ++k) {
-        double a = angle_sum + (double)k * delta_angle;
-        REDUCE_ANGLE(a);
-        phase_Ptr[k] = lv_cmake((float)cos(a), (float)sin(a));
-    }
-    phase_Val = _mm256_loadu_ps((float*)phase_Ptr);
-
-    unsigned int i, j;
-
-    // Main loop with periodic resync
-    for (i = 0; i < (unsigned int)(num_points / ROTATOR_RELOAD); ++i) {
-        for (j = 0; j < ROTATOR_RELOAD_4; ++j) {
-            aVal = _mm256_loadu_ps((const float*)aPtr);
-            z = _mm256_complexmul_ps(aVal, phase_Val);
-            phase_Val = _mm256_complexmul_ps(phase_Val, inc_Val);
-            _mm256_storeu_ps((float*)cPtr, z);
-            aPtr += 4;
-            cPtr += 4;
-        }
-
-        // Advance angle using Kahan summation
-        {
-            double y = block_delta - angle_c;
-            double t = angle_sum + y;
-            angle_c = (t - angle_sum) - y;
-            angle_sum = t;
-        }
-
-        // Resync: recompute phase from accumulated angle
-        for (unsigned int k = 0; k < 4; ++k) {
-            double a = angle_sum + (double)k * delta_angle;
-            REDUCE_ANGLE(a);
-            phase_Ptr[k] = lv_cmake((float)cos(a), (float)sin(a));
-        }
-        phase_Val = _mm256_loadu_ps((float*)phase_Ptr);
-    }
-
-    // Handle remainder
-    for (i = 0; i < (num_points % ROTATOR_RELOAD) / 4; ++i) {
-        aVal = _mm256_loadu_ps((const float*)aPtr);
-        z = _mm256_complexmul_ps(aVal, phase_Val);
-        phase_Val = _mm256_complexmul_ps(phase_Val, inc_Val);
-        _mm256_storeu_ps((float*)cPtr, z);
-        aPtr += 4;
-        cPtr += 4;
-
-        {
-            double y = (4.0 * delta_angle) - angle_c;
-            double t = angle_sum + y;
-            angle_c = (t - angle_sum) - y;
-            angle_sum = t;
-        }
-    }
-
-    // Final phase output
-    {
-        double a = angle_sum;
-        REDUCE_ANGLE(a);
-        *phase = lv_cmake((float)cos(a), (float)sin(a));
-    }
-
-    // Scalar remainder
-    for (i = 0; i < num_points % 4; ++i) {
-        *cPtr++ = *aPtr++ * (*phase);
-        {
-            double y = delta_angle - angle_c;
-            double t = angle_sum + y;
-            angle_c = (t - angle_sum) - y;
-            angle_sum = t;
-        }
-        double a = angle_sum;
-        REDUCE_ANGLE(a);
-        *phase = lv_cmake((float)cos(a), (float)sin(a));
-    }
-
-#undef REDUCE_ANGLE
-}
-
-#endif /* LV_HAVE_AVX */
-
-
 #ifdef LV_HAVE_AVX512F
 #include <immintrin.h>
 #include <volk/volk_avx512_intrinsics.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
 /*!
  * \brief Aligned AVX512F implementation with angle-based resync for numerical stability.
@@ -699,292 +1009,4 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_a_avx512f(lv_32fc_t* outVect
 #endif /* LV_HAVE_AVX512F */
 
 
-#ifdef LV_HAVE_AVX512F
-#include <immintrin.h>
-#include <volk/volk_avx512_intrinsics.h>
-
-/*!
- * \brief Unaligned AVX512F implementation with angle-based resync for numerical
- * stability.
- */
-static inline void volk_32fc_s32fc_x2_rotator2_32fc_u_avx512f(lv_32fc_t* outVector,
-                                                              const lv_32fc_t* inVector,
-                                                              const lv_32fc_t* phase_inc,
-                                                              lv_32fc_t* phase,
-                                                              unsigned int num_points)
-{
-    lv_32fc_t* cPtr = outVector;
-    const lv_32fc_t* aPtr = inVector;
-
-    const double initial_angle =
-        atan2((double)lv_cimag(*phase), (double)lv_creal(*phase));
-    const double delta_angle =
-        atan2((double)lv_cimag(*phase_inc), (double)lv_creal(*phase_inc));
-
-    double angle_sum = initial_angle;
-    double angle_c = 0.0;
-
-    const double block_delta = (double)ROTATOR_RELOAD * delta_angle;
-
-    const double delta8 = 8.0 * delta_angle;
-    lv_32fc_t incr = lv_cmake((float)cos(delta8), (float)sin(delta8));
-
-    __m512 aVal, phase_Val, z;
-    lv_32fc_t phase_Ptr[8];
-
-    const __m512 inc_Val = _mm512_set_ps(lv_cimag(incr),
-                                         lv_creal(incr),
-                                         lv_cimag(incr),
-                                         lv_creal(incr),
-                                         lv_cimag(incr),
-                                         lv_creal(incr),
-                                         lv_cimag(incr),
-                                         lv_creal(incr),
-                                         lv_cimag(incr),
-                                         lv_creal(incr),
-                                         lv_cimag(incr),
-                                         lv_creal(incr),
-                                         lv_cimag(incr),
-                                         lv_creal(incr),
-                                         lv_cimag(incr),
-                                         lv_creal(incr));
-
-#define REDUCE_ANGLE(a)              \
-    do {                             \
-        (a) = fmod((a), 2.0 * M_PI); \
-        if ((a) > M_PI)              \
-            (a) -= 2.0 * M_PI;       \
-        else if ((a) < -M_PI)        \
-            (a) += 2.0 * M_PI;       \
-    } while (0)
-
-    for (unsigned int k = 0; k < 8; ++k) {
-        double a = angle_sum + (double)k * delta_angle;
-        REDUCE_ANGLE(a);
-        phase_Ptr[k] = lv_cmake((float)cos(a), (float)sin(a));
-    }
-    phase_Val = _mm512_loadu_ps((float*)phase_Ptr);
-
-    unsigned int i, j;
-
-    for (i = 0; i < (unsigned int)(num_points / ROTATOR_RELOAD); ++i) {
-        for (j = 0; j < ROTATOR_RELOAD_8; ++j) {
-            aVal = _mm512_loadu_ps((const float*)aPtr);
-            z = _mm512_complexmul_ps(aVal, phase_Val);
-            phase_Val = _mm512_complexmul_ps(phase_Val, inc_Val);
-            _mm512_storeu_ps((float*)cPtr, z);
-            aPtr += 8;
-            cPtr += 8;
-        }
-
-        {
-            double y = block_delta - angle_c;
-            double t = angle_sum + y;
-            angle_c = (t - angle_sum) - y;
-            angle_sum = t;
-        }
-
-        for (unsigned int k = 0; k < 8; ++k) {
-            double a = angle_sum + (double)k * delta_angle;
-            REDUCE_ANGLE(a);
-            phase_Ptr[k] = lv_cmake((float)cos(a), (float)sin(a));
-        }
-        phase_Val = _mm512_loadu_ps((float*)phase_Ptr);
-    }
-
-    for (i = 0; i < (num_points % ROTATOR_RELOAD) / 8; ++i) {
-        aVal = _mm512_loadu_ps((const float*)aPtr);
-        z = _mm512_complexmul_ps(aVal, phase_Val);
-        phase_Val = _mm512_complexmul_ps(phase_Val, inc_Val);
-        _mm512_storeu_ps((float*)cPtr, z);
-        aPtr += 8;
-        cPtr += 8;
-
-        {
-            double y = (8.0 * delta_angle) - angle_c;
-            double t = angle_sum + y;
-            angle_c = (t - angle_sum) - y;
-            angle_sum = t;
-        }
-    }
-
-    {
-        double a = angle_sum;
-        REDUCE_ANGLE(a);
-        *phase = lv_cmake((float)cos(a), (float)sin(a));
-    }
-
-    for (i = 0; i < num_points % 8; ++i) {
-        *cPtr++ = *aPtr++ * (*phase);
-        {
-            double y = delta_angle - angle_c;
-            double t = angle_sum + y;
-            angle_c = (t - angle_sum) - y;
-            angle_sum = t;
-        }
-        double a = angle_sum;
-        REDUCE_ANGLE(a);
-        *phase = lv_cmake((float)cos(a), (float)sin(a));
-    }
-
-#undef REDUCE_ANGLE
-}
-
-#endif /* LV_HAVE_AVX512F */
-
-
-/* Note on the RVV implementation:
- * The complex multiply was expanded, because we don't care about the corner cases.
- * Otherwise, without -ffast-math, the compiler would inserts function calls,
- * which invalidates all vector registers and spills them on each loop iteration. */
-
-#ifdef LV_HAVE_RVV
-#include <riscv_vector.h>
-
-static inline void volk_32fc_s32fc_x2_rotator2_32fc_rvv(lv_32fc_t* outVector,
-                                                        const lv_32fc_t* inVector,
-                                                        const lv_32fc_t* phase_inc,
-                                                        lv_32fc_t* phase,
-                                                        unsigned int num_points)
-{
-    size_t vlmax = __riscv_vsetvlmax_e32m2();
-    vlmax = vlmax < ROTATOR_RELOAD ? vlmax : ROTATOR_RELOAD;
-
-    lv_32fc_t inc = 1.0f;
-    vfloat32m2_t phr = __riscv_vfmv_v_f_f32m2(0, vlmax), phi = phr;
-    for (size_t i = 0; i < vlmax; ++i) {
-        lv_32fc_t ph =
-            lv_cmake(lv_creal(*phase) * lv_creal(inc) - lv_cimag(*phase) * lv_cimag(inc),
-                     lv_creal(*phase) * lv_cimag(inc) + lv_cimag(*phase) * lv_creal(inc));
-        phr = __riscv_vfslide1down(phr, lv_creal(ph), vlmax);
-        phi = __riscv_vfslide1down(phi, lv_cimag(ph), vlmax);
-        inc = lv_cmake(
-            lv_creal(*phase_inc) * lv_creal(inc) - lv_cimag(*phase_inc) * lv_cimag(inc),
-            lv_creal(*phase_inc) * lv_cimag(inc) + lv_cimag(*phase_inc) * lv_creal(inc));
-    }
-    vfloat32m2_t incr = __riscv_vfmv_v_f_f32m2(lv_creal(inc), vlmax);
-    vfloat32m2_t inci = __riscv_vfmv_v_f_f32m2(lv_cimag(inc), vlmax);
-
-    size_t vl = 0;
-    if (num_points > 0)
-        while (1) {
-            size_t n = num_points < ROTATOR_RELOAD ? num_points : ROTATOR_RELOAD;
-            num_points -= n;
-
-            for (; n > 0; n -= vl, inVector += vl, outVector += vl) {
-                // vl<vlmax can only happen on the last iteration of the loops
-                vl = __riscv_vsetvl_e32m2(n < vlmax ? n : vlmax);
-
-                vuint64m4_t va = __riscv_vle64_v_u64m4((const uint64_t*)inVector, vl);
-                vfloat32m2_t var = __riscv_vreinterpret_f32m2(__riscv_vnsrl(va, 0, vl));
-                vfloat32m2_t vai = __riscv_vreinterpret_f32m2(__riscv_vnsrl(va, 32, vl));
-
-                vfloat32m2_t vr =
-                    __riscv_vfnmsac(__riscv_vfmul(var, phr, vl), vai, phi, vl);
-                vfloat32m2_t vi =
-                    __riscv_vfmacc(__riscv_vfmul(var, phi, vl), vai, phr, vl);
-
-                vuint32m2_t vru = __riscv_vreinterpret_u32m2(vr);
-                vuint32m2_t viu = __riscv_vreinterpret_u32m2(vi);
-                vuint64m4_t res =
-                    __riscv_vwmaccu(__riscv_vwaddu_vv(vru, viu, vl), 0xFFFFFFFF, viu, vl);
-                __riscv_vse64((uint64_t*)outVector, res, vl);
-
-                vfloat32m2_t tmp = phr;
-                phr = __riscv_vfnmsac(__riscv_vfmul(tmp, incr, vl), phi, inci, vl);
-                phi = __riscv_vfmacc(__riscv_vfmul(tmp, inci, vl), phi, incr, vl);
-            }
-
-            if (num_points <= 0)
-                break;
-
-            // normalize
-            vfloat32m2_t scale =
-                __riscv_vfmacc(__riscv_vfmul(phr, phr, vl), phi, phi, vl);
-            scale = __riscv_vfsqrt(scale, vl);
-            phr = __riscv_vfdiv(phr, scale, vl);
-            phi = __riscv_vfdiv(phi, scale, vl);
-        }
-
-    lv_32fc_t ph = lv_cmake(__riscv_vfmv_f(phr), __riscv_vfmv_f(phi));
-    for (size_t i = 0; i < vlmax - vl; ++i) {
-        ph /= *phase_inc; // we're going backwards
-    }
-    *phase = ph * 1.0f / hypotf(lv_creal(ph), lv_cimag(ph));
-}
-#endif /*LV_HAVE_RVV*/
-
-#ifdef LV_HAVE_RVVSEG
-#include <riscv_vector.h>
-
-static inline void volk_32fc_s32fc_x2_rotator2_32fc_rvvseg(lv_32fc_t* outVector,
-                                                           const lv_32fc_t* inVector,
-                                                           const lv_32fc_t* phase_inc,
-                                                           lv_32fc_t* phase,
-                                                           unsigned int num_points)
-{
-    size_t vlmax = __riscv_vsetvlmax_e32m2();
-    vlmax = vlmax < ROTATOR_RELOAD ? vlmax : ROTATOR_RELOAD;
-
-    lv_32fc_t inc = 1.0f;
-    vfloat32m2_t phr = __riscv_vfmv_v_f_f32m2(0, vlmax), phi = phr;
-    for (size_t i = 0; i < vlmax; ++i) {
-        lv_32fc_t ph =
-            lv_cmake(lv_creal(*phase) * lv_creal(inc) - lv_cimag(*phase) * lv_cimag(inc),
-                     lv_creal(*phase) * lv_cimag(inc) + lv_cimag(*phase) * lv_creal(inc));
-        phr = __riscv_vfslide1down(phr, lv_creal(ph), vlmax);
-        phi = __riscv_vfslide1down(phi, lv_cimag(ph), vlmax);
-        inc = lv_cmake(
-            lv_creal(*phase_inc) * lv_creal(inc) - lv_cimag(*phase_inc) * lv_cimag(inc),
-            lv_creal(*phase_inc) * lv_cimag(inc) + lv_cimag(*phase_inc) * lv_creal(inc));
-    }
-    vfloat32m2_t incr = __riscv_vfmv_v_f_f32m2(lv_creal(inc), vlmax);
-    vfloat32m2_t inci = __riscv_vfmv_v_f_f32m2(lv_cimag(inc), vlmax);
-
-    size_t vl = 0;
-    if (num_points > 0)
-        while (1) {
-            size_t n = num_points < ROTATOR_RELOAD ? num_points : ROTATOR_RELOAD;
-            num_points -= n;
-
-            for (; n > 0; n -= vl, inVector += vl, outVector += vl) {
-                // vl<vlmax can only happen on the last iteration of the loops
-                vl = __riscv_vsetvl_e32m2(n < vlmax ? n : vlmax);
-
-                vfloat32m2x2_t va =
-                    __riscv_vlseg2e32_v_f32m2x2((const float*)inVector, vl);
-                vfloat32m2_t var = __riscv_vget_f32m2(va, 0);
-                vfloat32m2_t vai = __riscv_vget_f32m2(va, 1);
-
-                vfloat32m2_t vr =
-                    __riscv_vfnmsac(__riscv_vfmul(var, phr, vl), vai, phi, vl);
-                vfloat32m2_t vi =
-                    __riscv_vfmacc(__riscv_vfmul(var, phi, vl), vai, phr, vl);
-                vfloat32m2x2_t vc = __riscv_vcreate_v_f32m2x2(vr, vi);
-                __riscv_vsseg2e32_v_f32m2x2((float*)outVector, vc, vl);
-
-                vfloat32m2_t tmp = phr;
-                phr = __riscv_vfnmsac(__riscv_vfmul(tmp, incr, vl), phi, inci, vl);
-                phi = __riscv_vfmacc(__riscv_vfmul(tmp, inci, vl), phi, incr, vl);
-            }
-
-            if (num_points <= 0)
-                break;
-
-            // normalize
-            vfloat32m2_t scale =
-                __riscv_vfmacc(__riscv_vfmul(phr, phr, vl), phi, phi, vl);
-            scale = __riscv_vfsqrt(scale, vl);
-            phr = __riscv_vfdiv(phr, scale, vl);
-            phi = __riscv_vfdiv(phi, scale, vl);
-        }
-
-    lv_32fc_t ph = lv_cmake(__riscv_vfmv_f(phr), __riscv_vfmv_f(phi));
-    for (size_t i = 0; i < vlmax - vl; ++i) {
-        ph /= *phase_inc; // we're going backwards
-    }
-    *phase = ph * 1.0f / hypotf(lv_creal(ph), lv_cimag(ph));
-}
-#endif /*LV_HAVE_RVVSEG*/
-
-#endif /* INCLUDED_volk_32fc_s32fc_rotator2_32fc_a_H */
+#endif /* INCLUDED_volk_32fc_s32fc_x2_rotator2_32fc_a_H */

--- a/kernels/volk/volk_32fc_s32fc_x2_rotator2_32fc.h
+++ b/kernels/volk/volk_32fc_s32fc_x2_rotator2_32fc.h
@@ -155,7 +155,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_neon(lv_32fc_t* outVector,
     lv_32fc_t phasePtr[4];
 
     const lv_32fc_t incrPtr[4] = { incr, incr, incr, incr };
-    const float32x4x2_t incr_vec = vld2q_f32((float*)incrPtr);
+    const float32x4x2_t incr_vec = vld2q_f32((const float*)incrPtr);
     float32x4x2_t phase_vec;
 
 // Helper macro for angle reduction
@@ -182,7 +182,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_neon(lv_32fc_t* outVector,
     for (i = 0; i < (unsigned int)(num_points / ROTATOR_RELOAD); i++) {
         // Inner loop: use fast SIMD multiply
         for (j = 0; j < ROTATOR_RELOAD_4; j++) {
-            input_vec = vld2q_f32((float*)inputVectorPtr);
+            input_vec = vld2q_f32((const float*)inputVectorPtr);
             __VOLK_PREFETCH(inputVectorPtr + 4);
 
             // Rotate
@@ -215,7 +215,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_neon(lv_32fc_t* outVector,
 
     // Handle remainder
     for (i = 0; i < (num_points % ROTATOR_RELOAD) / 4; i++) {
-        input_vec = vld2q_f32((float*)inputVectorPtr);
+        input_vec = vld2q_f32((const float*)inputVectorPtr);
         __VOLK_PREFETCH(inputVectorPtr + 4);
 
         output_vec = _vmultiply_complexq_f32(input_vec, phase_vec);
@@ -337,7 +337,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_a_avx(lv_32fc_t* outVector,
     for (i = 0; i < (unsigned int)(num_points / ROTATOR_RELOAD); ++i) {
         // Inner loop: use fast SIMD multiply
         for (j = 0; j < ROTATOR_RELOAD_4; ++j) {
-            aVal = _mm256_loadu_ps((float*)aPtr);
+            aVal = _mm256_loadu_ps((const float*)aPtr);
 
             z = _mm256_complexmul_ps(aVal, phase_Val);
             phase_Val = _mm256_complexmul_ps(phase_Val, inc_Val);
@@ -367,7 +367,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_a_avx(lv_32fc_t* outVector,
 
     // Handle remainder
     for (i = 0; i < (num_points % ROTATOR_RELOAD) / 4; ++i) {
-        aVal = _mm256_loadu_ps((float*)aPtr);
+        aVal = _mm256_loadu_ps((const float*)aPtr);
 
         z = _mm256_complexmul_ps(aVal, phase_Val);
         phase_Val = _mm256_complexmul_ps(phase_Val, inc_Val);
@@ -482,7 +482,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_u_avx(lv_32fc_t* outVector,
     // Main loop with periodic resync
     for (i = 0; i < (unsigned int)(num_points / ROTATOR_RELOAD); ++i) {
         for (j = 0; j < ROTATOR_RELOAD_4; ++j) {
-            aVal = _mm256_loadu_ps((float*)aPtr);
+            aVal = _mm256_loadu_ps((const float*)aPtr);
             z = _mm256_complexmul_ps(aVal, phase_Val);
             phase_Val = _mm256_complexmul_ps(phase_Val, inc_Val);
             _mm256_storeu_ps((float*)cPtr, z);
@@ -509,7 +509,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_u_avx(lv_32fc_t* outVector,
 
     // Handle remainder
     for (i = 0; i < (num_points % ROTATOR_RELOAD) / 4; ++i) {
-        aVal = _mm256_loadu_ps((float*)aPtr);
+        aVal = _mm256_loadu_ps((const float*)aPtr);
         z = _mm256_complexmul_ps(aVal, phase_Val);
         phase_Val = _mm256_complexmul_ps(phase_Val, inc_Val);
         _mm256_storeu_ps((float*)cPtr, z);
@@ -630,7 +630,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_a_avx512f(lv_32fc_t* outVect
     // Main loop with periodic resync
     for (i = 0; i < (unsigned int)(num_points / ROTATOR_RELOAD); ++i) {
         for (j = 0; j < ROTATOR_RELOAD_8; ++j) {
-            aVal = _mm512_load_ps((float*)aPtr);
+            aVal = _mm512_load_ps((const float*)aPtr);
             z = _mm512_complexmul_ps(aVal, phase_Val);
             phase_Val = _mm512_complexmul_ps(phase_Val, inc_Val);
             _mm512_store_ps((float*)cPtr, z);
@@ -657,7 +657,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_a_avx512f(lv_32fc_t* outVect
 
     // Handle remainder
     for (i = 0; i < (num_points % ROTATOR_RELOAD) / 8; ++i) {
-        aVal = _mm512_load_ps((float*)aPtr);
+        aVal = _mm512_load_ps((const float*)aPtr);
         z = _mm512_complexmul_ps(aVal, phase_Val);
         phase_Val = _mm512_complexmul_ps(phase_Val, inc_Val);
         _mm512_store_ps((float*)cPtr, z);
@@ -769,7 +769,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_u_avx512f(lv_32fc_t* outVect
 
     for (i = 0; i < (unsigned int)(num_points / ROTATOR_RELOAD); ++i) {
         for (j = 0; j < ROTATOR_RELOAD_8; ++j) {
-            aVal = _mm512_loadu_ps((float*)aPtr);
+            aVal = _mm512_loadu_ps((const float*)aPtr);
             z = _mm512_complexmul_ps(aVal, phase_Val);
             phase_Val = _mm512_complexmul_ps(phase_Val, inc_Val);
             _mm512_storeu_ps((float*)cPtr, z);
@@ -793,7 +793,7 @@ static inline void volk_32fc_s32fc_x2_rotator2_32fc_u_avx512f(lv_32fc_t* outVect
     }
 
     for (i = 0; i < (num_points % ROTATOR_RELOAD) / 8; ++i) {
-        aVal = _mm512_loadu_ps((float*)aPtr);
+        aVal = _mm512_loadu_ps((const float*)aPtr);
         z = _mm512_complexmul_ps(aVal, phase_Val);
         phase_Val = _mm512_complexmul_ps(phase_Val, inc_Val);
         _mm512_storeu_ps((float*)cPtr, z);

--- a/kernels/volk/volk_32fc_x2_add_32fc.h
+++ b/kernels/volk/volk_32fc_x2_add_32fc.h
@@ -79,8 +79,8 @@ static inline void volk_32fc_x2_add_32fc_u_avx(lv_32fc_t* cVector,
     __m256 aVal, bVal, cVal;
     for (; number < quarterPoints; number++) {
 
-        aVal = _mm256_loadu_ps((float*)aPtr);
-        bVal = _mm256_loadu_ps((float*)bPtr);
+        aVal = _mm256_loadu_ps((const float*)aPtr);
+        bVal = _mm256_loadu_ps((const float*)bPtr);
 
         cVal = _mm256_add_ps(aVal, bVal);
 
@@ -118,8 +118,8 @@ static inline void volk_32fc_x2_add_32fc_a_avx(lv_32fc_t* cVector,
     __m256 aVal, bVal, cVal;
     for (; number < quarterPoints; number++) {
 
-        aVal = _mm256_load_ps((float*)aPtr);
-        bVal = _mm256_load_ps((float*)bPtr);
+        aVal = _mm256_load_ps((const float*)aPtr);
+        bVal = _mm256_load_ps((const float*)bPtr);
 
         cVal = _mm256_add_ps(aVal, bVal);
 
@@ -157,8 +157,8 @@ static inline void volk_32fc_x2_add_32fc_u_sse(lv_32fc_t* cVector,
     __m128 aVal, bVal, cVal;
     for (; number < halfPoints; number++) {
 
-        aVal = _mm_loadu_ps((float*)aPtr);
-        bVal = _mm_loadu_ps((float*)bPtr);
+        aVal = _mm_loadu_ps((const float*)aPtr);
+        bVal = _mm_loadu_ps((const float*)bPtr);
 
         cVal = _mm_add_ps(aVal, bVal);
 
@@ -213,8 +213,8 @@ static inline void volk_32fc_x2_add_32fc_a_sse(lv_32fc_t* cVector,
 
     __m128 aVal, bVal, cVal;
     for (; number < halfPoints; number++) {
-        aVal = _mm_load_ps((float*)aPtr);
-        bVal = _mm_load_ps((float*)bPtr);
+        aVal = _mm_load_ps((const float*)aPtr);
+        bVal = _mm_load_ps((const float*)bPtr);
 
         cVal = _mm_add_ps(aVal, bVal);
 

--- a/kernels/volk/volk_32fc_x2_add_32fc.h
+++ b/kernels/volk/volk_32fc_x2_add_32fc.h
@@ -61,82 +61,23 @@
 #ifndef INCLUDED_volk_32fc_x2_add_32fc_u_H
 #define INCLUDED_volk_32fc_x2_add_32fc_u_H
 
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
+#ifdef LV_HAVE_GENERIC
 
-static inline void volk_32fc_x2_add_32fc_u_avx(lv_32fc_t* cVector,
-                                               const lv_32fc_t* aVector,
-                                               const lv_32fc_t* bVector,
-                                               unsigned int num_points)
+static inline void volk_32fc_x2_add_32fc_generic(lv_32fc_t* cVector,
+                                                 const lv_32fc_t* aVector,
+                                                 const lv_32fc_t* bVector,
+                                                 unsigned int num_points)
 {
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-
     lv_32fc_t* cPtr = cVector;
     const lv_32fc_t* aPtr = aVector;
     const lv_32fc_t* bPtr = bVector;
-
-    __m256 aVal, bVal, cVal;
-    for (; number < quarterPoints; number++) {
-
-        aVal = _mm256_loadu_ps((const float*)aPtr);
-        bVal = _mm256_loadu_ps((const float*)bPtr);
-
-        cVal = _mm256_add_ps(aVal, bVal);
-
-        _mm256_storeu_ps((float*)cPtr,
-                         cVal); // Store the results back into the C container
-
-        aPtr += 4;
-        bPtr += 4;
-        cPtr += 4;
-    }
-
-    number = quarterPoints * 4;
-    for (; number < num_points; number++) {
-        *cPtr++ = (*aPtr++) + (*bPtr++);
-    }
-}
-#endif /* LV_HAVE_AVX */
-
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-
-static inline void volk_32fc_x2_add_32fc_a_avx(lv_32fc_t* cVector,
-                                               const lv_32fc_t* aVector,
-                                               const lv_32fc_t* bVector,
-                                               unsigned int num_points)
-{
     unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
 
-    lv_32fc_t* cPtr = cVector;
-    const lv_32fc_t* aPtr = aVector;
-    const lv_32fc_t* bPtr = bVector;
-
-    __m256 aVal, bVal, cVal;
-    for (; number < quarterPoints; number++) {
-
-        aVal = _mm256_load_ps((const float*)aPtr);
-        bVal = _mm256_load_ps((const float*)bPtr);
-
-        cVal = _mm256_add_ps(aVal, bVal);
-
-        _mm256_store_ps((float*)cPtr,
-                        cVal); // Store the results back into the C container
-
-        aPtr += 4;
-        bPtr += 4;
-        cPtr += 4;
-    }
-
-    number = quarterPoints * 4;
-    for (; number < num_points; number++) {
+    for (number = 0; number < num_points; number++) {
         *cPtr++ = (*aPtr++) + (*bPtr++);
     }
 }
-#endif /* LV_HAVE_AVX */
+#endif /* LV_HAVE_GENERIC */
 
 
 #ifdef LV_HAVE_SSE
@@ -177,60 +118,43 @@ static inline void volk_32fc_x2_add_32fc_u_sse(lv_32fc_t* cVector,
 #endif /* LV_HAVE_SSE */
 
 
-#ifdef LV_HAVE_GENERIC
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
 
-static inline void volk_32fc_x2_add_32fc_generic(lv_32fc_t* cVector,
-                                                 const lv_32fc_t* aVector,
-                                                 const lv_32fc_t* bVector,
-                                                 unsigned int num_points)
-{
-    lv_32fc_t* cPtr = cVector;
-    const lv_32fc_t* aPtr = aVector;
-    const lv_32fc_t* bPtr = bVector;
-    unsigned int number = 0;
-
-    for (number = 0; number < num_points; number++) {
-        *cPtr++ = (*aPtr++) + (*bPtr++);
-    }
-}
-#endif /* LV_HAVE_GENERIC */
-
-
-#ifdef LV_HAVE_SSE
-#include <xmmintrin.h>
-
-static inline void volk_32fc_x2_add_32fc_a_sse(lv_32fc_t* cVector,
+static inline void volk_32fc_x2_add_32fc_u_avx(lv_32fc_t* cVector,
                                                const lv_32fc_t* aVector,
                                                const lv_32fc_t* bVector,
                                                unsigned int num_points)
 {
     unsigned int number = 0;
-    const unsigned int halfPoints = num_points / 2;
+    const unsigned int quarterPoints = num_points / 4;
 
     lv_32fc_t* cPtr = cVector;
     const lv_32fc_t* aPtr = aVector;
     const lv_32fc_t* bPtr = bVector;
 
-    __m128 aVal, bVal, cVal;
-    for (; number < halfPoints; number++) {
-        aVal = _mm_load_ps((const float*)aPtr);
-        bVal = _mm_load_ps((const float*)bPtr);
+    __m256 aVal, bVal, cVal;
+    for (; number < quarterPoints; number++) {
 
-        cVal = _mm_add_ps(aVal, bVal);
+        aVal = _mm256_loadu_ps((const float*)aPtr);
+        bVal = _mm256_loadu_ps((const float*)bPtr);
 
-        _mm_store_ps((float*)cPtr, cVal); // Store the results back into the C container
+        cVal = _mm256_add_ps(aVal, bVal);
 
-        aPtr += 2;
-        bPtr += 2;
-        cPtr += 2;
+        _mm256_storeu_ps((float*)cPtr,
+                         cVal); // Store the results back into the C container
+
+        aPtr += 4;
+        bPtr += 4;
+        cPtr += 4;
     }
 
-    number = halfPoints * 2;
+    number = quarterPoints * 4;
     for (; number < num_points; number++) {
         *cPtr++ = (*aPtr++) + (*bPtr++);
     }
 }
-#endif /* LV_HAVE_SSE */
+#endif /* LV_HAVE_AVX */
 
 
 #ifdef LV_HAVE_NEON
@@ -328,6 +252,86 @@ static inline void volk_32fc_x2_add_32fc_rvv(lv_32fc_t* cVector,
         __riscv_vse32(out, __riscv_vfadd(va, vb, vl), vl);
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
+
+#endif /* INCLUDED_volk_32fc_x2_add_32fc_u_H */
+
+#ifndef INCLUDED_volk_32fc_x2_add_32fc_a_H
+#define INCLUDED_volk_32fc_x2_add_32fc_a_H
+
+#ifdef LV_HAVE_SSE
+#include <xmmintrin.h>
+
+static inline void volk_32fc_x2_add_32fc_a_sse(lv_32fc_t* cVector,
+                                               const lv_32fc_t* aVector,
+                                               const lv_32fc_t* bVector,
+                                               unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int halfPoints = num_points / 2;
+
+    lv_32fc_t* cPtr = cVector;
+    const lv_32fc_t* aPtr = aVector;
+    const lv_32fc_t* bPtr = bVector;
+
+    __m128 aVal, bVal, cVal;
+    for (; number < halfPoints; number++) {
+        aVal = _mm_load_ps((const float*)aPtr);
+        bVal = _mm_load_ps((const float*)bPtr);
+
+        cVal = _mm_add_ps(aVal, bVal);
+
+        _mm_store_ps((float*)cPtr, cVal); // Store the results back into the C container
+
+        aPtr += 2;
+        bPtr += 2;
+        cPtr += 2;
+    }
+
+    number = halfPoints * 2;
+    for (; number < num_points; number++) {
+        *cPtr++ = (*aPtr++) + (*bPtr++);
+    }
+}
+#endif /* LV_HAVE_SSE */
+
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void volk_32fc_x2_add_32fc_a_avx(lv_32fc_t* cVector,
+                                               const lv_32fc_t* aVector,
+                                               const lv_32fc_t* bVector,
+                                               unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    lv_32fc_t* cPtr = cVector;
+    const lv_32fc_t* aPtr = aVector;
+    const lv_32fc_t* bPtr = bVector;
+
+    __m256 aVal, bVal, cVal;
+    for (; number < quarterPoints; number++) {
+
+        aVal = _mm256_load_ps((const float*)aPtr);
+        bVal = _mm256_load_ps((const float*)bPtr);
+
+        cVal = _mm256_add_ps(aVal, bVal);
+
+        _mm256_store_ps((float*)cPtr,
+                        cVal); // Store the results back into the C container
+
+        aPtr += 4;
+        bPtr += 4;
+        cPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        *cPtr++ = (*aPtr++) + (*bPtr++);
+    }
+}
+#endif /* LV_HAVE_AVX */
 
 #endif /* INCLUDED_volk_32fc_x2_add_32fc_a_H */

--- a/kernels/volk/volk_32fc_x2_conjugate_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_x2_conjugate_dot_prod_32fc.h
@@ -92,8 +92,8 @@ static inline void volk_32fc_x2_conjugate_dot_prod_32fc_block(lv_32fc_t* result,
     const unsigned int num_bytes = num_points * 8;
 
     float* res = (float*)result;
-    float* in = (float*)input;
-    float* tp = (float*)taps;
+    const float* in = (const float*)input;
+    const float* tp = (const float*)taps;
     unsigned int n_2_ccomplex_blocks = num_bytes >> 4;
 
     float sum0[2] = { 0, 0 };
@@ -538,8 +538,8 @@ static inline void volk_32fc_x2_conjugate_dot_prod_32fc_neon(lv_32fc_t* result,
     unsigned int quarter_points = num_points / 4;
     unsigned int number;
 
-    lv_32fc_t* a_ptr = (lv_32fc_t*)taps;
-    lv_32fc_t* b_ptr = (lv_32fc_t*)input;
+    const lv_32fc_t* a_ptr = taps;
+    const lv_32fc_t* b_ptr = input;
     // for 2-lane vectors, 1st lane holds the real part,
     // 2nd lane holds the imaginary part
     float32x4x2_t a_val, b_val, accumulator;
@@ -548,8 +548,8 @@ static inline void volk_32fc_x2_conjugate_dot_prod_32fc_neon(lv_32fc_t* result,
     accumulator.val[1] = vdupq_n_f32(0);
 
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld2q_f32((float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
-        b_val = vld2q_f32((float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
+        a_val = vld2q_f32((const float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
+        b_val = vld2q_f32((const float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
         __VOLK_PREFETCH(a_ptr + 8);
         __VOLK_PREFETCH(b_ptr + 8);
 

--- a/kernels/volk/volk_32fc_x2_conjugate_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_x2_conjugate_dot_prod_32fc.h
@@ -179,65 +179,6 @@ static inline void volk_32fc_x2_conjugate_dot_prod_32fc_u_sse3(lv_32fc_t* result
 
 #endif /*LV_HAVE_SSE3*/
 
-#ifdef LV_HAVE_SSE3
-
-#include <pmmintrin.h>
-#include <xmmintrin.h>
-
-static inline void volk_32fc_x2_conjugate_dot_prod_32fc_a_sse3(lv_32fc_t* result,
-                                                               const lv_32fc_t* input,
-                                                               const lv_32fc_t* taps,
-                                                               unsigned int num_points)
-{
-    // Partial sums for indices i and i+1.
-    __m128 sum_a_mult_b_real = _mm_setzero_ps();
-    __m128 sum_a_mult_b_imag = _mm_setzero_ps();
-
-    for (long unsigned i = 0; i < (num_points & ~1u); i += 2) {
-        /* Two complex elements a time are processed.
-         * (ar + j⋅ai)*conj(br + j⋅bi) =
-         * ar⋅br + ai⋅bi + j⋅(ai⋅br − ar⋅bi)
-         */
-
-        /* Load input and taps, split and duplicate real und imaginary parts of taps.
-         * a: | ai,i+1 | ar,i+1 | ai,i+0 | ar,i+0 |
-         * b: | bi,i+1 | br,i+1 | bi,i+0 | br,i+0 |
-         * b_real: | br,i+1 | br,i+1 | br,i+0 | br,i+0 |
-         * b_imag: | bi,i+1 | bi,i+1 | bi,i+0 | bi,i+0 |
-         */
-        __m128 a = _mm_load_ps((const float*)&input[i]);
-        __m128 b = _mm_load_ps((const float*)&taps[i]);
-        __m128 b_real = _mm_moveldup_ps(b);
-        __m128 b_imag = _mm_movehdup_ps(b);
-
-        // Add | ai⋅br,i+1 | ar⋅br,i+1 | ai⋅br,i+0 | ar⋅br,i+0 | to partial sum.
-        sum_a_mult_b_real = _mm_add_ps(sum_a_mult_b_real, _mm_mul_ps(a, b_real));
-        // Add | ai⋅bi,i+1 | −ar⋅bi,i+1 | ai⋅bi,i+0 | −ar⋅bi,i+0 | to partial sum.
-        sum_a_mult_b_imag = _mm_addsub_ps(sum_a_mult_b_imag, _mm_mul_ps(a, b_imag));
-    }
-
-    // Swap position of −ar⋅bi and ai⋅bi.
-    sum_a_mult_b_imag =
-        _mm_shuffle_ps(sum_a_mult_b_imag, sum_a_mult_b_imag, _MM_SHUFFLE(2, 3, 0, 1));
-    // | ai⋅br + ai⋅bi | ai⋅br − ar⋅bi |, sum contains two such partial sums.
-    __m128 sum = _mm_add_ps(sum_a_mult_b_real, sum_a_mult_b_imag);
-    // Sum the two partial sums.
-    sum = _mm_add_ps(sum, _mm_shuffle_ps(sum, sum, _MM_SHUFFLE(1, 0, 3, 2)));
-    // Store result.
-    _mm_storel_pi((__m64*)result, sum);
-
-    // Handle the last element if num_points mod 2 is 1.
-    if (num_points & 1u) {
-        *result += lv_cmake(
-            lv_creal(input[num_points - 1]) * lv_creal(taps[num_points - 1]) +
-                lv_cimag(input[num_points - 1]) * lv_cimag(taps[num_points - 1]),
-            lv_cimag(input[num_points - 1]) * lv_creal(taps[num_points - 1]) -
-                lv_creal(input[num_points - 1]) * lv_cimag(taps[num_points - 1]));
-    }
-}
-
-#endif /*LV_HAVE_SSE3*/
-
 #ifdef LV_HAVE_AVX
 
 #include <immintrin.h>
@@ -297,65 +238,6 @@ static inline void volk_32fc_x2_conjugate_dot_prod_32fc_u_avx(lv_32fc_t* result,
     }
 }
 
-#endif /* LV_HAVE_AVX */
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-
-static inline void volk_32fc_x2_conjugate_dot_prod_32fc_a_avx(lv_32fc_t* result,
-                                                              const lv_32fc_t* input,
-                                                              const lv_32fc_t* taps,
-                                                              unsigned int num_points)
-{
-    // Partial sums for indices i, i+1, i+2 and i+3.
-    __m256 sum_a_mult_b_real = _mm256_setzero_ps();
-    __m256 sum_a_mult_b_imag = _mm256_setzero_ps();
-
-    for (long unsigned i = 0; i < (num_points & ~3u); i += 4) {
-        /* Four complex elements a time are processed.
-         * (ar + j⋅ai)*conj(br + j⋅bi) =
-         * ar⋅br + ai⋅bi + j⋅(ai⋅br − ar⋅bi)
-         */
-
-        /* Load input and taps, split and duplicate real und imaginary parts of taps.
-         * a: | ai,i+3 | ar,i+3 | … | ai,i+1 | ar,i+1 | ai,i+0 | ar,i+0 |
-         * b: | bi,i+3 | br,i+3 | … | bi,i+1 | br,i+1 | bi,i+0 | br,i+0 |
-         * b_real: | br,i+3 | br,i+3 | … | br,i+1 | br,i+1 | br,i+0 | br,i+0 |
-         * b_imag: | bi,i+3 | bi,i+3 | … | bi,i+1 | bi,i+1 | bi,i+0 | bi,i+0 |
-         */
-        __m256 a = _mm256_load_ps((const float*)&input[i]);
-        __m256 b = _mm256_load_ps((const float*)&taps[i]);
-        __m256 b_real = _mm256_moveldup_ps(b);
-        __m256 b_imag = _mm256_movehdup_ps(b);
-
-        // Add | ai⋅br,i+3 | ar⋅br,i+3 | … | ai⋅br,i+0 | ar⋅br,i+0 | to partial sum.
-        sum_a_mult_b_real = _mm256_add_ps(sum_a_mult_b_real, _mm256_mul_ps(a, b_real));
-        // Add | ai⋅bi,i+3 | −ar⋅bi,i+3 | … | ai⋅bi,i+0 | −ar⋅bi,i+0 | to partial sum.
-        sum_a_mult_b_imag = _mm256_addsub_ps(sum_a_mult_b_imag, _mm256_mul_ps(a, b_imag));
-    }
-
-    // Swap position of −ar⋅bi and ai⋅bi.
-    sum_a_mult_b_imag = _mm256_permute_ps(sum_a_mult_b_imag, _MM_SHUFFLE(2, 3, 0, 1));
-    // | ai⋅br + ai⋅bi | ai⋅br − ar⋅bi |, sum contains four such partial sums.
-    __m256 sum = _mm256_add_ps(sum_a_mult_b_real, sum_a_mult_b_imag);
-    /* Sum the four partial sums: Add high half of vector sum to the low one, i.e.
-     * s1 + s3 and s0 + s2 …
-     */
-    sum = _mm256_add_ps(sum, _mm256_permute2f128_ps(sum, sum, 0x01));
-    // … and now (s0 + s2) + (s1 + s3)
-    sum = _mm256_add_ps(sum, _mm256_permute_ps(sum, _MM_SHUFFLE(1, 0, 3, 2)));
-    // Store result.
-    __m128 lower = _mm256_extractf128_ps(sum, 0);
-    _mm_storel_pi((__m64*)result, lower);
-
-    // Handle the last elements if num_points mod 4 is bigger than 0.
-    for (long unsigned i = num_points & ~3u; i < num_points; ++i) {
-        *result += lv_cmake(lv_creal(input[i]) * lv_creal(taps[i]) +
-                                lv_cimag(input[i]) * lv_cimag(taps[i]),
-                            lv_cimag(input[i]) * lv_creal(taps[i]) -
-                                lv_creal(input[i]) * lv_cimag(taps[i]));
-    }
-}
 #endif /* LV_HAVE_AVX */
 
 #if LV_HAVE_AVX512F && LV_HAVE_AVX512DQ
@@ -443,88 +325,6 @@ volk_32fc_x2_conjugate_dot_prod_32fc_u_avx512dq(lv_32fc_t* result,
     }
 }
 
-#endif /* LV_HAVE_AVX512F && LV_HAVE_AVX512DQ */
-
-#if LV_HAVE_AVX512F && LV_HAVE_AVX512DQ
-
-#include <immintrin.h>
-
-static inline void
-volk_32fc_x2_conjugate_dot_prod_32fc_a_avx512dq(lv_32fc_t* result,
-                                                const lv_32fc_t* input,
-                                                const lv_32fc_t* taps,
-                                                unsigned int num_points)
-{
-    // Partial sums for indices i through i+7 (8 complex elements).
-    __m512 sum_a_mult_b_real = _mm512_setzero_ps();
-    __m512 sum_a_mult_b_imag = _mm512_setzero_ps();
-
-    // Sign mask for emulating addsub: negate even indices (real parts)
-    const __m512 sign_mask = _mm512_castsi512_ps(_mm512_set_epi32(0,
-                                                                  0x80000000,
-                                                                  0,
-                                                                  0x80000000,
-                                                                  0,
-                                                                  0x80000000,
-                                                                  0,
-                                                                  0x80000000,
-                                                                  0,
-                                                                  0x80000000,
-                                                                  0,
-                                                                  0x80000000,
-                                                                  0,
-                                                                  0x80000000,
-                                                                  0,
-                                                                  0x80000000));
-
-    for (long unsigned i = 0; i < (num_points & ~7u); i += 8) {
-        /* Eight complex elements a time are processed.
-         * (ar + j⋅ai)*conj(br + j⋅bi) =
-         * ar⋅br + ai⋅bi + j⋅(ai⋅br − ar⋅bi)
-         */
-
-        // Load input and taps (aligned).
-        __m512 a = _mm512_load_ps((const float*)&input[i]);
-        __m512 b = _mm512_load_ps((const float*)&taps[i]);
-
-        // Duplicate real and imaginary parts of taps
-        __m512 b_real = _mm512_moveldup_ps(b); // duplicate even elements (real)
-        __m512 b_imag = _mm512_movehdup_ps(b); // duplicate odd elements (imag)
-
-        // Accumulate ar⋅br and ai⋅br
-        sum_a_mult_b_real = _mm512_fmadd_ps(a, b_real, sum_a_mult_b_real);
-
-        // Emulate addsub: compute a*b_imag then negate even indices
-        __m512 mult_imag = _mm512_mul_ps(a, b_imag);
-        mult_imag = _mm512_xor_ps(mult_imag, sign_mask); // flip sign of even indices
-        sum_a_mult_b_imag = _mm512_add_ps(sum_a_mult_b_imag, mult_imag);
-    }
-
-    // Swap position of −ar⋅bi and ai⋅bi, then add
-    sum_a_mult_b_imag = _mm512_permute_ps(sum_a_mult_b_imag, 0xB1);
-    __m512 sum = _mm512_add_ps(sum_a_mult_b_real, sum_a_mult_b_imag);
-
-    // Horizontal sum: reduce 8 complex numbers to 1
-    __m256 sum_high = _mm512_extractf32x8_ps(sum, 1);
-    __m256 sum_low = _mm512_castps512_ps256(sum);
-    __m256 sum256 = _mm256_add_ps(sum_high, sum_low);
-
-    __m128 sum128_high = _mm256_extractf128_ps(sum256, 1);
-    __m128 sum128_low = _mm256_castps256_ps128(sum256);
-    __m128 sum128 = _mm_add_ps(sum128_high, sum128_low);
-
-    sum128 = _mm_add_ps(sum128, _mm_shuffle_ps(sum128, sum128, _MM_SHUFFLE(1, 0, 3, 2)));
-
-    _mm_storel_pi((__m64*)result, sum128);
-
-    // Handle remaining elements
-    for (long unsigned i = num_points & ~7u; i < num_points; ++i) {
-        *result += lv_cmake(lv_creal(input[i]) * lv_creal(taps[i]) +
-                                lv_cimag(input[i]) * lv_cimag(taps[i]),
-                            lv_cimag(input[i]) * lv_creal(taps[i]) -
-                                lv_creal(input[i]) * lv_cimag(taps[i]));
-    }
-}
 #endif /* LV_HAVE_AVX512F && LV_HAVE_AVX512DQ */
 
 #ifdef LV_HAVE_NEON
@@ -747,5 +547,208 @@ static inline void volk_32fc_x2_conjugate_dot_prod_32fc_rvvseg(lv_32fc_t* result
 #include <stdio.h>
 #include <volk/volk_common.h>
 #include <volk/volk_complex.h>
+
+#ifdef LV_HAVE_SSE3
+
+#include <pmmintrin.h>
+#include <xmmintrin.h>
+
+static inline void volk_32fc_x2_conjugate_dot_prod_32fc_a_sse3(lv_32fc_t* result,
+                                                               const lv_32fc_t* input,
+                                                               const lv_32fc_t* taps,
+                                                               unsigned int num_points)
+{
+    // Partial sums for indices i and i+1.
+    __m128 sum_a_mult_b_real = _mm_setzero_ps();
+    __m128 sum_a_mult_b_imag = _mm_setzero_ps();
+
+    for (long unsigned i = 0; i < (num_points & ~1u); i += 2) {
+        /* Two complex elements a time are processed.
+         * (ar + j⋅ai)*conj(br + j⋅bi) =
+         * ar⋅br + ai⋅bi + j⋅(ai⋅br − ar⋅bi)
+         */
+
+        /* Load input and taps, split and duplicate real und imaginary parts of taps.
+         * a: | ai,i+1 | ar,i+1 | ai,i+0 | ar,i+0 |
+         * b: | bi,i+1 | br,i+1 | bi,i+0 | br,i+0 |
+         * b_real: | br,i+1 | br,i+1 | br,i+0 | br,i+0 |
+         * b_imag: | bi,i+1 | bi,i+1 | bi,i+0 | bi,i+0 |
+         */
+        __m128 a = _mm_load_ps((const float*)&input[i]);
+        __m128 b = _mm_load_ps((const float*)&taps[i]);
+        __m128 b_real = _mm_moveldup_ps(b);
+        __m128 b_imag = _mm_movehdup_ps(b);
+
+        // Add | ai⋅br,i+1 | ar⋅br,i+1 | ai⋅br,i+0 | ar⋅br,i+0 | to partial sum.
+        sum_a_mult_b_real = _mm_add_ps(sum_a_mult_b_real, _mm_mul_ps(a, b_real));
+        // Add | ai⋅bi,i+1 | −ar⋅bi,i+1 | ai⋅bi,i+0 | −ar⋅bi,i+0 | to partial sum.
+        sum_a_mult_b_imag = _mm_addsub_ps(sum_a_mult_b_imag, _mm_mul_ps(a, b_imag));
+    }
+
+    // Swap position of −ar⋅bi and ai⋅bi.
+    sum_a_mult_b_imag =
+        _mm_shuffle_ps(sum_a_mult_b_imag, sum_a_mult_b_imag, _MM_SHUFFLE(2, 3, 0, 1));
+    // | ai⋅br + ai⋅bi | ai⋅br − ar⋅bi |, sum contains two such partial sums.
+    __m128 sum = _mm_add_ps(sum_a_mult_b_real, sum_a_mult_b_imag);
+    // Sum the two partial sums.
+    sum = _mm_add_ps(sum, _mm_shuffle_ps(sum, sum, _MM_SHUFFLE(1, 0, 3, 2)));
+    // Store result.
+    _mm_storel_pi((__m64*)result, sum);
+
+    // Handle the last element if num_points mod 2 is 1.
+    if (num_points & 1u) {
+        *result += lv_cmake(
+            lv_creal(input[num_points - 1]) * lv_creal(taps[num_points - 1]) +
+                lv_cimag(input[num_points - 1]) * lv_cimag(taps[num_points - 1]),
+            lv_cimag(input[num_points - 1]) * lv_creal(taps[num_points - 1]) -
+                lv_creal(input[num_points - 1]) * lv_cimag(taps[num_points - 1]));
+    }
+}
+
+#endif /*LV_HAVE_SSE3*/
+
+#ifdef LV_HAVE_AVX
+
+#include <immintrin.h>
+
+static inline void volk_32fc_x2_conjugate_dot_prod_32fc_a_avx(lv_32fc_t* result,
+                                                              const lv_32fc_t* input,
+                                                              const lv_32fc_t* taps,
+                                                              unsigned int num_points)
+{
+    // Partial sums for indices i, i+1, i+2 and i+3.
+    __m256 sum_a_mult_b_real = _mm256_setzero_ps();
+    __m256 sum_a_mult_b_imag = _mm256_setzero_ps();
+
+    for (long unsigned i = 0; i < (num_points & ~3u); i += 4) {
+        /* Four complex elements a time are processed.
+         * (ar + j⋅ai)*conj(br + j⋅bi) =
+         * ar⋅br + ai⋅bi + j⋅(ai⋅br − ar⋅bi)
+         */
+
+        /* Load input and taps, split and duplicate real und imaginary parts of taps.
+         * a: | ai,i+3 | ar,i+3 | … | ai,i+1 | ar,i+1 | ai,i+0 | ar,i+0 |
+         * b: | bi,i+3 | br,i+3 | … | bi,i+1 | br,i+1 | bi,i+0 | br,i+0 |
+         * b_real: | br,i+3 | br,i+3 | … | br,i+1 | br,i+1 | br,i+0 | br,i+0 |
+         * b_imag: | bi,i+3 | bi,i+3 | … | bi,i+1 | bi,i+1 | bi,i+0 | bi,i+0 |
+         */
+        __m256 a = _mm256_load_ps((const float*)&input[i]);
+        __m256 b = _mm256_load_ps((const float*)&taps[i]);
+        __m256 b_real = _mm256_moveldup_ps(b);
+        __m256 b_imag = _mm256_movehdup_ps(b);
+
+        // Add | ai⋅br,i+3 | ar⋅br,i+3 | … | ai⋅br,i+0 | ar⋅br,i+0 | to partial sum.
+        sum_a_mult_b_real = _mm256_add_ps(sum_a_mult_b_real, _mm256_mul_ps(a, b_real));
+        // Add | ai⋅bi,i+3 | −ar⋅bi,i+3 | … | ai⋅bi,i+0 | −ar⋅bi,i+0 | to partial sum.
+        sum_a_mult_b_imag = _mm256_addsub_ps(sum_a_mult_b_imag, _mm256_mul_ps(a, b_imag));
+    }
+
+    // Swap position of −ar⋅bi and ai⋅bi.
+    sum_a_mult_b_imag = _mm256_permute_ps(sum_a_mult_b_imag, _MM_SHUFFLE(2, 3, 0, 1));
+    // | ai⋅br + ai⋅bi | ai⋅br − ar⋅bi |, sum contains four such partial sums.
+    __m256 sum = _mm256_add_ps(sum_a_mult_b_real, sum_a_mult_b_imag);
+    /* Sum the four partial sums: Add high half of vector sum to the low one, i.e.
+     * s1 + s3 and s0 + s2 …
+     */
+    sum = _mm256_add_ps(sum, _mm256_permute2f128_ps(sum, sum, 0x01));
+    // … and now (s0 + s2) + (s1 + s3)
+    sum = _mm256_add_ps(sum, _mm256_permute_ps(sum, _MM_SHUFFLE(1, 0, 3, 2)));
+    // Store result.
+    __m128 lower = _mm256_extractf128_ps(sum, 0);
+    _mm_storel_pi((__m64*)result, lower);
+
+    // Handle the last elements if num_points mod 4 is bigger than 0.
+    for (long unsigned i = num_points & ~3u; i < num_points; ++i) {
+        *result += lv_cmake(lv_creal(input[i]) * lv_creal(taps[i]) +
+                                lv_cimag(input[i]) * lv_cimag(taps[i]),
+                            lv_cimag(input[i]) * lv_creal(taps[i]) -
+                                lv_creal(input[i]) * lv_cimag(taps[i]));
+    }
+}
+
+#endif /* LV_HAVE_AVX */
+
+#if LV_HAVE_AVX512F && LV_HAVE_AVX512DQ
+
+#include <immintrin.h>
+
+static inline void
+volk_32fc_x2_conjugate_dot_prod_32fc_a_avx512dq(lv_32fc_t* result,
+                                                const lv_32fc_t* input,
+                                                const lv_32fc_t* taps,
+                                                unsigned int num_points)
+{
+    // Partial sums for indices i through i+7 (8 complex elements).
+    __m512 sum_a_mult_b_real = _mm512_setzero_ps();
+    __m512 sum_a_mult_b_imag = _mm512_setzero_ps();
+
+    // Sign mask for emulating addsub: negate even indices (real parts)
+    const __m512 sign_mask = _mm512_castsi512_ps(_mm512_set_epi32(0,
+                                                                  0x80000000,
+                                                                  0,
+                                                                  0x80000000,
+                                                                  0,
+                                                                  0x80000000,
+                                                                  0,
+                                                                  0x80000000,
+                                                                  0,
+                                                                  0x80000000,
+                                                                  0,
+                                                                  0x80000000,
+                                                                  0,
+                                                                  0x80000000,
+                                                                  0,
+                                                                  0x80000000));
+
+    for (long unsigned i = 0; i < (num_points & ~7u); i += 8) {
+        /* Eight complex elements a time are processed.
+         * (ar + j⋅ai)*conj(br + j⋅bi) =
+         * ar⋅br + ai⋅bi + j⋅(ai⋅br − ar⋅bi)
+         */
+
+        // Load input and taps (aligned).
+        __m512 a = _mm512_load_ps((const float*)&input[i]);
+        __m512 b = _mm512_load_ps((const float*)&taps[i]);
+
+        // Duplicate real and imaginary parts of taps
+        __m512 b_real = _mm512_moveldup_ps(b); // duplicate even elements (real)
+        __m512 b_imag = _mm512_movehdup_ps(b); // duplicate odd elements (imag)
+
+        // Accumulate ar⋅br and ai⋅br
+        sum_a_mult_b_real = _mm512_fmadd_ps(a, b_real, sum_a_mult_b_real);
+
+        // Emulate addsub: compute a*b_imag then negate even indices
+        __m512 mult_imag = _mm512_mul_ps(a, b_imag);
+        mult_imag = _mm512_xor_ps(mult_imag, sign_mask); // flip sign of even indices
+        sum_a_mult_b_imag = _mm512_add_ps(sum_a_mult_b_imag, mult_imag);
+    }
+
+    // Swap position of −ar⋅bi and ai⋅bi, then add
+    sum_a_mult_b_imag = _mm512_permute_ps(sum_a_mult_b_imag, 0xB1);
+    __m512 sum = _mm512_add_ps(sum_a_mult_b_real, sum_a_mult_b_imag);
+
+    // Horizontal sum: reduce 8 complex numbers to 1
+    __m256 sum_high = _mm512_extractf32x8_ps(sum, 1);
+    __m256 sum_low = _mm512_castps512_ps256(sum);
+    __m256 sum256 = _mm256_add_ps(sum_high, sum_low);
+
+    __m128 sum128_high = _mm256_extractf128_ps(sum256, 1);
+    __m128 sum128_low = _mm256_castps256_ps128(sum256);
+    __m128 sum128 = _mm_add_ps(sum128_high, sum128_low);
+
+    sum128 = _mm_add_ps(sum128, _mm_shuffle_ps(sum128, sum128, _MM_SHUFFLE(1, 0, 3, 2)));
+
+    _mm_storel_pi((__m64*)result, sum128);
+
+    // Handle remaining elements
+    for (long unsigned i = num_points & ~7u; i < num_points; ++i) {
+        *result += lv_cmake(lv_creal(input[i]) * lv_creal(taps[i]) +
+                                lv_cimag(input[i]) * lv_cimag(taps[i]),
+                            lv_cimag(input[i]) * lv_creal(taps[i]) -
+                                lv_creal(input[i]) * lv_cimag(taps[i]));
+    }
+}
+
+#endif /* LV_HAVE_AVX512F && LV_HAVE_AVX512DQ */
 
 #endif /*INCLUDED_volk_32fc_x2_conjugate_dot_prod_32fc_a_H*/

--- a/kernels/volk/volk_32fc_x2_divide_32fc.h
+++ b/kernels/volk/volk_32fc_x2_divide_32fc.h
@@ -145,14 +145,14 @@ static inline void volk_32fc_x2_divide_32fc_u_sse3(lv_32fc_t* cVector,
     const lv_32fc_t* b = denumeratorVector;
 
     for (; number < quarterPoints; number++) {
-        num01 = _mm_loadu_ps((float*)a);                  // first pair
-        den01 = _mm_loadu_ps((float*)b);                  // first pair
+        num01 = _mm_loadu_ps((const float*)a);                  // first pair
+        den01 = _mm_loadu_ps((const float*)b);                  // first pair
         num01 = _mm_complexconjugatemul_ps(num01, den01); // a conj(b)
         a += 2;
         b += 2;
 
-        num23 = _mm_loadu_ps((float*)a);                  // second pair
-        den23 = _mm_loadu_ps((float*)b);                  // second pair
+        num23 = _mm_loadu_ps((const float*)a);                  // second pair
+        den23 = _mm_loadu_ps((const float*)b);                  // second pair
         num23 = _mm_complexconjugatemul_ps(num23, den23); // a conj(b)
         a += 2;
         b += 2;
@@ -205,9 +205,9 @@ static inline void volk_32fc_x2_divide_32fc_u_avx(lv_32fc_t* cVector,
 
     for (; number < quarterPoints; number++) {
         num = _mm256_loadu_ps(
-            (float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
+            (const float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
         denum = _mm256_loadu_ps(
-            (float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
+            (const float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
         mul_conj = _mm256_complexconjugatemul_ps(num, denum);
         sq = _mm256_mul_ps(denum, denum); // Square the values
         mag_sq_un = _mm256_hadd_ps(
@@ -251,14 +251,14 @@ static inline void volk_32fc_x2_divide_32fc_u_avx2_fma(lv_32fc_t* cVector,
     __m256 num01, num23, denum01, denum23, complex_result, result0, result1;
 
     for (unsigned int number = 0; number < eighthPoints; number++) {
-        num01 = _mm256_loadu_ps((float*)a);
-        denum01 = _mm256_loadu_ps((float*)b);
+        num01 = _mm256_loadu_ps((const float*)a);
+        denum01 = _mm256_loadu_ps((const float*)b);
         num01 = _mm256_complexconjugatemul_ps(num01, denum01);
         a += 4;
         b += 4;
 
-        num23 = _mm256_loadu_ps((float*)a);
-        denum23 = _mm256_loadu_ps((float*)b);
+        num23 = _mm256_loadu_ps((const float*)a);
+        denum23 = _mm256_loadu_ps((const float*)b);
         num23 = _mm256_complexconjugatemul_ps(num23, denum23);
         a += 4;
         b += 4;
@@ -303,14 +303,14 @@ static inline void volk_32fc_x2_divide_32fc_u_avx512(lv_32fc_t* cVector,
     __m512 result0, result1;
 
     for (unsigned int number = 0; number < sixteenthPoints; number++) {
-        num01 = _mm512_loadu_ps((float*)a);
-        denum01 = _mm512_loadu_ps((float*)b);
+        num01 = _mm512_loadu_ps((const float*)a);
+        denum01 = _mm512_loadu_ps((const float*)b);
         num01 = _mm512_complexconjugatemul_ps(num01, denum01);
         a += 8;
         b += 8;
 
-        num23 = _mm512_loadu_ps((float*)a);
-        denum23 = _mm512_loadu_ps((float*)b);
+        num23 = _mm512_loadu_ps((const float*)a);
+        denum23 = _mm512_loadu_ps((const float*)b);
         num23 = _mm512_complexconjugatemul_ps(num23, denum23);
         a += 8;
         b += 8;
@@ -373,14 +373,14 @@ static inline void volk_32fc_x2_divide_32fc_a_sse3(lv_32fc_t* cVector,
     const lv_32fc_t* b = denumeratorVector;
 
     for (; number < quarterPoints; number++) {
-        num01 = _mm_load_ps((float*)a);                   // first pair
-        den01 = _mm_load_ps((float*)b);                   // first pair
+        num01 = _mm_load_ps((const float*)a);                   // first pair
+        den01 = _mm_load_ps((const float*)b);                   // first pair
         num01 = _mm_complexconjugatemul_ps(num01, den01); // a conj(b)
         a += 2;
         b += 2;
 
-        num23 = _mm_load_ps((float*)a);                   // second pair
-        den23 = _mm_load_ps((float*)b);                   // second pair
+        num23 = _mm_load_ps((const float*)a);                   // second pair
+        den23 = _mm_load_ps((const float*)b);                   // second pair
         num23 = _mm_complexconjugatemul_ps(num23, den23); // a conj(b)
         a += 2;
         b += 2;
@@ -437,15 +437,15 @@ static inline void volk_32fc_x2_divide_32fc_a_avx(lv_32fc_t* cVector,
 
     for (unsigned int number = 0; number < eigthPoints; number++) {
         // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
-        num01 = _mm256_load_ps((float*)a);
-        denum01 = _mm256_load_ps((float*)b);
+        num01 = _mm256_load_ps((const float*)a);
+        denum01 = _mm256_load_ps((const float*)b);
 
         num01 = _mm256_complexconjugatemul_ps(num01, denum01);
         a += 4;
         b += 4;
 
-        num23 = _mm256_load_ps((float*)a);
-        denum23 = _mm256_load_ps((float*)b);
+        num23 = _mm256_load_ps((const float*)a);
+        denum23 = _mm256_load_ps((const float*)b);
         num23 = _mm256_complexconjugatemul_ps(num23, denum23);
         a += 4;
         b += 4;
@@ -488,14 +488,14 @@ static inline void volk_32fc_x2_divide_32fc_a_avx2_fma(lv_32fc_t* cVector,
     __m256 num01, num23, denum01, denum23, complex_result, result0, result1;
 
     for (unsigned int number = 0; number < eighthPoints; number++) {
-        num01 = _mm256_load_ps((float*)a);
-        denum01 = _mm256_load_ps((float*)b);
+        num01 = _mm256_load_ps((const float*)a);
+        denum01 = _mm256_load_ps((const float*)b);
         num01 = _mm256_complexconjugatemul_ps(num01, denum01);
         a += 4;
         b += 4;
 
-        num23 = _mm256_load_ps((float*)a);
-        denum23 = _mm256_load_ps((float*)b);
+        num23 = _mm256_load_ps((const float*)a);
+        denum23 = _mm256_load_ps((const float*)b);
         num23 = _mm256_complexconjugatemul_ps(num23, denum23);
         a += 4;
         b += 4;
@@ -540,14 +540,14 @@ static inline void volk_32fc_x2_divide_32fc_a_avx512(lv_32fc_t* cVector,
     __m512 result0, result1;
 
     for (unsigned int number = 0; number < sixteenthPoints; number++) {
-        num01 = _mm512_load_ps((float*)a);
-        denum01 = _mm512_load_ps((float*)b);
+        num01 = _mm512_load_ps((const float*)a);
+        denum01 = _mm512_load_ps((const float*)b);
         num01 = _mm512_complexconjugatemul_ps(num01, denum01);
         a += 8;
         b += 8;
 
-        num23 = _mm512_load_ps((float*)a);
-        denum23 = _mm512_load_ps((float*)b);
+        num23 = _mm512_load_ps((const float*)a);
+        denum23 = _mm512_load_ps((const float*)b);
         num23 = _mm512_complexconjugatemul_ps(num23, denum23);
         a += 8;
         b += 8;

--- a/kernels/volk/volk_32fc_x2_divide_32fc.h
+++ b/kernels/volk/volk_32fc_x2_divide_32fc.h
@@ -337,6 +337,170 @@ static inline void volk_32fc_x2_divide_32fc_u_avx512(lv_32fc_t* cVector,
 }
 #endif /* LV_HAVE_AVX512F */
 
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+
+static inline void volk_32fc_x2_divide_32fc_neon(lv_32fc_t* cVector,
+                                                 const lv_32fc_t* aVector,
+                                                 const lv_32fc_t* bVector,
+                                                 unsigned int num_points)
+{
+    lv_32fc_t* cPtr = cVector;
+    const lv_32fc_t* aPtr = aVector;
+    const lv_32fc_t* bPtr = bVector;
+
+    float32x4x2_t aVal, bVal, cVal;
+    float32x4_t bAbs, bAbsInv;
+
+    const unsigned int quarterPoints = num_points / 4;
+    unsigned int number = 0;
+    for (; number < quarterPoints; number++) {
+        aVal = vld2q_f32((const float*)(aPtr));
+        bVal = vld2q_f32((const float*)(bPtr));
+        aPtr += 4;
+        bPtr += 4;
+        __VOLK_PREFETCH(aPtr + 4);
+        __VOLK_PREFETCH(bPtr + 4);
+
+        bAbs = vmulq_f32(bVal.val[0], bVal.val[0]);
+        bAbs = vmlaq_f32(bAbs, bVal.val[1], bVal.val[1]);
+
+        bAbsInv = vrecpeq_f32(bAbs);
+        bAbsInv = vmulq_f32(bAbsInv, vrecpsq_f32(bAbsInv, bAbs));
+        bAbsInv = vmulq_f32(bAbsInv, vrecpsq_f32(bAbsInv, bAbs));
+
+        cVal.val[0] = vmulq_f32(aVal.val[0], bVal.val[0]);
+        cVal.val[0] = vmlaq_f32(cVal.val[0], aVal.val[1], bVal.val[1]);
+        cVal.val[0] = vmulq_f32(cVal.val[0], bAbsInv);
+
+        cVal.val[1] = vmulq_f32(aVal.val[1], bVal.val[0]);
+        cVal.val[1] = vmlsq_f32(cVal.val[1], aVal.val[0], bVal.val[1]);
+        cVal.val[1] = vmulq_f32(cVal.val[1], bAbsInv);
+
+        vst2q_f32((float*)(cPtr), cVal);
+        cPtr += 4;
+    }
+
+    for (number = quarterPoints * 4; number < num_points; number++) {
+        *cPtr++ = (*aPtr++) / (*bPtr++);
+    }
+}
+#endif /* LV_HAVE_NEON */
+
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32fc_x2_divide_32fc_neonv8(lv_32fc_t* cVector,
+                                                   const lv_32fc_t* aVector,
+                                                   const lv_32fc_t* bVector,
+                                                   unsigned int num_points)
+{
+    lv_32fc_t* cPtr = cVector;
+    const lv_32fc_t* aPtr = aVector;
+    const lv_32fc_t* bPtr = bVector;
+
+    float32x4x2_t aVal, bVal, cVal;
+    float32x4_t bMagSq;
+
+    const unsigned int quarterPoints = num_points / 4;
+    unsigned int number = 0;
+
+    for (; number < quarterPoints; number++) {
+        aVal = vld2q_f32((const float*)(aPtr));
+        bVal = vld2q_f32((const float*)(bPtr));
+        aPtr += 4;
+        bPtr += 4;
+        __VOLK_PREFETCH(aPtr + 4);
+        __VOLK_PREFETCH(bPtr + 4);
+
+        /* Compute |b|^2 = br^2 + bi^2 using FMA */
+        bMagSq = vfmaq_f32(vmulq_f32(bVal.val[0], bVal.val[0]), bVal.val[1], bVal.val[1]);
+
+        /* Use ARMv8 native division for 1/|b|^2 */
+        float32x4_t bMagSqInv = vdivq_f32(vdupq_n_f32(1.0f), bMagSq);
+
+        /* real = (ar*br + ai*bi) / |b|^2 */
+        cVal.val[0] =
+            vfmaq_f32(vmulq_f32(aVal.val[0], bVal.val[0]), aVal.val[1], bVal.val[1]);
+        cVal.val[0] = vmulq_f32(cVal.val[0], bMagSqInv);
+
+        /* imag = (ai*br - ar*bi) / |b|^2 */
+        cVal.val[1] =
+            vfmsq_f32(vmulq_f32(aVal.val[1], bVal.val[0]), aVal.val[0], bVal.val[1]);
+        cVal.val[1] = vmulq_f32(cVal.val[1], bMagSqInv);
+
+        vst2q_f32((float*)(cPtr), cVal);
+        cPtr += 4;
+    }
+
+    for (number = quarterPoints * 4; number < num_points; number++) {
+        *cPtr++ = (*aPtr++) / (*bPtr++);
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+
+static inline void volk_32fc_x2_divide_32fc_rvv(lv_32fc_t* cVector,
+                                                const lv_32fc_t* aVector,
+                                                const lv_32fc_t* bVector,
+                                                unsigned int num_points)
+{
+    uint64_t* out = (uint64_t*)cVector;
+    size_t n = num_points;
+    for (size_t vl; n > 0; n -= vl, aVector += vl, bVector += vl, out += vl) {
+        vl = __riscv_vsetvl_e32m4(n);
+        vuint64m8_t va = __riscv_vle64_v_u64m8((const uint64_t*)aVector, vl);
+        vuint64m8_t vb = __riscv_vle64_v_u64m8((const uint64_t*)bVector, vl);
+        vfloat32m4_t var = __riscv_vreinterpret_f32m4(__riscv_vnsrl(va, 0, vl));
+        vfloat32m4_t vbr = __riscv_vreinterpret_f32m4(__riscv_vnsrl(vb, 0, vl));
+        vfloat32m4_t vai = __riscv_vreinterpret_f32m4(__riscv_vnsrl(va, 32, vl));
+        vfloat32m4_t vbi = __riscv_vreinterpret_f32m4(__riscv_vnsrl(vb, 32, vl));
+        vfloat32m4_t mul = __riscv_vfrdiv(
+            __riscv_vfmacc(__riscv_vfmul(vbi, vbi, vl), vbr, vbr, vl), 1.0f, vl);
+        vfloat32m4_t vr = __riscv_vfmul(
+            __riscv_vfmacc(__riscv_vfmul(var, vbr, vl), vai, vbi, vl), mul, vl);
+        vfloat32m4_t vi = __riscv_vfmul(
+            __riscv_vfnmsac(__riscv_vfmul(vai, vbr, vl), var, vbi, vl), mul, vl);
+        vuint32m4_t vru = __riscv_vreinterpret_u32m4(vr);
+        vuint32m4_t viu = __riscv_vreinterpret_u32m4(vi);
+        vuint64m8_t v =
+            __riscv_vwmaccu(__riscv_vwaddu_vv(vru, viu, vl), 0xFFFFFFFF, viu, vl);
+        __riscv_vse64(out, v, vl);
+    }
+}
+#endif /*LV_HAVE_RVV*/
+
+#ifdef LV_HAVE_RVVSEG
+#include <riscv_vector.h>
+
+static inline void volk_32fc_x2_divide_32fc_rvvseg(lv_32fc_t* cVector,
+                                                   const lv_32fc_t* aVector,
+                                                   const lv_32fc_t* bVector,
+                                                   unsigned int num_points)
+{
+    size_t n = num_points;
+    for (size_t vl; n > 0; n -= vl, aVector += vl, bVector += vl, cVector += vl) {
+        vl = __riscv_vsetvl_e32m4(n);
+        vfloat32m4x2_t va = __riscv_vlseg2e32_v_f32m4x2((const float*)aVector, vl);
+        vfloat32m4x2_t vb = __riscv_vlseg2e32_v_f32m4x2((const float*)bVector, vl);
+        vfloat32m4_t var = __riscv_vget_f32m4(va, 0), vai = __riscv_vget_f32m4(va, 1);
+        vfloat32m4_t vbr = __riscv_vget_f32m4(vb, 0), vbi = __riscv_vget_f32m4(vb, 1);
+        vfloat32m4_t mul = __riscv_vfrdiv(
+            __riscv_vfmacc(__riscv_vfmul(vbi, vbi, vl), vbr, vbr, vl), 1.0f, vl);
+        vfloat32m4_t vr = __riscv_vfmul(
+            __riscv_vfmacc(__riscv_vfmul(var, vbr, vl), vai, vbi, vl), mul, vl);
+        vfloat32m4_t vi = __riscv_vfmul(
+            __riscv_vfnmsac(__riscv_vfmul(vai, vbr, vl), var, vbi, vl), mul, vl);
+        __riscv_vsseg2e32_v_f32m4x2(
+            (float*)cVector, __riscv_vcreate_v_f32m4x2(vr, vi), vl);
+    }
+}
+
+#endif /*LV_HAVE_RVVSEG*/
+
 
 #endif /* INCLUDED_volk_32fc_x2_divide_32fc_u_H */
 
@@ -406,7 +570,7 @@ static inline void volk_32fc_x2_divide_32fc_a_sse3(lv_32fc_t* cVector,
         c++;
     }
 }
-#endif /* LV_HAVE_SSE */
+#endif /* LV_HAVE_SSE3 */
 
 #ifdef LV_HAVE_AVX
 #include <immintrin.h>
@@ -574,169 +738,5 @@ static inline void volk_32fc_x2_divide_32fc_a_avx512(lv_32fc_t* cVector,
 }
 #endif /* LV_HAVE_AVX512F */
 
-
-#ifdef LV_HAVE_NEON
-#include <arm_neon.h>
-
-static inline void volk_32fc_x2_divide_32fc_neon(lv_32fc_t* cVector,
-                                                 const lv_32fc_t* aVector,
-                                                 const lv_32fc_t* bVector,
-                                                 unsigned int num_points)
-{
-    lv_32fc_t* cPtr = cVector;
-    const lv_32fc_t* aPtr = aVector;
-    const lv_32fc_t* bPtr = bVector;
-
-    float32x4x2_t aVal, bVal, cVal;
-    float32x4_t bAbs, bAbsInv;
-
-    const unsigned int quarterPoints = num_points / 4;
-    unsigned int number = 0;
-    for (; number < quarterPoints; number++) {
-        aVal = vld2q_f32((const float*)(aPtr));
-        bVal = vld2q_f32((const float*)(bPtr));
-        aPtr += 4;
-        bPtr += 4;
-        __VOLK_PREFETCH(aPtr + 4);
-        __VOLK_PREFETCH(bPtr + 4);
-
-        bAbs = vmulq_f32(bVal.val[0], bVal.val[0]);
-        bAbs = vmlaq_f32(bAbs, bVal.val[1], bVal.val[1]);
-
-        bAbsInv = vrecpeq_f32(bAbs);
-        bAbsInv = vmulq_f32(bAbsInv, vrecpsq_f32(bAbsInv, bAbs));
-        bAbsInv = vmulq_f32(bAbsInv, vrecpsq_f32(bAbsInv, bAbs));
-
-        cVal.val[0] = vmulq_f32(aVal.val[0], bVal.val[0]);
-        cVal.val[0] = vmlaq_f32(cVal.val[0], aVal.val[1], bVal.val[1]);
-        cVal.val[0] = vmulq_f32(cVal.val[0], bAbsInv);
-
-        cVal.val[1] = vmulq_f32(aVal.val[1], bVal.val[0]);
-        cVal.val[1] = vmlsq_f32(cVal.val[1], aVal.val[0], bVal.val[1]);
-        cVal.val[1] = vmulq_f32(cVal.val[1], bAbsInv);
-
-        vst2q_f32((float*)(cPtr), cVal);
-        cPtr += 4;
-    }
-
-    for (number = quarterPoints * 4; number < num_points; number++) {
-        *cPtr++ = (*aPtr++) / (*bPtr++);
-    }
-}
-#endif /* LV_HAVE_NEON */
-
-#ifdef LV_HAVE_NEONV8
-#include <arm_neon.h>
-
-static inline void volk_32fc_x2_divide_32fc_neonv8(lv_32fc_t* cVector,
-                                                   const lv_32fc_t* aVector,
-                                                   const lv_32fc_t* bVector,
-                                                   unsigned int num_points)
-{
-    lv_32fc_t* cPtr = cVector;
-    const lv_32fc_t* aPtr = aVector;
-    const lv_32fc_t* bPtr = bVector;
-
-    float32x4x2_t aVal, bVal, cVal;
-    float32x4_t bMagSq;
-
-    const unsigned int quarterPoints = num_points / 4;
-    unsigned int number = 0;
-
-    for (; number < quarterPoints; number++) {
-        aVal = vld2q_f32((const float*)(aPtr));
-        bVal = vld2q_f32((const float*)(bPtr));
-        aPtr += 4;
-        bPtr += 4;
-        __VOLK_PREFETCH(aPtr + 4);
-        __VOLK_PREFETCH(bPtr + 4);
-
-        /* Compute |b|^2 = br^2 + bi^2 using FMA */
-        bMagSq = vfmaq_f32(vmulq_f32(bVal.val[0], bVal.val[0]), bVal.val[1], bVal.val[1]);
-
-        /* Use ARMv8 native division for 1/|b|^2 */
-        float32x4_t bMagSqInv = vdivq_f32(vdupq_n_f32(1.0f), bMagSq);
-
-        /* real = (ar*br + ai*bi) / |b|^2 */
-        cVal.val[0] =
-            vfmaq_f32(vmulq_f32(aVal.val[0], bVal.val[0]), aVal.val[1], bVal.val[1]);
-        cVal.val[0] = vmulq_f32(cVal.val[0], bMagSqInv);
-
-        /* imag = (ai*br - ar*bi) / |b|^2 */
-        cVal.val[1] =
-            vfmsq_f32(vmulq_f32(aVal.val[1], bVal.val[0]), aVal.val[0], bVal.val[1]);
-        cVal.val[1] = vmulq_f32(cVal.val[1], bMagSqInv);
-
-        vst2q_f32((float*)(cPtr), cVal);
-        cPtr += 4;
-    }
-
-    for (number = quarterPoints * 4; number < num_points; number++) {
-        *cPtr++ = (*aPtr++) / (*bPtr++);
-    }
-}
-#endif /* LV_HAVE_NEONV8 */
-
-#ifdef LV_HAVE_RVV
-#include <riscv_vector.h>
-
-
-static inline void volk_32fc_x2_divide_32fc_rvv(lv_32fc_t* cVector,
-                                                const lv_32fc_t* aVector,
-                                                const lv_32fc_t* bVector,
-                                                unsigned int num_points)
-{
-    uint64_t* out = (uint64_t*)cVector;
-    size_t n = num_points;
-    for (size_t vl; n > 0; n -= vl, aVector += vl, bVector += vl, out += vl) {
-        vl = __riscv_vsetvl_e32m4(n);
-        vuint64m8_t va = __riscv_vle64_v_u64m8((const uint64_t*)aVector, vl);
-        vuint64m8_t vb = __riscv_vle64_v_u64m8((const uint64_t*)bVector, vl);
-        vfloat32m4_t var = __riscv_vreinterpret_f32m4(__riscv_vnsrl(va, 0, vl));
-        vfloat32m4_t vbr = __riscv_vreinterpret_f32m4(__riscv_vnsrl(vb, 0, vl));
-        vfloat32m4_t vai = __riscv_vreinterpret_f32m4(__riscv_vnsrl(va, 32, vl));
-        vfloat32m4_t vbi = __riscv_vreinterpret_f32m4(__riscv_vnsrl(vb, 32, vl));
-        vfloat32m4_t mul = __riscv_vfrdiv(
-            __riscv_vfmacc(__riscv_vfmul(vbi, vbi, vl), vbr, vbr, vl), 1.0f, vl);
-        vfloat32m4_t vr = __riscv_vfmul(
-            __riscv_vfmacc(__riscv_vfmul(var, vbr, vl), vai, vbi, vl), mul, vl);
-        vfloat32m4_t vi = __riscv_vfmul(
-            __riscv_vfnmsac(__riscv_vfmul(vai, vbr, vl), var, vbi, vl), mul, vl);
-        vuint32m4_t vru = __riscv_vreinterpret_u32m4(vr);
-        vuint32m4_t viu = __riscv_vreinterpret_u32m4(vi);
-        vuint64m8_t v =
-            __riscv_vwmaccu(__riscv_vwaddu_vv(vru, viu, vl), 0xFFFFFFFF, viu, vl);
-        __riscv_vse64(out, v, vl);
-    }
-}
-#endif /*LV_HAVE_RVV*/
-
-#ifdef LV_HAVE_RVVSEG
-#include <riscv_vector.h>
-
-static inline void volk_32fc_x2_divide_32fc_rvvseg(lv_32fc_t* cVector,
-                                                   const lv_32fc_t* aVector,
-                                                   const lv_32fc_t* bVector,
-                                                   unsigned int num_points)
-{
-    size_t n = num_points;
-    for (size_t vl; n > 0; n -= vl, aVector += vl, bVector += vl, cVector += vl) {
-        vl = __riscv_vsetvl_e32m4(n);
-        vfloat32m4x2_t va = __riscv_vlseg2e32_v_f32m4x2((const float*)aVector, vl);
-        vfloat32m4x2_t vb = __riscv_vlseg2e32_v_f32m4x2((const float*)bVector, vl);
-        vfloat32m4_t var = __riscv_vget_f32m4(va, 0), vai = __riscv_vget_f32m4(va, 1);
-        vfloat32m4_t vbr = __riscv_vget_f32m4(vb, 0), vbi = __riscv_vget_f32m4(vb, 1);
-        vfloat32m4_t mul = __riscv_vfrdiv(
-            __riscv_vfmacc(__riscv_vfmul(vbi, vbi, vl), vbr, vbr, vl), 1.0f, vl);
-        vfloat32m4_t vr = __riscv_vfmul(
-            __riscv_vfmacc(__riscv_vfmul(var, vbr, vl), vai, vbi, vl), mul, vl);
-        vfloat32m4_t vi = __riscv_vfmul(
-            __riscv_vfnmsac(__riscv_vfmul(vai, vbr, vl), var, vbi, vl), mul, vl);
-        __riscv_vsseg2e32_v_f32m4x2(
-            (float*)cVector, __riscv_vcreate_v_f32m4x2(vr, vi), vl);
-    }
-}
-
-#endif /*LV_HAVE_RVVSEG*/
 
 #endif /* INCLUDED_volk_32fc_x2_divide_32fc_a_H */

--- a/kernels/volk/volk_32fc_x2_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_x2_dot_prod_32fc.h
@@ -68,8 +68,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_generic(lv_32fc_t* result,
 {
 
     float* res = (float*)result;
-    float* in = (float*)input;
-    float* tp = (float*)taps;
+    const float* in = (const float*)input;
+    const float* tp = (const float*)taps;
     unsigned int n_2_ccomplex_blocks = num_points / 2;
 
     float sum0[2] = { 0, 0 };
@@ -124,8 +124,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_u_sse3(lv_32fc_t* result,
 
     for (; number < halfPoints; number++) {
 
-        x = _mm_loadu_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
-        y = _mm_loadu_ps((float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+        x = _mm_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        y = _mm_loadu_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
 
         yl = _mm_moveldup_ps(y); // Load yl with cr,cr,dr,dr
         yh = _mm_movehdup_ps(y); // Load yh with ci,ci,di,di
@@ -188,8 +188,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_u_avx(lv_32fc_t* result,
     dotProdVal = _mm256_setzero_ps();
 
     for (; number < quarterPoints; number++) {
-        x = _mm256_loadu_ps((float*)a); // Load a,b,e,f as ar,ai,br,bi,er,ei,fr,fi
-        y = _mm256_loadu_ps((float*)b); // Load c,d,g,h as cr,ci,dr,di,gr,gi,hr,hi
+        x = _mm256_loadu_ps((const float*)a); // Load a,b,e,f as ar,ai,br,bi,er,ei,fr,fi
+        y = _mm256_loadu_ps((const float*)b); // Load c,d,g,h as cr,ci,dr,di,gr,gi,hr,hi
 
         yl = _mm256_moveldup_ps(y); // Load yl with cr,cr,dr,dr,gr,gr,hr,hr
         yh = _mm256_movehdup_ps(y); // Load yh with ci,ci,di,di,gi,gi,hi,hi
@@ -253,8 +253,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_u_avx_fma(lv_32fc_t* result,
 
     for (; number < quarterPoints; number++) {
 
-        x = _mm256_loadu_ps((float*)a); // Load a,b,e,f as ar,ai,br,bi,er,ei,fr,fi
-        y = _mm256_loadu_ps((float*)b); // Load c,d,g,h as cr,ci,dr,di,gr,gi,hr,hi
+        x = _mm256_loadu_ps((const float*)a); // Load a,b,e,f as ar,ai,br,bi,er,ei,fr,fi
+        y = _mm256_loadu_ps((const float*)b); // Load c,d,g,h as cr,ci,dr,di,gr,gi,hr,hi
 
         yl = _mm256_moveldup_ps(y); // Load yl with cr,cr,dr,dr,gr,gr,hr,hr
         yh = _mm256_movehdup_ps(y); // Load yh with ci,ci,di,di,gi,gi,hi,hi
@@ -331,8 +331,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_a_sse3(lv_32fc_t* result,
 
     for (; number < halfPoints; number++) {
 
-        x = _mm_load_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
-        y = _mm_load_ps((float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+        x = _mm_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        y = _mm_load_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
 
         yl = _mm_moveldup_ps(y); // Load yl with cr,cr,dr,dr
         yh = _mm_movehdup_ps(y); // Load yh with ci,ci,di,di
@@ -382,8 +382,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_neon(lv_32fc_t* result,
     unsigned int quarter_points = num_points / 4;
     unsigned int number;
 
-    lv_32fc_t* a_ptr = (lv_32fc_t*)taps;
-    lv_32fc_t* b_ptr = (lv_32fc_t*)input;
+    const lv_32fc_t* a_ptr = taps;
+    const lv_32fc_t* b_ptr = input;
     // for 2-lane vectors, 1st lane holds the real part,
     // 2nd lane holds the imaginary part
     float32x4x2_t a_val, b_val, c_val, accumulator;
@@ -392,8 +392,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_neon(lv_32fc_t* result,
     accumulator.val[1] = vdupq_n_f32(0);
 
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld2q_f32((float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
-        b_val = vld2q_f32((float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
+        a_val = vld2q_f32((const float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
+        b_val = vld2q_f32((const float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
         __VOLK_PREFETCH(a_ptr + 8);
         __VOLK_PREFETCH(b_ptr + 8);
 
@@ -440,8 +440,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_neon_opttests(lv_32fc_t* result,
     unsigned int quarter_points = num_points / 4;
     unsigned int number;
 
-    lv_32fc_t* a_ptr = (lv_32fc_t*)taps;
-    lv_32fc_t* b_ptr = (lv_32fc_t*)input;
+    const lv_32fc_t* a_ptr = taps;
+    const lv_32fc_t* b_ptr = input;
     // for 2-lane vectors, 1st lane holds the real part,
     // 2nd lane holds the imaginary part
     float32x4x2_t a_val, b_val, accumulator;
@@ -450,8 +450,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_neon_opttests(lv_32fc_t* result,
     accumulator.val[1] = vdupq_n_f32(0);
 
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld2q_f32((float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
-        b_val = vld2q_f32((float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
+        a_val = vld2q_f32((const float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
+        b_val = vld2q_f32((const float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
         __VOLK_PREFETCH(a_ptr + 8);
         __VOLK_PREFETCH(b_ptr + 8);
 
@@ -491,8 +491,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_neon_optfma(lv_32fc_t* result,
     unsigned int quarter_points = num_points / 4;
     unsigned int number;
 
-    lv_32fc_t* a_ptr = (lv_32fc_t*)taps;
-    lv_32fc_t* b_ptr = (lv_32fc_t*)input;
+    const lv_32fc_t* a_ptr = taps;
+    const lv_32fc_t* b_ptr = input;
     // for 2-lane vectors, 1st lane holds the real part,
     // 2nd lane holds the imaginary part
     float32x4x2_t a_val, b_val, accumulator1, accumulator2;
@@ -502,8 +502,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_neon_optfma(lv_32fc_t* result,
     accumulator2.val[1] = vdupq_n_f32(0);
 
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld2q_f32((float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
-        b_val = vld2q_f32((float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
+        a_val = vld2q_f32((const float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
+        b_val = vld2q_f32((const float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
         __VOLK_PREFETCH(a_ptr + 8);
         __VOLK_PREFETCH(b_ptr + 8);
 
@@ -541,8 +541,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_neon_optfmaunroll(lv_32fc_t* resul
     unsigned int quarter_points = num_points / 8;
     unsigned int number;
 
-    lv_32fc_t* a_ptr = (lv_32fc_t*)taps;
-    lv_32fc_t* b_ptr = (lv_32fc_t*)input;
+    const lv_32fc_t* a_ptr = taps;
+    const lv_32fc_t* b_ptr = input;
     // for 2-lane vectors, 1st lane holds the real part,
     // 2nd lane holds the imaginary part
     float32x4x4_t a_val, b_val, accumulator1, accumulator2;
@@ -558,8 +558,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_neon_optfmaunroll(lv_32fc_t* resul
 
     // 8 input regs, 8 accumulators -> 16/16 neon regs are used
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld4q_f32((float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
-        b_val = vld4q_f32((float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
+        a_val = vld4q_f32((const float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
+        b_val = vld4q_f32((const float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
         __VOLK_PREFETCH(a_ptr + 8);
         __VOLK_PREFETCH(b_ptr + 8);
 
@@ -715,8 +715,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_a_avx(lv_32fc_t* result,
 
     for (; number < quarterPoints; number++) {
 
-        x = _mm256_load_ps((float*)a); // Load a,b,e,f as ar,ai,br,bi,er,ei,fr,fi
-        y = _mm256_load_ps((float*)b); // Load c,d,g,h as cr,ci,dr,di,gr,gi,hr,hi
+        x = _mm256_load_ps((const float*)a); // Load a,b,e,f as ar,ai,br,bi,er,ei,fr,fi
+        y = _mm256_load_ps((const float*)b); // Load c,d,g,h as cr,ci,dr,di,gr,gi,hr,hi
 
         yl = _mm256_moveldup_ps(y); // Load yl with cr,cr,dr,dr,gr,gr,hr,hr
         yh = _mm256_movehdup_ps(y); // Load yh with ci,ci,di,di,gi,gi,hi,hi
@@ -780,8 +780,8 @@ static inline void volk_32fc_x2_dot_prod_32fc_a_avx_fma(lv_32fc_t* result,
 
     for (; number < quarterPoints; number++) {
 
-        x = _mm256_load_ps((float*)a); // Load a,b,e,f as ar,ai,br,bi,er,ei,fr,fi
-        y = _mm256_load_ps((float*)b); // Load c,d,g,h as cr,ci,dr,di,gr,gi,hr,hi
+        x = _mm256_load_ps((const float*)a); // Load a,b,e,f as ar,ai,br,bi,er,ei,fr,fi
+        y = _mm256_load_ps((const float*)b); // Load c,d,g,h as cr,ci,dr,di,gr,gi,hr,hi
 
         yl = _mm256_moveldup_ps(y); // Load yl with cr,cr,dr,dr,gr,gr,hr,hr
         yh = _mm256_movehdup_ps(y); // Load yh with ci,ci,di,di,gi,gi,hi,hi

--- a/kernels/volk/volk_32fc_x2_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_x2_dot_prod_32fc.h
@@ -53,18 +53,18 @@
 
 #ifdef LV_HAVE_RISCV64
 extern void volk_32fc_x2_dot_prod_32fc_sifive_u74(lv_32fc_t* result,
-                                                  const lv_32fc_t* input,
-                                                  const lv_32fc_t* taps,
-                                                  unsigned int num_points);
+                                                   const lv_32fc_t* input,
+                                                   const lv_32fc_t* taps,
+                                                   unsigned int num_points);
 #endif
 
 #ifdef LV_HAVE_GENERIC
 
 
 static inline void volk_32fc_x2_dot_prod_32fc_generic(lv_32fc_t* result,
-                                                      const lv_32fc_t* input,
-                                                      const lv_32fc_t* taps,
-                                                      unsigned int num_points)
+                                                       const lv_32fc_t* input,
+                                                       const lv_32fc_t* taps,
+                                                       unsigned int num_points)
 {
 
     float* res = (float*)result;
@@ -103,9 +103,9 @@ static inline void volk_32fc_x2_dot_prod_32fc_generic(lv_32fc_t* result,
 #include <pmmintrin.h>
 
 static inline void volk_32fc_x2_dot_prod_32fc_u_sse3(lv_32fc_t* result,
-                                                     const lv_32fc_t* input,
-                                                     const lv_32fc_t* taps,
-                                                     unsigned int num_points)
+                                                      const lv_32fc_t* input,
+                                                      const lv_32fc_t* taps,
+                                                      unsigned int num_points)
 {
 
     lv_32fc_t dotProduct;
@@ -167,9 +167,9 @@ static inline void volk_32fc_x2_dot_prod_32fc_u_sse3(lv_32fc_t* result,
 #include <immintrin.h>
 
 static inline void volk_32fc_x2_dot_prod_32fc_u_avx(lv_32fc_t* result,
-                                                    const lv_32fc_t* input,
-                                                    const lv_32fc_t* taps,
-                                                    unsigned int num_points)
+                                                     const lv_32fc_t* input,
+                                                     const lv_32fc_t* taps,
+                                                     unsigned int num_points)
 {
 
     unsigned int isodd = num_points & 3;
@@ -231,9 +231,9 @@ static inline void volk_32fc_x2_dot_prod_32fc_u_avx(lv_32fc_t* result,
 #include <immintrin.h>
 
 static inline void volk_32fc_x2_dot_prod_32fc_u_avx_fma(lv_32fc_t* result,
-                                                        const lv_32fc_t* input,
-                                                        const lv_32fc_t* taps,
-                                                        unsigned int num_points)
+                                                         const lv_32fc_t* input,
+                                                         const lv_32fc_t* taps,
+                                                         unsigned int num_points)
 {
 
     unsigned int isodd = num_points & 3;
@@ -292,91 +292,13 @@ static inline void volk_32fc_x2_dot_prod_32fc_u_avx_fma(lv_32fc_t* result,
 
 #endif /*LV_HAVE_AVX && LV_HAVE_FMA*/
 
-#endif /*INCLUDED_volk_32fc_x2_dot_prod_32fc_u_H*/
-
-#ifndef INCLUDED_volk_32fc_x2_dot_prod_32fc_a_H
-#define INCLUDED_volk_32fc_x2_dot_prod_32fc_a_H
-
-#include <stdio.h>
-#include <string.h>
-#include <volk/volk_common.h>
-#include <volk/volk_complex.h>
-
-
-#ifdef LV_HAVE_SSE3
-
-#include <pmmintrin.h>
-
-static inline void volk_32fc_x2_dot_prod_32fc_a_sse3(lv_32fc_t* result,
-                                                     const lv_32fc_t* input,
-                                                     const lv_32fc_t* taps,
-                                                     unsigned int num_points)
-{
-
-    const unsigned int num_bytes = num_points * 8;
-    unsigned int isodd = num_points & 1;
-
-    lv_32fc_t dotProduct;
-    memset(&dotProduct, 0x0, 2 * sizeof(float));
-
-    unsigned int number = 0;
-    const unsigned int halfPoints = num_bytes >> 4;
-
-    __m128 x, y, yl, yh, z, tmp1, tmp2, dotProdVal;
-
-    const lv_32fc_t* a = input;
-    const lv_32fc_t* b = taps;
-
-    dotProdVal = _mm_setzero_ps();
-
-    for (; number < halfPoints; number++) {
-
-        x = _mm_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
-        y = _mm_load_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
-
-        yl = _mm_moveldup_ps(y); // Load yl with cr,cr,dr,dr
-        yh = _mm_movehdup_ps(y); // Load yh with ci,ci,di,di
-
-        tmp1 = _mm_mul_ps(x, yl); // tmp1 = ar*cr,ai*cr,br*dr,bi*dr
-
-        x = _mm_shuffle_ps(x, x, 0xB1); // Re-arrange x to be ai,ar,bi,br
-
-        tmp2 = _mm_mul_ps(x, yh); // tmp2 = ai*ci,ar*ci,bi*di,br*di
-
-        z = _mm_addsub_ps(tmp1,
-                          tmp2); // ar*cr-ai*ci, ai*cr+ar*ci, br*dr-bi*di, bi*dr+br*di
-
-        dotProdVal =
-            _mm_add_ps(dotProdVal, z); // Add the complex multiplication results together
-
-        a += 2;
-        b += 2;
-    }
-
-    __VOLK_ATTR_ALIGNED(16) lv_32fc_t dotProductVector[2];
-
-    _mm_store_ps((float*)dotProductVector,
-                 dotProdVal); // Store the results back into the dot product vector
-
-    dotProduct += (dotProductVector[0] + dotProductVector[1]);
-
-    if (isodd) {
-        dotProduct += input[num_points - 1] * taps[num_points - 1];
-    }
-
-    *result = dotProduct;
-}
-
-#endif /*LV_HAVE_SSE3*/
-
-
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
 
 static inline void volk_32fc_x2_dot_prod_32fc_neon(lv_32fc_t* result,
-                                                   const lv_32fc_t* input,
-                                                   const lv_32fc_t* taps,
-                                                   unsigned int num_points)
+                                                    const lv_32fc_t* input,
+                                                    const lv_32fc_t* taps,
+                                                    unsigned int num_points)
 {
 
     unsigned int quarter_points = num_points / 4;
@@ -432,9 +354,9 @@ static inline void volk_32fc_x2_dot_prod_32fc_neon(lv_32fc_t* result,
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
 static inline void volk_32fc_x2_dot_prod_32fc_neon_opttests(lv_32fc_t* result,
-                                                            const lv_32fc_t* input,
-                                                            const lv_32fc_t* taps,
-                                                            unsigned int num_points)
+                                                             const lv_32fc_t* input,
+                                                             const lv_32fc_t* taps,
+                                                             unsigned int num_points)
 {
 
     unsigned int quarter_points = num_points / 4;
@@ -483,9 +405,9 @@ static inline void volk_32fc_x2_dot_prod_32fc_neon_opttests(lv_32fc_t* result,
 
 #ifdef LV_HAVE_NEON
 static inline void volk_32fc_x2_dot_prod_32fc_neon_optfma(lv_32fc_t* result,
-                                                          const lv_32fc_t* input,
-                                                          const lv_32fc_t* taps,
-                                                          unsigned int num_points)
+                                                           const lv_32fc_t* input,
+                                                           const lv_32fc_t* taps,
+                                                           unsigned int num_points)
 {
 
     unsigned int quarter_points = num_points / 4;
@@ -531,9 +453,9 @@ static inline void volk_32fc_x2_dot_prod_32fc_neon_optfma(lv_32fc_t* result,
 
 #ifdef LV_HAVE_NEON
 static inline void volk_32fc_x2_dot_prod_32fc_neon_optfmaunroll(lv_32fc_t* result,
-                                                                const lv_32fc_t* input,
-                                                                const lv_32fc_t* taps,
-                                                                unsigned int num_points)
+                                                                 const lv_32fc_t* input,
+                                                                 const lv_32fc_t* taps,
+                                                                 unsigned int num_points)
 {
     // NOTE: GCC does a poor job with this kernel, but the equivalent ASM code is very
     // fast
@@ -603,9 +525,9 @@ static inline void volk_32fc_x2_dot_prod_32fc_neon_optfmaunroll(lv_32fc_t* resul
 #include <arm_neon.h>
 
 static inline void volk_32fc_x2_dot_prod_32fc_neonv8(lv_32fc_t* result,
-                                                     const lv_32fc_t* input,
-                                                     const lv_32fc_t* taps,
-                                                     unsigned int num_points)
+                                                      const lv_32fc_t* input,
+                                                      const lv_32fc_t* taps,
+                                                      unsigned int num_points)
 {
     unsigned int n = num_points;
     const lv_32fc_t* a = input;
@@ -687,15 +609,158 @@ static inline void volk_32fc_x2_dot_prod_32fc_neonv8(lv_32fc_t* result,
 
 #endif /* LV_HAVE_NEONV8 */
 
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+#include <volk/volk_rvv_intrinsics.h>
+
+static inline void volk_32fc_x2_dot_prod_32fc_rvv(lv_32fc_t* result,
+                                                   const lv_32fc_t* input,
+                                                   const lv_32fc_t* taps,
+                                                   unsigned int num_points)
+{
+    vfloat32m2_t vsumr = __riscv_vfmv_v_f_f32m2(0, __riscv_vsetvlmax_e32m2());
+    vfloat32m2_t vsumi = vsumr;
+    size_t n = num_points;
+    for (size_t vl; n > 0; n -= vl, input += vl, taps += vl) {
+        vl = __riscv_vsetvl_e32m2(n);
+        vuint64m4_t va = __riscv_vle64_v_u64m4((const uint64_t*)input, vl);
+        vuint64m4_t vb = __riscv_vle64_v_u64m4((const uint64_t*)taps, vl);
+        vfloat32m2_t var = __riscv_vreinterpret_f32m2(__riscv_vnsrl(va, 0, vl));
+        vfloat32m2_t vbr = __riscv_vreinterpret_f32m2(__riscv_vnsrl(vb, 0, vl));
+        vfloat32m2_t vai = __riscv_vreinterpret_f32m2(__riscv_vnsrl(va, 32, vl));
+        vfloat32m2_t vbi = __riscv_vreinterpret_f32m2(__riscv_vnsrl(vb, 32, vl));
+        vfloat32m2_t vr = __riscv_vfnmsac(__riscv_vfmul(var, vbr, vl), vai, vbi, vl);
+        vfloat32m2_t vi = __riscv_vfmacc(__riscv_vfmul(var, vbi, vl), vai, vbr, vl);
+        vsumr = __riscv_vfadd_tu(vsumr, vsumr, vr, vl);
+        vsumi = __riscv_vfadd_tu(vsumi, vsumi, vi, vl);
+    }
+    size_t vl = __riscv_vsetvlmax_e32m1();
+    vfloat32m1_t vr = RISCV_SHRINK2(vfadd, f, 32, vsumr);
+    vfloat32m1_t vi = RISCV_SHRINK2(vfadd, f, 32, vsumi);
+    vfloat32m1_t z = __riscv_vfmv_s_f_f32m1(0, vl);
+    *result = lv_cmake(__riscv_vfmv_f(__riscv_vfredusum(vr, z, vl)),
+                       __riscv_vfmv_f(__riscv_vfredusum(vi, z, vl)));
+}
+#endif /*LV_HAVE_RVV*/
+
+#ifdef LV_HAVE_RVVSEG
+#include <riscv_vector.h>
+#include <volk/volk_rvv_intrinsics.h>
+
+static inline void volk_32fc_x2_dot_prod_32fc_rvvseg(lv_32fc_t* result,
+                                                      const lv_32fc_t* input,
+                                                      const lv_32fc_t* taps,
+                                                      unsigned int num_points)
+{
+    vfloat32m4_t vsumr = __riscv_vfmv_v_f_f32m4(0, __riscv_vsetvlmax_e32m4());
+    vfloat32m4_t vsumi = vsumr;
+    size_t n = num_points;
+    for (size_t vl; n > 0; n -= vl, input += vl, taps += vl) {
+        vl = __riscv_vsetvl_e32m4(n);
+        vfloat32m4x2_t va = __riscv_vlseg2e32_v_f32m4x2((const float*)input, vl);
+        vfloat32m4x2_t vb = __riscv_vlseg2e32_v_f32m4x2((const float*)taps, vl);
+        vfloat32m4_t var = __riscv_vget_f32m4(va, 0), vai = __riscv_vget_f32m4(va, 1);
+        vfloat32m4_t vbr = __riscv_vget_f32m4(vb, 0), vbi = __riscv_vget_f32m4(vb, 1);
+        vfloat32m4_t vr = __riscv_vfnmsac(__riscv_vfmul(var, vbr, vl), vai, vbi, vl);
+        vfloat32m4_t vi = __riscv_vfmacc(__riscv_vfmul(var, vbi, vl), vai, vbr, vl);
+        vsumr = __riscv_vfadd_tu(vsumr, vsumr, vr, vl);
+        vsumi = __riscv_vfadd_tu(vsumi, vsumi, vi, vl);
+    }
+    size_t vl = __riscv_vsetvlmax_e32m1();
+    vfloat32m1_t vr = RISCV_SHRINK4(vfadd, f, 32, vsumr);
+    vfloat32m1_t vi = RISCV_SHRINK4(vfadd, f, 32, vsumi);
+    vfloat32m1_t z = __riscv_vfmv_s_f_f32m1(0, vl);
+    *result = lv_cmake(__riscv_vfmv_f(__riscv_vfredusum(vr, z, vl)),
+                       __riscv_vfmv_f(__riscv_vfredusum(vi, z, vl)));
+}
+#endif /*LV_HAVE_RVVSEG*/
+
+#endif /*INCLUDED_volk_32fc_x2_dot_prod_32fc_u_H*/
+
+#ifndef INCLUDED_volk_32fc_x2_dot_prod_32fc_a_H
+#define INCLUDED_volk_32fc_x2_dot_prod_32fc_a_H
+
+#include <stdio.h>
+#include <string.h>
+#include <volk/volk_common.h>
+#include <volk/volk_complex.h>
+
+
+#ifdef LV_HAVE_SSE3
+
+#include <pmmintrin.h>
+
+static inline void volk_32fc_x2_dot_prod_32fc_a_sse3(lv_32fc_t* result,
+                                                      const lv_32fc_t* input,
+                                                      const lv_32fc_t* taps,
+                                                      unsigned int num_points)
+{
+
+    const unsigned int num_bytes = num_points * 8;
+    unsigned int isodd = num_points & 1;
+
+    lv_32fc_t dotProduct;
+    memset(&dotProduct, 0x0, 2 * sizeof(float));
+
+    unsigned int number = 0;
+    const unsigned int halfPoints = num_bytes >> 4;
+
+    __m128 x, y, yl, yh, z, tmp1, tmp2, dotProdVal;
+
+    const lv_32fc_t* a = input;
+    const lv_32fc_t* b = taps;
+
+    dotProdVal = _mm_setzero_ps();
+
+    for (; number < halfPoints; number++) {
+
+        x = _mm_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        y = _mm_load_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+
+        yl = _mm_moveldup_ps(y); // Load yl with cr,cr,dr,dr
+        yh = _mm_movehdup_ps(y); // Load yh with ci,ci,di,di
+
+        tmp1 = _mm_mul_ps(x, yl); // tmp1 = ar*cr,ai*cr,br*dr,bi*dr
+
+        x = _mm_shuffle_ps(x, x, 0xB1); // Re-arrange x to be ai,ar,bi,br
+
+        tmp2 = _mm_mul_ps(x, yh); // tmp2 = ai*ci,ar*ci,bi*di,br*di
+
+        z = _mm_addsub_ps(tmp1,
+                          tmp2); // ar*cr-ai*ci, ai*cr+ar*ci, br*dr-bi*di, bi*dr+br*di
+
+        dotProdVal =
+            _mm_add_ps(dotProdVal, z); // Add the complex multiplication results together
+
+        a += 2;
+        b += 2;
+    }
+
+    __VOLK_ATTR_ALIGNED(16) lv_32fc_t dotProductVector[2];
+
+    _mm_store_ps((float*)dotProductVector,
+                 dotProdVal); // Store the results back into the dot product vector
+
+    dotProduct += (dotProductVector[0] + dotProductVector[1]);
+
+    if (isodd) {
+        dotProduct += input[num_points - 1] * taps[num_points - 1];
+    }
+
+    *result = dotProduct;
+}
+
+#endif /*LV_HAVE_SSE3*/
+
 
 #ifdef LV_HAVE_AVX
 
 #include <immintrin.h>
 
 static inline void volk_32fc_x2_dot_prod_32fc_a_avx(lv_32fc_t* result,
-                                                    const lv_32fc_t* input,
-                                                    const lv_32fc_t* taps,
-                                                    unsigned int num_points)
+                                                     const lv_32fc_t* input,
+                                                     const lv_32fc_t* taps,
+                                                     unsigned int num_points)
 {
 
     unsigned int isodd = num_points & 3;
@@ -758,9 +823,9 @@ static inline void volk_32fc_x2_dot_prod_32fc_a_avx(lv_32fc_t* result,
 #include <immintrin.h>
 
 static inline void volk_32fc_x2_dot_prod_32fc_a_avx_fma(lv_32fc_t* result,
-                                                        const lv_32fc_t* input,
-                                                        const lv_32fc_t* taps,
-                                                        unsigned int num_points)
+                                                         const lv_32fc_t* input,
+                                                         const lv_32fc_t* taps,
+                                                         unsigned int num_points)
 {
 
     unsigned int isodd = num_points & 3;
@@ -818,71 +883,5 @@ static inline void volk_32fc_x2_dot_prod_32fc_a_avx_fma(lv_32fc_t* result,
 }
 
 #endif /*LV_HAVE_AVX && LV_HAVE_FMA*/
-
-#ifdef LV_HAVE_RVV
-#include <riscv_vector.h>
-#include <volk/volk_rvv_intrinsics.h>
-
-static inline void volk_32fc_x2_dot_prod_32fc_rvv(lv_32fc_t* result,
-                                                  const lv_32fc_t* input,
-                                                  const lv_32fc_t* taps,
-                                                  unsigned int num_points)
-{
-    vfloat32m2_t vsumr = __riscv_vfmv_v_f_f32m2(0, __riscv_vsetvlmax_e32m2());
-    vfloat32m2_t vsumi = vsumr;
-    size_t n = num_points;
-    for (size_t vl; n > 0; n -= vl, input += vl, taps += vl) {
-        vl = __riscv_vsetvl_e32m2(n);
-        vuint64m4_t va = __riscv_vle64_v_u64m4((const uint64_t*)input, vl);
-        vuint64m4_t vb = __riscv_vle64_v_u64m4((const uint64_t*)taps, vl);
-        vfloat32m2_t var = __riscv_vreinterpret_f32m2(__riscv_vnsrl(va, 0, vl));
-        vfloat32m2_t vbr = __riscv_vreinterpret_f32m2(__riscv_vnsrl(vb, 0, vl));
-        vfloat32m2_t vai = __riscv_vreinterpret_f32m2(__riscv_vnsrl(va, 32, vl));
-        vfloat32m2_t vbi = __riscv_vreinterpret_f32m2(__riscv_vnsrl(vb, 32, vl));
-        vfloat32m2_t vr = __riscv_vfnmsac(__riscv_vfmul(var, vbr, vl), vai, vbi, vl);
-        vfloat32m2_t vi = __riscv_vfmacc(__riscv_vfmul(var, vbi, vl), vai, vbr, vl);
-        vsumr = __riscv_vfadd_tu(vsumr, vsumr, vr, vl);
-        vsumi = __riscv_vfadd_tu(vsumi, vsumi, vi, vl);
-    }
-    size_t vl = __riscv_vsetvlmax_e32m1();
-    vfloat32m1_t vr = RISCV_SHRINK2(vfadd, f, 32, vsumr);
-    vfloat32m1_t vi = RISCV_SHRINK2(vfadd, f, 32, vsumi);
-    vfloat32m1_t z = __riscv_vfmv_s_f_f32m1(0, vl);
-    *result = lv_cmake(__riscv_vfmv_f(__riscv_vfredusum(vr, z, vl)),
-                       __riscv_vfmv_f(__riscv_vfredusum(vi, z, vl)));
-}
-#endif /*LV_HAVE_RVV*/
-
-#ifdef LV_HAVE_RVVSEG
-#include <riscv_vector.h>
-#include <volk/volk_rvv_intrinsics.h>
-
-static inline void volk_32fc_x2_dot_prod_32fc_rvvseg(lv_32fc_t* result,
-                                                     const lv_32fc_t* input,
-                                                     const lv_32fc_t* taps,
-                                                     unsigned int num_points)
-{
-    vfloat32m4_t vsumr = __riscv_vfmv_v_f_f32m4(0, __riscv_vsetvlmax_e32m4());
-    vfloat32m4_t vsumi = vsumr;
-    size_t n = num_points;
-    for (size_t vl; n > 0; n -= vl, input += vl, taps += vl) {
-        vl = __riscv_vsetvl_e32m4(n);
-        vfloat32m4x2_t va = __riscv_vlseg2e32_v_f32m4x2((const float*)input, vl);
-        vfloat32m4x2_t vb = __riscv_vlseg2e32_v_f32m4x2((const float*)taps, vl);
-        vfloat32m4_t var = __riscv_vget_f32m4(va, 0), vai = __riscv_vget_f32m4(va, 1);
-        vfloat32m4_t vbr = __riscv_vget_f32m4(vb, 0), vbi = __riscv_vget_f32m4(vb, 1);
-        vfloat32m4_t vr = __riscv_vfnmsac(__riscv_vfmul(var, vbr, vl), vai, vbi, vl);
-        vfloat32m4_t vi = __riscv_vfmacc(__riscv_vfmul(var, vbi, vl), vai, vbr, vl);
-        vsumr = __riscv_vfadd_tu(vsumr, vsumr, vr, vl);
-        vsumi = __riscv_vfadd_tu(vsumi, vsumi, vi, vl);
-    }
-    size_t vl = __riscv_vsetvlmax_e32m1();
-    vfloat32m1_t vr = RISCV_SHRINK4(vfadd, f, 32, vsumr);
-    vfloat32m1_t vi = RISCV_SHRINK4(vfadd, f, 32, vsumi);
-    vfloat32m1_t z = __riscv_vfmv_s_f_f32m1(0, vl);
-    *result = lv_cmake(__riscv_vfmv_f(__riscv_vfredusum(vr, z, vl)),
-                       __riscv_vfmv_f(__riscv_vfredusum(vi, z, vl)));
-}
-#endif /*LV_HAVE_RVVSEG*/
 
 #endif /*INCLUDED_volk_32fc_x2_dot_prod_32fc_a_H*/

--- a/kernels/volk/volk_32fc_x2_multiply_32fc.h
+++ b/kernels/volk/volk_32fc_x2_multiply_32fc.h
@@ -86,9 +86,9 @@ static inline void volk_32fc_x2_multiply_32fc_u_avx2_fma(lv_32fc_t* cVector,
     for (; number < quarterPoints; number++) {
 
         const __m256 x =
-            _mm256_loadu_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+            _mm256_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
         const __m256 y =
-            _mm256_loadu_ps((float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+            _mm256_loadu_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
 
         const __m256 yl = _mm256_moveldup_ps(y); // Load yl with cr,cr,dr,dr
         const __m256 yh = _mm256_movehdup_ps(y); // Load yh with ci,ci,di,di
@@ -134,9 +134,9 @@ static inline void volk_32fc_x2_multiply_32fc_u_avx(lv_32fc_t* cVector,
 
     for (; number < quarterPoints; number++) {
         x = _mm256_loadu_ps(
-            (float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
+            (const float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
         y = _mm256_loadu_ps(
-            (float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
+            (const float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
         z = _mm256_complexmul_ps(x, y);
         _mm256_storeu_ps((float*)c, z); // Store the results back into the C container
 
@@ -172,8 +172,8 @@ static inline void volk_32fc_x2_multiply_32fc_u_sse3(lv_32fc_t* cVector,
     const lv_32fc_t* b = bVector;
 
     for (; number < halfPoints; number++) {
-        x = _mm_loadu_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
-        y = _mm_loadu_ps((float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+        x = _mm_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        y = _mm_loadu_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
         z = _mm_complexmul_ps(x, y);
         _mm_storeu_ps((float*)c, z); // Store the results back into the C container
 
@@ -241,9 +241,9 @@ static inline void volk_32fc_x2_multiply_32fc_a_avx2_fma(lv_32fc_t* cVector,
     for (; number < quarterPoints; number++) {
 
         const __m256 x =
-            _mm256_load_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+            _mm256_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
         const __m256 y =
-            _mm256_load_ps((float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+            _mm256_load_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
 
         const __m256 yl = _mm256_moveldup_ps(y); // Load yl with cr,cr,dr,dr
         const __m256 yh = _mm256_movehdup_ps(y); // Load yh with ci,ci,di,di
@@ -288,8 +288,8 @@ static inline void volk_32fc_x2_multiply_32fc_a_avx(lv_32fc_t* cVector,
     const lv_32fc_t* b = bVector;
 
     for (; number < quarterPoints; number++) {
-        x = _mm256_load_ps((float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
-        y = _mm256_load_ps((float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
+        x = _mm256_load_ps((const float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
+        y = _mm256_load_ps((const float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
         z = _mm256_complexmul_ps(x, y);
         _mm256_store_ps((float*)c, z); // Store the results back into the C container
 
@@ -324,8 +324,8 @@ static inline void volk_32fc_x2_multiply_32fc_a_sse3(lv_32fc_t* cVector,
     const lv_32fc_t* b = bVector;
 
     for (; number < halfPoints; number++) {
-        x = _mm_load_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
-        y = _mm_load_ps((float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+        x = _mm_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        y = _mm_load_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
         z = _mm_complexmul_ps(x, y);
         _mm_store_ps((float*)c, z); // Store the results back into the C container
 
@@ -349,16 +349,16 @@ static inline void volk_32fc_x2_multiply_32fc_neon(lv_32fc_t* cVector,
                                                    const lv_32fc_t* bVector,
                                                    unsigned int num_points)
 {
-    lv_32fc_t* a_ptr = (lv_32fc_t*)aVector;
-    lv_32fc_t* b_ptr = (lv_32fc_t*)bVector;
+    const lv_32fc_t* a_ptr = aVector;
+    const lv_32fc_t* b_ptr = bVector;
     unsigned int quarter_points = num_points / 4;
     float32x4x2_t a_val, b_val, c_val;
     float32x4x2_t tmp_real, tmp_imag;
     unsigned int number = 0;
 
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld2q_f32((float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
-        b_val = vld2q_f32((float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
+        a_val = vld2q_f32((const float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
+        b_val = vld2q_f32((const float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
         __VOLK_PREFETCH(a_ptr + 4);
         __VOLK_PREFETCH(b_ptr + 4);
 

--- a/kernels/volk/volk_32fc_x2_multiply_32fc.h
+++ b/kernels/volk/volk_32fc_x2_multiply_32fc.h
@@ -62,6 +62,99 @@
 #include <stdio.h>
 #include <volk/volk_complex.h>
 
+#ifdef LV_HAVE_GENERIC
+
+static inline void volk_32fc_x2_multiply_32fc_generic(lv_32fc_t* cVector,
+                                                      const lv_32fc_t* aVector,
+                                                      const lv_32fc_t* bVector,
+                                                      unsigned int num_points)
+{
+    lv_32fc_t* cPtr = cVector;
+    const lv_32fc_t* aPtr = aVector;
+    const lv_32fc_t* bPtr = bVector;
+    unsigned int number = 0;
+
+    for (number = 0; number < num_points; number++) {
+        *cPtr++ = (*aPtr++) * (*bPtr++);
+    }
+}
+#endif /* LV_HAVE_GENERIC */
+
+
+#ifdef LV_HAVE_SSE3
+#include <pmmintrin.h>
+#include <volk/volk_sse3_intrinsics.h>
+
+static inline void volk_32fc_x2_multiply_32fc_u_sse3(lv_32fc_t* cVector,
+                                                     const lv_32fc_t* aVector,
+                                                     const lv_32fc_t* bVector,
+                                                     unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int halfPoints = num_points / 2;
+
+    __m128 x, y, z;
+    lv_32fc_t* c = cVector;
+    const lv_32fc_t* a = aVector;
+    const lv_32fc_t* b = bVector;
+
+    for (; number < halfPoints; number++) {
+        x = _mm_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        y = _mm_loadu_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+        z = _mm_complexmul_ps(x, y);
+        _mm_storeu_ps((float*)c, z); // Store the results back into the C container
+
+        a += 2;
+        b += 2;
+        c += 2;
+    }
+
+    if ((num_points % 2) != 0) {
+        *c = (*a) * (*b);
+    }
+}
+#endif /* LV_HAVE_SSE3 */
+
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
+static inline void volk_32fc_x2_multiply_32fc_u_avx(lv_32fc_t* cVector,
+                                                    const lv_32fc_t* aVector,
+                                                    const lv_32fc_t* bVector,
+                                                    unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    __m256 x, y, z;
+    lv_32fc_t* c = cVector;
+    const lv_32fc_t* a = aVector;
+    const lv_32fc_t* b = bVector;
+
+    for (; number < quarterPoints; number++) {
+        x = _mm256_loadu_ps(
+            (const float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
+        y = _mm256_loadu_ps(
+            (const float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
+        z = _mm256_complexmul_ps(x, y);
+        _mm256_storeu_ps((float*)c, z); // Store the results back into the C container
+
+        a += 4;
+        b += 4;
+        c += 4;
+    }
+
+    number = quarterPoints * 4;
+
+    for (; number < num_points; number++) {
+        *c++ = (*a++) * (*b++);
+    }
+}
+#endif /* LV_HAVE_AVX */
+
+
 #if LV_HAVE_AVX2 && LV_HAVE_FMA
 #include <immintrin.h>
 /*!
@@ -113,232 +206,6 @@ static inline void volk_32fc_x2_multiply_32fc_u_avx2_fma(lv_32fc_t* cVector,
     }
 }
 #endif /* LV_HAVE_AVX2 && LV_HAVE_FMA */
-
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-#include <volk/volk_avx_intrinsics.h>
-
-static inline void volk_32fc_x2_multiply_32fc_u_avx(lv_32fc_t* cVector,
-                                                    const lv_32fc_t* aVector,
-                                                    const lv_32fc_t* bVector,
-                                                    unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-
-    __m256 x, y, z;
-    lv_32fc_t* c = cVector;
-    const lv_32fc_t* a = aVector;
-    const lv_32fc_t* b = bVector;
-
-    for (; number < quarterPoints; number++) {
-        x = _mm256_loadu_ps(
-            (const float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
-        y = _mm256_loadu_ps(
-            (const float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
-        z = _mm256_complexmul_ps(x, y);
-        _mm256_storeu_ps((float*)c, z); // Store the results back into the C container
-
-        a += 4;
-        b += 4;
-        c += 4;
-    }
-
-    number = quarterPoints * 4;
-
-    for (; number < num_points; number++) {
-        *c++ = (*a++) * (*b++);
-    }
-}
-#endif /* LV_HAVE_AVX */
-
-
-#ifdef LV_HAVE_SSE3
-#include <pmmintrin.h>
-#include <volk/volk_sse3_intrinsics.h>
-
-static inline void volk_32fc_x2_multiply_32fc_u_sse3(lv_32fc_t* cVector,
-                                                     const lv_32fc_t* aVector,
-                                                     const lv_32fc_t* bVector,
-                                                     unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int halfPoints = num_points / 2;
-
-    __m128 x, y, z;
-    lv_32fc_t* c = cVector;
-    const lv_32fc_t* a = aVector;
-    const lv_32fc_t* b = bVector;
-
-    for (; number < halfPoints; number++) {
-        x = _mm_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
-        y = _mm_loadu_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
-        z = _mm_complexmul_ps(x, y);
-        _mm_storeu_ps((float*)c, z); // Store the results back into the C container
-
-        a += 2;
-        b += 2;
-        c += 2;
-    }
-
-    if ((num_points % 2) != 0) {
-        *c = (*a) * (*b);
-    }
-}
-#endif /* LV_HAVE_SSE */
-
-
-#ifdef LV_HAVE_GENERIC
-
-static inline void volk_32fc_x2_multiply_32fc_generic(lv_32fc_t* cVector,
-                                                      const lv_32fc_t* aVector,
-                                                      const lv_32fc_t* bVector,
-                                                      unsigned int num_points)
-{
-    lv_32fc_t* cPtr = cVector;
-    const lv_32fc_t* aPtr = aVector;
-    const lv_32fc_t* bPtr = bVector;
-    unsigned int number = 0;
-
-    for (number = 0; number < num_points; number++) {
-        *cPtr++ = (*aPtr++) * (*bPtr++);
-    }
-}
-#endif /* LV_HAVE_GENERIC */
-
-
-#endif /* INCLUDED_volk_32fc_x2_multiply_32fc_u_H */
-#ifndef INCLUDED_volk_32fc_x2_multiply_32fc_a_H
-#define INCLUDED_volk_32fc_x2_multiply_32fc_a_H
-
-#include <float.h>
-#include <inttypes.h>
-#include <stdio.h>
-#include <volk/volk_complex.h>
-
-#if LV_HAVE_AVX2 && LV_HAVE_FMA
-#include <immintrin.h>
-/*!
-  \brief Multiplies the two input complex vectors and stores their results in the third
-  vector \param cVector The vector where the results will be stored \param aVector One of
-  the vectors to be multiplied \param bVector One of the vectors to be multiplied \param
-  num_points The number of complex values in aVector and bVector to be multiplied together
-  and stored into cVector
-*/
-static inline void volk_32fc_x2_multiply_32fc_a_avx2_fma(lv_32fc_t* cVector,
-                                                         const lv_32fc_t* aVector,
-                                                         const lv_32fc_t* bVector,
-                                                         unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-
-    lv_32fc_t* c = cVector;
-    const lv_32fc_t* a = aVector;
-    const lv_32fc_t* b = bVector;
-
-    for (; number < quarterPoints; number++) {
-
-        const __m256 x =
-            _mm256_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
-        const __m256 y =
-            _mm256_load_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
-
-        const __m256 yl = _mm256_moveldup_ps(y); // Load yl with cr,cr,dr,dr
-        const __m256 yh = _mm256_movehdup_ps(y); // Load yh with ci,ci,di,di
-
-        const __m256 tmp2x = _mm256_permute_ps(x, 0xB1); // Re-arrange x to be ai,ar,bi,br
-
-        const __m256 tmp2 = _mm256_mul_ps(tmp2x, yh); // tmp2 = ai*ci,ar*ci,bi*di,br*di
-
-        const __m256 z = _mm256_fmaddsub_ps(
-            x, yl, tmp2); // ar*cr-ai*ci, ai*cr+ar*ci, br*dr-bi*di, bi*dr+br*di
-
-        _mm256_store_ps((float*)c, z); // Store the results back into the C container
-
-        a += 4;
-        b += 4;
-        c += 4;
-    }
-
-    number = quarterPoints * 4;
-    for (; number < num_points; number++) {
-        *c++ = (*a++) * (*b++);
-    }
-}
-#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA */
-
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-#include <volk/volk_avx_intrinsics.h>
-
-static inline void volk_32fc_x2_multiply_32fc_a_avx(lv_32fc_t* cVector,
-                                                    const lv_32fc_t* aVector,
-                                                    const lv_32fc_t* bVector,
-                                                    unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-
-    __m256 x, y, z;
-    lv_32fc_t* c = cVector;
-    const lv_32fc_t* a = aVector;
-    const lv_32fc_t* b = bVector;
-
-    for (; number < quarterPoints; number++) {
-        x = _mm256_load_ps((const float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
-        y = _mm256_load_ps((const float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
-        z = _mm256_complexmul_ps(x, y);
-        _mm256_store_ps((float*)c, z); // Store the results back into the C container
-
-        a += 4;
-        b += 4;
-        c += 4;
-    }
-
-    number = quarterPoints * 4;
-
-    for (; number < num_points; number++) {
-        *c++ = (*a++) * (*b++);
-    }
-}
-#endif /* LV_HAVE_AVX */
-
-#ifdef LV_HAVE_SSE3
-#include <pmmintrin.h>
-#include <volk/volk_sse3_intrinsics.h>
-
-static inline void volk_32fc_x2_multiply_32fc_a_sse3(lv_32fc_t* cVector,
-                                                     const lv_32fc_t* aVector,
-                                                     const lv_32fc_t* bVector,
-                                                     unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int halfPoints = num_points / 2;
-
-    __m128 x, y, z;
-    lv_32fc_t* c = cVector;
-    const lv_32fc_t* a = aVector;
-    const lv_32fc_t* b = bVector;
-
-    for (; number < halfPoints; number++) {
-        x = _mm_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
-        y = _mm_load_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
-        z = _mm_complexmul_ps(x, y);
-        _mm_store_ps((float*)c, z); // Store the results back into the C container
-
-        a += 2;
-        b += 2;
-        c += 2;
-    }
-
-    if ((num_points % 2) != 0) {
-        *c = (*a) * (*b);
-    }
-}
-#endif /* LV_HAVE_SSE */
 
 
 #ifdef LV_HAVE_NEON
@@ -512,7 +379,7 @@ static inline void volk_32fc_x2_multiply_32fc_rvv(lv_32fc_t* cVector,
         __riscv_vse64((uint64_t*)cVector, v, vl);
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
 
 #ifdef LV_HAVE_RVVSEG
 #include <riscv_vector.h>
@@ -535,6 +402,138 @@ static inline void volk_32fc_x2_multiply_32fc_rvvseg(lv_32fc_t* cVector,
             (float*)cVector, __riscv_vcreate_v_f32m4x2(vr, vi), vl);
     }
 }
-#endif /*LV_HAVE_RVVSEG*/
+#endif /* LV_HAVE_RVVSEG */
+
+#endif /* INCLUDED_volk_32fc_x2_multiply_32fc_u_H */
+#ifndef INCLUDED_volk_32fc_x2_multiply_32fc_a_H
+#define INCLUDED_volk_32fc_x2_multiply_32fc_a_H
+
+#include <float.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <volk/volk_complex.h>
+
+#ifdef LV_HAVE_SSE3
+#include <pmmintrin.h>
+#include <volk/volk_sse3_intrinsics.h>
+
+static inline void volk_32fc_x2_multiply_32fc_a_sse3(lv_32fc_t* cVector,
+                                                     const lv_32fc_t* aVector,
+                                                     const lv_32fc_t* bVector,
+                                                     unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int halfPoints = num_points / 2;
+
+    __m128 x, y, z;
+    lv_32fc_t* c = cVector;
+    const lv_32fc_t* a = aVector;
+    const lv_32fc_t* b = bVector;
+
+    for (; number < halfPoints; number++) {
+        x = _mm_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        y = _mm_load_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+        z = _mm_complexmul_ps(x, y);
+        _mm_store_ps((float*)c, z); // Store the results back into the C container
+
+        a += 2;
+        b += 2;
+        c += 2;
+    }
+
+    if ((num_points % 2) != 0) {
+        *c = (*a) * (*b);
+    }
+}
+#endif /* LV_HAVE_SSE3 */
+
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
+static inline void volk_32fc_x2_multiply_32fc_a_avx(lv_32fc_t* cVector,
+                                                    const lv_32fc_t* aVector,
+                                                    const lv_32fc_t* bVector,
+                                                    unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    __m256 x, y, z;
+    lv_32fc_t* c = cVector;
+    const lv_32fc_t* a = aVector;
+    const lv_32fc_t* b = bVector;
+
+    for (; number < quarterPoints; number++) {
+        x = _mm256_load_ps((const float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
+        y = _mm256_load_ps((const float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
+        z = _mm256_complexmul_ps(x, y);
+        _mm256_store_ps((float*)c, z); // Store the results back into the C container
+
+        a += 4;
+        b += 4;
+        c += 4;
+    }
+
+    number = quarterPoints * 4;
+
+    for (; number < num_points; number++) {
+        *c++ = (*a++) * (*b++);
+    }
+}
+#endif /* LV_HAVE_AVX */
+
+#if LV_HAVE_AVX2 && LV_HAVE_FMA
+#include <immintrin.h>
+/*!
+  \brief Multiplies the two input complex vectors and stores their results in the third
+  vector \param cVector The vector where the results will be stored \param aVector One of
+  the vectors to be multiplied \param bVector One of the vectors to be multiplied \param
+  num_points The number of complex values in aVector and bVector to be multiplied together
+  and stored into cVector
+*/
+static inline void volk_32fc_x2_multiply_32fc_a_avx2_fma(lv_32fc_t* cVector,
+                                                         const lv_32fc_t* aVector,
+                                                         const lv_32fc_t* bVector,
+                                                         unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    lv_32fc_t* c = cVector;
+    const lv_32fc_t* a = aVector;
+    const lv_32fc_t* b = bVector;
+
+    for (; number < quarterPoints; number++) {
+
+        const __m256 x =
+            _mm256_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        const __m256 y =
+            _mm256_load_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+
+        const __m256 yl = _mm256_moveldup_ps(y); // Load yl with cr,cr,dr,dr
+        const __m256 yh = _mm256_movehdup_ps(y); // Load yh with ci,ci,di,di
+
+        const __m256 tmp2x = _mm256_permute_ps(x, 0xB1); // Re-arrange x to be ai,ar,bi,br
+
+        const __m256 tmp2 = _mm256_mul_ps(tmp2x, yh); // tmp2 = ai*ci,ar*ci,bi*di,br*di
+
+        const __m256 z = _mm256_fmaddsub_ps(
+            x, yl, tmp2); // ar*cr-ai*ci, ai*cr+ar*ci, br*dr-bi*di, bi*dr+br*di
+
+        _mm256_store_ps((float*)c, z); // Store the results back into the C container
+
+        a += 4;
+        b += 4;
+        c += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        *c++ = (*a++) * (*b++);
+    }
+}
+#endif /* LV_HAVE_AVX2 && LV_HAVE_FMA */
 
 #endif /* INCLUDED_volk_32fc_x2_multiply_32fc_a_H */

--- a/kernels/volk/volk_32fc_x2_multiply_conjugate_32fc.h
+++ b/kernels/volk/volk_32fc_x2_multiply_conjugate_32fc.h
@@ -63,6 +63,60 @@
 #include <stdio.h>
 #include <volk/volk_complex.h>
 
+#ifdef LV_HAVE_GENERIC
+
+static inline void volk_32fc_x2_multiply_conjugate_32fc_generic(lv_32fc_t* cVector,
+                                                                const lv_32fc_t* aVector,
+                                                                const lv_32fc_t* bVector,
+                                                                unsigned int num_points)
+{
+    lv_32fc_t* cPtr = cVector;
+    const lv_32fc_t* aPtr = aVector;
+    const lv_32fc_t* bPtr = bVector;
+    unsigned int number = 0;
+
+    for (number = 0; number < num_points; number++) {
+        *cPtr++ = (*aPtr++) * lv_conj(*bPtr++);
+    }
+}
+#endif /* LV_HAVE_GENERIC */
+
+
+#ifdef LV_HAVE_SSE3
+#include <pmmintrin.h>
+#include <volk/volk_sse3_intrinsics.h>
+
+static inline void volk_32fc_x2_multiply_conjugate_32fc_u_sse3(lv_32fc_t* cVector,
+                                                               const lv_32fc_t* aVector,
+                                                               const lv_32fc_t* bVector,
+                                                               unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int halfPoints = num_points / 2;
+
+    __m128 x, y, z;
+    lv_32fc_t* c = cVector;
+    const lv_32fc_t* a = aVector;
+    const lv_32fc_t* b = bVector;
+
+    for (; number < halfPoints; number++) {
+        x = _mm_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        y = _mm_loadu_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+        z = _mm_complexconjugatemul_ps(x, y);
+        _mm_storeu_ps((float*)c, z); // Store the results back into the C container
+
+        a += 2;
+        b += 2;
+        c += 2;
+    }
+
+    if ((num_points % 2) != 0) {
+        *c = (*a) * lv_conj(*b);
+    }
+}
+#endif /* LV_HAVE_SSE3 */
+
+
 #ifdef LV_HAVE_AVX
 #include <immintrin.h>
 #include <volk/volk_avx_intrinsics.h>
@@ -100,141 +154,6 @@ static inline void volk_32fc_x2_multiply_conjugate_32fc_u_avx(lv_32fc_t* cVector
     }
 }
 #endif /* LV_HAVE_AVX */
-
-
-#ifdef LV_HAVE_SSE3
-#include <pmmintrin.h>
-#include <volk/volk_sse3_intrinsics.h>
-
-static inline void volk_32fc_x2_multiply_conjugate_32fc_u_sse3(lv_32fc_t* cVector,
-                                                               const lv_32fc_t* aVector,
-                                                               const lv_32fc_t* bVector,
-                                                               unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int halfPoints = num_points / 2;
-
-    __m128 x, y, z;
-    lv_32fc_t* c = cVector;
-    const lv_32fc_t* a = aVector;
-    const lv_32fc_t* b = bVector;
-
-    for (; number < halfPoints; number++) {
-        x = _mm_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
-        y = _mm_loadu_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
-        z = _mm_complexconjugatemul_ps(x, y);
-        _mm_storeu_ps((float*)c, z); // Store the results back into the C container
-
-        a += 2;
-        b += 2;
-        c += 2;
-    }
-
-    if ((num_points % 2) != 0) {
-        *c = (*a) * lv_conj(*b);
-    }
-}
-#endif /* LV_HAVE_SSE */
-
-
-#ifdef LV_HAVE_GENERIC
-
-static inline void volk_32fc_x2_multiply_conjugate_32fc_generic(lv_32fc_t* cVector,
-                                                                const lv_32fc_t* aVector,
-                                                                const lv_32fc_t* bVector,
-                                                                unsigned int num_points)
-{
-    lv_32fc_t* cPtr = cVector;
-    const lv_32fc_t* aPtr = aVector;
-    const lv_32fc_t* bPtr = bVector;
-    unsigned int number = 0;
-
-    for (number = 0; number < num_points; number++) {
-        *cPtr++ = (*aPtr++) * lv_conj(*bPtr++);
-    }
-}
-#endif /* LV_HAVE_GENERIC */
-
-
-#endif /* INCLUDED_volk_32fc_x2_multiply_conjugate_32fc_u_H */
-#ifndef INCLUDED_volk_32fc_x2_multiply_conjugate_32fc_a_H
-#define INCLUDED_volk_32fc_x2_multiply_conjugate_32fc_a_H
-
-#include <float.h>
-#include <inttypes.h>
-#include <stdio.h>
-#include <volk/volk_complex.h>
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-#include <volk/volk_avx_intrinsics.h>
-
-static inline void volk_32fc_x2_multiply_conjugate_32fc_a_avx(lv_32fc_t* cVector,
-                                                              const lv_32fc_t* aVector,
-                                                              const lv_32fc_t* bVector,
-                                                              unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-
-    __m256 x, y, z;
-    lv_32fc_t* c = cVector;
-    const lv_32fc_t* a = aVector;
-    const lv_32fc_t* b = bVector;
-
-    for (; number < quarterPoints; number++) {
-        x = _mm256_load_ps((const float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
-        y = _mm256_load_ps((const float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
-        z = _mm256_complexconjugatemul_ps(x, y);
-        _mm256_store_ps((float*)c, z); // Store the results back into the C container
-
-        a += 4;
-        b += 4;
-        c += 4;
-    }
-
-    number = quarterPoints * 4;
-
-    for (; number < num_points; number++) {
-        *c++ = (*a++) * lv_conj(*b++);
-    }
-}
-#endif /* LV_HAVE_AVX */
-
-
-#ifdef LV_HAVE_SSE3
-#include <pmmintrin.h>
-#include <volk/volk_sse3_intrinsics.h>
-
-static inline void volk_32fc_x2_multiply_conjugate_32fc_a_sse3(lv_32fc_t* cVector,
-                                                               const lv_32fc_t* aVector,
-                                                               const lv_32fc_t* bVector,
-                                                               unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int halfPoints = num_points / 2;
-
-    __m128 x, y, z;
-    lv_32fc_t* c = cVector;
-    const lv_32fc_t* a = aVector;
-    const lv_32fc_t* b = bVector;
-
-    for (; number < halfPoints; number++) {
-        x = _mm_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
-        y = _mm_load_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
-        z = _mm_complexconjugatemul_ps(x, y);
-        _mm_store_ps((float*)c, z); // Store the results back into the C container
-
-        a += 2;
-        b += 2;
-        c += 2;
-    }
-
-    if ((num_points % 2) != 0) {
-        *c = (*a) * lv_conj(*b);
-    }
-}
-#endif /* LV_HAVE_SSE */
 
 
 #ifdef LV_HAVE_NEON
@@ -355,7 +274,7 @@ static inline void volk_32fc_x2_multiply_conjugate_32fc_rvv(lv_32fc_t* cVector,
         __riscv_vse64((uint64_t*)cVector, v, vl);
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
 
 #ifdef LV_HAVE_RVVSEG
 #include <riscv_vector.h>
@@ -379,6 +298,87 @@ static inline void volk_32fc_x2_multiply_conjugate_32fc_rvvseg(lv_32fc_t* cVecto
     }
 }
 
-#endif /*LV_HAVE_RVVSEG*/
+#endif /* LV_HAVE_RVVSEG */
+
+#endif /* INCLUDED_volk_32fc_x2_multiply_conjugate_32fc_u_H */
+
+#ifndef INCLUDED_volk_32fc_x2_multiply_conjugate_32fc_a_H
+#define INCLUDED_volk_32fc_x2_multiply_conjugate_32fc_a_H
+
+#include <float.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <volk/volk_complex.h>
+
+#ifdef LV_HAVE_SSE3
+#include <pmmintrin.h>
+#include <volk/volk_sse3_intrinsics.h>
+
+static inline void volk_32fc_x2_multiply_conjugate_32fc_a_sse3(lv_32fc_t* cVector,
+                                                               const lv_32fc_t* aVector,
+                                                               const lv_32fc_t* bVector,
+                                                               unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int halfPoints = num_points / 2;
+
+    __m128 x, y, z;
+    lv_32fc_t* c = cVector;
+    const lv_32fc_t* a = aVector;
+    const lv_32fc_t* b = bVector;
+
+    for (; number < halfPoints; number++) {
+        x = _mm_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        y = _mm_load_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+        z = _mm_complexconjugatemul_ps(x, y);
+        _mm_store_ps((float*)c, z); // Store the results back into the C container
+
+        a += 2;
+        b += 2;
+        c += 2;
+    }
+
+    if ((num_points % 2) != 0) {
+        *c = (*a) * lv_conj(*b);
+    }
+}
+#endif /* LV_HAVE_SSE3 */
+
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
+static inline void volk_32fc_x2_multiply_conjugate_32fc_a_avx(lv_32fc_t* cVector,
+                                                              const lv_32fc_t* aVector,
+                                                              const lv_32fc_t* bVector,
+                                                              unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    __m256 x, y, z;
+    lv_32fc_t* c = cVector;
+    const lv_32fc_t* a = aVector;
+    const lv_32fc_t* b = bVector;
+
+    for (; number < quarterPoints; number++) {
+        x = _mm256_load_ps((const float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
+        y = _mm256_load_ps((const float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
+        z = _mm256_complexconjugatemul_ps(x, y);
+        _mm256_store_ps((float*)c, z); // Store the results back into the C container
+
+        a += 4;
+        b += 4;
+        c += 4;
+    }
+
+    number = quarterPoints * 4;
+
+    for (; number < num_points; number++) {
+        *c++ = (*a++) * lv_conj(*b++);
+    }
+}
+#endif /* LV_HAVE_AVX */
 
 #endif /* INCLUDED_volk_32fc_x2_multiply_conjugate_32fc_a_H */

--- a/kernels/volk/volk_32fc_x2_multiply_conjugate_32fc.h
+++ b/kernels/volk/volk_32fc_x2_multiply_conjugate_32fc.h
@@ -82,9 +82,9 @@ static inline void volk_32fc_x2_multiply_conjugate_32fc_u_avx(lv_32fc_t* cVector
 
     for (; number < quarterPoints; number++) {
         x = _mm256_loadu_ps(
-            (float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
+            (const float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
         y = _mm256_loadu_ps(
-            (float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
+            (const float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
         z = _mm256_complexconjugatemul_ps(x, y);
         _mm256_storeu_ps((float*)c, z); // Store the results back into the C container
 
@@ -120,8 +120,8 @@ static inline void volk_32fc_x2_multiply_conjugate_32fc_u_sse3(lv_32fc_t* cVecto
     const lv_32fc_t* b = bVector;
 
     for (; number < halfPoints; number++) {
-        x = _mm_loadu_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
-        y = _mm_loadu_ps((float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+        x = _mm_loadu_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        y = _mm_loadu_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
         z = _mm_complexconjugatemul_ps(x, y);
         _mm_storeu_ps((float*)c, z); // Store the results back into the C container
 
@@ -183,8 +183,8 @@ static inline void volk_32fc_x2_multiply_conjugate_32fc_a_avx(lv_32fc_t* cVector
     const lv_32fc_t* b = bVector;
 
     for (; number < quarterPoints; number++) {
-        x = _mm256_load_ps((float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
-        y = _mm256_load_ps((float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
+        x = _mm256_load_ps((const float*)a); // Load the ar + ai, br + bi ... as ar,ai,br,bi ...
+        y = _mm256_load_ps((const float*)b); // Load the cr + ci, dr + di ... as cr,ci,dr,di ...
         z = _mm256_complexconjugatemul_ps(x, y);
         _mm256_store_ps((float*)c, z); // Store the results back into the C container
 
@@ -220,8 +220,8 @@ static inline void volk_32fc_x2_multiply_conjugate_32fc_a_sse3(lv_32fc_t* cVecto
     const lv_32fc_t* b = bVector;
 
     for (; number < halfPoints; number++) {
-        x = _mm_load_ps((float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
-        y = _mm_load_ps((float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
+        x = _mm_load_ps((const float*)a); // Load the ar + ai, br + bi as ar,ai,br,bi
+        y = _mm_load_ps((const float*)b); // Load the cr + ci, dr + di as cr,ci,dr,di
         z = _mm_complexconjugatemul_ps(x, y);
         _mm_store_ps((float*)c, z); // Store the results back into the C container
 
@@ -245,16 +245,16 @@ static inline void volk_32fc_x2_multiply_conjugate_32fc_neon(lv_32fc_t* cVector,
                                                              const lv_32fc_t* bVector,
                                                              unsigned int num_points)
 {
-    lv_32fc_t* a_ptr = (lv_32fc_t*)aVector;
-    lv_32fc_t* b_ptr = (lv_32fc_t*)bVector;
+    const lv_32fc_t* a_ptr = aVector;
+    const lv_32fc_t* b_ptr = bVector;
     unsigned int quarter_points = num_points / 4;
     float32x4x2_t a_val, b_val, c_val;
     float32x4x2_t tmp_real, tmp_imag;
     unsigned int number = 0;
 
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld2q_f32((float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
-        b_val = vld2q_f32((float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
+        a_val = vld2q_f32((const float*)a_ptr); // a0r|a1r|a2r|a3r || a0i|a1i|a2i|a3i
+        b_val = vld2q_f32((const float*)b_ptr); // b0r|b1r|b2r|b3r || b0i|b1i|b2i|b3i
         b_val.val[1] = vnegq_f32(b_val.val[1]);
         __VOLK_PREFETCH(a_ptr + 4);
         __VOLK_PREFETCH(b_ptr + 4);
@@ -302,8 +302,8 @@ static inline void volk_32fc_x2_multiply_conjugate_32fc_neonv8(lv_32fc_t* cVecto
     unsigned int number = 0;
 
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld2q_f32((float*)a_ptr);
-        b_val = vld2q_f32((float*)b_ptr);
+        a_val = vld2q_f32((const float*)a_ptr);
+        b_val = vld2q_f32((const float*)b_ptr);
         __VOLK_PREFETCH(a_ptr + 8);
         __VOLK_PREFETCH(b_ptr + 8);
 

--- a/kernels/volk/volk_32fc_x2_s32f_square_dist_scalar_mult_32f.h
+++ b/kernels/volk/volk_32fc_x2_s32f_square_dist_scalar_mult_32f.h
@@ -63,8 +63,8 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_H
-#define INCLUDED_volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_H
+#ifndef INCLUDED_volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_H
+#define INCLUDED_volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_H
 
 #include <volk/volk_complex.h>
 
@@ -88,137 +88,53 @@ static inline void calculate_scaled_distances(float* target,
 }
 
 
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-#include <volk/volk_avx2_intrinsics.h>
-
+#ifdef LV_HAVE_GENERIC
 static inline void
-volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_avx2(float* target,
-                                                     const lv_32fc_t* src0,
-                                                     const lv_32fc_t* points,
-                                                     float scalar,
-                                                     unsigned int num_points)
+volk_32fc_x2_s32f_square_dist_scalar_mult_32f_generic(float* target,
+                                                      const lv_32fc_t* src0,
+                                                      const lv_32fc_t* points,
+                                                      float scalar,
+                                                      unsigned int num_points)
 {
-    const unsigned int num_bytes = num_points * 8;
-    __m128 xmm9, xmm10;
-    __m256 xmm4, xmm6;
-    __m256 xmm_points0, xmm_points1, xmm_result;
-
-    const unsigned int bound = num_bytes >> 6;
-
-    // load complex value into all parts of the register.
-    const __m256 xmm_symbol = _mm256_castpd_ps(_mm256_broadcast_sd((const double*)src0));
-    const __m128 xmm128_symbol = _mm256_extractf128_ps(xmm_symbol, 1);
-
-    // Load scalar into all 8 parts of the register
-    const __m256 xmm_scalar = _mm256_broadcast_ss(&scalar);
-    const __m128 xmm128_scalar = _mm256_extractf128_ps(xmm_scalar, 1);
-
-    // Set permutation constant
-    const __m256i idx = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
-
-    for (unsigned int i = 0; i < bound; ++i) {
-        xmm_points0 = _mm256_load_ps((const float*)points);
-        xmm_points1 = _mm256_load_ps((const float*)(points + 4));
-        points += 8;
-        __VOLK_PREFETCH(points);
-
-        xmm_result = _mm256_scaled_norm_dist_ps_avx2(
-            xmm_symbol, xmm_symbol, xmm_points0, xmm_points1, xmm_scalar);
-
-        _mm256_store_ps(target, xmm_result);
-        target += 8;
-    }
-
-    if (num_bytes >> 5 & 1) {
-        xmm_points0 = _mm256_load_ps((const float*)points);
-
-        xmm4 = _mm256_sub_ps(xmm_symbol, xmm_points0);
-
-        points += 4;
-
-        xmm6 = _mm256_mul_ps(xmm4, xmm4);
-
-        xmm4 = _mm256_hadd_ps(xmm6, xmm6);
-        xmm4 = _mm256_permutevar8x32_ps(xmm4, idx);
-
-        xmm_result = _mm256_mul_ps(xmm4, xmm_scalar);
-
-        xmm9 = _mm256_extractf128_ps(xmm_result, 1);
-        _mm_store_ps(target, xmm9);
-        target += 4;
-    }
-
-    if (num_bytes >> 4 & 1) {
-        xmm9 = _mm_load_ps((const float*)points);
-
-        xmm10 = _mm_sub_ps(xmm128_symbol, xmm9);
-
-        points += 2;
-
-        xmm9 = _mm_mul_ps(xmm10, xmm10);
-
-        xmm10 = _mm_hadd_ps(xmm9, xmm9);
-
-        xmm10 = _mm_mul_ps(xmm10, xmm128_scalar);
-
-        _mm_storeh_pi((__m64*)target, xmm10);
-        target += 2;
-    }
-
-    calculate_scaled_distances(target, src0[0], points, scalar, (num_bytes >> 3) & 1);
+    const lv_32fc_t symbol = *src0;
+    calculate_scaled_distances(target, symbol, points, scalar, num_points);
 }
 
-#endif /*LV_HAVE_AVX2*/
+#endif /*LV_HAVE_GENERIC*/
 
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-#include <volk/volk_avx_intrinsics.h>
-
+#ifdef LV_HAVE_SSE
+#include <volk/volk_sse_intrinsics.h>
+#include <xmmintrin.h>
 static inline void
-volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_avx(float* target,
+volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_sse(float* target,
                                                     const lv_32fc_t* src0,
                                                     const lv_32fc_t* points,
                                                     float scalar,
                                                     unsigned int num_points)
 {
-    const int eightsPoints = num_points / 8;
-    const int remainder = num_points - 8 * eightsPoints;
+    const __m128 xmm_scalar = _mm_set1_ps(scalar);
+    const __m128 xmm_symbol = _mm_castpd_ps(_mm_load1_pd((const double*)src0));
 
-    __m256 xmm_points0, xmm_points1, xmm_result;
-
-    // load complex value into all parts of the register.
-    const __m256 xmm_symbol = _mm256_castpd_ps(_mm256_broadcast_sd((const double*)src0));
-
-    // Load scalar into all 8 parts of the register
-    const __m256 xmm_scalar = _mm256_broadcast_ss(&scalar);
-
-    for (int i = 0; i < eightsPoints; ++i) {
-        xmm_points0 = _mm256_load_ps((const float*)points);
-        xmm_points1 = _mm256_load_ps((const float*)(points + 4));
-        points += 8;
-
-        xmm_result = _mm256_scaled_norm_dist_ps(
+    for (unsigned i = 0; i < num_points / 4; ++i) {
+        __m128 xmm_points0 = _mm_loadu_ps((const float*)points);
+        __m128 xmm_points1 = _mm_loadu_ps((const float*)(points + 2));
+        points += 4;
+        __m128 xmm_result = _mm_scaled_norm_dist_ps_sse(
             xmm_symbol, xmm_symbol, xmm_points0, xmm_points1, xmm_scalar);
-
-        _mm256_store_ps(target, xmm_result);
-        target += 8;
+        _mm_storeu_ps((float*)target, xmm_result);
+        target += 4;
     }
 
-    const lv_32fc_t symbol = *src0;
-    calculate_scaled_distances(target, symbol, points, scalar, remainder);
+    calculate_scaled_distances(target, src0[0], points, scalar, num_points % 4);
 }
-
-#endif /* LV_HAVE_AVX */
-
+#endif /* LV_HAVE_SSE */
 
 #ifdef LV_HAVE_SSE3
 #include <pmmintrin.h>
 #include <volk/volk_sse3_intrinsics.h>
 
 static inline void
-volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_sse3(float* target,
+volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_sse3(float* target,
                                                      const lv_32fc_t* src0,
                                                      const lv_32fc_t* points,
                                                      float scalar,
@@ -243,20 +159,20 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_sse3(float* target,
     const __m128 xmm_scalar = _mm_load1_ps(&scalar);
 
     for (int i = 0; i < quarterPoints; ++i) {
-        xmm_points0 = _mm_load_ps((const float*)points);
-        xmm_points1 = _mm_load_ps((const float*)(points + 2));
+        xmm_points0 = _mm_loadu_ps((const float*)points);
+        xmm_points1 = _mm_loadu_ps((const float*)(points + 2));
         points += 4;
         __VOLK_PREFETCH(points);
         // calculate distances
         xmm_result = _mm_scaled_norm_dist_ps_sse3(
             xmm_symbol, xmm_symbol, xmm_points0, xmm_points1, xmm_scalar);
 
-        _mm_store_ps(target, xmm_result);
+        _mm_storeu_ps(target, xmm_result);
         target += 4;
     }
 
     for (int i = 0; i < leftovers0; ++i) {
-        xmm_points0 = _mm_load_ps((const float*)points);
+        xmm_points0 = _mm_loadu_ps((const float*)points);
         points += 2;
 
         xmm_points0 = _mm_sub_ps(xmm_symbol, xmm_points0);
@@ -273,46 +189,129 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_sse3(float* target,
 
 #endif /*LV_HAVE_SSE3*/
 
-#ifdef LV_HAVE_SSE
-#include <volk/volk_sse_intrinsics.h>
-#include <xmmintrin.h>
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
 static inline void
-volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_sse(float* target,
+volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_avx(float* target,
                                                     const lv_32fc_t* src0,
                                                     const lv_32fc_t* points,
                                                     float scalar,
                                                     unsigned int num_points)
 {
-    const __m128 xmm_scalar = _mm_set1_ps(scalar);
-    const __m128 xmm_symbol = _mm_castpd_ps(_mm_load1_pd((const double*)src0));
+    const int eightsPoints = num_points / 8;
+    const int remainder = num_points - 8 * eightsPoints;
 
-    for (unsigned i = 0; i < num_points / 4; ++i) {
-        __m128 xmm_points0 = _mm_load_ps((const float*)points);
-        __m128 xmm_points1 = _mm_load_ps((const float*)(points + 2));
-        points += 4;
-        __m128 xmm_result = _mm_scaled_norm_dist_ps_sse(
+    __m256 xmm_points0, xmm_points1, xmm_result;
+
+    // load complex value into all parts of the register.
+    const __m256 xmm_symbol = _mm256_castpd_ps(_mm256_broadcast_sd((const double*)src0));
+
+    // Load scalar into all 8 parts of the register
+    const __m256 xmm_scalar = _mm256_broadcast_ss(&scalar);
+
+    for (int i = 0; i < eightsPoints; ++i) {
+        xmm_points0 = _mm256_loadu_ps((const float*)points);
+        xmm_points1 = _mm256_loadu_ps((const float*)(points + 4));
+        points += 8;
+
+        xmm_result = _mm256_scaled_norm_dist_ps(
             xmm_symbol, xmm_symbol, xmm_points0, xmm_points1, xmm_scalar);
-        _mm_store_ps((float*)target, xmm_result);
+
+        _mm256_storeu_ps(target, xmm_result);
+        target += 8;
+    }
+
+    const lv_32fc_t symbol = *src0;
+    calculate_scaled_distances(target, symbol, points, scalar, remainder);
+}
+
+#endif /* LV_HAVE_AVX */
+
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+#include <volk/volk_avx2_intrinsics.h>
+
+static inline void
+volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_avx2(float* target,
+                                                     const lv_32fc_t* src0,
+                                                     const lv_32fc_t* points,
+                                                     float scalar,
+                                                     unsigned int num_points)
+{
+    const unsigned int num_bytes = num_points * 8;
+    __m128 xmm9, xmm10;
+    __m256 xmm4, xmm6;
+    __m256 xmm_points0, xmm_points1, xmm_result;
+
+    const unsigned int bound = num_bytes >> 6;
+
+    // load complex value into all parts of the register.
+    const __m256 xmm_symbol = _mm256_castpd_ps(_mm256_broadcast_sd((const double*)src0));
+    const __m128 xmm128_symbol = _mm256_extractf128_ps(xmm_symbol, 1);
+
+    // Load scalar into all 8 parts of the register
+    const __m256 xmm_scalar = _mm256_broadcast_ss(&scalar);
+    const __m128 xmm128_scalar = _mm256_extractf128_ps(xmm_scalar, 1);
+
+    // Set permutation constant
+    const __m256i idx = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
+
+    for (unsigned int i = 0; i < bound; ++i) {
+        xmm_points0 = _mm256_loadu_ps((const float*)points);
+        xmm_points1 = _mm256_loadu_ps((const float*)(points + 4));
+        points += 8;
+        __VOLK_PREFETCH(points);
+
+        xmm_result = _mm256_scaled_norm_dist_ps_avx2(
+            xmm_symbol, xmm_symbol, xmm_points0, xmm_points1, xmm_scalar);
+
+        _mm256_storeu_ps(target, xmm_result);
+        target += 8;
+    }
+
+    if (num_bytes >> 5 & 1) {
+        xmm_points0 = _mm256_loadu_ps((const float*)points);
+
+        xmm4 = _mm256_sub_ps(xmm_symbol, xmm_points0);
+
+        points += 4;
+
+        xmm6 = _mm256_mul_ps(xmm4, xmm4);
+
+        xmm4 = _mm256_hadd_ps(xmm6, xmm6);
+        xmm4 = _mm256_permutevar8x32_ps(xmm4, idx);
+
+        xmm_result = _mm256_mul_ps(xmm4, xmm_scalar);
+
+        xmm9 = _mm256_extractf128_ps(xmm_result, 1);
+        _mm_storeu_ps(target, xmm9);
         target += 4;
     }
 
-    calculate_scaled_distances(target, src0[0], points, scalar, num_points % 4);
-}
-#endif // LV_HAVE_SSE
+    if (num_bytes >> 4 & 1) {
+        xmm9 = _mm_loadu_ps((const float*)points);
 
-#ifdef LV_HAVE_GENERIC
-static inline void
-volk_32fc_x2_s32f_square_dist_scalar_mult_32f_generic(float* target,
-                                                      const lv_32fc_t* src0,
-                                                      const lv_32fc_t* points,
-                                                      float scalar,
-                                                      unsigned int num_points)
-{
-    const lv_32fc_t symbol = *src0;
-    calculate_scaled_distances(target, symbol, points, scalar, num_points);
+        xmm10 = _mm_sub_ps(xmm128_symbol, xmm9);
+
+        points += 2;
+
+        xmm9 = _mm_mul_ps(xmm10, xmm10);
+
+        xmm10 = _mm_hadd_ps(xmm9, xmm9);
+
+        xmm10 = _mm_mul_ps(xmm10, xmm128_scalar);
+
+        _mm_storeh_pi((__m64*)target, xmm10);
+        target += 2;
+    }
+
+    calculate_scaled_distances(target, src0[0], points, scalar, (num_bytes >> 3) & 1);
 }
 
-#endif /*LV_HAVE_GENERIC*/
+#endif /*LV_HAVE_AVX2*/
 
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
@@ -411,226 +410,6 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_neonv8(float* target,
 
 #endif /*LV_HAVE_NEONV8*/
 
-#endif /*INCLUDED_volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_H*/
-
-#ifndef INCLUDED_volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_H
-#define INCLUDED_volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_H
-
-#include <volk/volk_complex.h>
-
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-#include <volk/volk_avx2_intrinsics.h>
-
-static inline void
-volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_avx2(float* target,
-                                                     const lv_32fc_t* src0,
-                                                     const lv_32fc_t* points,
-                                                     float scalar,
-                                                     unsigned int num_points)
-{
-    const unsigned int num_bytes = num_points * 8;
-    __m128 xmm9, xmm10;
-    __m256 xmm4, xmm6;
-    __m256 xmm_points0, xmm_points1, xmm_result;
-
-    const unsigned int bound = num_bytes >> 6;
-
-    // load complex value into all parts of the register.
-    const __m256 xmm_symbol = _mm256_castpd_ps(_mm256_broadcast_sd((const double*)src0));
-    const __m128 xmm128_symbol = _mm256_extractf128_ps(xmm_symbol, 1);
-
-    // Load scalar into all 8 parts of the register
-    const __m256 xmm_scalar = _mm256_broadcast_ss(&scalar);
-    const __m128 xmm128_scalar = _mm256_extractf128_ps(xmm_scalar, 1);
-
-    // Set permutation constant
-    const __m256i idx = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
-
-    for (unsigned int i = 0; i < bound; ++i) {
-        xmm_points0 = _mm256_loadu_ps((const float*)points);
-        xmm_points1 = _mm256_loadu_ps((const float*)(points + 4));
-        points += 8;
-        __VOLK_PREFETCH(points);
-
-        xmm_result = _mm256_scaled_norm_dist_ps_avx2(
-            xmm_symbol, xmm_symbol, xmm_points0, xmm_points1, xmm_scalar);
-
-        _mm256_storeu_ps(target, xmm_result);
-        target += 8;
-    }
-
-    if (num_bytes >> 5 & 1) {
-        xmm_points0 = _mm256_loadu_ps((const float*)points);
-
-        xmm4 = _mm256_sub_ps(xmm_symbol, xmm_points0);
-
-        points += 4;
-
-        xmm6 = _mm256_mul_ps(xmm4, xmm4);
-
-        xmm4 = _mm256_hadd_ps(xmm6, xmm6);
-        xmm4 = _mm256_permutevar8x32_ps(xmm4, idx);
-
-        xmm_result = _mm256_mul_ps(xmm4, xmm_scalar);
-
-        xmm9 = _mm256_extractf128_ps(xmm_result, 1);
-        _mm_storeu_ps(target, xmm9);
-        target += 4;
-    }
-
-    if (num_bytes >> 4 & 1) {
-        xmm9 = _mm_loadu_ps((const float*)points);
-
-        xmm10 = _mm_sub_ps(xmm128_symbol, xmm9);
-
-        points += 2;
-
-        xmm9 = _mm_mul_ps(xmm10, xmm10);
-
-        xmm10 = _mm_hadd_ps(xmm9, xmm9);
-
-        xmm10 = _mm_mul_ps(xmm10, xmm128_scalar);
-
-        _mm_storeh_pi((__m64*)target, xmm10);
-        target += 2;
-    }
-
-    calculate_scaled_distances(target, src0[0], points, scalar, (num_bytes >> 3) & 1);
-}
-
-#endif /*LV_HAVE_AVX2*/
-
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-#include <volk/volk_avx_intrinsics.h>
-
-static inline void
-volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_avx(float* target,
-                                                    const lv_32fc_t* src0,
-                                                    const lv_32fc_t* points,
-                                                    float scalar,
-                                                    unsigned int num_points)
-{
-    const int eightsPoints = num_points / 8;
-    const int remainder = num_points - 8 * eightsPoints;
-
-    __m256 xmm_points0, xmm_points1, xmm_result;
-
-    // load complex value into all parts of the register.
-    const __m256 xmm_symbol = _mm256_castpd_ps(_mm256_broadcast_sd((const double*)src0));
-
-    // Load scalar into all 8 parts of the register
-    const __m256 xmm_scalar = _mm256_broadcast_ss(&scalar);
-
-    for (int i = 0; i < eightsPoints; ++i) {
-        xmm_points0 = _mm256_loadu_ps((const float*)points);
-        xmm_points1 = _mm256_loadu_ps((const float*)(points + 4));
-        points += 8;
-
-        xmm_result = _mm256_scaled_norm_dist_ps(
-            xmm_symbol, xmm_symbol, xmm_points0, xmm_points1, xmm_scalar);
-
-        _mm256_storeu_ps(target, xmm_result);
-        target += 8;
-    }
-
-    const lv_32fc_t symbol = *src0;
-    calculate_scaled_distances(target, symbol, points, scalar, remainder);
-}
-
-#endif /* LV_HAVE_AVX */
-
-
-#ifdef LV_HAVE_SSE3
-#include <pmmintrin.h>
-#include <volk/volk_sse3_intrinsics.h>
-
-static inline void
-volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_sse3(float* target,
-                                                     const lv_32fc_t* src0,
-                                                     const lv_32fc_t* points,
-                                                     float scalar,
-                                                     unsigned int num_points)
-{
-    __m128 xmm_points0, xmm_points1, xmm_result;
-
-    /*
-     * First do 4 values in every loop iteration.
-     * There may be up to 3 values left.
-     * leftovers0 indicates if at least 2 more are available for SSE execution.
-     * leftovers1 indicates if there is a single element left.
-     */
-    const int quarterPoints = num_points / 4;
-    const int leftovers0 = (num_points / 2) - 2 * quarterPoints;
-    const int leftovers1 = num_points % 2;
-
-    // load complex value into both parts of the register.
-    const __m128 xmm_symbol = _mm_castpd_ps(_mm_load1_pd((const double*)src0));
-
-    // Load scalar into all 4 parts of the register
-    const __m128 xmm_scalar = _mm_load1_ps(&scalar);
-
-    for (int i = 0; i < quarterPoints; ++i) {
-        xmm_points0 = _mm_loadu_ps((const float*)points);
-        xmm_points1 = _mm_loadu_ps((const float*)(points + 2));
-        points += 4;
-        __VOLK_PREFETCH(points);
-        // calculate distances
-        xmm_result = _mm_scaled_norm_dist_ps_sse3(
-            xmm_symbol, xmm_symbol, xmm_points0, xmm_points1, xmm_scalar);
-
-        _mm_storeu_ps(target, xmm_result);
-        target += 4;
-    }
-
-    for (int i = 0; i < leftovers0; ++i) {
-        xmm_points0 = _mm_loadu_ps((const float*)points);
-        points += 2;
-
-        xmm_points0 = _mm_sub_ps(xmm_symbol, xmm_points0);
-        xmm_points0 = _mm_mul_ps(xmm_points0, xmm_points0);
-        xmm_points0 = _mm_hadd_ps(xmm_points0, xmm_points0);
-        xmm_result = _mm_mul_ps(xmm_points0, xmm_scalar);
-
-        _mm_storeh_pi((__m64*)target, xmm_result);
-        target += 2;
-    }
-
-    calculate_scaled_distances(target, src0[0], points, scalar, leftovers1);
-}
-
-#endif /*LV_HAVE_SSE3*/
-
-#ifdef LV_HAVE_SSE
-#include <volk/volk_sse_intrinsics.h>
-#include <xmmintrin.h>
-static inline void
-volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_sse(float* target,
-                                                    const lv_32fc_t* src0,
-                                                    const lv_32fc_t* points,
-                                                    float scalar,
-                                                    unsigned int num_points)
-{
-    const __m128 xmm_scalar = _mm_set1_ps(scalar);
-    const __m128 xmm_symbol = _mm_castpd_ps(_mm_load1_pd((const double*)src0));
-
-    for (unsigned i = 0; i < num_points / 4; ++i) {
-        __m128 xmm_points0 = _mm_loadu_ps((const float*)points);
-        __m128 xmm_points1 = _mm_loadu_ps((const float*)(points + 2));
-        points += 4;
-        __m128 xmm_result = _mm_scaled_norm_dist_ps_sse(
-            xmm_symbol, xmm_symbol, xmm_points0, xmm_points1, xmm_scalar);
-        _mm_storeu_ps((float*)target, xmm_result);
-        target += 4;
-    }
-
-    calculate_scaled_distances(target, src0[0], points, scalar, num_points % 4);
-}
-#endif // LV_HAVE_SSE
-
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 
@@ -690,3 +469,219 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_rvvseg(float* target,
 #endif /*LV_HAVE_RVVSEG*/
 
 #endif /*INCLUDED_volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_H*/
+
+#ifndef INCLUDED_volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_H
+#define INCLUDED_volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_H
+
+#ifdef LV_HAVE_SSE
+#include <volk/volk_sse_intrinsics.h>
+#include <xmmintrin.h>
+static inline void
+volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_sse(float* target,
+                                                    const lv_32fc_t* src0,
+                                                    const lv_32fc_t* points,
+                                                    float scalar,
+                                                    unsigned int num_points)
+{
+    const __m128 xmm_scalar = _mm_set1_ps(scalar);
+    const __m128 xmm_symbol = _mm_castpd_ps(_mm_load1_pd((const double*)src0));
+
+    for (unsigned i = 0; i < num_points / 4; ++i) {
+        __m128 xmm_points0 = _mm_load_ps((const float*)points);
+        __m128 xmm_points1 = _mm_load_ps((const float*)(points + 2));
+        points += 4;
+        __m128 xmm_result = _mm_scaled_norm_dist_ps_sse(
+            xmm_symbol, xmm_symbol, xmm_points0, xmm_points1, xmm_scalar);
+        _mm_store_ps((float*)target, xmm_result);
+        target += 4;
+    }
+
+    calculate_scaled_distances(target, src0[0], points, scalar, num_points % 4);
+}
+#endif /* LV_HAVE_SSE */
+
+#ifdef LV_HAVE_SSE3
+#include <pmmintrin.h>
+#include <volk/volk_sse3_intrinsics.h>
+
+static inline void
+volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_sse3(float* target,
+                                                     const lv_32fc_t* src0,
+                                                     const lv_32fc_t* points,
+                                                     float scalar,
+                                                     unsigned int num_points)
+{
+    __m128 xmm_points0, xmm_points1, xmm_result;
+
+    /*
+     * First do 4 values in every loop iteration.
+     * There may be up to 3 values left.
+     * leftovers0 indicates if at least 2 more are available for SSE execution.
+     * leftovers1 indicates if there is a single element left.
+     */
+    const int quarterPoints = num_points / 4;
+    const int leftovers0 = (num_points / 2) - 2 * quarterPoints;
+    const int leftovers1 = num_points % 2;
+
+    // load complex value into both parts of the register.
+    const __m128 xmm_symbol = _mm_castpd_ps(_mm_load1_pd((const double*)src0));
+
+    // Load scalar into all 4 parts of the register
+    const __m128 xmm_scalar = _mm_load1_ps(&scalar);
+
+    for (int i = 0; i < quarterPoints; ++i) {
+        xmm_points0 = _mm_load_ps((const float*)points);
+        xmm_points1 = _mm_load_ps((const float*)(points + 2));
+        points += 4;
+        __VOLK_PREFETCH(points);
+        // calculate distances
+        xmm_result = _mm_scaled_norm_dist_ps_sse3(
+            xmm_symbol, xmm_symbol, xmm_points0, xmm_points1, xmm_scalar);
+
+        _mm_store_ps(target, xmm_result);
+        target += 4;
+    }
+
+    for (int i = 0; i < leftovers0; ++i) {
+        xmm_points0 = _mm_load_ps((const float*)points);
+        points += 2;
+
+        xmm_points0 = _mm_sub_ps(xmm_symbol, xmm_points0);
+        xmm_points0 = _mm_mul_ps(xmm_points0, xmm_points0);
+        xmm_points0 = _mm_hadd_ps(xmm_points0, xmm_points0);
+        xmm_result = _mm_mul_ps(xmm_points0, xmm_scalar);
+
+        _mm_storeh_pi((__m64*)target, xmm_result);
+        target += 2;
+    }
+
+    calculate_scaled_distances(target, src0[0], points, scalar, leftovers1);
+}
+
+#endif /*LV_HAVE_SSE3*/
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
+static inline void
+volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_avx(float* target,
+                                                    const lv_32fc_t* src0,
+                                                    const lv_32fc_t* points,
+                                                    float scalar,
+                                                    unsigned int num_points)
+{
+    const int eightsPoints = num_points / 8;
+    const int remainder = num_points - 8 * eightsPoints;
+
+    __m256 xmm_points0, xmm_points1, xmm_result;
+
+    // load complex value into all parts of the register.
+    const __m256 xmm_symbol = _mm256_castpd_ps(_mm256_broadcast_sd((const double*)src0));
+
+    // Load scalar into all 8 parts of the register
+    const __m256 xmm_scalar = _mm256_broadcast_ss(&scalar);
+
+    for (int i = 0; i < eightsPoints; ++i) {
+        xmm_points0 = _mm256_load_ps((const float*)points);
+        xmm_points1 = _mm256_load_ps((const float*)(points + 4));
+        points += 8;
+
+        xmm_result = _mm256_scaled_norm_dist_ps(
+            xmm_symbol, xmm_symbol, xmm_points0, xmm_points1, xmm_scalar);
+
+        _mm256_store_ps(target, xmm_result);
+        target += 8;
+    }
+
+    const lv_32fc_t symbol = *src0;
+    calculate_scaled_distances(target, symbol, points, scalar, remainder);
+}
+
+#endif /* LV_HAVE_AVX */
+
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+#include <volk/volk_avx2_intrinsics.h>
+
+static inline void
+volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_avx2(float* target,
+                                                     const lv_32fc_t* src0,
+                                                     const lv_32fc_t* points,
+                                                     float scalar,
+                                                     unsigned int num_points)
+{
+    const unsigned int num_bytes = num_points * 8;
+    __m128 xmm9, xmm10;
+    __m256 xmm4, xmm6;
+    __m256 xmm_points0, xmm_points1, xmm_result;
+
+    const unsigned int bound = num_bytes >> 6;
+
+    // load complex value into all parts of the register.
+    const __m256 xmm_symbol = _mm256_castpd_ps(_mm256_broadcast_sd((const double*)src0));
+    const __m128 xmm128_symbol = _mm256_extractf128_ps(xmm_symbol, 1);
+
+    // Load scalar into all 8 parts of the register
+    const __m256 xmm_scalar = _mm256_broadcast_ss(&scalar);
+    const __m128 xmm128_scalar = _mm256_extractf128_ps(xmm_scalar, 1);
+
+    // Set permutation constant
+    const __m256i idx = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
+
+    for (unsigned int i = 0; i < bound; ++i) {
+        xmm_points0 = _mm256_load_ps((const float*)points);
+        xmm_points1 = _mm256_load_ps((const float*)(points + 4));
+        points += 8;
+        __VOLK_PREFETCH(points);
+
+        xmm_result = _mm256_scaled_norm_dist_ps_avx2(
+            xmm_symbol, xmm_symbol, xmm_points0, xmm_points1, xmm_scalar);
+
+        _mm256_store_ps(target, xmm_result);
+        target += 8;
+    }
+
+    if (num_bytes >> 5 & 1) {
+        xmm_points0 = _mm256_load_ps((const float*)points);
+
+        xmm4 = _mm256_sub_ps(xmm_symbol, xmm_points0);
+
+        points += 4;
+
+        xmm6 = _mm256_mul_ps(xmm4, xmm4);
+
+        xmm4 = _mm256_hadd_ps(xmm6, xmm6);
+        xmm4 = _mm256_permutevar8x32_ps(xmm4, idx);
+
+        xmm_result = _mm256_mul_ps(xmm4, xmm_scalar);
+
+        xmm9 = _mm256_extractf128_ps(xmm_result, 1);
+        _mm_store_ps(target, xmm9);
+        target += 4;
+    }
+
+    if (num_bytes >> 4 & 1) {
+        xmm9 = _mm_load_ps((const float*)points);
+
+        xmm10 = _mm_sub_ps(xmm128_symbol, xmm9);
+
+        points += 2;
+
+        xmm9 = _mm_mul_ps(xmm10, xmm10);
+
+        xmm10 = _mm_hadd_ps(xmm9, xmm9);
+
+        xmm10 = _mm_mul_ps(xmm10, xmm128_scalar);
+
+        _mm_storeh_pi((__m64*)target, xmm10);
+        target += 2;
+    }
+
+    calculate_scaled_distances(target, src0[0], points, scalar, (num_bytes >> 3) & 1);
+}
+
+#endif /*LV_HAVE_AVX2*/
+
+#endif /*INCLUDED_volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_H*/

--- a/kernels/volk/volk_32fc_x2_s32f_square_dist_scalar_mult_32f.h
+++ b/kernels/volk/volk_32fc_x2_s32f_square_dist_scalar_mult_32f.h
@@ -118,8 +118,8 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_avx2(float* target,
     const __m256i idx = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
 
     for (unsigned int i = 0; i < bound; ++i) {
-        xmm_points0 = _mm256_load_ps((float*)points);
-        xmm_points1 = _mm256_load_ps((float*)(points + 4));
+        xmm_points0 = _mm256_load_ps((const float*)points);
+        xmm_points1 = _mm256_load_ps((const float*)(points + 4));
         points += 8;
         __VOLK_PREFETCH(points);
 
@@ -131,7 +131,7 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_avx2(float* target,
     }
 
     if (num_bytes >> 5 & 1) {
-        xmm_points0 = _mm256_load_ps((float*)points);
+        xmm_points0 = _mm256_load_ps((const float*)points);
 
         xmm4 = _mm256_sub_ps(xmm_symbol, xmm_points0);
 
@@ -150,7 +150,7 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_avx2(float* target,
     }
 
     if (num_bytes >> 4 & 1) {
-        xmm9 = _mm_load_ps((float*)points);
+        xmm9 = _mm_load_ps((const float*)points);
 
         xmm10 = _mm_sub_ps(xmm128_symbol, xmm9);
 
@@ -195,8 +195,8 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_avx(float* target,
     const __m256 xmm_scalar = _mm256_broadcast_ss(&scalar);
 
     for (int i = 0; i < eightsPoints; ++i) {
-        xmm_points0 = _mm256_load_ps((float*)points);
-        xmm_points1 = _mm256_load_ps((float*)(points + 4));
+        xmm_points0 = _mm256_load_ps((const float*)points);
+        xmm_points1 = _mm256_load_ps((const float*)(points + 4));
         points += 8;
 
         xmm_result = _mm256_scaled_norm_dist_ps(
@@ -243,8 +243,8 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_sse3(float* target,
     const __m128 xmm_scalar = _mm_load1_ps(&scalar);
 
     for (int i = 0; i < quarterPoints; ++i) {
-        xmm_points0 = _mm_load_ps((float*)points);
-        xmm_points1 = _mm_load_ps((float*)(points + 2));
+        xmm_points0 = _mm_load_ps((const float*)points);
+        xmm_points1 = _mm_load_ps((const float*)(points + 2));
         points += 4;
         __VOLK_PREFETCH(points);
         // calculate distances
@@ -256,7 +256,7 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_sse3(float* target,
     }
 
     for (int i = 0; i < leftovers0; ++i) {
-        xmm_points0 = _mm_load_ps((float*)points);
+        xmm_points0 = _mm_load_ps((const float*)points);
         points += 2;
 
         xmm_points0 = _mm_sub_ps(xmm_symbol, xmm_points0);
@@ -287,8 +287,8 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_a_sse(float* target,
     const __m128 xmm_symbol = _mm_castpd_ps(_mm_load1_pd((const double*)src0));
 
     for (unsigned i = 0; i < num_points / 4; ++i) {
-        __m128 xmm_points0 = _mm_load_ps((float*)points);
-        __m128 xmm_points1 = _mm_load_ps((float*)(points + 2));
+        __m128 xmm_points0 = _mm_load_ps((const float*)points);
+        __m128 xmm_points1 = _mm_load_ps((const float*)(points + 2));
         points += 4;
         __m128 xmm_result = _mm_scaled_norm_dist_ps_sse(
             xmm_symbol, xmm_symbol, xmm_points0, xmm_points1, xmm_scalar);
@@ -449,8 +449,8 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_avx2(float* target,
     const __m256i idx = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
 
     for (unsigned int i = 0; i < bound; ++i) {
-        xmm_points0 = _mm256_loadu_ps((float*)points);
-        xmm_points1 = _mm256_loadu_ps((float*)(points + 4));
+        xmm_points0 = _mm256_loadu_ps((const float*)points);
+        xmm_points1 = _mm256_loadu_ps((const float*)(points + 4));
         points += 8;
         __VOLK_PREFETCH(points);
 
@@ -462,7 +462,7 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_avx2(float* target,
     }
 
     if (num_bytes >> 5 & 1) {
-        xmm_points0 = _mm256_loadu_ps((float*)points);
+        xmm_points0 = _mm256_loadu_ps((const float*)points);
 
         xmm4 = _mm256_sub_ps(xmm_symbol, xmm_points0);
 
@@ -481,7 +481,7 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_avx2(float* target,
     }
 
     if (num_bytes >> 4 & 1) {
-        xmm9 = _mm_loadu_ps((float*)points);
+        xmm9 = _mm_loadu_ps((const float*)points);
 
         xmm10 = _mm_sub_ps(xmm128_symbol, xmm9);
 
@@ -526,8 +526,8 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_avx(float* target,
     const __m256 xmm_scalar = _mm256_broadcast_ss(&scalar);
 
     for (int i = 0; i < eightsPoints; ++i) {
-        xmm_points0 = _mm256_loadu_ps((float*)points);
-        xmm_points1 = _mm256_loadu_ps((float*)(points + 4));
+        xmm_points0 = _mm256_loadu_ps((const float*)points);
+        xmm_points1 = _mm256_loadu_ps((const float*)(points + 4));
         points += 8;
 
         xmm_result = _mm256_scaled_norm_dist_ps(
@@ -574,8 +574,8 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_sse3(float* target,
     const __m128 xmm_scalar = _mm_load1_ps(&scalar);
 
     for (int i = 0; i < quarterPoints; ++i) {
-        xmm_points0 = _mm_loadu_ps((float*)points);
-        xmm_points1 = _mm_loadu_ps((float*)(points + 2));
+        xmm_points0 = _mm_loadu_ps((const float*)points);
+        xmm_points1 = _mm_loadu_ps((const float*)(points + 2));
         points += 4;
         __VOLK_PREFETCH(points);
         // calculate distances
@@ -587,7 +587,7 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_sse3(float* target,
     }
 
     for (int i = 0; i < leftovers0; ++i) {
-        xmm_points0 = _mm_loadu_ps((float*)points);
+        xmm_points0 = _mm_loadu_ps((const float*)points);
         points += 2;
 
         xmm_points0 = _mm_sub_ps(xmm_symbol, xmm_points0);
@@ -618,8 +618,8 @@ volk_32fc_x2_s32f_square_dist_scalar_mult_32f_u_sse(float* target,
     const __m128 xmm_symbol = _mm_castpd_ps(_mm_load1_pd((const double*)src0));
 
     for (unsigned i = 0; i < num_points / 4; ++i) {
-        __m128 xmm_points0 = _mm_loadu_ps((float*)points);
-        __m128 xmm_points1 = _mm_loadu_ps((float*)(points + 2));
+        __m128 xmm_points0 = _mm_loadu_ps((const float*)points);
+        __m128 xmm_points1 = _mm_loadu_ps((const float*)(points + 2));
         points += 4;
         __m128 xmm_result = _mm_scaled_norm_dist_ps_sse(
             xmm_symbol, xmm_symbol, xmm_points0, xmm_points1, xmm_scalar);

--- a/kernels/volk/volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc.h
+++ b/kernels/volk/volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc.h
@@ -71,8 +71,8 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_H
-#define INCLUDED_volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_H
+#ifndef INCLUDED_volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_u_H
+#define INCLUDED_volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_u_H
 
 #include <float.h>
 #include <inttypes.h>
@@ -113,6 +113,49 @@ volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_generic(lv_32fc_t* cVector,
     }
 }
 #endif /* LV_HAVE_GENERIC */
+
+
+#ifdef LV_HAVE_SSE3
+#include <pmmintrin.h>
+#include <volk/volk_sse3_intrinsics.h>
+
+static inline void
+volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_u_sse3(lv_32fc_t* cVector,
+                                                       const lv_32fc_t* aVector,
+                                                       const lv_32fc_t* bVector,
+                                                       const lv_32fc_t* scalar,
+                                                       unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int halfPoints = num_points / 2;
+
+    __m128 x, y, s, z;
+    lv_32fc_t v_scalar[2] = { *scalar, *scalar };
+
+    const lv_32fc_t* a = aVector;
+    const lv_32fc_t* b = bVector;
+    lv_32fc_t* c = cVector;
+
+    // Set up constant scalar vector
+    s = _mm_loadu_ps((float*)v_scalar);
+
+    for (; number < halfPoints; number++) {
+        x = _mm_loadu_ps((const float*)b);
+        y = _mm_loadu_ps((const float*)a);
+        z = _mm_complexconjugatemul_ps(s, x);
+        z = _mm_add_ps(y, z);
+        _mm_storeu_ps((float*)c, z);
+
+        a += 2;
+        b += 2;
+        c += 2;
+    }
+
+    if ((num_points % 2) != 0) {
+        *c = *a + lv_conj(*b) * (*scalar);
+    }
+}
+#endif /* LV_HAVE_SSE3 */
 
 
 #ifdef LV_HAVE_AVX
@@ -158,137 +201,6 @@ volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_u_avx(lv_32fc_t* cVector,
     }
 }
 #endif /* LV_HAVE_AVX */
-
-
-#ifdef LV_HAVE_SSE3
-#include <pmmintrin.h>
-#include <volk/volk_sse3_intrinsics.h>
-
-static inline void
-volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_u_sse3(lv_32fc_t* cVector,
-                                                       const lv_32fc_t* aVector,
-                                                       const lv_32fc_t* bVector,
-                                                       const lv_32fc_t* scalar,
-                                                       unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int halfPoints = num_points / 2;
-
-    __m128 x, y, s, z;
-    lv_32fc_t v_scalar[2] = { *scalar, *scalar };
-
-    const lv_32fc_t* a = aVector;
-    const lv_32fc_t* b = bVector;
-    lv_32fc_t* c = cVector;
-
-    // Set up constant scalar vector
-    s = _mm_loadu_ps((float*)v_scalar);
-
-    for (; number < halfPoints; number++) {
-        x = _mm_loadu_ps((const float*)b);
-        y = _mm_loadu_ps((const float*)a);
-        z = _mm_complexconjugatemul_ps(s, x);
-        z = _mm_add_ps(y, z);
-        _mm_storeu_ps((float*)c, z);
-
-        a += 2;
-        b += 2;
-        c += 2;
-    }
-
-    if ((num_points % 2) != 0) {
-        *c = *a + lv_conj(*b) * (*scalar);
-    }
-}
-#endif /* LV_HAVE_SSE */
-
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-#include <volk/volk_avx_intrinsics.h>
-
-static inline void
-volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_a_avx(lv_32fc_t* cVector,
-                                                      const lv_32fc_t* aVector,
-                                                      const lv_32fc_t* bVector,
-                                                      const lv_32fc_t* scalar,
-                                                      unsigned int num_points)
-{
-    unsigned int number = 0;
-    unsigned int i = 0;
-    const unsigned int quarterPoints = num_points / 4;
-    unsigned int isodd = num_points & 3;
-
-    __m256 x, y, s, z;
-    lv_32fc_t v_scalar[4] = { *scalar, *scalar, *scalar, *scalar };
-
-    const lv_32fc_t* a = aVector;
-    const lv_32fc_t* b = bVector;
-    lv_32fc_t* c = cVector;
-
-    // Set up constant scalar vector
-    s = _mm256_loadu_ps((float*)v_scalar);
-
-    for (; number < quarterPoints; number++) {
-        x = _mm256_load_ps((const float*)b);
-        y = _mm256_load_ps((const float*)a);
-        z = _mm256_complexconjugatemul_ps(s, x);
-        z = _mm256_add_ps(y, z);
-        _mm256_store_ps((float*)c, z);
-
-        a += 4;
-        b += 4;
-        c += 4;
-    }
-
-    for (i = num_points - isodd; i < num_points; i++) {
-        *c++ = (*a++) + lv_conj(*b++) * (*scalar);
-    }
-}
-#endif /* LV_HAVE_AVX */
-
-
-#ifdef LV_HAVE_SSE3
-#include <pmmintrin.h>
-#include <volk/volk_sse3_intrinsics.h>
-
-static inline void
-volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_a_sse3(lv_32fc_t* cVector,
-                                                       const lv_32fc_t* aVector,
-                                                       const lv_32fc_t* bVector,
-                                                       const lv_32fc_t* scalar,
-                                                       unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int halfPoints = num_points / 2;
-
-    __m128 x, y, s, z;
-    lv_32fc_t v_scalar[2] = { *scalar, *scalar };
-
-    const lv_32fc_t* a = aVector;
-    const lv_32fc_t* b = bVector;
-    lv_32fc_t* c = cVector;
-
-    // Set up constant scalar vector
-    s = _mm_loadu_ps((float*)v_scalar);
-
-    for (; number < halfPoints; number++) {
-        x = _mm_load_ps((const float*)b);
-        y = _mm_load_ps((const float*)a);
-        z = _mm_complexconjugatemul_ps(s, x);
-        z = _mm_add_ps(y, z);
-        _mm_store_ps((float*)c, z);
-
-        a += 2;
-        b += 2;
-        c += 2;
-    }
-
-    if ((num_points % 2) != 0) {
-        *c = *a + lv_conj(*b) * (*scalar);
-    }
-}
-#endif /* LV_HAVE_SSE */
 
 
 #ifdef LV_HAVE_NEON
@@ -428,7 +340,7 @@ volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_rvv(lv_32fc_t* cVector,
         __riscv_vse64((uint64_t*)cVector, v, vl);
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
 
 #ifdef LV_HAVE_RVVSEG
 #include <riscv_vector.h>
@@ -459,6 +371,98 @@ volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_rvvseg(lv_32fc_t* cVector,
             (float*)cVector, __riscv_vcreate_v_f32m4x2(vr, vi), vl);
     }
 }
-#endif /*LV_HAVE_RVVSEG*/
+#endif /* LV_HAVE_RVVSEG */
 
-#endif /* INCLUDED_volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_H */
+#endif /* INCLUDED_volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_u_H */
+
+#ifndef INCLUDED_volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_a_H
+#define INCLUDED_volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_a_H
+
+#ifdef LV_HAVE_SSE3
+#include <pmmintrin.h>
+#include <volk/volk_sse3_intrinsics.h>
+
+static inline void
+volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_a_sse3(lv_32fc_t* cVector,
+                                                       const lv_32fc_t* aVector,
+                                                       const lv_32fc_t* bVector,
+                                                       const lv_32fc_t* scalar,
+                                                       unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int halfPoints = num_points / 2;
+
+    __m128 x, y, s, z;
+    lv_32fc_t v_scalar[2] = { *scalar, *scalar };
+
+    const lv_32fc_t* a = aVector;
+    const lv_32fc_t* b = bVector;
+    lv_32fc_t* c = cVector;
+
+    // Set up constant scalar vector
+    s = _mm_loadu_ps((float*)v_scalar);
+
+    for (; number < halfPoints; number++) {
+        x = _mm_load_ps((const float*)b);
+        y = _mm_load_ps((const float*)a);
+        z = _mm_complexconjugatemul_ps(s, x);
+        z = _mm_add_ps(y, z);
+        _mm_store_ps((float*)c, z);
+
+        a += 2;
+        b += 2;
+        c += 2;
+    }
+
+    if ((num_points % 2) != 0) {
+        *c = *a + lv_conj(*b) * (*scalar);
+    }
+}
+#endif /* LV_HAVE_SSE3 */
+
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+#include <volk/volk_avx_intrinsics.h>
+
+static inline void
+volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_a_avx(lv_32fc_t* cVector,
+                                                      const lv_32fc_t* aVector,
+                                                      const lv_32fc_t* bVector,
+                                                      const lv_32fc_t* scalar,
+                                                      unsigned int num_points)
+{
+    unsigned int number = 0;
+    unsigned int i = 0;
+    const unsigned int quarterPoints = num_points / 4;
+    unsigned int isodd = num_points & 3;
+
+    __m256 x, y, s, z;
+    lv_32fc_t v_scalar[4] = { *scalar, *scalar, *scalar, *scalar };
+
+    const lv_32fc_t* a = aVector;
+    const lv_32fc_t* b = bVector;
+    lv_32fc_t* c = cVector;
+
+    // Set up constant scalar vector
+    s = _mm256_loadu_ps((float*)v_scalar);
+
+    for (; number < quarterPoints; number++) {
+        x = _mm256_load_ps((const float*)b);
+        y = _mm256_load_ps((const float*)a);
+        z = _mm256_complexconjugatemul_ps(s, x);
+        z = _mm256_add_ps(y, z);
+        _mm256_store_ps((float*)c, z);
+
+        a += 4;
+        b += 4;
+        c += 4;
+    }
+
+    for (i = num_points - isodd; i < num_points; i++) {
+        *c++ = (*a++) + lv_conj(*b++) * (*scalar);
+    }
+}
+#endif /* LV_HAVE_AVX */
+
+#endif /* INCLUDED_volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_a_H */

--- a/kernels/volk/volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc.h
+++ b/kernels/volk/volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc.h
@@ -142,8 +142,8 @@ volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_u_avx(lv_32fc_t* cVector,
     s = _mm256_loadu_ps((float*)v_scalar);
 
     for (; number < quarterPoints; number++) {
-        x = _mm256_loadu_ps((float*)b);
-        y = _mm256_loadu_ps((float*)a);
+        x = _mm256_loadu_ps((const float*)b);
+        y = _mm256_loadu_ps((const float*)a);
         z = _mm256_complexconjugatemul_ps(s, x);
         z = _mm256_add_ps(y, z);
         _mm256_storeu_ps((float*)c, z);
@@ -185,8 +185,8 @@ volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_u_sse3(lv_32fc_t* cVector,
     s = _mm_loadu_ps((float*)v_scalar);
 
     for (; number < halfPoints; number++) {
-        x = _mm_loadu_ps((float*)b);
-        y = _mm_loadu_ps((float*)a);
+        x = _mm_loadu_ps((const float*)b);
+        y = _mm_loadu_ps((const float*)a);
         z = _mm_complexconjugatemul_ps(s, x);
         z = _mm_add_ps(y, z);
         _mm_storeu_ps((float*)c, z);
@@ -230,8 +230,8 @@ volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_a_avx(lv_32fc_t* cVector,
     s = _mm256_loadu_ps((float*)v_scalar);
 
     for (; number < quarterPoints; number++) {
-        x = _mm256_load_ps((float*)b);
-        y = _mm256_load_ps((float*)a);
+        x = _mm256_load_ps((const float*)b);
+        y = _mm256_load_ps((const float*)a);
         z = _mm256_complexconjugatemul_ps(s, x);
         z = _mm256_add_ps(y, z);
         _mm256_store_ps((float*)c, z);
@@ -273,8 +273,8 @@ volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_a_sse3(lv_32fc_t* cVector,
     s = _mm_loadu_ps((float*)v_scalar);
 
     for (; number < halfPoints; number++) {
-        x = _mm_load_ps((float*)b);
-        y = _mm_load_ps((float*)a);
+        x = _mm_load_ps((const float*)b);
+        y = _mm_load_ps((const float*)a);
         z = _mm_complexconjugatemul_ps(s, x);
         z = _mm_add_ps(y, z);
         _mm_store_ps((float*)c, z);
@@ -314,8 +314,8 @@ volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_neon(lv_32fc_t* cVector,
     scalar_val.val[1] = vld1q_dup_f32(((const float*)scalar) + 1);
 
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld2q_f32((float*)aPtr);
-        b_val = vld2q_f32((float*)bPtr);
+        a_val = vld2q_f32((const float*)aPtr);
+        b_val = vld2q_f32((const float*)bPtr);
         b_val.val[1] = vnegq_f32(b_val.val[1]);
         __VOLK_PREFETCH(aPtr + 8);
         __VOLK_PREFETCH(bPtr + 8);
@@ -365,8 +365,8 @@ volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc_neonv8(lv_32fc_t* cVector,
     float32x4_t scalar_imag = vdupq_n_f32(lv_cimag(*scalar));
 
     for (number = 0; number < quarter_points; ++number) {
-        a_val = vld2q_f32((float*)aPtr);
-        b_val = vld2q_f32((float*)bPtr);
+        a_val = vld2q_f32((const float*)aPtr);
+        b_val = vld2q_f32((const float*)bPtr);
         __VOLK_PREFETCH(aPtr + 8);
         __VOLK_PREFETCH(bPtr + 8);
 

--- a/kernels/volk/volk_32fc_x2_square_dist_32f.h
+++ b/kernels/volk/volk_32fc_x2_square_dist_32f.h
@@ -62,12 +62,312 @@
  * \endcode
  */
 
+#ifndef INCLUDED_volk_32fc_x2_square_dist_32f_u_H
+#define INCLUDED_volk_32fc_x2_square_dist_32f_u_H
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <volk/volk_complex.h>
+
+#ifdef LV_HAVE_GENERIC
+static inline void volk_32fc_x2_square_dist_32f_generic(float* target,
+                                                        const lv_32fc_t* src0,
+                                                        const lv_32fc_t* points,
+                                                        unsigned int num_points)
+{
+    const unsigned int num_bytes = num_points * 8;
+
+    lv_32fc_t diff;
+    float sq_dist;
+    unsigned int i = 0;
+
+    for (; i < (num_bytes >> 3); ++i) {
+        diff = src0[0] - points[i];
+
+        sq_dist = lv_creal(diff) * lv_creal(diff) + lv_cimag(diff) * lv_cimag(diff);
+
+        target[i] = sq_dist;
+    }
+}
+
+#endif /*LV_HAVE_GENERIC*/
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void volk_32fc_x2_square_dist_32f_u_avx2(float* target,
+                                                       const lv_32fc_t* src0,
+                                                       const lv_32fc_t* points,
+                                                       unsigned int num_points)
+{
+    const unsigned int num_bytes = num_points * 8;
+    __m128 xmm0, xmm9;
+    __m256 xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7;
+
+    lv_32fc_t diff;
+    float sq_dist;
+    int bound = num_bytes >> 6;
+    int leftovers1 = (num_bytes >> 3) & 0b11;
+    int i = 0;
+
+    __m256i idx = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
+    xmm1 = _mm256_setzero_ps();
+    xmm0 = _mm_loadu_ps((const float*)src0);
+    xmm0 = _mm_permute_ps(xmm0, 0b01000100);
+    xmm1 = _mm256_insertf128_ps(xmm1, xmm0, 0);
+    xmm1 = _mm256_insertf128_ps(xmm1, xmm0, 1);
+
+    for (; i < bound; ++i) {
+        xmm2 = _mm256_loadu_ps((const float*)&points[0]);
+        xmm3 = _mm256_loadu_ps((const float*)&points[4]);
+        points += 8;
+
+        xmm4 = _mm256_sub_ps(xmm1, xmm2);
+        xmm5 = _mm256_sub_ps(xmm1, xmm3);
+        xmm6 = _mm256_mul_ps(xmm4, xmm4);
+        xmm7 = _mm256_mul_ps(xmm5, xmm5);
+
+        xmm4 = _mm256_hadd_ps(xmm6, xmm7);
+        xmm4 = _mm256_permutevar8x32_ps(xmm4, idx);
+
+        _mm256_storeu_ps(target, xmm4);
+
+        target += 8;
+    }
+
+    if (num_bytes >> 5 & 1) {
+
+        xmm2 = _mm256_loadu_ps((const float*)&points[0]);
+
+        xmm4 = _mm256_sub_ps(xmm1, xmm2);
+
+        points += 4;
+
+        xmm6 = _mm256_mul_ps(xmm4, xmm4);
+
+        xmm4 = _mm256_hadd_ps(xmm6, xmm6);
+        xmm4 = _mm256_permutevar8x32_ps(xmm4, idx);
+
+        xmm9 = _mm256_extractf128_ps(xmm4, 1);
+        _mm_storeu_ps(target, xmm9);
+
+        target += 4;
+    }
+
+    for (i = 0; i < leftovers1; ++i) {
+
+        diff = src0[0] - points[0];
+        points += 1;
+
+        sq_dist = lv_creal(diff) * lv_creal(diff) + lv_cimag(diff) * lv_cimag(diff);
+
+        target[0] = sq_dist;
+        target += 1;
+    }
+}
+
+#endif /*LV_HAVE_AVX2*/
+
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+static inline void volk_32fc_x2_square_dist_32f_neon(float* target,
+                                                     const lv_32fc_t* src0,
+                                                     const lv_32fc_t* points,
+                                                     unsigned int num_points)
+{
+    const unsigned int quarter_points = num_points / 4;
+    unsigned int number;
+
+    float32x4x2_t a_vec, b_vec;
+    float32x4x2_t diff_vec;
+    float32x4_t tmp, tmp1, dist_sq;
+    a_vec.val[0] = vdupq_n_f32(lv_creal(src0[0]));
+    a_vec.val[1] = vdupq_n_f32(lv_cimag(src0[0]));
+    for (number = 0; number < quarter_points; ++number) {
+        b_vec = vld2q_f32((const float*)points);
+        diff_vec.val[0] = vsubq_f32(a_vec.val[0], b_vec.val[0]);
+        diff_vec.val[1] = vsubq_f32(a_vec.val[1], b_vec.val[1]);
+        tmp = vmulq_f32(diff_vec.val[0], diff_vec.val[0]);
+        tmp1 = vmulq_f32(diff_vec.val[1], diff_vec.val[1]);
+
+        dist_sq = vaddq_f32(tmp, tmp1);
+        vst1q_f32(target, dist_sq);
+        points += 4;
+        target += 4;
+    }
+    for (number = quarter_points * 4; number < num_points; ++number) {
+        lv_32fc_t diff = src0[0] - *points++;
+        *target++ = lv_creal(diff) * lv_creal(diff) + lv_cimag(diff) * lv_cimag(diff);
+    }
+}
+#endif /* LV_HAVE_NEON */
+
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_32fc_x2_square_dist_32f_neonv8(float* target,
+                                                       const lv_32fc_t* src0,
+                                                       const lv_32fc_t* points,
+                                                       unsigned int num_points)
+{
+    const unsigned int quarter_points = num_points / 4;
+    unsigned int number;
+
+    float32x4x2_t b_vec;
+    float32x4_t diff_real, diff_imag, dist_sq;
+    float32x4_t a_real = vdupq_n_f32(lv_creal(src0[0]));
+    float32x4_t a_imag = vdupq_n_f32(lv_cimag(src0[0]));
+
+    for (number = 0; number < quarter_points; ++number) {
+        b_vec = vld2q_f32((const float*)points);
+        __VOLK_PREFETCH(points + 8);
+
+        diff_real = vsubq_f32(a_real, b_vec.val[0]);
+        diff_imag = vsubq_f32(a_imag, b_vec.val[1]);
+
+        /* dist_sq = diff_real^2 + diff_imag^2 using FMA */
+        dist_sq = vfmaq_f32(vmulq_f32(diff_real, diff_real), diff_imag, diff_imag);
+
+        vst1q_f32(target, dist_sq);
+        points += 4;
+        target += 4;
+    }
+
+    for (number = quarter_points * 4; number < num_points; ++number) {
+        lv_32fc_t diff = src0[0] - *points++;
+        *target++ = lv_creal(diff) * lv_creal(diff) + lv_cimag(diff) * lv_cimag(diff);
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_32fc_x2_square_dist_32f_rvv(float* target,
+                                                    const lv_32fc_t* src0,
+                                                    const lv_32fc_t* points,
+                                                    unsigned int num_points)
+{
+    size_t vlmax = __riscv_vsetvlmax_e32m4();
+    vfloat32m4_t var = __riscv_vfmv_v_f_f32m4(lv_creal(*src0), vlmax);
+    vfloat32m4_t vai = __riscv_vfmv_v_f_f32m4(lv_cimag(*src0), vlmax);
+
+    size_t n = num_points;
+    for (size_t vl; n > 0; n -= vl, target += vl, points += vl) {
+        vl = __riscv_vsetvl_e32m4(n);
+        vuint64m8_t vb = __riscv_vle64_v_u64m8((const uint64_t*)points, vl);
+        vfloat32m4_t vbr = __riscv_vreinterpret_f32m4(__riscv_vnsrl(vb, 0, vl));
+        vfloat32m4_t vbi = __riscv_vreinterpret_f32m4(__riscv_vnsrl(vb, 32, vl));
+        vfloat32m4_t vr = __riscv_vfsub(var, vbr, vl);
+        vfloat32m4_t vi = __riscv_vfsub(vai, vbi, vl);
+        vfloat32m4_t v = __riscv_vfmacc(__riscv_vfmul(vi, vi, vl), vr, vr, vl);
+        __riscv_vse32(target, v, vl);
+    }
+}
+#endif /*LV_HAVE_RVV*/
+
+#ifdef LV_HAVE_RVVSEG
+#include <riscv_vector.h>
+
+static inline void volk_32fc_x2_square_dist_32f_rvvseg(float* target,
+                                                       const lv_32fc_t* src0,
+                                                       const lv_32fc_t* points,
+                                                       unsigned int num_points)
+{
+    size_t vlmax = __riscv_vsetvlmax_e32m4();
+    vfloat32m4_t var = __riscv_vfmv_v_f_f32m4(lv_creal(*src0), vlmax);
+    vfloat32m4_t vai = __riscv_vfmv_v_f_f32m4(lv_cimag(*src0), vlmax);
+
+    size_t n = num_points;
+    for (size_t vl; n > 0; n -= vl, target += vl, points += vl) {
+        vl = __riscv_vsetvl_e32m4(n);
+        vfloat32m4x2_t vb = __riscv_vlseg2e32_v_f32m4x2((const float*)points, vl);
+        vfloat32m4_t vbr = __riscv_vget_f32m4(vb, 0);
+        vfloat32m4_t vbi = __riscv_vget_f32m4(vb, 1);
+        vfloat32m4_t vr = __riscv_vfsub(var, vbr, vl);
+        vfloat32m4_t vi = __riscv_vfsub(vai, vbi, vl);
+        vfloat32m4_t v = __riscv_vfmacc(__riscv_vfmul(vi, vi, vl), vr, vr, vl);
+        __riscv_vse32(target, v, vl);
+    }
+}
+#endif /*LV_HAVE_RVVSEG*/
+
+#endif /*INCLUDED_volk_32fc_x2_square_dist_32f_u_H*/
+
 #ifndef INCLUDED_volk_32fc_x2_square_dist_32f_a_H
 #define INCLUDED_volk_32fc_x2_square_dist_32f_a_H
 
 #include <inttypes.h>
 #include <stdio.h>
 #include <volk/volk_complex.h>
+
+#ifdef LV_HAVE_SSE3
+#include <pmmintrin.h>
+#include <xmmintrin.h>
+
+static inline void volk_32fc_x2_square_dist_32f_a_sse3(float* target,
+                                                       const lv_32fc_t* src0,
+                                                       const lv_32fc_t* points,
+                                                       unsigned int num_points)
+{
+    const unsigned int num_bytes = num_points * 8;
+
+    __m128 xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7;
+
+    lv_32fc_t diff;
+    float sq_dist;
+    int bound = num_bytes >> 5;
+    int i = 0;
+
+    xmm1 = _mm_setzero_ps();
+    xmm1 = _mm_loadl_pi(xmm1, (const __m64*)src0);
+    xmm1 = _mm_movelh_ps(xmm1, xmm1);
+
+    for (; i < bound; ++i) {
+        xmm2 = _mm_load_ps((const float*)&points[0]);
+        xmm4 = _mm_sub_ps(xmm1, xmm2);
+        xmm3 = _mm_load_ps((const float*)&points[2]);
+        xmm5 = _mm_sub_ps(xmm1, xmm3);
+
+        xmm6 = _mm_mul_ps(xmm4, xmm4);
+        xmm7 = _mm_mul_ps(xmm5, xmm5);
+
+        xmm4 = _mm_hadd_ps(xmm6, xmm7);
+
+        _mm_store_ps(target, xmm4);
+
+        points += 4;
+        target += 4;
+    }
+
+    if (num_bytes >> 4 & 1) {
+
+        xmm2 = _mm_load_ps((const float*)&points[0]);
+
+        xmm4 = _mm_sub_ps(xmm1, xmm2);
+
+        points += 2;
+
+        xmm6 = _mm_mul_ps(xmm4, xmm4);
+
+        xmm4 = _mm_hadd_ps(xmm6, xmm6);
+
+        _mm_storeh_pi((__m64*)target, xmm4);
+
+        target += 2;
+    }
+
+    if (num_bytes >> 3 & 1) {
+
+        diff = src0[0] - points[0];
+
+        sq_dist = lv_creal(diff) * lv_creal(diff) + lv_cimag(diff) * lv_cimag(diff);
+
+        target[0] = sq_dist;
+    }
+}
+
+#endif /*LV_HAVE_SSE3*/
 
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
@@ -161,307 +461,4 @@ static inline void volk_32fc_x2_square_dist_32f_a_avx2(float* target,
 
 #endif /*LV_HAVE_AVX2*/
 
-#ifdef LV_HAVE_SSE3
-#include <pmmintrin.h>
-#include <xmmintrin.h>
-
-static inline void volk_32fc_x2_square_dist_32f_a_sse3(float* target,
-                                                       const lv_32fc_t* src0,
-                                                       const lv_32fc_t* points,
-                                                       unsigned int num_points)
-{
-    const unsigned int num_bytes = num_points * 8;
-
-    __m128 xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7;
-
-    lv_32fc_t diff;
-    float sq_dist;
-    int bound = num_bytes >> 5;
-    int i = 0;
-
-    xmm1 = _mm_setzero_ps();
-    xmm1 = _mm_loadl_pi(xmm1, (const __m64*)src0);
-    xmm1 = _mm_movelh_ps(xmm1, xmm1);
-
-    for (; i < bound; ++i) {
-        xmm2 = _mm_load_ps((const float*)&points[0]);
-        xmm4 = _mm_sub_ps(xmm1, xmm2);
-        xmm3 = _mm_load_ps((const float*)&points[2]);
-        xmm5 = _mm_sub_ps(xmm1, xmm3);
-
-        xmm6 = _mm_mul_ps(xmm4, xmm4);
-        xmm7 = _mm_mul_ps(xmm5, xmm5);
-
-        xmm4 = _mm_hadd_ps(xmm6, xmm7);
-
-        _mm_store_ps(target, xmm4);
-
-        points += 4;
-        target += 4;
-    }
-
-    if (num_bytes >> 4 & 1) {
-
-        xmm2 = _mm_load_ps((const float*)&points[0]);
-
-        xmm4 = _mm_sub_ps(xmm1, xmm2);
-
-        points += 2;
-
-        xmm6 = _mm_mul_ps(xmm4, xmm4);
-
-        xmm4 = _mm_hadd_ps(xmm6, xmm6);
-
-        _mm_storeh_pi((__m64*)target, xmm4);
-
-        target += 2;
-    }
-
-    if (num_bytes >> 3 & 1) {
-
-        diff = src0[0] - points[0];
-
-        sq_dist = lv_creal(diff) * lv_creal(diff) + lv_cimag(diff) * lv_cimag(diff);
-
-        target[0] = sq_dist;
-    }
-}
-
-#endif /*LV_HAVE_SSE3*/
-
-
-#ifdef LV_HAVE_NEON
-#include <arm_neon.h>
-static inline void volk_32fc_x2_square_dist_32f_neon(float* target,
-                                                     const lv_32fc_t* src0,
-                                                     const lv_32fc_t* points,
-                                                     unsigned int num_points)
-{
-    const unsigned int quarter_points = num_points / 4;
-    unsigned int number;
-
-    float32x4x2_t a_vec, b_vec;
-    float32x4x2_t diff_vec;
-    float32x4_t tmp, tmp1, dist_sq;
-    a_vec.val[0] = vdupq_n_f32(lv_creal(src0[0]));
-    a_vec.val[1] = vdupq_n_f32(lv_cimag(src0[0]));
-    for (number = 0; number < quarter_points; ++number) {
-        b_vec = vld2q_f32((const float*)points);
-        diff_vec.val[0] = vsubq_f32(a_vec.val[0], b_vec.val[0]);
-        diff_vec.val[1] = vsubq_f32(a_vec.val[1], b_vec.val[1]);
-        tmp = vmulq_f32(diff_vec.val[0], diff_vec.val[0]);
-        tmp1 = vmulq_f32(diff_vec.val[1], diff_vec.val[1]);
-
-        dist_sq = vaddq_f32(tmp, tmp1);
-        vst1q_f32(target, dist_sq);
-        points += 4;
-        target += 4;
-    }
-    for (number = quarter_points * 4; number < num_points; ++number) {
-        lv_32fc_t diff = src0[0] - *points++;
-        *target++ = lv_creal(diff) * lv_creal(diff) + lv_cimag(diff) * lv_cimag(diff);
-    }
-}
-#endif /* LV_HAVE_NEON */
-
-#ifdef LV_HAVE_NEONV8
-#include <arm_neon.h>
-
-static inline void volk_32fc_x2_square_dist_32f_neonv8(float* target,
-                                                       const lv_32fc_t* src0,
-                                                       const lv_32fc_t* points,
-                                                       unsigned int num_points)
-{
-    const unsigned int quarter_points = num_points / 4;
-    unsigned int number;
-
-    float32x4x2_t b_vec;
-    float32x4_t diff_real, diff_imag, dist_sq;
-    float32x4_t a_real = vdupq_n_f32(lv_creal(src0[0]));
-    float32x4_t a_imag = vdupq_n_f32(lv_cimag(src0[0]));
-
-    for (number = 0; number < quarter_points; ++number) {
-        b_vec = vld2q_f32((const float*)points);
-        __VOLK_PREFETCH(points + 8);
-
-        diff_real = vsubq_f32(a_real, b_vec.val[0]);
-        diff_imag = vsubq_f32(a_imag, b_vec.val[1]);
-
-        /* dist_sq = diff_real^2 + diff_imag^2 using FMA */
-        dist_sq = vfmaq_f32(vmulq_f32(diff_real, diff_real), diff_imag, diff_imag);
-
-        vst1q_f32(target, dist_sq);
-        points += 4;
-        target += 4;
-    }
-
-    for (number = quarter_points * 4; number < num_points; ++number) {
-        lv_32fc_t diff = src0[0] - *points++;
-        *target++ = lv_creal(diff) * lv_creal(diff) + lv_cimag(diff) * lv_cimag(diff);
-    }
-}
-#endif /* LV_HAVE_NEONV8 */
-
-
-#ifdef LV_HAVE_GENERIC
-static inline void volk_32fc_x2_square_dist_32f_generic(float* target,
-                                                        const lv_32fc_t* src0,
-                                                        const lv_32fc_t* points,
-                                                        unsigned int num_points)
-{
-    const unsigned int num_bytes = num_points * 8;
-
-    lv_32fc_t diff;
-    float sq_dist;
-    unsigned int i = 0;
-
-    for (; i < (num_bytes >> 3); ++i) {
-        diff = src0[0] - points[i];
-
-        sq_dist = lv_creal(diff) * lv_creal(diff) + lv_cimag(diff) * lv_cimag(diff);
-
-        target[i] = sq_dist;
-    }
-}
-
-#endif /*LV_HAVE_GENERIC*/
-
-
 #endif /*INCLUDED_volk_32fc_x2_square_dist_32f_a_H*/
-
-#ifndef INCLUDED_volk_32fc_x2_square_dist_32f_u_H
-#define INCLUDED_volk_32fc_x2_square_dist_32f_u_H
-
-#include <inttypes.h>
-#include <stdio.h>
-#include <volk/volk_complex.h>
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-
-static inline void volk_32fc_x2_square_dist_32f_u_avx2(float* target,
-                                                       const lv_32fc_t* src0,
-                                                       const lv_32fc_t* points,
-                                                       unsigned int num_points)
-{
-    const unsigned int num_bytes = num_points * 8;
-    __m128 xmm0, xmm9;
-    __m256 xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7;
-
-    lv_32fc_t diff;
-    float sq_dist;
-    int bound = num_bytes >> 6;
-    int leftovers1 = (num_bytes >> 3) & 0b11;
-    int i = 0;
-
-    __m256i idx = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
-    xmm1 = _mm256_setzero_ps();
-    xmm0 = _mm_loadu_ps((const float*)src0);
-    xmm0 = _mm_permute_ps(xmm0, 0b01000100);
-    xmm1 = _mm256_insertf128_ps(xmm1, xmm0, 0);
-    xmm1 = _mm256_insertf128_ps(xmm1, xmm0, 1);
-
-    for (; i < bound; ++i) {
-        xmm2 = _mm256_loadu_ps((const float*)&points[0]);
-        xmm3 = _mm256_loadu_ps((const float*)&points[4]);
-        points += 8;
-
-        xmm4 = _mm256_sub_ps(xmm1, xmm2);
-        xmm5 = _mm256_sub_ps(xmm1, xmm3);
-        xmm6 = _mm256_mul_ps(xmm4, xmm4);
-        xmm7 = _mm256_mul_ps(xmm5, xmm5);
-
-        xmm4 = _mm256_hadd_ps(xmm6, xmm7);
-        xmm4 = _mm256_permutevar8x32_ps(xmm4, idx);
-
-        _mm256_storeu_ps(target, xmm4);
-
-        target += 8;
-    }
-
-    if (num_bytes >> 5 & 1) {
-
-        xmm2 = _mm256_loadu_ps((const float*)&points[0]);
-
-        xmm4 = _mm256_sub_ps(xmm1, xmm2);
-
-        points += 4;
-
-        xmm6 = _mm256_mul_ps(xmm4, xmm4);
-
-        xmm4 = _mm256_hadd_ps(xmm6, xmm6);
-        xmm4 = _mm256_permutevar8x32_ps(xmm4, idx);
-
-        xmm9 = _mm256_extractf128_ps(xmm4, 1);
-        _mm_storeu_ps(target, xmm9);
-
-        target += 4;
-    }
-
-    for (i = 0; i < leftovers1; ++i) {
-
-        diff = src0[0] - points[0];
-        points += 1;
-
-        sq_dist = lv_creal(diff) * lv_creal(diff) + lv_cimag(diff) * lv_cimag(diff);
-
-        target[0] = sq_dist;
-        target += 1;
-    }
-}
-
-#endif /*LV_HAVE_AVX2*/
-
-#ifdef LV_HAVE_RVV
-#include <riscv_vector.h>
-
-static inline void volk_32fc_x2_square_dist_32f_rvv(float* target,
-                                                    const lv_32fc_t* src0,
-                                                    const lv_32fc_t* points,
-                                                    unsigned int num_points)
-{
-    size_t vlmax = __riscv_vsetvlmax_e32m4();
-    vfloat32m4_t var = __riscv_vfmv_v_f_f32m4(lv_creal(*src0), vlmax);
-    vfloat32m4_t vai = __riscv_vfmv_v_f_f32m4(lv_cimag(*src0), vlmax);
-
-    size_t n = num_points;
-    for (size_t vl; n > 0; n -= vl, target += vl, points += vl) {
-        vl = __riscv_vsetvl_e32m4(n);
-        vuint64m8_t vb = __riscv_vle64_v_u64m8((const uint64_t*)points, vl);
-        vfloat32m4_t vbr = __riscv_vreinterpret_f32m4(__riscv_vnsrl(vb, 0, vl));
-        vfloat32m4_t vbi = __riscv_vreinterpret_f32m4(__riscv_vnsrl(vb, 32, vl));
-        vfloat32m4_t vr = __riscv_vfsub(var, vbr, vl);
-        vfloat32m4_t vi = __riscv_vfsub(vai, vbi, vl);
-        vfloat32m4_t v = __riscv_vfmacc(__riscv_vfmul(vi, vi, vl), vr, vr, vl);
-        __riscv_vse32(target, v, vl);
-    }
-}
-#endif /*LV_HAVE_RVV*/
-
-#ifdef LV_HAVE_RVVSEG
-#include <riscv_vector.h>
-
-static inline void volk_32fc_x2_square_dist_32f_rvvseg(float* target,
-                                                       const lv_32fc_t* src0,
-                                                       const lv_32fc_t* points,
-                                                       unsigned int num_points)
-{
-    size_t vlmax = __riscv_vsetvlmax_e32m4();
-    vfloat32m4_t var = __riscv_vfmv_v_f_f32m4(lv_creal(*src0), vlmax);
-    vfloat32m4_t vai = __riscv_vfmv_v_f_f32m4(lv_cimag(*src0), vlmax);
-
-    size_t n = num_points;
-    for (size_t vl; n > 0; n -= vl, target += vl, points += vl) {
-        vl = __riscv_vsetvl_e32m4(n);
-        vfloat32m4x2_t vb = __riscv_vlseg2e32_v_f32m4x2((const float*)points, vl);
-        vfloat32m4_t vbr = __riscv_vget_f32m4(vb, 0);
-        vfloat32m4_t vbi = __riscv_vget_f32m4(vb, 1);
-        vfloat32m4_t vr = __riscv_vfsub(var, vbr, vl);
-        vfloat32m4_t vi = __riscv_vfsub(vai, vbi, vl);
-        vfloat32m4_t v = __riscv_vfmacc(__riscv_vfmul(vi, vi, vl), vr, vr, vl);
-        __riscv_vse32(target, v, vl);
-    }
-}
-#endif /*LV_HAVE_RVVSEG*/
-
-#endif /*INCLUDED_volk_32fc_x2_square_dist_32f_u_H*/

--- a/kernels/volk/volk_32fc_x2_square_dist_32f.h
+++ b/kernels/volk/volk_32fc_x2_square_dist_32f.h
@@ -91,14 +91,14 @@ static inline void volk_32fc_x2_square_dist_32f_a_avx2(float* target,
 
     __m256i idx = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
     xmm1 = _mm256_setzero_ps();
-    xmm0 = _mm_load_ps((float*)src0);
+    xmm0 = _mm_load_ps((const float*)src0);
     xmm0 = _mm_permute_ps(xmm0, 0b01000100);
     xmm1 = _mm256_insertf128_ps(xmm1, xmm0, 0);
     xmm1 = _mm256_insertf128_ps(xmm1, xmm0, 1);
 
     for (; i < bound; ++i) {
-        xmm2 = _mm256_load_ps((float*)&points[0]);
-        xmm3 = _mm256_load_ps((float*)&points[4]);
+        xmm2 = _mm256_load_ps((const float*)&points[0]);
+        xmm3 = _mm256_load_ps((const float*)&points[4]);
         points += 8;
 
         xmm4 = _mm256_sub_ps(xmm1, xmm2);
@@ -116,7 +116,7 @@ static inline void volk_32fc_x2_square_dist_32f_a_avx2(float* target,
 
     for (i = 0; i < leftovers0; ++i) {
 
-        xmm2 = _mm256_load_ps((float*)&points[0]);
+        xmm2 = _mm256_load_ps((const float*)&points[0]);
 
         xmm4 = _mm256_sub_ps(xmm1, xmm2);
 
@@ -134,7 +134,7 @@ static inline void volk_32fc_x2_square_dist_32f_a_avx2(float* target,
     }
 
     for (i = 0; i < leftovers1; ++i) {
-        xmm9 = _mm_load_ps((float*)&points[0]);
+        xmm9 = _mm_load_ps((const float*)&points[0]);
 
         xmm10 = _mm_sub_ps(xmm0, xmm9);
 
@@ -180,13 +180,13 @@ static inline void volk_32fc_x2_square_dist_32f_a_sse3(float* target,
     int i = 0;
 
     xmm1 = _mm_setzero_ps();
-    xmm1 = _mm_loadl_pi(xmm1, (__m64*)src0);
+    xmm1 = _mm_loadl_pi(xmm1, (const __m64*)src0);
     xmm1 = _mm_movelh_ps(xmm1, xmm1);
 
     for (; i < bound; ++i) {
-        xmm2 = _mm_load_ps((float*)&points[0]);
+        xmm2 = _mm_load_ps((const float*)&points[0]);
         xmm4 = _mm_sub_ps(xmm1, xmm2);
-        xmm3 = _mm_load_ps((float*)&points[2]);
+        xmm3 = _mm_load_ps((const float*)&points[2]);
         xmm5 = _mm_sub_ps(xmm1, xmm3);
 
         xmm6 = _mm_mul_ps(xmm4, xmm4);
@@ -202,7 +202,7 @@ static inline void volk_32fc_x2_square_dist_32f_a_sse3(float* target,
 
     if (num_bytes >> 4 & 1) {
 
-        xmm2 = _mm_load_ps((float*)&points[0]);
+        xmm2 = _mm_load_ps((const float*)&points[0]);
 
         xmm4 = _mm_sub_ps(xmm1, xmm2);
 
@@ -246,7 +246,7 @@ static inline void volk_32fc_x2_square_dist_32f_neon(float* target,
     a_vec.val[0] = vdupq_n_f32(lv_creal(src0[0]));
     a_vec.val[1] = vdupq_n_f32(lv_cimag(src0[0]));
     for (number = 0; number < quarter_points; ++number) {
-        b_vec = vld2q_f32((float*)points);
+        b_vec = vld2q_f32((const float*)points);
         diff_vec.val[0] = vsubq_f32(a_vec.val[0], b_vec.val[0]);
         diff_vec.val[1] = vsubq_f32(a_vec.val[1], b_vec.val[1]);
         tmp = vmulq_f32(diff_vec.val[0], diff_vec.val[0]);
@@ -281,7 +281,7 @@ static inline void volk_32fc_x2_square_dist_32f_neonv8(float* target,
     float32x4_t a_imag = vdupq_n_f32(lv_cimag(src0[0]));
 
     for (number = 0; number < quarter_points; ++number) {
-        b_vec = vld2q_f32((float*)points);
+        b_vec = vld2q_f32((const float*)points);
         __VOLK_PREFETCH(points + 8);
 
         diff_real = vsubq_f32(a_real, b_vec.val[0]);
@@ -356,14 +356,14 @@ static inline void volk_32fc_x2_square_dist_32f_u_avx2(float* target,
 
     __m256i idx = _mm256_set_epi32(7, 6, 3, 2, 5, 4, 1, 0);
     xmm1 = _mm256_setzero_ps();
-    xmm0 = _mm_loadu_ps((float*)src0);
+    xmm0 = _mm_loadu_ps((const float*)src0);
     xmm0 = _mm_permute_ps(xmm0, 0b01000100);
     xmm1 = _mm256_insertf128_ps(xmm1, xmm0, 0);
     xmm1 = _mm256_insertf128_ps(xmm1, xmm0, 1);
 
     for (; i < bound; ++i) {
-        xmm2 = _mm256_loadu_ps((float*)&points[0]);
-        xmm3 = _mm256_loadu_ps((float*)&points[4]);
+        xmm2 = _mm256_loadu_ps((const float*)&points[0]);
+        xmm3 = _mm256_loadu_ps((const float*)&points[4]);
         points += 8;
 
         xmm4 = _mm256_sub_ps(xmm1, xmm2);
@@ -381,7 +381,7 @@ static inline void volk_32fc_x2_square_dist_32f_u_avx2(float* target,
 
     if (num_bytes >> 5 & 1) {
 
-        xmm2 = _mm256_loadu_ps((float*)&points[0]);
+        xmm2 = _mm256_loadu_ps((const float*)&points[0]);
 
         xmm4 = _mm256_sub_ps(xmm1, xmm2);
 

--- a/kernels/volk/volk_32i_s32f_convert_32f.h
+++ b/kernels/volk/volk_32i_s32f_convert_32f.h
@@ -68,13 +68,13 @@ static inline void volk_32i_s32f_convert_32f_u_avx512f(float* outputVector,
     float* outputVectorPtr = outputVector;
     const float iScalar = 1.0 / scalar;
     __m512 invScalar = _mm512_set1_ps(iScalar);
-    int32_t* inputPtr = (int32_t*)inputVector;
+    const int32_t* inputPtr = (const int32_t*)inputVector;
     __m512i inputVal;
     __m512 ret;
 
     for (; number < onesixteenthPoints; number++) {
         // Load the values
-        inputVal = _mm512_loadu_si512((__m512i*)inputPtr);
+        inputVal = _mm512_loadu_si512((const __m512i*)inputPtr);
 
         ret = _mm512_cvtepi32_ps(inputVal);
         ret = _mm512_mul_ps(ret, invScalar);
@@ -107,13 +107,13 @@ static inline void volk_32i_s32f_convert_32f_u_avx2(float* outputVector,
     float* outputVectorPtr = outputVector;
     const float iScalar = 1.0 / scalar;
     __m256 invScalar = _mm256_set1_ps(iScalar);
-    int32_t* inputPtr = (int32_t*)inputVector;
+    const int32_t* inputPtr = (const int32_t*)inputVector;
     __m256i inputVal;
     __m256 ret;
 
     for (; number < oneEightPoints; number++) {
         // Load the 4 values
-        inputVal = _mm256_loadu_si256((__m256i*)inputPtr);
+        inputVal = _mm256_loadu_si256((const __m256i*)inputPtr);
 
         ret = _mm256_cvtepi32_ps(inputVal);
         ret = _mm256_mul_ps(ret, invScalar);
@@ -146,13 +146,13 @@ static inline void volk_32i_s32f_convert_32f_u_sse2(float* outputVector,
     float* outputVectorPtr = outputVector;
     const float iScalar = 1.0 / scalar;
     __m128 invScalar = _mm_set_ps1(iScalar);
-    int32_t* inputPtr = (int32_t*)inputVector;
+    const int32_t* inputPtr = (const int32_t*)inputVector;
     __m128i inputVal;
     __m128 ret;
 
     for (; number < quarterPoints; number++) {
         // Load the 4 values
-        inputVal = _mm_loadu_si128((__m128i*)inputPtr);
+        inputVal = _mm_loadu_si128((const __m128i*)inputPtr);
 
         ret = _mm_cvtepi32_ps(inputVal);
         ret = _mm_mul_ps(ret, invScalar);
@@ -212,13 +212,13 @@ static inline void volk_32i_s32f_convert_32f_a_avx512f(float* outputVector,
     float* outputVectorPtr = outputVector;
     const float iScalar = 1.0 / scalar;
     __m512 invScalar = _mm512_set1_ps(iScalar);
-    int32_t* inputPtr = (int32_t*)inputVector;
+    const int32_t* inputPtr = (const int32_t*)inputVector;
     __m512i inputVal;
     __m512 ret;
 
     for (; number < onesixteenthPoints; number++) {
         // Load the values
-        inputVal = _mm512_load_si512((__m512i*)inputPtr);
+        inputVal = _mm512_load_si512((const __m512i*)inputPtr);
 
         ret = _mm512_cvtepi32_ps(inputVal);
         ret = _mm512_mul_ps(ret, invScalar);
@@ -250,13 +250,13 @@ static inline void volk_32i_s32f_convert_32f_a_avx2(float* outputVector,
     float* outputVectorPtr = outputVector;
     const float iScalar = 1.0 / scalar;
     __m256 invScalar = _mm256_set1_ps(iScalar);
-    int32_t* inputPtr = (int32_t*)inputVector;
+    const int32_t* inputPtr = (const int32_t*)inputVector;
     __m256i inputVal;
     __m256 ret;
 
     for (; number < oneEightPoints; number++) {
         // Load the 4 values
-        inputVal = _mm256_load_si256((__m256i*)inputPtr);
+        inputVal = _mm256_load_si256((const __m256i*)inputPtr);
 
         ret = _mm256_cvtepi32_ps(inputVal);
         ret = _mm256_mul_ps(ret, invScalar);
@@ -289,13 +289,13 @@ static inline void volk_32i_s32f_convert_32f_a_sse2(float* outputVector,
     float* outputVectorPtr = outputVector;
     const float iScalar = 1.0 / scalar;
     __m128 invScalar = _mm_set_ps1(iScalar);
-    int32_t* inputPtr = (int32_t*)inputVector;
+    const int32_t* inputPtr = (const int32_t*)inputVector;
     __m128i inputVal;
     __m128 ret;
 
     for (; number < quarterPoints; number++) {
         // Load the 4 values
-        inputVal = _mm_load_si128((__m128i*)inputPtr);
+        inputVal = _mm_load_si128((const __m128i*)inputPtr);
 
         ret = _mm_cvtepi32_ps(inputVal);
         ret = _mm_mul_ps(ret, invScalar);

--- a/kernels/volk/volk_32i_s32f_convert_32f.h
+++ b/kernels/volk/volk_32i_s32f_convert_32f.h
@@ -54,82 +54,23 @@
 #include <inttypes.h>
 #include <stdio.h>
 
-#ifdef LV_HAVE_AVX512F
-#include <immintrin.h>
+#ifdef LV_HAVE_GENERIC
 
-static inline void volk_32i_s32f_convert_32f_u_avx512f(float* outputVector,
-                                                       const int32_t* inputVector,
-                                                       const float scalar,
-                                                       unsigned int num_points)
+static inline void volk_32i_s32f_convert_32f_generic(float* outputVector,
+                                                     const int32_t* inputVector,
+                                                     const float scalar,
+                                                     unsigned int num_points)
 {
-    unsigned int number = 0;
-    const unsigned int onesixteenthPoints = num_points / 16;
-
     float* outputVectorPtr = outputVector;
+    const int32_t* inputVectorPtr = inputVector;
+    unsigned int number = 0;
     const float iScalar = 1.0 / scalar;
-    __m512 invScalar = _mm512_set1_ps(iScalar);
-    const int32_t* inputPtr = (const int32_t*)inputVector;
-    __m512i inputVal;
-    __m512 ret;
 
-    for (; number < onesixteenthPoints; number++) {
-        // Load the values
-        inputVal = _mm512_loadu_si512((const __m512i*)inputPtr);
-
-        ret = _mm512_cvtepi32_ps(inputVal);
-        ret = _mm512_mul_ps(ret, invScalar);
-
-        _mm512_storeu_ps(outputVectorPtr, ret);
-
-        outputVectorPtr += 16;
-        inputPtr += 16;
-    }
-
-    number = onesixteenthPoints * 16;
-    for (; number < num_points; number++) {
-        outputVector[number] = ((float)(inputVector[number])) * iScalar;
+    for (number = 0; number < num_points; number++) {
+        *outputVectorPtr++ = ((float)(*inputVectorPtr++)) * iScalar;
     }
 }
-#endif /* LV_HAVE_AVX512F */
-
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-
-static inline void volk_32i_s32f_convert_32f_u_avx2(float* outputVector,
-                                                    const int32_t* inputVector,
-                                                    const float scalar,
-                                                    unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int oneEightPoints = num_points / 8;
-
-    float* outputVectorPtr = outputVector;
-    const float iScalar = 1.0 / scalar;
-    __m256 invScalar = _mm256_set1_ps(iScalar);
-    const int32_t* inputPtr = (const int32_t*)inputVector;
-    __m256i inputVal;
-    __m256 ret;
-
-    for (; number < oneEightPoints; number++) {
-        // Load the 4 values
-        inputVal = _mm256_loadu_si256((const __m256i*)inputPtr);
-
-        ret = _mm256_cvtepi32_ps(inputVal);
-        ret = _mm256_mul_ps(ret, invScalar);
-
-        _mm256_storeu_ps(outputVectorPtr, ret);
-
-        outputVectorPtr += 8;
-        inputPtr += 8;
-    }
-
-    number = oneEightPoints * 8;
-    for (; number < num_points; number++) {
-        outputVector[number] = ((float)(inputVector[number])) * iScalar;
-    }
-}
-#endif /* LV_HAVE_AVX2 */
+#endif /* LV_HAVE_GENERIC */
 
 
 #ifdef LV_HAVE_SSE2
@@ -171,75 +112,10 @@ static inline void volk_32i_s32f_convert_32f_u_sse2(float* outputVector,
 #endif /* LV_HAVE_SSE2 */
 
 
-#ifdef LV_HAVE_GENERIC
-
-static inline void volk_32i_s32f_convert_32f_generic(float* outputVector,
-                                                     const int32_t* inputVector,
-                                                     const float scalar,
-                                                     unsigned int num_points)
-{
-    float* outputVectorPtr = outputVector;
-    const int32_t* inputVectorPtr = inputVector;
-    unsigned int number = 0;
-    const float iScalar = 1.0 / scalar;
-
-    for (number = 0; number < num_points; number++) {
-        *outputVectorPtr++ = ((float)(*inputVectorPtr++)) * iScalar;
-    }
-}
-#endif /* LV_HAVE_GENERIC */
-
-#endif /* INCLUDED_volk_32i_s32f_convert_32f_u_H */
-
-
-#ifndef INCLUDED_volk_32i_s32f_convert_32f_a_H
-#define INCLUDED_volk_32i_s32f_convert_32f_a_H
-
-#include <inttypes.h>
-#include <stdio.h>
-
-#ifdef LV_HAVE_AVX512F
-#include <immintrin.h>
-
-static inline void volk_32i_s32f_convert_32f_a_avx512f(float* outputVector,
-                                                       const int32_t* inputVector,
-                                                       const float scalar,
-                                                       unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int onesixteenthPoints = num_points / 16;
-
-    float* outputVectorPtr = outputVector;
-    const float iScalar = 1.0 / scalar;
-    __m512 invScalar = _mm512_set1_ps(iScalar);
-    const int32_t* inputPtr = (const int32_t*)inputVector;
-    __m512i inputVal;
-    __m512 ret;
-
-    for (; number < onesixteenthPoints; number++) {
-        // Load the values
-        inputVal = _mm512_load_si512((const __m512i*)inputPtr);
-
-        ret = _mm512_cvtepi32_ps(inputVal);
-        ret = _mm512_mul_ps(ret, invScalar);
-
-        _mm512_store_ps(outputVectorPtr, ret);
-
-        outputVectorPtr += 16;
-        inputPtr += 16;
-    }
-
-    number = onesixteenthPoints * 16;
-    for (; number < num_points; number++) {
-        outputVector[number] = ((float)(inputVector[number])) * iScalar;
-    }
-}
-#endif /* LV_HAVE_AVX512F */
-
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
 
-static inline void volk_32i_s32f_convert_32f_a_avx2(float* outputVector,
+static inline void volk_32i_s32f_convert_32f_u_avx2(float* outputVector,
                                                     const int32_t* inputVector,
                                                     const float scalar,
                                                     unsigned int num_points)
@@ -256,12 +132,12 @@ static inline void volk_32i_s32f_convert_32f_a_avx2(float* outputVector,
 
     for (; number < oneEightPoints; number++) {
         // Load the 4 values
-        inputVal = _mm256_load_si256((const __m256i*)inputPtr);
+        inputVal = _mm256_loadu_si256((const __m256i*)inputPtr);
 
         ret = _mm256_cvtepi32_ps(inputVal);
         ret = _mm256_mul_ps(ret, invScalar);
 
-        _mm256_store_ps(outputVectorPtr, ret);
+        _mm256_storeu_ps(outputVectorPtr, ret);
 
         outputVectorPtr += 8;
         inputPtr += 8;
@@ -275,43 +151,43 @@ static inline void volk_32i_s32f_convert_32f_a_avx2(float* outputVector,
 #endif /* LV_HAVE_AVX2 */
 
 
-#ifdef LV_HAVE_SSE2
-#include <emmintrin.h>
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
 
-static inline void volk_32i_s32f_convert_32f_a_sse2(float* outputVector,
-                                                    const int32_t* inputVector,
-                                                    const float scalar,
-                                                    unsigned int num_points)
+static inline void volk_32i_s32f_convert_32f_u_avx512f(float* outputVector,
+                                                       const int32_t* inputVector,
+                                                       const float scalar,
+                                                       unsigned int num_points)
 {
     unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
+    const unsigned int onesixteenthPoints = num_points / 16;
 
     float* outputVectorPtr = outputVector;
     const float iScalar = 1.0 / scalar;
-    __m128 invScalar = _mm_set_ps1(iScalar);
+    __m512 invScalar = _mm512_set1_ps(iScalar);
     const int32_t* inputPtr = (const int32_t*)inputVector;
-    __m128i inputVal;
-    __m128 ret;
+    __m512i inputVal;
+    __m512 ret;
 
-    for (; number < quarterPoints; number++) {
-        // Load the 4 values
-        inputVal = _mm_load_si128((const __m128i*)inputPtr);
+    for (; number < onesixteenthPoints; number++) {
+        // Load the values
+        inputVal = _mm512_loadu_si512((const __m512i*)inputPtr);
 
-        ret = _mm_cvtepi32_ps(inputVal);
-        ret = _mm_mul_ps(ret, invScalar);
+        ret = _mm512_cvtepi32_ps(inputVal);
+        ret = _mm512_mul_ps(ret, invScalar);
 
-        _mm_store_ps(outputVectorPtr, ret);
+        _mm512_storeu_ps(outputVectorPtr, ret);
 
-        outputVectorPtr += 4;
-        inputPtr += 4;
+        outputVectorPtr += 16;
+        inputPtr += 16;
     }
 
-    number = quarterPoints * 4;
+    number = onesixteenthPoints * 16;
     for (; number < num_points; number++) {
         outputVector[number] = ((float)(inputVector[number])) * iScalar;
     }
 }
-#endif /* LV_HAVE_SSE2 */
+#endif /* LV_HAVE_AVX512F */
 
 
 #ifdef LV_HAVE_NEON
@@ -405,5 +281,129 @@ static inline void volk_32i_s32f_convert_32f_rvv(float* outputVector,
     }
 }
 #endif /*LV_HAVE_RVV*/
+
+#endif /* INCLUDED_volk_32i_s32f_convert_32f_u_H */
+
+
+#ifndef INCLUDED_volk_32i_s32f_convert_32f_a_H
+#define INCLUDED_volk_32i_s32f_convert_32f_a_H
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#ifdef LV_HAVE_SSE2
+#include <emmintrin.h>
+
+static inline void volk_32i_s32f_convert_32f_a_sse2(float* outputVector,
+                                                    const int32_t* inputVector,
+                                                    const float scalar,
+                                                    unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    float* outputVectorPtr = outputVector;
+    const float iScalar = 1.0 / scalar;
+    __m128 invScalar = _mm_set_ps1(iScalar);
+    const int32_t* inputPtr = (const int32_t*)inputVector;
+    __m128i inputVal;
+    __m128 ret;
+
+    for (; number < quarterPoints; number++) {
+        // Load the 4 values
+        inputVal = _mm_load_si128((const __m128i*)inputPtr);
+
+        ret = _mm_cvtepi32_ps(inputVal);
+        ret = _mm_mul_ps(ret, invScalar);
+
+        _mm_store_ps(outputVectorPtr, ret);
+
+        outputVectorPtr += 4;
+        inputPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        outputVector[number] = ((float)(inputVector[number])) * iScalar;
+    }
+}
+#endif /* LV_HAVE_SSE2 */
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void volk_32i_s32f_convert_32f_a_avx2(float* outputVector,
+                                                    const int32_t* inputVector,
+                                                    const float scalar,
+                                                    unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int oneEightPoints = num_points / 8;
+
+    float* outputVectorPtr = outputVector;
+    const float iScalar = 1.0 / scalar;
+    __m256 invScalar = _mm256_set1_ps(iScalar);
+    const int32_t* inputPtr = (const int32_t*)inputVector;
+    __m256i inputVal;
+    __m256 ret;
+
+    for (; number < oneEightPoints; number++) {
+        // Load the 4 values
+        inputVal = _mm256_load_si256((const __m256i*)inputPtr);
+
+        ret = _mm256_cvtepi32_ps(inputVal);
+        ret = _mm256_mul_ps(ret, invScalar);
+
+        _mm256_store_ps(outputVectorPtr, ret);
+
+        outputVectorPtr += 8;
+        inputPtr += 8;
+    }
+
+    number = oneEightPoints * 8;
+    for (; number < num_points; number++) {
+        outputVector[number] = ((float)(inputVector[number])) * iScalar;
+    }
+}
+#endif /* LV_HAVE_AVX2 */
+
+
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+
+static inline void volk_32i_s32f_convert_32f_a_avx512f(float* outputVector,
+                                                       const int32_t* inputVector,
+                                                       const float scalar,
+                                                       unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int onesixteenthPoints = num_points / 16;
+
+    float* outputVectorPtr = outputVector;
+    const float iScalar = 1.0 / scalar;
+    __m512 invScalar = _mm512_set1_ps(iScalar);
+    const int32_t* inputPtr = (const int32_t*)inputVector;
+    __m512i inputVal;
+    __m512 ret;
+
+    for (; number < onesixteenthPoints; number++) {
+        // Load the values
+        inputVal = _mm512_load_si512((const __m512i*)inputPtr);
+
+        ret = _mm512_cvtepi32_ps(inputVal);
+        ret = _mm512_mul_ps(ret, invScalar);
+
+        _mm512_store_ps(outputVectorPtr, ret);
+
+        outputVectorPtr += 16;
+        inputPtr += 16;
+    }
+
+    number = onesixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        outputVector[number] = ((float)(inputVector[number])) * iScalar;
+    }
+}
+#endif /* LV_HAVE_AVX512F */
 
 #endif /* INCLUDED_volk_32i_s32f_convert_32f_a_H */

--- a/kernels/volk/volk_32i_x2_and_32i.h
+++ b/kernels/volk/volk_32i_x2_and_32i.h
@@ -65,53 +65,34 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32i_x2_and_32i_a_H
-#define INCLUDED_volk_32i_x2_and_32i_a_H
+#ifndef INCLUDED_volk_32i_x2_and_32i_u_H
+#define INCLUDED_volk_32i_x2_and_32i_u_H
 
 #include <inttypes.h>
 #include <stdio.h>
 
-#ifdef LV_HAVE_AVX512F
-#include <immintrin.h>
+#ifdef LV_HAVE_GENERIC
 
-static inline void volk_32i_x2_and_32i_a_avx512f(int32_t* cVector,
-                                                 const int32_t* aVector,
-                                                 const int32_t* bVector,
-                                                 unsigned int num_points)
+static inline void volk_32i_x2_and_32i_generic(int32_t* cVector,
+                                               const int32_t* aVector,
+                                               const int32_t* bVector,
+                                               unsigned int num_points)
 {
-    unsigned int number = 0;
-    const unsigned int sixteenthPoints = num_points / 16;
-
-    int32_t* cPtr = (int32_t*)cVector;
+    int32_t* cPtr = cVector;
     const int32_t* aPtr = aVector;
     const int32_t* bPtr = bVector;
+    unsigned int number = 0;
 
-    __m512i aVal, bVal, cVal;
-    for (; number < sixteenthPoints; number++) {
-
-        aVal = _mm512_load_si512(aPtr);
-        bVal = _mm512_load_si512(bPtr);
-
-        cVal = _mm512_and_si512(aVal, bVal);
-
-        _mm512_store_si512(cPtr, cVal); // Store the results back into the C container
-
-        aPtr += 16;
-        bPtr += 16;
-        cPtr += 16;
-    }
-
-    number = sixteenthPoints * 16;
-    for (; number < num_points; number++) {
-        cVector[number] = aVector[number] & bVector[number];
+    for (number = 0; number < num_points; number++) {
+        *cPtr++ = (*aPtr++) & (*bPtr++);
     }
 }
-#endif /* LV_HAVE_AVX512F */
+#endif /* LV_HAVE_GENERIC */
 
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
 
-static inline void volk_32i_x2_and_32i_a_avx2(int32_t* cVector,
+static inline void volk_32i_x2_and_32i_u_avx2(int32_t* cVector,
                                               const int32_t* aVector,
                                               const int32_t* bVector,
                                               unsigned int num_points)
@@ -126,13 +107,13 @@ static inline void volk_32i_x2_and_32i_a_avx2(int32_t* cVector,
     __m256i aVal, bVal, cVal;
     for (; number < oneEightPoints; number++) {
 
-        aVal = _mm256_load_si256((const __m256i*)aPtr);
-        bVal = _mm256_load_si256((const __m256i*)bPtr);
+        aVal = _mm256_loadu_si256((const __m256i*)aPtr);
+        bVal = _mm256_loadu_si256((const __m256i*)bPtr);
 
         cVal = _mm256_and_si256(aVal, bVal);
 
-        _mm256_store_si256((__m256i*)cPtr,
-                           cVal); // Store the results back into the C container
+        _mm256_storeu_si256((__m256i*)cPtr,
+                            cVal); // Store the results back into the C container
 
         aPtr += 8;
         bPtr += 8;
@@ -146,44 +127,42 @@ static inline void volk_32i_x2_and_32i_a_avx2(int32_t* cVector,
 }
 #endif /* LV_HAVE_AVX2 */
 
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
 
-#ifdef LV_HAVE_SSE
-#include <xmmintrin.h>
-
-static inline void volk_32i_x2_and_32i_a_sse(int32_t* cVector,
-                                             const int32_t* aVector,
-                                             const int32_t* bVector,
-                                             unsigned int num_points)
+static inline void volk_32i_x2_and_32i_u_avx512f(int32_t* cVector,
+                                                 const int32_t* aVector,
+                                                 const int32_t* bVector,
+                                                 unsigned int num_points)
 {
     unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
+    const unsigned int sixteenthPoints = num_points / 16;
 
-    float* cPtr = (float*)cVector;
-    const float* aPtr = (const float*)aVector;
-    const float* bPtr = (const float*)bVector;
+    int32_t* cPtr = (int32_t*)cVector;
+    const int32_t* aPtr = aVector;
+    const int32_t* bPtr = bVector;
 
-    __m128 aVal, bVal, cVal;
-    for (; number < quarterPoints; number++) {
+    __m512i aVal, bVal, cVal;
+    for (; number < sixteenthPoints; number++) {
 
-        aVal = _mm_load_ps(aPtr);
-        bVal = _mm_load_ps(bPtr);
+        aVal = _mm512_loadu_si512(aPtr);
+        bVal = _mm512_loadu_si512(bPtr);
 
-        cVal = _mm_and_ps(aVal, bVal);
+        cVal = _mm512_and_si512(aVal, bVal);
 
-        _mm_store_ps(cPtr, cVal); // Store the results back into the C container
+        _mm512_storeu_si512(cPtr, cVal); // Store the results back into the C container
 
-        aPtr += 4;
-        bPtr += 4;
-        cPtr += 4;
+        aPtr += 16;
+        bPtr += 16;
+        cPtr += 16;
     }
 
-    number = quarterPoints * 4;
+    number = sixteenthPoints * 16;
     for (; number < num_points; number++) {
         cVector[number] = aVector[number] & bVector[number];
     }
 }
-#endif /* LV_HAVE_SSE */
-
+#endif /* LV_HAVE_AVX512F */
 
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
@@ -253,25 +232,23 @@ static inline void volk_32i_x2_and_32i_neonv8(int32_t* cVector,
 }
 #endif /* LV_HAVE_NEONV8 */
 
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
 
-#ifdef LV_HAVE_GENERIC
-
-static inline void volk_32i_x2_and_32i_generic(int32_t* cVector,
-                                               const int32_t* aVector,
-                                               const int32_t* bVector,
-                                               unsigned int num_points)
+static inline void volk_32i_x2_and_32i_rvv(int32_t* cVector,
+                                           const int32_t* aVector,
+                                           const int32_t* bVector,
+                                           unsigned int num_points)
 {
-    int32_t* cPtr = cVector;
-    const int32_t* aPtr = aVector;
-    const int32_t* bPtr = bVector;
-    unsigned int number = 0;
-
-    for (number = 0; number < num_points; number++) {
-        *cPtr++ = (*aPtr++) & (*bPtr++);
+    size_t n = num_points;
+    for (size_t vl; n > 0; n -= vl, aVector += vl, bVector += vl, cVector += vl) {
+        vl = __riscv_vsetvl_e32m8(n);
+        vint32m8_t va = __riscv_vle32_v_i32m8(aVector, vl);
+        vint32m8_t vb = __riscv_vle32_v_i32m8(bVector, vl);
+        __riscv_vse32(cVector, __riscv_vand(va, vb, vl), vl);
     }
 }
-#endif /* LV_HAVE_GENERIC */
-
+#endif /* LV_HAVE_RVV */
 
 #ifdef LV_HAVE_ORC
 extern void volk_32i_x2_and_32i_a_orc_impl(int32_t* cVector,
@@ -289,56 +266,56 @@ static inline void volk_32i_x2_and_32i_u_orc(int32_t* cVector,
 #endif /* LV_HAVE_ORC */
 
 
-#endif /* INCLUDED_volk_32i_x2_and_32i_a_H */
+#endif /* INCLUDED_volk_32i_x2_and_32i_u_H */
 
 
-#ifndef INCLUDED_volk_32i_x2_and_32i_u_H
-#define INCLUDED_volk_32i_x2_and_32i_u_H
+#ifndef INCLUDED_volk_32i_x2_and_32i_a_H
+#define INCLUDED_volk_32i_x2_and_32i_a_H
 
 #include <inttypes.h>
 #include <stdio.h>
 
-#ifdef LV_HAVE_AVX512F
-#include <immintrin.h>
+#ifdef LV_HAVE_SSE
+#include <xmmintrin.h>
 
-static inline void volk_32i_x2_and_32i_u_avx512f(int32_t* cVector,
-                                                 const int32_t* aVector,
-                                                 const int32_t* bVector,
-                                                 unsigned int num_points)
+static inline void volk_32i_x2_and_32i_a_sse(int32_t* cVector,
+                                             const int32_t* aVector,
+                                             const int32_t* bVector,
+                                             unsigned int num_points)
 {
     unsigned int number = 0;
-    const unsigned int sixteenthPoints = num_points / 16;
+    const unsigned int quarterPoints = num_points / 4;
 
-    int32_t* cPtr = (int32_t*)cVector;
-    const int32_t* aPtr = aVector;
-    const int32_t* bPtr = bVector;
+    float* cPtr = (float*)cVector;
+    const float* aPtr = (const float*)aVector;
+    const float* bPtr = (const float*)bVector;
 
-    __m512i aVal, bVal, cVal;
-    for (; number < sixteenthPoints; number++) {
+    __m128 aVal, bVal, cVal;
+    for (; number < quarterPoints; number++) {
 
-        aVal = _mm512_loadu_si512(aPtr);
-        bVal = _mm512_loadu_si512(bPtr);
+        aVal = _mm_load_ps(aPtr);
+        bVal = _mm_load_ps(bPtr);
 
-        cVal = _mm512_and_si512(aVal, bVal);
+        cVal = _mm_and_ps(aVal, bVal);
 
-        _mm512_storeu_si512(cPtr, cVal); // Store the results back into the C container
+        _mm_store_ps(cPtr, cVal); // Store the results back into the C container
 
-        aPtr += 16;
-        bPtr += 16;
-        cPtr += 16;
+        aPtr += 4;
+        bPtr += 4;
+        cPtr += 4;
     }
 
-    number = sixteenthPoints * 16;
+    number = quarterPoints * 4;
     for (; number < num_points; number++) {
         cVector[number] = aVector[number] & bVector[number];
     }
 }
-#endif /* LV_HAVE_AVX512F */
+#endif /* LV_HAVE_SSE */
 
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
 
-static inline void volk_32i_x2_and_32i_u_avx2(int32_t* cVector,
+static inline void volk_32i_x2_and_32i_a_avx2(int32_t* cVector,
                                               const int32_t* aVector,
                                               const int32_t* bVector,
                                               unsigned int num_points)
@@ -353,13 +330,13 @@ static inline void volk_32i_x2_and_32i_u_avx2(int32_t* cVector,
     __m256i aVal, bVal, cVal;
     for (; number < oneEightPoints; number++) {
 
-        aVal = _mm256_loadu_si256((const __m256i*)aPtr);
-        bVal = _mm256_loadu_si256((const __m256i*)bPtr);
+        aVal = _mm256_load_si256((const __m256i*)aPtr);
+        bVal = _mm256_load_si256((const __m256i*)bPtr);
 
         cVal = _mm256_and_si256(aVal, bVal);
 
-        _mm256_storeu_si256((__m256i*)cPtr,
-                            cVal); // Store the results back into the C container
+        _mm256_store_si256((__m256i*)cPtr,
+                           cVal); // Store the results back into the C container
 
         aPtr += 8;
         bPtr += 8;
@@ -373,22 +350,42 @@ static inline void volk_32i_x2_and_32i_u_avx2(int32_t* cVector,
 }
 #endif /* LV_HAVE_AVX2 */
 
-#ifdef LV_HAVE_RVV
-#include <riscv_vector.h>
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
 
-static inline void volk_32i_x2_and_32i_rvv(int32_t* cVector,
-                                           const int32_t* aVector,
-                                           const int32_t* bVector,
-                                           unsigned int num_points)
+static inline void volk_32i_x2_and_32i_a_avx512f(int32_t* cVector,
+                                                 const int32_t* aVector,
+                                                 const int32_t* bVector,
+                                                 unsigned int num_points)
 {
-    size_t n = num_points;
-    for (size_t vl; n > 0; n -= vl, aVector += vl, bVector += vl, cVector += vl) {
-        vl = __riscv_vsetvl_e32m8(n);
-        vint32m8_t va = __riscv_vle32_v_i32m8(aVector, vl);
-        vint32m8_t vb = __riscv_vle32_v_i32m8(bVector, vl);
-        __riscv_vse32(cVector, __riscv_vand(va, vb, vl), vl);
+    unsigned int number = 0;
+    const unsigned int sixteenthPoints = num_points / 16;
+
+    int32_t* cPtr = (int32_t*)cVector;
+    const int32_t* aPtr = aVector;
+    const int32_t* bPtr = bVector;
+
+    __m512i aVal, bVal, cVal;
+    for (; number < sixteenthPoints; number++) {
+
+        aVal = _mm512_load_si512(aPtr);
+        bVal = _mm512_load_si512(bPtr);
+
+        cVal = _mm512_and_si512(aVal, bVal);
+
+        _mm512_store_si512(cPtr, cVal); // Store the results back into the C container
+
+        aPtr += 16;
+        bPtr += 16;
+        cPtr += 16;
+    }
+
+    number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        cVector[number] = aVector[number] & bVector[number];
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_AVX512F */
 
-#endif /* INCLUDED_volk_32i_x2_and_32i_u_H */
+
+#endif /* INCLUDED_volk_32i_x2_and_32i_a_H */

--- a/kernels/volk/volk_32i_x2_and_32i.h
+++ b/kernels/volk/volk_32i_x2_and_32i.h
@@ -83,8 +83,8 @@ static inline void volk_32i_x2_and_32i_a_avx512f(int32_t* cVector,
     const unsigned int sixteenthPoints = num_points / 16;
 
     int32_t* cPtr = (int32_t*)cVector;
-    const int32_t* aPtr = (int32_t*)aVector;
-    const int32_t* bPtr = (int32_t*)bVector;
+    const int32_t* aPtr = aVector;
+    const int32_t* bPtr = bVector;
 
     __m512i aVal, bVal, cVal;
     for (; number < sixteenthPoints; number++) {
@@ -126,8 +126,8 @@ static inline void volk_32i_x2_and_32i_a_avx2(int32_t* cVector,
     __m256i aVal, bVal, cVal;
     for (; number < oneEightPoints; number++) {
 
-        aVal = _mm256_load_si256((__m256i*)aPtr);
-        bVal = _mm256_load_si256((__m256i*)bPtr);
+        aVal = _mm256_load_si256((const __m256i*)aPtr);
+        bVal = _mm256_load_si256((const __m256i*)bPtr);
 
         cVal = _mm256_and_si256(aVal, bVal);
 
@@ -159,8 +159,8 @@ static inline void volk_32i_x2_and_32i_a_sse(int32_t* cVector,
     const unsigned int quarterPoints = num_points / 4;
 
     float* cPtr = (float*)cVector;
-    const float* aPtr = (float*)aVector;
-    const float* bPtr = (float*)bVector;
+    const float* aPtr = (const float*)aVector;
+    const float* bPtr = (const float*)bVector;
 
     __m128 aVal, bVal, cVal;
     for (; number < quarterPoints; number++) {
@@ -310,8 +310,8 @@ static inline void volk_32i_x2_and_32i_u_avx512f(int32_t* cVector,
     const unsigned int sixteenthPoints = num_points / 16;
 
     int32_t* cPtr = (int32_t*)cVector;
-    const int32_t* aPtr = (int32_t*)aVector;
-    const int32_t* bPtr = (int32_t*)bVector;
+    const int32_t* aPtr = aVector;
+    const int32_t* bPtr = bVector;
 
     __m512i aVal, bVal, cVal;
     for (; number < sixteenthPoints; number++) {
@@ -353,8 +353,8 @@ static inline void volk_32i_x2_and_32i_u_avx2(int32_t* cVector,
     __m256i aVal, bVal, cVal;
     for (; number < oneEightPoints; number++) {
 
-        aVal = _mm256_loadu_si256((__m256i*)aPtr);
-        bVal = _mm256_loadu_si256((__m256i*)bPtr);
+        aVal = _mm256_loadu_si256((const __m256i*)aPtr);
+        bVal = _mm256_loadu_si256((const __m256i*)bPtr);
 
         cVal = _mm256_and_si256(aVal, bVal);
 

--- a/kernels/volk/volk_32i_x2_or_32i.h
+++ b/kernels/volk/volk_32i_x2_or_32i.h
@@ -65,53 +65,34 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_32i_x2_or_32i_a_H
-#define INCLUDED_volk_32i_x2_or_32i_a_H
+#ifndef INCLUDED_volk_32i_x2_or_32i_u_H
+#define INCLUDED_volk_32i_x2_or_32i_u_H
 
 #include <inttypes.h>
 #include <stdio.h>
 
-#ifdef LV_HAVE_AVX512F
-#include <immintrin.h>
+#ifdef LV_HAVE_GENERIC
 
-static inline void volk_32i_x2_or_32i_a_avx512f(int32_t* cVector,
-                                                const int32_t* aVector,
-                                                const int32_t* bVector,
-                                                unsigned int num_points)
+static inline void volk_32i_x2_or_32i_generic(int32_t* cVector,
+                                              const int32_t* aVector,
+                                              const int32_t* bVector,
+                                              unsigned int num_points)
 {
-    unsigned int number = 0;
-    const unsigned int sixteenthPoints = num_points / 16;
-
-    int32_t* cPtr = (int32_t*)cVector;
+    int32_t* cPtr = cVector;
     const int32_t* aPtr = aVector;
     const int32_t* bPtr = bVector;
+    unsigned int number = 0;
 
-    __m512i aVal, bVal, cVal;
-    for (; number < sixteenthPoints; number++) {
-
-        aVal = _mm512_load_si512(aPtr);
-        bVal = _mm512_load_si512(bPtr);
-
-        cVal = _mm512_or_si512(aVal, bVal);
-
-        _mm512_store_si512(cPtr, cVal); // Store the results back into the C container
-
-        aPtr += 16;
-        bPtr += 16;
-        cPtr += 16;
-    }
-
-    number = sixteenthPoints * 16;
-    for (; number < num_points; number++) {
-        cVector[number] = aVector[number] | bVector[number];
+    for (number = 0; number < num_points; number++) {
+        *cPtr++ = (*aPtr++) | (*bPtr++);
     }
 }
-#endif /* LV_HAVE_AVX512F */
+#endif /* LV_HAVE_GENERIC */
 
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
 
-static inline void volk_32i_x2_or_32i_a_avx2(int32_t* cVector,
+static inline void volk_32i_x2_or_32i_u_avx2(int32_t* cVector,
                                              const int32_t* aVector,
                                              const int32_t* bVector,
                                              unsigned int num_points)
@@ -126,13 +107,13 @@ static inline void volk_32i_x2_or_32i_a_avx2(int32_t* cVector,
     __m256i aVal, bVal, cVal;
     for (; number < oneEightPoints; number++) {
 
-        aVal = _mm256_load_si256((const __m256i*)aPtr);
-        bVal = _mm256_load_si256((const __m256i*)bPtr);
+        aVal = _mm256_loadu_si256((const __m256i*)aPtr);
+        bVal = _mm256_loadu_si256((const __m256i*)bPtr);
 
         cVal = _mm256_or_si256(aVal, bVal);
 
-        _mm256_store_si256((__m256i*)cPtr,
-                           cVal); // Store the results back into the C container
+        _mm256_storeu_si256((__m256i*)cPtr,
+                            cVal); // Store the results back into the C container
 
         aPtr += 8;
         bPtr += 8;
@@ -146,43 +127,42 @@ static inline void volk_32i_x2_or_32i_a_avx2(int32_t* cVector,
 }
 #endif /* LV_HAVE_AVX2 */
 
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
 
-#ifdef LV_HAVE_SSE
-#include <xmmintrin.h>
-
-static inline void volk_32i_x2_or_32i_a_sse(int32_t* cVector,
-                                            const int32_t* aVector,
-                                            const int32_t* bVector,
-                                            unsigned int num_points)
+static inline void volk_32i_x2_or_32i_u_avx512f(int32_t* cVector,
+                                                const int32_t* aVector,
+                                                const int32_t* bVector,
+                                                unsigned int num_points)
 {
     unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
+    const unsigned int sixteenthPoints = num_points / 16;
 
-    float* cPtr = (float*)cVector;
-    const float* aPtr = (const float*)aVector;
-    const float* bPtr = (const float*)bVector;
+    int32_t* cPtr = (int32_t*)cVector;
+    const int32_t* aPtr = aVector;
+    const int32_t* bPtr = bVector;
 
-    __m128 aVal, bVal, cVal;
-    for (; number < quarterPoints; number++) {
-        aVal = _mm_load_ps(aPtr);
-        bVal = _mm_load_ps(bPtr);
+    __m512i aVal, bVal, cVal;
+    for (; number < sixteenthPoints; number++) {
 
-        cVal = _mm_or_ps(aVal, bVal);
+        aVal = _mm512_loadu_si512(aPtr);
+        bVal = _mm512_loadu_si512(bPtr);
 
-        _mm_store_ps(cPtr, cVal); // Store the results back into the C container
+        cVal = _mm512_or_si512(aVal, bVal);
 
-        aPtr += 4;
-        bPtr += 4;
-        cPtr += 4;
+        _mm512_storeu_si512(cPtr, cVal); // Store the results back into the C container
+
+        aPtr += 16;
+        bPtr += 16;
+        cPtr += 16;
     }
 
-    number = quarterPoints * 4;
+    number = sixteenthPoints * 16;
     for (; number < num_points; number++) {
         cVector[number] = aVector[number] | bVector[number];
     }
 }
-#endif /* LV_HAVE_SSE */
-
+#endif /* LV_HAVE_AVX512F */
 
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
@@ -252,126 +232,6 @@ static inline void volk_32i_x2_or_32i_neonv8(int32_t* cVector,
 }
 #endif /* LV_HAVE_NEONV8 */
 
-
-#ifdef LV_HAVE_GENERIC
-
-static inline void volk_32i_x2_or_32i_generic(int32_t* cVector,
-                                              const int32_t* aVector,
-                                              const int32_t* bVector,
-                                              unsigned int num_points)
-{
-    int32_t* cPtr = cVector;
-    const int32_t* aPtr = aVector;
-    const int32_t* bPtr = bVector;
-    unsigned int number = 0;
-
-    for (number = 0; number < num_points; number++) {
-        *cPtr++ = (*aPtr++) | (*bPtr++);
-    }
-}
-#endif /* LV_HAVE_GENERIC */
-
-
-#ifdef LV_HAVE_ORC
-extern void volk_32i_x2_or_32i_a_orc_impl(int32_t* cVector,
-                                          const int32_t* aVector,
-                                          const int32_t* bVector,
-                                          int num_points);
-
-static inline void volk_32i_x2_or_32i_u_orc(int32_t* cVector,
-                                            const int32_t* aVector,
-                                            const int32_t* bVector,
-                                            unsigned int num_points)
-{
-    volk_32i_x2_or_32i_a_orc_impl(cVector, aVector, bVector, num_points);
-}
-#endif /* LV_HAVE_ORC */
-
-
-#endif /* INCLUDED_volk_32i_x2_or_32i_a_H */
-
-
-#ifndef INCLUDED_volk_32i_x2_or_32i_u_H
-#define INCLUDED_volk_32i_x2_or_32i_u_H
-
-#include <inttypes.h>
-#include <stdio.h>
-
-#ifdef LV_HAVE_AVX512F
-#include <immintrin.h>
-
-static inline void volk_32i_x2_or_32i_u_avx512f(int32_t* cVector,
-                                                const int32_t* aVector,
-                                                const int32_t* bVector,
-                                                unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int sixteenthPoints = num_points / 16;
-
-    int32_t* cPtr = (int32_t*)cVector;
-    const int32_t* aPtr = aVector;
-    const int32_t* bPtr = bVector;
-
-    __m512i aVal, bVal, cVal;
-    for (; number < sixteenthPoints; number++) {
-
-        aVal = _mm512_loadu_si512(aPtr);
-        bVal = _mm512_loadu_si512(bPtr);
-
-        cVal = _mm512_or_si512(aVal, bVal);
-
-        _mm512_storeu_si512(cPtr, cVal); // Store the results back into the C container
-
-        aPtr += 16;
-        bPtr += 16;
-        cPtr += 16;
-    }
-
-    number = sixteenthPoints * 16;
-    for (; number < num_points; number++) {
-        cVector[number] = aVector[number] | bVector[number];
-    }
-}
-#endif /* LV_HAVE_AVX512F */
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-
-static inline void volk_32i_x2_or_32i_u_avx2(int32_t* cVector,
-                                             const int32_t* aVector,
-                                             const int32_t* bVector,
-                                             unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int oneEightPoints = num_points / 8;
-
-    int32_t* cPtr = cVector;
-    const int32_t* aPtr = aVector;
-    const int32_t* bPtr = bVector;
-
-    __m256i aVal, bVal, cVal;
-    for (; number < oneEightPoints; number++) {
-
-        aVal = _mm256_loadu_si256((const __m256i*)aPtr);
-        bVal = _mm256_loadu_si256((const __m256i*)bPtr);
-
-        cVal = _mm256_or_si256(aVal, bVal);
-
-        _mm256_storeu_si256((__m256i*)cPtr,
-                            cVal); // Store the results back into the C container
-
-        aPtr += 8;
-        bPtr += 8;
-        cPtr += 8;
-    }
-
-    number = oneEightPoints * 8;
-    for (; number < num_points; number++) {
-        cVector[number] = aVector[number] | bVector[number];
-    }
-}
-#endif /* LV_HAVE_AVX2 */
-
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 
@@ -388,6 +248,141 @@ static inline void volk_32i_x2_or_32i_rvv(int32_t* cVector,
         __riscv_vse32(cVector, __riscv_vor(va, vb, vl), vl);
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
+
+#ifdef LV_HAVE_ORC
+extern void volk_32i_x2_or_32i_a_orc_impl(int32_t* cVector,
+                                          const int32_t* aVector,
+                                          const int32_t* bVector,
+                                          int num_points);
+
+static inline void volk_32i_x2_or_32i_u_orc(int32_t* cVector,
+                                            const int32_t* aVector,
+                                            const int32_t* bVector,
+                                            unsigned int num_points)
+{
+    volk_32i_x2_or_32i_a_orc_impl(cVector, aVector, bVector, num_points);
+}
+#endif /* LV_HAVE_ORC */
 
 #endif /* INCLUDED_volk_32i_x2_or_32i_u_H */
+
+
+#ifndef INCLUDED_volk_32i_x2_or_32i_a_H
+#define INCLUDED_volk_32i_x2_or_32i_a_H
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#ifdef LV_HAVE_SSE
+#include <xmmintrin.h>
+
+static inline void volk_32i_x2_or_32i_a_sse(int32_t* cVector,
+                                            const int32_t* aVector,
+                                            const int32_t* bVector,
+                                            unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    float* cPtr = (float*)cVector;
+    const float* aPtr = (const float*)aVector;
+    const float* bPtr = (const float*)bVector;
+
+    __m128 aVal, bVal, cVal;
+    for (; number < quarterPoints; number++) {
+        aVal = _mm_load_ps(aPtr);
+        bVal = _mm_load_ps(bPtr);
+
+        cVal = _mm_or_ps(aVal, bVal);
+
+        _mm_store_ps(cPtr, cVal); // Store the results back into the C container
+
+        aPtr += 4;
+        bPtr += 4;
+        cPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        cVector[number] = aVector[number] | bVector[number];
+    }
+}
+#endif /* LV_HAVE_SSE */
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void volk_32i_x2_or_32i_a_avx2(int32_t* cVector,
+                                             const int32_t* aVector,
+                                             const int32_t* bVector,
+                                             unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int oneEightPoints = num_points / 8;
+
+    int32_t* cPtr = cVector;
+    const int32_t* aPtr = aVector;
+    const int32_t* bPtr = bVector;
+
+    __m256i aVal, bVal, cVal;
+    for (; number < oneEightPoints; number++) {
+
+        aVal = _mm256_load_si256((const __m256i*)aPtr);
+        bVal = _mm256_load_si256((const __m256i*)bPtr);
+
+        cVal = _mm256_or_si256(aVal, bVal);
+
+        _mm256_store_si256((__m256i*)cPtr,
+                           cVal); // Store the results back into the C container
+
+        aPtr += 8;
+        bPtr += 8;
+        cPtr += 8;
+    }
+
+    number = oneEightPoints * 8;
+    for (; number < num_points; number++) {
+        cVector[number] = aVector[number] | bVector[number];
+    }
+}
+#endif /* LV_HAVE_AVX2 */
+
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+
+static inline void volk_32i_x2_or_32i_a_avx512f(int32_t* cVector,
+                                                const int32_t* aVector,
+                                                const int32_t* bVector,
+                                                unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int sixteenthPoints = num_points / 16;
+
+    int32_t* cPtr = (int32_t*)cVector;
+    const int32_t* aPtr = aVector;
+    const int32_t* bPtr = bVector;
+
+    __m512i aVal, bVal, cVal;
+    for (; number < sixteenthPoints; number++) {
+
+        aVal = _mm512_load_si512(aPtr);
+        bVal = _mm512_load_si512(bPtr);
+
+        cVal = _mm512_or_si512(aVal, bVal);
+
+        _mm512_store_si512(cPtr, cVal); // Store the results back into the C container
+
+        aPtr += 16;
+        bPtr += 16;
+        cPtr += 16;
+    }
+
+    number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        cVector[number] = aVector[number] | bVector[number];
+    }
+}
+#endif /* LV_HAVE_AVX512F */
+
+#endif /* INCLUDED_volk_32i_x2_or_32i_a_H */

--- a/kernels/volk/volk_32i_x2_or_32i.h
+++ b/kernels/volk/volk_32i_x2_or_32i.h
@@ -83,8 +83,8 @@ static inline void volk_32i_x2_or_32i_a_avx512f(int32_t* cVector,
     const unsigned int sixteenthPoints = num_points / 16;
 
     int32_t* cPtr = (int32_t*)cVector;
-    const int32_t* aPtr = (int32_t*)aVector;
-    const int32_t* bPtr = (int32_t*)bVector;
+    const int32_t* aPtr = aVector;
+    const int32_t* bPtr = bVector;
 
     __m512i aVal, bVal, cVal;
     for (; number < sixteenthPoints; number++) {
@@ -126,8 +126,8 @@ static inline void volk_32i_x2_or_32i_a_avx2(int32_t* cVector,
     __m256i aVal, bVal, cVal;
     for (; number < oneEightPoints; number++) {
 
-        aVal = _mm256_load_si256((__m256i*)aPtr);
-        bVal = _mm256_load_si256((__m256i*)bPtr);
+        aVal = _mm256_load_si256((const __m256i*)aPtr);
+        bVal = _mm256_load_si256((const __m256i*)bPtr);
 
         cVal = _mm256_or_si256(aVal, bVal);
 
@@ -159,8 +159,8 @@ static inline void volk_32i_x2_or_32i_a_sse(int32_t* cVector,
     const unsigned int quarterPoints = num_points / 4;
 
     float* cPtr = (float*)cVector;
-    const float* aPtr = (float*)aVector;
-    const float* bPtr = (float*)bVector;
+    const float* aPtr = (const float*)aVector;
+    const float* bPtr = (const float*)bVector;
 
     __m128 aVal, bVal, cVal;
     for (; number < quarterPoints; number++) {
@@ -309,8 +309,8 @@ static inline void volk_32i_x2_or_32i_u_avx512f(int32_t* cVector,
     const unsigned int sixteenthPoints = num_points / 16;
 
     int32_t* cPtr = (int32_t*)cVector;
-    const int32_t* aPtr = (int32_t*)aVector;
-    const int32_t* bPtr = (int32_t*)bVector;
+    const int32_t* aPtr = aVector;
+    const int32_t* bPtr = bVector;
 
     __m512i aVal, bVal, cVal;
     for (; number < sixteenthPoints; number++) {
@@ -352,8 +352,8 @@ static inline void volk_32i_x2_or_32i_u_avx2(int32_t* cVector,
     __m256i aVal, bVal, cVal;
     for (; number < oneEightPoints; number++) {
 
-        aVal = _mm256_loadu_si256((__m256i*)aPtr);
-        bVal = _mm256_loadu_si256((__m256i*)bPtr);
+        aVal = _mm256_loadu_si256((const __m256i*)aPtr);
+        bVal = _mm256_loadu_si256((const __m256i*)bPtr);
 
         cVal = _mm256_or_si256(aVal, bVal);
 

--- a/kernels/volk/volk_64u_popcnt.h
+++ b/kernels/volk/volk_64u_popcnt.h
@@ -105,7 +105,7 @@ static inline void volk_64u_popcnt_neon(uint64_t* ret, const uint64_t value)
     uint32x2_t count32x2_val;
     uint64x1_t count64x1_val;
 
-    input_val = vld1_u8((unsigned char*)&value);
+    input_val = vld1_u8((const unsigned char*)&value);
     count8x8_val = vcnt_u8(input_val);
     count16x4_val = vpaddl_u8(count8x8_val);
     count32x2_val = vpaddl_u16(count16x4_val);

--- a/kernels/volk/volk_64u_popcnt.h
+++ b/kernels/volk/volk_64u_popcnt.h
@@ -44,8 +44,8 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_64u_popcnt_a_H
-#define INCLUDED_volk_64u_popcnt_a_H
+#ifndef INCLUDED_volk_64u_popcnt_u_H
+#define INCLUDED_volk_64u_popcnt_u_H
 
 #include <inttypes.h>
 #include <stdio.h>
@@ -82,18 +82,6 @@ static inline void volk_64u_popcnt_generic(uint64_t* ret, const uint64_t value)
 }
 
 #endif /*LV_HAVE_GENERIC*/
-
-
-#if LV_HAVE_SSE4_2 && LV_HAVE_64
-
-#include <nmmintrin.h>
-
-static inline void volk_64u_popcnt_a_sse4_2(uint64_t* ret, const uint64_t value)
-{
-    *ret = _mm_popcnt_u64(value);
-}
-
-#endif /*LV_HAVE_SSE4_2*/
 
 
 #if LV_HAVE_NEON
@@ -145,5 +133,21 @@ static inline void volk_64u_popcnt_rva22(uint64_t* ret, const uint64_t value)
     *ret = __riscv_cpop_64(value);
 }
 #endif /*LV_HAVE_RVA22V*/
+
+#endif /*INCLUDED_volk_64u_popcnt_u_H*/
+
+#ifndef INCLUDED_volk_64u_popcnt_a_H
+#define INCLUDED_volk_64u_popcnt_a_H
+
+#if LV_HAVE_SSE4_2 && LV_HAVE_64
+
+#include <nmmintrin.h>
+
+static inline void volk_64u_popcnt_a_sse4_2(uint64_t* ret, const uint64_t value)
+{
+    *ret = _mm_popcnt_u64(value);
+}
+
+#endif /*LV_HAVE_SSE4_2*/
 
 #endif /*INCLUDED_volk_64u_popcnt_a_H*/

--- a/kernels/volk/volk_8i_s32f_convert_32f.h
+++ b/kernels/volk/volk_8i_s32f_convert_32f.h
@@ -44,6 +44,83 @@
 #include <inttypes.h>
 #include <stdio.h>
 
+#ifdef LV_HAVE_GENERIC
+
+static inline void volk_8i_s32f_convert_32f_generic(float* outputVector,
+                                                    const int8_t* inputVector,
+                                                    const float scalar,
+                                                    unsigned int num_points)
+{
+    float* outputVectorPtr = outputVector;
+    const int8_t* inputVectorPtr = inputVector;
+    unsigned int number = 0;
+    const float iScalar = 1.0 / scalar;
+
+    for (number = 0; number < num_points; number++) {
+        *outputVectorPtr++ = ((float)(*inputVectorPtr++)) * iScalar;
+    }
+}
+#endif /* LV_HAVE_GENERIC */
+
+#ifdef LV_HAVE_SSE4_1
+#include <smmintrin.h>
+
+static inline void volk_8i_s32f_convert_32f_u_sse4_1(float* outputVector,
+                                                     const int8_t* inputVector,
+                                                     const float scalar,
+                                                     unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int sixteenthPoints = num_points / 16;
+
+    float* outputVectorPtr = outputVector;
+    const float iScalar = 1.0 / scalar;
+    __m128 invScalar = _mm_set_ps1(iScalar);
+    const int8_t* inputVectorPtr = inputVector;
+    __m128 ret;
+    __m128i inputVal;
+    __m128i interimVal;
+
+    for (; number < sixteenthPoints; number++) {
+        inputVal = _mm_loadu_si128((const __m128i*)inputVectorPtr);
+
+        interimVal = _mm_cvtepi8_epi32(inputVal);
+        ret = _mm_cvtepi32_ps(interimVal);
+        ret = _mm_mul_ps(ret, invScalar);
+        _mm_storeu_ps(outputVectorPtr, ret);
+        outputVectorPtr += 4;
+
+        inputVal = _mm_srli_si128(inputVal, 4);
+        interimVal = _mm_cvtepi8_epi32(inputVal);
+        ret = _mm_cvtepi32_ps(interimVal);
+        ret = _mm_mul_ps(ret, invScalar);
+        _mm_storeu_ps(outputVectorPtr, ret);
+        outputVectorPtr += 4;
+
+        inputVal = _mm_srli_si128(inputVal, 4);
+        interimVal = _mm_cvtepi8_epi32(inputVal);
+        ret = _mm_cvtepi32_ps(interimVal);
+        ret = _mm_mul_ps(ret, invScalar);
+        _mm_storeu_ps(outputVectorPtr, ret);
+        outputVectorPtr += 4;
+
+        inputVal = _mm_srli_si128(inputVal, 4);
+        interimVal = _mm_cvtepi8_epi32(inputVal);
+        ret = _mm_cvtepi32_ps(interimVal);
+        ret = _mm_mul_ps(ret, invScalar);
+        _mm_storeu_ps(outputVectorPtr, ret);
+        outputVectorPtr += 4;
+
+        inputVectorPtr += 16;
+    }
+
+    number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        outputVector[number] = (float)(inputVector[number]) * iScalar;
+    }
+}
+#endif /* LV_HAVE_SSE4_1 */
+
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
 
@@ -126,235 +203,6 @@ static inline void volk_8i_s32f_convert_32f_u_avx512(float* outputVector,
     }
 }
 #endif /* LV_HAVE_AVX512F */
-
-
-#ifdef LV_HAVE_SSE4_1
-#include <smmintrin.h>
-
-static inline void volk_8i_s32f_convert_32f_u_sse4_1(float* outputVector,
-                                                     const int8_t* inputVector,
-                                                     const float scalar,
-                                                     unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int sixteenthPoints = num_points / 16;
-
-    float* outputVectorPtr = outputVector;
-    const float iScalar = 1.0 / scalar;
-    __m128 invScalar = _mm_set_ps1(iScalar);
-    const int8_t* inputVectorPtr = inputVector;
-    __m128 ret;
-    __m128i inputVal;
-    __m128i interimVal;
-
-    for (; number < sixteenthPoints; number++) {
-        inputVal = _mm_loadu_si128((const __m128i*)inputVectorPtr);
-
-        interimVal = _mm_cvtepi8_epi32(inputVal);
-        ret = _mm_cvtepi32_ps(interimVal);
-        ret = _mm_mul_ps(ret, invScalar);
-        _mm_storeu_ps(outputVectorPtr, ret);
-        outputVectorPtr += 4;
-
-        inputVal = _mm_srli_si128(inputVal, 4);
-        interimVal = _mm_cvtepi8_epi32(inputVal);
-        ret = _mm_cvtepi32_ps(interimVal);
-        ret = _mm_mul_ps(ret, invScalar);
-        _mm_storeu_ps(outputVectorPtr, ret);
-        outputVectorPtr += 4;
-
-        inputVal = _mm_srli_si128(inputVal, 4);
-        interimVal = _mm_cvtepi8_epi32(inputVal);
-        ret = _mm_cvtepi32_ps(interimVal);
-        ret = _mm_mul_ps(ret, invScalar);
-        _mm_storeu_ps(outputVectorPtr, ret);
-        outputVectorPtr += 4;
-
-        inputVal = _mm_srli_si128(inputVal, 4);
-        interimVal = _mm_cvtepi8_epi32(inputVal);
-        ret = _mm_cvtepi32_ps(interimVal);
-        ret = _mm_mul_ps(ret, invScalar);
-        _mm_storeu_ps(outputVectorPtr, ret);
-        outputVectorPtr += 4;
-
-        inputVectorPtr += 16;
-    }
-
-    number = sixteenthPoints * 16;
-    for (; number < num_points; number++) {
-        outputVector[number] = (float)(inputVector[number]) * iScalar;
-    }
-}
-#endif /* LV_HAVE_SSE4_1 */
-
-#ifdef LV_HAVE_GENERIC
-
-static inline void volk_8i_s32f_convert_32f_generic(float* outputVector,
-                                                    const int8_t* inputVector,
-                                                    const float scalar,
-                                                    unsigned int num_points)
-{
-    float* outputVectorPtr = outputVector;
-    const int8_t* inputVectorPtr = inputVector;
-    unsigned int number = 0;
-    const float iScalar = 1.0 / scalar;
-
-    for (number = 0; number < num_points; number++) {
-        *outputVectorPtr++ = ((float)(*inputVectorPtr++)) * iScalar;
-    }
-}
-#endif /* LV_HAVE_GENERIC */
-
-
-#endif /* INCLUDED_VOLK_8s_CONVERT_32f_UNALIGNED8_H */
-
-#ifndef INCLUDED_volk_8i_s32f_convert_32f_a_H
-#define INCLUDED_volk_8i_s32f_convert_32f_a_H
-
-#include <inttypes.h>
-#include <stdio.h>
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-
-static inline void volk_8i_s32f_convert_32f_a_avx2(float* outputVector,
-                                                   const int8_t* inputVector,
-                                                   const float scalar,
-                                                   unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int sixteenthPoints = num_points / 16;
-
-    float* outputVectorPtr = outputVector;
-    const float iScalar = 1.0 / scalar;
-    __m256 invScalar = _mm256_set1_ps(iScalar);
-    const int8_t* inputVectorPtr = inputVector;
-    __m256 ret;
-    __m128i inputVal128;
-    __m256i interimVal;
-
-    for (; number < sixteenthPoints; number++) {
-        inputVal128 = _mm_load_si128((const __m128i*)inputVectorPtr);
-
-        interimVal = _mm256_cvtepi8_epi32(inputVal128);
-        ret = _mm256_cvtepi32_ps(interimVal);
-        ret = _mm256_mul_ps(ret, invScalar);
-        _mm256_store_ps(outputVectorPtr, ret);
-        outputVectorPtr += 8;
-
-        inputVal128 = _mm_srli_si128(inputVal128, 8);
-        interimVal = _mm256_cvtepi8_epi32(inputVal128);
-        ret = _mm256_cvtepi32_ps(interimVal);
-        ret = _mm256_mul_ps(ret, invScalar);
-        _mm256_store_ps(outputVectorPtr, ret);
-        outputVectorPtr += 8;
-
-        inputVectorPtr += 16;
-    }
-
-    number = sixteenthPoints * 16;
-    for (; number < num_points; number++) {
-        outputVector[number] = (float)(inputVector[number]) * iScalar;
-    }
-}
-#endif /* LV_HAVE_AVX2 */
-
-#ifdef LV_HAVE_AVX512F
-#include <immintrin.h>
-
-static inline void volk_8i_s32f_convert_32f_a_avx512(float* outputVector,
-                                                     const int8_t* inputVector,
-                                                     const float scalar,
-                                                     unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int sixteenthPoints = num_points / 16;
-
-    float* outputVectorPtr = outputVector;
-    const float iScalar = 1.0 / scalar;
-    __m512 invScalar = _mm512_set1_ps(iScalar);
-    const int8_t* inputVectorPtr = inputVector;
-    __m512 ret;
-    __m128i inputVal128;
-    __m512i interimVal;
-
-    for (; number < sixteenthPoints; number++) {
-        inputVal128 = _mm_load_si128((const __m128i*)inputVectorPtr);
-
-        interimVal = _mm512_cvtepi8_epi32(inputVal128);
-        ret = _mm512_cvtepi32_ps(interimVal);
-        ret = _mm512_mul_ps(ret, invScalar);
-        _mm512_store_ps(outputVectorPtr, ret);
-        outputVectorPtr += 16;
-
-        inputVectorPtr += 16;
-    }
-
-    number = sixteenthPoints * 16;
-    for (; number < num_points; number++) {
-        outputVector[number] = (float)(inputVector[number]) * iScalar;
-    }
-}
-#endif /* LV_HAVE_AVX512F */
-
-#ifdef LV_HAVE_SSE4_1
-#include <smmintrin.h>
-
-static inline void volk_8i_s32f_convert_32f_a_sse4_1(float* outputVector,
-                                                     const int8_t* inputVector,
-                                                     const float scalar,
-                                                     unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int sixteenthPoints = num_points / 16;
-
-    float* outputVectorPtr = outputVector;
-    const float iScalar = 1.0 / scalar;
-    __m128 invScalar = _mm_set_ps1(iScalar);
-    const int8_t* inputVectorPtr = inputVector;
-    __m128 ret;
-    __m128i inputVal;
-    __m128i interimVal;
-
-    for (; number < sixteenthPoints; number++) {
-        inputVal = _mm_load_si128((const __m128i*)inputVectorPtr);
-
-        interimVal = _mm_cvtepi8_epi32(inputVal);
-        ret = _mm_cvtepi32_ps(interimVal);
-        ret = _mm_mul_ps(ret, invScalar);
-        _mm_store_ps(outputVectorPtr, ret);
-        outputVectorPtr += 4;
-
-        inputVal = _mm_srli_si128(inputVal, 4);
-        interimVal = _mm_cvtepi8_epi32(inputVal);
-        ret = _mm_cvtepi32_ps(interimVal);
-        ret = _mm_mul_ps(ret, invScalar);
-        _mm_store_ps(outputVectorPtr, ret);
-        outputVectorPtr += 4;
-
-        inputVal = _mm_srli_si128(inputVal, 4);
-        interimVal = _mm_cvtepi8_epi32(inputVal);
-        ret = _mm_cvtepi32_ps(interimVal);
-        ret = _mm_mul_ps(ret, invScalar);
-        _mm_store_ps(outputVectorPtr, ret);
-        outputVectorPtr += 4;
-
-        inputVal = _mm_srli_si128(inputVal, 4);
-        interimVal = _mm_cvtepi8_epi32(inputVal);
-        ret = _mm_cvtepi32_ps(interimVal);
-        ret = _mm_mul_ps(ret, invScalar);
-        _mm_store_ps(outputVectorPtr, ret);
-        outputVectorPtr += 4;
-
-        inputVectorPtr += 16;
-    }
-
-    number = sixteenthPoints * 16;
-    for (; number < num_points; number++) {
-        outputVector[number] = (float)(inputVector[number]) * iScalar;
-    }
-}
-#endif /* LV_HAVE_SSE4_1 */
 
 #ifdef LV_HAVE_NEON
 #include <arm_neon.h>
@@ -462,22 +310,6 @@ static inline void volk_8i_s32f_convert_32f_neonv8(float* outputVector,
 }
 #endif /* LV_HAVE_NEONV8 */
 
-#ifdef LV_HAVE_ORC
-extern void volk_8i_s32f_convert_32f_a_orc_impl(float* outputVector,
-                                                const int8_t* inputVector,
-                                                const float scalar,
-                                                int num_points);
-
-static inline void volk_8i_s32f_convert_32f_u_orc(float* outputVector,
-                                                  const int8_t* inputVector,
-                                                  const float scalar,
-                                                  unsigned int num_points)
-{
-    float invscalar = 1.0 / scalar;
-    volk_8i_s32f_convert_32f_a_orc_impl(outputVector, inputVector, invscalar, num_points);
-}
-#endif /* LV_HAVE_ORC */
-
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 
@@ -494,6 +326,172 @@ static inline void volk_8i_s32f_convert_32f_rvv(float* outputVector,
             outputVector, __riscv_vfmul(__riscv_vfwcvt_f(v, vl), 1.0f / scalar, vl), vl);
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
 
-#endif /* INCLUDED_VOLK_8s_CONVERT_32f_ALIGNED8_H */
+#ifdef LV_HAVE_ORC
+extern void volk_8i_s32f_convert_32f_a_orc_impl(float* outputVector,
+                                                const int8_t* inputVector,
+                                                const float scalar,
+                                                int num_points);
+
+static inline void volk_8i_s32f_convert_32f_u_orc(float* outputVector,
+                                                  const int8_t* inputVector,
+                                                  const float scalar,
+                                                  unsigned int num_points)
+{
+    float invscalar = 1.0 / scalar;
+    volk_8i_s32f_convert_32f_a_orc_impl(outputVector, inputVector, invscalar, num_points);
+}
+#endif /* LV_HAVE_ORC */
+
+#endif /* INCLUDED_volk_8i_s32f_convert_32f_u_H */
+
+#ifndef INCLUDED_volk_8i_s32f_convert_32f_a_H
+#define INCLUDED_volk_8i_s32f_convert_32f_a_H
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#ifdef LV_HAVE_SSE4_1
+#include <smmintrin.h>
+
+static inline void volk_8i_s32f_convert_32f_a_sse4_1(float* outputVector,
+                                                     const int8_t* inputVector,
+                                                     const float scalar,
+                                                     unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int sixteenthPoints = num_points / 16;
+
+    float* outputVectorPtr = outputVector;
+    const float iScalar = 1.0 / scalar;
+    __m128 invScalar = _mm_set_ps1(iScalar);
+    const int8_t* inputVectorPtr = inputVector;
+    __m128 ret;
+    __m128i inputVal;
+    __m128i interimVal;
+
+    for (; number < sixteenthPoints; number++) {
+        inputVal = _mm_load_si128((const __m128i*)inputVectorPtr);
+
+        interimVal = _mm_cvtepi8_epi32(inputVal);
+        ret = _mm_cvtepi32_ps(interimVal);
+        ret = _mm_mul_ps(ret, invScalar);
+        _mm_store_ps(outputVectorPtr, ret);
+        outputVectorPtr += 4;
+
+        inputVal = _mm_srli_si128(inputVal, 4);
+        interimVal = _mm_cvtepi8_epi32(inputVal);
+        ret = _mm_cvtepi32_ps(interimVal);
+        ret = _mm_mul_ps(ret, invScalar);
+        _mm_store_ps(outputVectorPtr, ret);
+        outputVectorPtr += 4;
+
+        inputVal = _mm_srli_si128(inputVal, 4);
+        interimVal = _mm_cvtepi8_epi32(inputVal);
+        ret = _mm_cvtepi32_ps(interimVal);
+        ret = _mm_mul_ps(ret, invScalar);
+        _mm_store_ps(outputVectorPtr, ret);
+        outputVectorPtr += 4;
+
+        inputVal = _mm_srli_si128(inputVal, 4);
+        interimVal = _mm_cvtepi8_epi32(inputVal);
+        ret = _mm_cvtepi32_ps(interimVal);
+        ret = _mm_mul_ps(ret, invScalar);
+        _mm_store_ps(outputVectorPtr, ret);
+        outputVectorPtr += 4;
+
+        inputVectorPtr += 16;
+    }
+
+    number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        outputVector[number] = (float)(inputVector[number]) * iScalar;
+    }
+}
+#endif /* LV_HAVE_SSE4_1 */
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void volk_8i_s32f_convert_32f_a_avx2(float* outputVector,
+                                                   const int8_t* inputVector,
+                                                   const float scalar,
+                                                   unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int sixteenthPoints = num_points / 16;
+
+    float* outputVectorPtr = outputVector;
+    const float iScalar = 1.0 / scalar;
+    __m256 invScalar = _mm256_set1_ps(iScalar);
+    const int8_t* inputVectorPtr = inputVector;
+    __m256 ret;
+    __m128i inputVal128;
+    __m256i interimVal;
+
+    for (; number < sixteenthPoints; number++) {
+        inputVal128 = _mm_load_si128((const __m128i*)inputVectorPtr);
+
+        interimVal = _mm256_cvtepi8_epi32(inputVal128);
+        ret = _mm256_cvtepi32_ps(interimVal);
+        ret = _mm256_mul_ps(ret, invScalar);
+        _mm256_store_ps(outputVectorPtr, ret);
+        outputVectorPtr += 8;
+
+        inputVal128 = _mm_srli_si128(inputVal128, 8);
+        interimVal = _mm256_cvtepi8_epi32(inputVal128);
+        ret = _mm256_cvtepi32_ps(interimVal);
+        ret = _mm256_mul_ps(ret, invScalar);
+        _mm256_store_ps(outputVectorPtr, ret);
+        outputVectorPtr += 8;
+
+        inputVectorPtr += 16;
+    }
+
+    number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        outputVector[number] = (float)(inputVector[number]) * iScalar;
+    }
+}
+#endif /* LV_HAVE_AVX2 */
+
+#ifdef LV_HAVE_AVX512F
+#include <immintrin.h>
+
+static inline void volk_8i_s32f_convert_32f_a_avx512(float* outputVector,
+                                                     const int8_t* inputVector,
+                                                     const float scalar,
+                                                     unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int sixteenthPoints = num_points / 16;
+
+    float* outputVectorPtr = outputVector;
+    const float iScalar = 1.0 / scalar;
+    __m512 invScalar = _mm512_set1_ps(iScalar);
+    const int8_t* inputVectorPtr = inputVector;
+    __m512 ret;
+    __m128i inputVal128;
+    __m512i interimVal;
+
+    for (; number < sixteenthPoints; number++) {
+        inputVal128 = _mm_load_si128((const __m128i*)inputVectorPtr);
+
+        interimVal = _mm512_cvtepi8_epi32(inputVal128);
+        ret = _mm512_cvtepi32_ps(interimVal);
+        ret = _mm512_mul_ps(ret, invScalar);
+        _mm512_store_ps(outputVectorPtr, ret);
+        outputVectorPtr += 16;
+
+        inputVectorPtr += 16;
+    }
+
+    number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        outputVector[number] = (float)(inputVector[number]) * iScalar;
+    }
+}
+#endif /* LV_HAVE_AVX512F */
+
+#endif /* INCLUDED_volk_8i_s32f_convert_32f_a_H */

--- a/kernels/volk/volk_8i_s32f_convert_32f.h
+++ b/kernels/volk/volk_8i_s32f_convert_32f.h
@@ -64,7 +64,7 @@ static inline void volk_8i_s32f_convert_32f_u_avx2(float* outputVector,
     __m256i interimVal;
 
     for (; number < sixteenthPoints; number++) {
-        inputVal128 = _mm_loadu_si128((__m128i*)inputVectorPtr);
+        inputVal128 = _mm_loadu_si128((const __m128i*)inputVectorPtr);
 
         interimVal = _mm256_cvtepi8_epi32(inputVal128);
         ret = _mm256_cvtepi32_ps(interimVal);
@@ -109,7 +109,7 @@ static inline void volk_8i_s32f_convert_32f_u_avx512(float* outputVector,
     __m512i interimVal;
 
     for (; number < sixteenthPoints; number++) {
-        inputVal128 = _mm_loadu_si128((__m128i*)inputVectorPtr);
+        inputVal128 = _mm_loadu_si128((const __m128i*)inputVectorPtr);
 
         interimVal = _mm512_cvtepi8_epi32(inputVal128);
         ret = _mm512_cvtepi32_ps(interimVal);
@@ -148,7 +148,7 @@ static inline void volk_8i_s32f_convert_32f_u_sse4_1(float* outputVector,
     __m128i interimVal;
 
     for (; number < sixteenthPoints; number++) {
-        inputVal = _mm_loadu_si128((__m128i*)inputVectorPtr);
+        inputVal = _mm_loadu_si128((const __m128i*)inputVectorPtr);
 
         interimVal = _mm_cvtepi8_epi32(inputVal);
         ret = _mm_cvtepi32_ps(interimVal);
@@ -234,7 +234,7 @@ static inline void volk_8i_s32f_convert_32f_a_avx2(float* outputVector,
     __m256i interimVal;
 
     for (; number < sixteenthPoints; number++) {
-        inputVal128 = _mm_load_si128((__m128i*)inputVectorPtr);
+        inputVal128 = _mm_load_si128((const __m128i*)inputVectorPtr);
 
         interimVal = _mm256_cvtepi8_epi32(inputVal128);
         ret = _mm256_cvtepi32_ps(interimVal);
@@ -279,7 +279,7 @@ static inline void volk_8i_s32f_convert_32f_a_avx512(float* outputVector,
     __m512i interimVal;
 
     for (; number < sixteenthPoints; number++) {
-        inputVal128 = _mm_load_si128((__m128i*)inputVectorPtr);
+        inputVal128 = _mm_load_si128((const __m128i*)inputVectorPtr);
 
         interimVal = _mm512_cvtepi8_epi32(inputVal128);
         ret = _mm512_cvtepi32_ps(interimVal);
@@ -317,7 +317,7 @@ static inline void volk_8i_s32f_convert_32f_a_sse4_1(float* outputVector,
     __m128i interimVal;
 
     for (; number < sixteenthPoints; number++) {
-        inputVal = _mm_load_si128((__m128i*)inputVectorPtr);
+        inputVal = _mm_load_si128((const __m128i*)inputVectorPtr);
 
         interimVal = _mm_cvtepi8_epi32(inputVal);
         ret = _mm_cvtepi32_ps(interimVal);

--- a/kernels/volk/volk_8ic_deinterleave_16i_x2.h
+++ b/kernels/volk/volk_8ic_deinterleave_16i_x2.h
@@ -53,7 +53,7 @@ static inline void volk_8ic_deinterleave_16i_x2_a_avx2(int16_t* iBuffer,
                                                        unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     int16_t* qBufferPtr = qBuffer;
     __m256i MoveMask = _mm256_set_epi8(15,
@@ -94,7 +94,7 @@ static inline void volk_8ic_deinterleave_16i_x2_a_avx2(int16_t* iBuffer,
     unsigned int sixteenthPoints = num_points / 16;
 
     for (number = 0; number < sixteenthPoints; number++) {
-        complexVal = _mm256_load_si256((__m256i*)complexVectorPtr);
+        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
 
         complexVal = _mm256_shuffle_epi8(complexVal, MoveMask);
@@ -135,7 +135,7 @@ static inline void volk_8ic_deinterleave_16i_x2_a_sse4_1(int16_t* iBuffer,
                                                          unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     int16_t* qBufferPtr = qBuffer;
     __m128i iMoveMask = _mm_set_epi8(0x80,
@@ -161,7 +161,7 @@ static inline void volk_8ic_deinterleave_16i_x2_a_sse4_1(int16_t* iBuffer,
     unsigned int eighthPoints = num_points / 8;
 
     for (number = 0; number < eighthPoints; number++) {
-        complexVal = _mm_load_si128((__m128i*)complexVectorPtr);
+        complexVal = _mm_load_si128((const __m128i*)complexVectorPtr);
         complexVectorPtr += 16; // aligned load
 
         iOutputVal = _mm_shuffle_epi8(complexVal,
@@ -204,7 +204,7 @@ static inline void volk_8ic_deinterleave_16i_x2_a_avx(int16_t* iBuffer,
                                                       unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     int16_t* qBufferPtr = qBuffer;
     __m128i iMoveMask = _mm_set_epi8(0x80,
@@ -232,7 +232,7 @@ static inline void volk_8ic_deinterleave_16i_x2_a_avx(int16_t* iBuffer,
     unsigned int sixteenthPoints = num_points / 16;
 
     for (number = 0; number < sixteenthPoints; number++) {
-        complexVal = _mm256_load_si256((__m256i*)complexVectorPtr);
+        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32; // aligned load
 
         // Extract from complexVal to iOutputVal and qOutputVal
@@ -320,7 +320,7 @@ static inline void volk_8ic_deinterleave_16i_x2_u_avx2(int16_t* iBuffer,
                                                        unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     int16_t* qBufferPtr = qBuffer;
     __m256i MoveMask = _mm256_set_epi8(15,
@@ -361,7 +361,7 @@ static inline void volk_8ic_deinterleave_16i_x2_u_avx2(int16_t* iBuffer,
     unsigned int sixteenthPoints = num_points / 16;
 
     for (number = 0; number < sixteenthPoints; number++) {
-        complexVal = _mm256_loadu_si256((__m256i*)complexVectorPtr);
+        complexVal = _mm256_loadu_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
 
         complexVal = _mm256_shuffle_epi8(complexVal, MoveMask);

--- a/kernels/volk/volk_8ic_deinterleave_16i_x2.h
+++ b/kernels/volk/volk_8ic_deinterleave_16i_x2.h
@@ -38,16 +38,34 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_8ic_deinterleave_16i_x2_a_H
-#define INCLUDED_volk_8ic_deinterleave_16i_x2_a_H
+#ifndef INCLUDED_volk_8ic_deinterleave_16i_x2_u_H
+#define INCLUDED_volk_8ic_deinterleave_16i_x2_u_H
 
 #include <inttypes.h>
 #include <stdio.h>
 
+#ifdef LV_HAVE_GENERIC
+
+static inline void volk_8ic_deinterleave_16i_x2_generic(int16_t* iBuffer,
+                                                        int16_t* qBuffer,
+                                                        const lv_8sc_t* complexVector,
+                                                        unsigned int num_points)
+{
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
+    int16_t* iBufferPtr = iBuffer;
+    int16_t* qBufferPtr = qBuffer;
+    unsigned int number;
+    for (number = 0; number < num_points; number++) {
+        *iBufferPtr++ = (int16_t)(*complexVectorPtr++) * 256;
+        *qBufferPtr++ = (int16_t)(*complexVectorPtr++) * 256;
+    }
+}
+#endif /* LV_HAVE_GENERIC */
+
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
 
-static inline void volk_8ic_deinterleave_16i_x2_a_avx2(int16_t* iBuffer,
+static inline void volk_8ic_deinterleave_16i_x2_u_avx2(int16_t* iBuffer,
                                                        int16_t* qBuffer,
                                                        const lv_8sc_t* complexVector,
                                                        unsigned int num_points)
@@ -94,7 +112,7 @@ static inline void volk_8ic_deinterleave_16i_x2_a_avx2(int16_t* iBuffer,
     unsigned int sixteenthPoints = num_points / 16;
 
     for (number = 0; number < sixteenthPoints; number++) {
-        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
+        complexVal = _mm256_loadu_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
 
         complexVal = _mm256_shuffle_epi8(complexVal, MoveMask);
@@ -109,8 +127,8 @@ static inline void volk_8ic_deinterleave_16i_x2_a_avx2(int16_t* iBuffer,
         qOutputVal = _mm256_cvtepi8_epi16(qOutputVal0);
         qOutputVal = _mm256_slli_epi16(qOutputVal, 8);
 
-        _mm256_store_si256((__m256i*)iBufferPtr, iOutputVal);
-        _mm256_store_si256((__m256i*)qBufferPtr, qOutputVal);
+        _mm256_storeu_si256((__m256i*)iBufferPtr, iOutputVal);
+        _mm256_storeu_si256((__m256i*)qBufferPtr, qOutputVal);
 
         iBufferPtr += 16;
         qBufferPtr += 16;
@@ -125,6 +143,70 @@ static inline void volk_8ic_deinterleave_16i_x2_a_avx2(int16_t* iBuffer,
     }
 }
 #endif /* LV_HAVE_AVX2 */
+
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+
+static inline void volk_8ic_deinterleave_16i_x2_neon(int16_t* iBuffer,
+                                                     int16_t* qBuffer,
+                                                     const lv_8sc_t* complexVector,
+                                                     unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int eighth_points = num_points / 8;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
+    int16_t* iBufferPtr = iBuffer;
+    int16_t* qBufferPtr = qBuffer;
+
+    for (; number < eighth_points; number++) {
+        int8x8x2_t input = vld2_s8(complexVectorPtr);
+        complexVectorPtr += 16;
+
+        int16x8_t iVal = vshll_n_s8(input.val[0], 8);
+        int16x8_t qVal = vshll_n_s8(input.val[1], 8);
+
+        vst1q_s16(iBufferPtr, iVal);
+        vst1q_s16(qBufferPtr, qVal);
+        iBufferPtr += 8;
+        qBufferPtr += 8;
+    }
+
+    number = eighth_points * 8;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = ((int16_t)*complexVectorPtr++) * 256;
+        *qBufferPtr++ = ((int16_t)*complexVectorPtr++) * 256;
+    }
+}
+#endif /* LV_HAVE_NEON */
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_8ic_deinterleave_16i_x2_rvv(int16_t* iBuffer,
+                                                    int16_t* qBuffer,
+                                                    const lv_8sc_t* complexVector,
+                                                    unsigned int num_points)
+{
+    const uint16_t* in = (const uint16_t*)complexVector;
+    size_t n = num_points;
+    for (size_t vl; n > 0; n -= vl, in += vl, iBuffer += vl, qBuffer += vl) {
+        vl = __riscv_vsetvl_e16m8(n);
+        vuint16m8_t vc = __riscv_vle16_v_u16m8(in, vl);
+        vuint16m8_t vr = __riscv_vsll(vc, 8, vl);
+        vuint16m8_t vi = __riscv_vand(vc, 0xFF00, vl);
+        __riscv_vse16((uint16_t*)iBuffer, vr, vl);
+        __riscv_vse16((uint16_t*)qBuffer, vi, vl);
+    }
+}
+#endif /* LV_HAVE_RVV */
+
+#endif /* INCLUDED_volk_8ic_deinterleave_16i_x2_u_H */
+
+#ifndef INCLUDED_volk_8ic_deinterleave_16i_x2_a_H
+#define INCLUDED_volk_8ic_deinterleave_16i_x2_a_H
+
+#include <inttypes.h>
+#include <stdio.h>
 
 #ifdef LV_HAVE_SSE4_1
 #include <smmintrin.h>
@@ -284,37 +366,10 @@ static inline void volk_8ic_deinterleave_16i_x2_a_avx(int16_t* iBuffer,
 #endif /* LV_HAVE_AVX */
 
 
-#ifdef LV_HAVE_GENERIC
-
-static inline void volk_8ic_deinterleave_16i_x2_generic(int16_t* iBuffer,
-                                                        int16_t* qBuffer,
-                                                        const lv_8sc_t* complexVector,
-                                                        unsigned int num_points)
-{
-    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
-    int16_t* iBufferPtr = iBuffer;
-    int16_t* qBufferPtr = qBuffer;
-    unsigned int number;
-    for (number = 0; number < num_points; number++) {
-        *iBufferPtr++ = (int16_t)(*complexVectorPtr++) * 256;
-        *qBufferPtr++ = (int16_t)(*complexVectorPtr++) * 256;
-    }
-}
-#endif /* LV_HAVE_GENERIC */
-
-
-#endif /* INCLUDED_volk_8ic_deinterleave_16i_x2_a_H */
-
-#ifndef INCLUDED_volk_8ic_deinterleave_16i_x2_u_H
-#define INCLUDED_volk_8ic_deinterleave_16i_x2_u_H
-
-#include <inttypes.h>
-#include <stdio.h>
-
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
 
-static inline void volk_8ic_deinterleave_16i_x2_u_avx2(int16_t* iBuffer,
+static inline void volk_8ic_deinterleave_16i_x2_a_avx2(int16_t* iBuffer,
                                                        int16_t* qBuffer,
                                                        const lv_8sc_t* complexVector,
                                                        unsigned int num_points)
@@ -361,7 +416,7 @@ static inline void volk_8ic_deinterleave_16i_x2_u_avx2(int16_t* iBuffer,
     unsigned int sixteenthPoints = num_points / 16;
 
     for (number = 0; number < sixteenthPoints; number++) {
-        complexVal = _mm256_loadu_si256((const __m256i*)complexVectorPtr);
+        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
 
         complexVal = _mm256_shuffle_epi8(complexVal, MoveMask);
@@ -376,8 +431,8 @@ static inline void volk_8ic_deinterleave_16i_x2_u_avx2(int16_t* iBuffer,
         qOutputVal = _mm256_cvtepi8_epi16(qOutputVal0);
         qOutputVal = _mm256_slli_epi16(qOutputVal, 8);
 
-        _mm256_storeu_si256((__m256i*)iBufferPtr, iOutputVal);
-        _mm256_storeu_si256((__m256i*)qBufferPtr, qOutputVal);
+        _mm256_store_si256((__m256i*)iBufferPtr, iOutputVal);
+        _mm256_store_si256((__m256i*)qBufferPtr, qOutputVal);
 
         iBufferPtr += 16;
         qBufferPtr += 16;
@@ -393,60 +448,4 @@ static inline void volk_8ic_deinterleave_16i_x2_u_avx2(int16_t* iBuffer,
 }
 #endif /* LV_HAVE_AVX2 */
 
-#ifdef LV_HAVE_NEON
-#include <arm_neon.h>
-
-static inline void volk_8ic_deinterleave_16i_x2_neon(int16_t* iBuffer,
-                                                     int16_t* qBuffer,
-                                                     const lv_8sc_t* complexVector,
-                                                     unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int eighth_points = num_points / 8;
-    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
-    int16_t* iBufferPtr = iBuffer;
-    int16_t* qBufferPtr = qBuffer;
-
-    for (; number < eighth_points; number++) {
-        int8x8x2_t input = vld2_s8(complexVectorPtr);
-        complexVectorPtr += 16;
-
-        int16x8_t iVal = vshll_n_s8(input.val[0], 8);
-        int16x8_t qVal = vshll_n_s8(input.val[1], 8);
-
-        vst1q_s16(iBufferPtr, iVal);
-        vst1q_s16(qBufferPtr, qVal);
-        iBufferPtr += 8;
-        qBufferPtr += 8;
-    }
-
-    number = eighth_points * 8;
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = ((int16_t)*complexVectorPtr++) * 256;
-        *qBufferPtr++ = ((int16_t)*complexVectorPtr++) * 256;
-    }
-}
-#endif /* LV_HAVE_NEON */
-
-#ifdef LV_HAVE_RVV
-#include <riscv_vector.h>
-
-static inline void volk_8ic_deinterleave_16i_x2_rvv(int16_t* iBuffer,
-                                                    int16_t* qBuffer,
-                                                    const lv_8sc_t* complexVector,
-                                                    unsigned int num_points)
-{
-    const uint16_t* in = (const uint16_t*)complexVector;
-    size_t n = num_points;
-    for (size_t vl; n > 0; n -= vl, in += vl, iBuffer += vl, qBuffer += vl) {
-        vl = __riscv_vsetvl_e16m8(n);
-        vuint16m8_t vc = __riscv_vle16_v_u16m8(in, vl);
-        vuint16m8_t vr = __riscv_vsll(vc, 8, vl);
-        vuint16m8_t vi = __riscv_vand(vc, 0xFF00, vl);
-        __riscv_vse16((uint16_t*)iBuffer, vr, vl);
-        __riscv_vse16((uint16_t*)qBuffer, vi, vl);
-    }
-}
-#endif /*LV_HAVE_RVV*/
-
-#endif /* INCLUDED_volk_8ic_deinterleave_16i_x2_u_H */
+#endif /* INCLUDED_volk_8ic_deinterleave_16i_x2_a_H */

--- a/kernels/volk/volk_8ic_deinterleave_real_16i.h
+++ b/kernels/volk/volk_8ic_deinterleave_real_16i.h
@@ -37,170 +37,11 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_8ic_deinterleave_real_16i_a_H
-#define INCLUDED_volk_8ic_deinterleave_real_16i_a_H
+#ifndef INCLUDED_volk_8ic_deinterleave_real_16i_u_H
+#define INCLUDED_volk_8ic_deinterleave_real_16i_u_H
 
 #include <inttypes.h>
 #include <stdio.h>
-
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-
-static inline void volk_8ic_deinterleave_real_16i_a_avx2(int16_t* iBuffer,
-                                                         const lv_8sc_t* complexVector,
-                                                         unsigned int num_points)
-{
-    unsigned int number = 0;
-    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
-    int16_t* iBufferPtr = iBuffer;
-    __m256i moveMask = _mm256_set_epi8(0x80,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       14,
-                                       12,
-                                       10,
-                                       8,
-                                       6,
-                                       4,
-                                       2,
-                                       0,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       14,
-                                       12,
-                                       10,
-                                       8,
-                                       6,
-                                       4,
-                                       2,
-                                       0);
-    __m256i complexVal, outputVal;
-    __m128i outputVal0;
-
-    unsigned int sixteenthPoints = num_points / 16;
-
-    for (number = 0; number < sixteenthPoints; number++) {
-        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
-        complexVectorPtr += 32;
-
-        complexVal = _mm256_shuffle_epi8(complexVal, moveMask);
-        complexVal = _mm256_permute4x64_epi64(complexVal, 0xd8);
-
-        outputVal0 = _mm256_extractf128_si256(complexVal, 0);
-
-        outputVal = _mm256_cvtepi8_epi16(outputVal0);
-        outputVal = _mm256_slli_epi16(outputVal, 7);
-
-        _mm256_store_si256((__m256i*)iBufferPtr, outputVal);
-
-        iBufferPtr += 16;
-    }
-
-    number = sixteenthPoints * 16;
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = ((int16_t)*complexVectorPtr++) * 128;
-        complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_AVX2 */
-
-#ifdef LV_HAVE_SSE4_1
-#include <smmintrin.h>
-
-static inline void volk_8ic_deinterleave_real_16i_a_sse4_1(int16_t* iBuffer,
-                                                           const lv_8sc_t* complexVector,
-                                                           unsigned int num_points)
-{
-    unsigned int number = 0;
-    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
-    int16_t* iBufferPtr = iBuffer;
-    __m128i moveMask = _mm_set_epi8(
-        0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
-    __m128i complexVal, outputVal;
-
-    unsigned int eighthPoints = num_points / 8;
-
-    for (number = 0; number < eighthPoints; number++) {
-        complexVal = _mm_load_si128((const __m128i*)complexVectorPtr);
-        complexVectorPtr += 16;
-
-        complexVal = _mm_shuffle_epi8(complexVal, moveMask);
-
-        outputVal = _mm_cvtepi8_epi16(complexVal);
-        outputVal = _mm_slli_epi16(outputVal, 7);
-
-        _mm_store_si128((__m128i*)iBufferPtr, outputVal);
-        iBufferPtr += 8;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = ((int16_t)*complexVectorPtr++) * 128;
-        complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_SSE4_1 */
-
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-
-static inline void volk_8ic_deinterleave_real_16i_a_avx(int16_t* iBuffer,
-                                                        const lv_8sc_t* complexVector,
-                                                        unsigned int num_points)
-{
-    unsigned int number = 0;
-    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
-    int16_t* iBufferPtr = iBuffer;
-    __m128i moveMask = _mm_set_epi8(
-        0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
-    __m256i complexVal, outputVal;
-    __m128i complexVal1, complexVal0, outputVal1, outputVal0;
-
-    unsigned int sixteenthPoints = num_points / 16;
-
-    for (number = 0; number < sixteenthPoints; number++) {
-        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
-        complexVectorPtr += 32;
-
-        complexVal1 = _mm256_extractf128_si256(complexVal, 1);
-        complexVal0 = _mm256_extractf128_si256(complexVal, 0);
-
-        outputVal1 = _mm_shuffle_epi8(complexVal1, moveMask);
-        outputVal0 = _mm_shuffle_epi8(complexVal0, moveMask);
-
-        outputVal1 = _mm_cvtepi8_epi16(outputVal1);
-        outputVal1 = _mm_slli_epi16(outputVal1, 7);
-        outputVal0 = _mm_cvtepi8_epi16(outputVal0);
-        outputVal0 = _mm_slli_epi16(outputVal0, 7);
-
-        __m256i dummy = _mm256_setzero_si256();
-        outputVal = _mm256_insertf128_si256(dummy, outputVal0, 0);
-        outputVal = _mm256_insertf128_si256(outputVal, outputVal1, 1);
-        _mm256_store_si256((__m256i*)iBufferPtr, outputVal);
-
-        iBufferPtr += 16;
-    }
-
-    number = sixteenthPoints * 16;
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = ((int16_t)*complexVectorPtr++) * 128;
-        complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_AVX */
 
 
 #ifdef LV_HAVE_GENERIC
@@ -218,15 +59,6 @@ static inline void volk_8ic_deinterleave_real_16i_generic(int16_t* iBuffer,
     }
 }
 #endif /* LV_HAVE_GENERIC */
-
-
-#endif /* INCLUDED_volk_8ic_deinterleave_real_16i_a_H */
-
-#ifndef INCLUDED_volk_8ic_deinterleave_real_16i_u_H
-#define INCLUDED_volk_8ic_deinterleave_real_16i_u_H
-
-#include <inttypes.h>
-#include <stdio.h>
 
 
 #ifdef LV_HAVE_AVX2
@@ -346,6 +178,174 @@ static inline void volk_8ic_deinterleave_real_16i_rvv(int16_t* iBuffer,
         __riscv_vse16(iBuffer, __riscv_vsra(__riscv_vsll(v, 8, vl), 1, vl), vl);
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
 
 #endif /* INCLUDED_volk_8ic_deinterleave_real_16i_u_H */
+
+#ifndef INCLUDED_volk_8ic_deinterleave_real_16i_a_H
+#define INCLUDED_volk_8ic_deinterleave_real_16i_a_H
+
+#include <inttypes.h>
+#include <stdio.h>
+
+
+#ifdef LV_HAVE_SSE4_1
+#include <smmintrin.h>
+
+static inline void volk_8ic_deinterleave_real_16i_a_sse4_1(int16_t* iBuffer,
+                                                           const lv_8sc_t* complexVector,
+                                                           unsigned int num_points)
+{
+    unsigned int number = 0;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
+    int16_t* iBufferPtr = iBuffer;
+    __m128i moveMask = _mm_set_epi8(
+        0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
+    __m128i complexVal, outputVal;
+
+    unsigned int eighthPoints = num_points / 8;
+
+    for (number = 0; number < eighthPoints; number++) {
+        complexVal = _mm_load_si128((const __m128i*)complexVectorPtr);
+        complexVectorPtr += 16;
+
+        complexVal = _mm_shuffle_epi8(complexVal, moveMask);
+
+        outputVal = _mm_cvtepi8_epi16(complexVal);
+        outputVal = _mm_slli_epi16(outputVal, 7);
+
+        _mm_store_si128((__m128i*)iBufferPtr, outputVal);
+        iBufferPtr += 8;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = ((int16_t)*complexVectorPtr++) * 128;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_SSE4_1 */
+
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void volk_8ic_deinterleave_real_16i_a_avx(int16_t* iBuffer,
+                                                        const lv_8sc_t* complexVector,
+                                                        unsigned int num_points)
+{
+    unsigned int number = 0;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
+    int16_t* iBufferPtr = iBuffer;
+    __m128i moveMask = _mm_set_epi8(
+        0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
+    __m256i complexVal, outputVal;
+    __m128i complexVal1, complexVal0, outputVal1, outputVal0;
+
+    unsigned int sixteenthPoints = num_points / 16;
+
+    for (number = 0; number < sixteenthPoints; number++) {
+        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
+        complexVectorPtr += 32;
+
+        complexVal1 = _mm256_extractf128_si256(complexVal, 1);
+        complexVal0 = _mm256_extractf128_si256(complexVal, 0);
+
+        outputVal1 = _mm_shuffle_epi8(complexVal1, moveMask);
+        outputVal0 = _mm_shuffle_epi8(complexVal0, moveMask);
+
+        outputVal1 = _mm_cvtepi8_epi16(outputVal1);
+        outputVal1 = _mm_slli_epi16(outputVal1, 7);
+        outputVal0 = _mm_cvtepi8_epi16(outputVal0);
+        outputVal0 = _mm_slli_epi16(outputVal0, 7);
+
+        __m256i dummy = _mm256_setzero_si256();
+        outputVal = _mm256_insertf128_si256(dummy, outputVal0, 0);
+        outputVal = _mm256_insertf128_si256(outputVal, outputVal1, 1);
+        _mm256_store_si256((__m256i*)iBufferPtr, outputVal);
+
+        iBufferPtr += 16;
+    }
+
+    number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = ((int16_t)*complexVectorPtr++) * 128;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_AVX */
+
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void volk_8ic_deinterleave_real_16i_a_avx2(int16_t* iBuffer,
+                                                         const lv_8sc_t* complexVector,
+                                                         unsigned int num_points)
+{
+    unsigned int number = 0;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
+    int16_t* iBufferPtr = iBuffer;
+    __m256i moveMask = _mm256_set_epi8(0x80,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       14,
+                                       12,
+                                       10,
+                                       8,
+                                       6,
+                                       4,
+                                       2,
+                                       0,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       14,
+                                       12,
+                                       10,
+                                       8,
+                                       6,
+                                       4,
+                                       2,
+                                       0);
+    __m256i complexVal, outputVal;
+    __m128i outputVal0;
+
+    unsigned int sixteenthPoints = num_points / 16;
+
+    for (number = 0; number < sixteenthPoints; number++) {
+        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
+        complexVectorPtr += 32;
+
+        complexVal = _mm256_shuffle_epi8(complexVal, moveMask);
+        complexVal = _mm256_permute4x64_epi64(complexVal, 0xd8);
+
+        outputVal0 = _mm256_extractf128_si256(complexVal, 0);
+
+        outputVal = _mm256_cvtepi8_epi16(outputVal0);
+        outputVal = _mm256_slli_epi16(outputVal, 7);
+
+        _mm256_store_si256((__m256i*)iBufferPtr, outputVal);
+
+        iBufferPtr += 16;
+    }
+
+    number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = ((int16_t)*complexVectorPtr++) * 128;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_AVX2 */
+
+#endif /* INCLUDED_volk_8ic_deinterleave_real_16i_a_H */

--- a/kernels/volk/volk_8ic_deinterleave_real_16i.h
+++ b/kernels/volk/volk_8ic_deinterleave_real_16i.h
@@ -52,7 +52,7 @@ static inline void volk_8ic_deinterleave_real_16i_a_avx2(int16_t* iBuffer,
                                                          unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     __m256i moveMask = _mm256_set_epi8(0x80,
                                        0x80,
@@ -92,7 +92,7 @@ static inline void volk_8ic_deinterleave_real_16i_a_avx2(int16_t* iBuffer,
     unsigned int sixteenthPoints = num_points / 16;
 
     for (number = 0; number < sixteenthPoints; number++) {
-        complexVal = _mm256_load_si256((__m256i*)complexVectorPtr);
+        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
 
         complexVal = _mm256_shuffle_epi8(complexVal, moveMask);
@@ -124,7 +124,7 @@ static inline void volk_8ic_deinterleave_real_16i_a_sse4_1(int16_t* iBuffer,
                                                            unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     __m128i moveMask = _mm_set_epi8(
         0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
@@ -133,7 +133,7 @@ static inline void volk_8ic_deinterleave_real_16i_a_sse4_1(int16_t* iBuffer,
     unsigned int eighthPoints = num_points / 8;
 
     for (number = 0; number < eighthPoints; number++) {
-        complexVal = _mm_load_si128((__m128i*)complexVectorPtr);
+        complexVal = _mm_load_si128((const __m128i*)complexVectorPtr);
         complexVectorPtr += 16;
 
         complexVal = _mm_shuffle_epi8(complexVal, moveMask);
@@ -162,7 +162,7 @@ static inline void volk_8ic_deinterleave_real_16i_a_avx(int16_t* iBuffer,
                                                         unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     __m128i moveMask = _mm_set_epi8(
         0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
@@ -172,7 +172,7 @@ static inline void volk_8ic_deinterleave_real_16i_a_avx(int16_t* iBuffer,
     unsigned int sixteenthPoints = num_points / 16;
 
     for (number = 0; number < sixteenthPoints; number++) {
-        complexVal = _mm256_load_si256((__m256i*)complexVectorPtr);
+        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
 
         complexVal1 = _mm256_extractf128_si256(complexVal, 1);
@@ -237,7 +237,7 @@ static inline void volk_8ic_deinterleave_real_16i_u_avx2(int16_t* iBuffer,
                                                          unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int16_t* iBufferPtr = iBuffer;
     __m256i moveMask = _mm256_set_epi8(0x80,
                                        0x80,
@@ -277,7 +277,7 @@ static inline void volk_8ic_deinterleave_real_16i_u_avx2(int16_t* iBuffer,
     unsigned int sixteenthPoints = num_points / 16;
 
     for (number = 0; number < sixteenthPoints; number++) {
-        complexVal = _mm256_loadu_si256((__m256i*)complexVectorPtr);
+        complexVal = _mm256_loadu_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
 
         complexVal = _mm256_shuffle_epi8(complexVal, moveMask);

--- a/kernels/volk/volk_8ic_deinterleave_real_8i.h
+++ b/kernels/volk/volk_8ic_deinterleave_real_8i.h
@@ -37,11 +37,314 @@
  * \endcode
  */
 
-#ifndef INCLUDED_VOLK_8sc_DEINTERLEAVE_REAL_8s_ALIGNED8_H
-#define INCLUDED_VOLK_8sc_DEINTERLEAVE_REAL_8s_ALIGNED8_H
+#ifndef INCLUDED_volk_8ic_deinterleave_real_8i_u_H
+#define INCLUDED_volk_8ic_deinterleave_real_8i_u_H
 
 #include <inttypes.h>
 #include <stdio.h>
+
+#ifdef LV_HAVE_GENERIC
+
+static inline void volk_8ic_deinterleave_real_8i_generic(int8_t* iBuffer,
+                                                         const lv_8sc_t* complexVector,
+                                                         unsigned int num_points)
+{
+    unsigned int number = 0;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
+    int8_t* iBufferPtr = iBuffer;
+    for (number = 0; number < num_points; number++) {
+        *iBufferPtr++ = *complexVectorPtr++;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_GENERIC */
+
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void volk_8ic_deinterleave_real_8i_u_avx2(int8_t* iBuffer,
+                                                        const lv_8sc_t* complexVector,
+                                                        unsigned int num_points)
+{
+    unsigned int number = 0;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
+    int8_t* iBufferPtr = iBuffer;
+    __m256i moveMask1 = _mm256_set_epi8(0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        14,
+                                        12,
+                                        10,
+                                        8,
+                                        6,
+                                        4,
+                                        2,
+                                        0,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        14,
+                                        12,
+                                        10,
+                                        8,
+                                        6,
+                                        4,
+                                        2,
+                                        0);
+    __m256i moveMask2 = _mm256_set_epi8(14,
+                                        12,
+                                        10,
+                                        8,
+                                        6,
+                                        4,
+                                        2,
+                                        0,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        14,
+                                        12,
+                                        10,
+                                        8,
+                                        6,
+                                        4,
+                                        2,
+                                        0,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80);
+    __m256i complexVal1, complexVal2, outputVal;
+
+    unsigned int thirtysecondPoints = num_points / 32;
+
+    for (number = 0; number < thirtysecondPoints; number++) {
+
+        complexVal1 = _mm256_loadu_si256((const __m256i*)complexVectorPtr);
+        complexVectorPtr += 32;
+        complexVal2 = _mm256_loadu_si256((const __m256i*)complexVectorPtr);
+        complexVectorPtr += 32;
+
+        complexVal1 = _mm256_shuffle_epi8(complexVal1, moveMask1);
+        complexVal2 = _mm256_shuffle_epi8(complexVal2, moveMask2);
+        outputVal = _mm256_or_si256(complexVal1, complexVal2);
+        outputVal = _mm256_permute4x64_epi64(outputVal, 0xd8);
+
+        _mm256_storeu_si256((__m256i*)iBufferPtr, outputVal);
+        iBufferPtr += 32;
+    }
+
+    number = thirtysecondPoints * 32;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = *complexVectorPtr++;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_AVX2 */
+
+
+#ifdef LV_HAVE_NEON
+#include <arm_neon.h>
+
+static inline void volk_8ic_deinterleave_real_8i_neon(int8_t* iBuffer,
+                                                      const lv_8sc_t* complexVector,
+                                                      unsigned int num_points)
+{
+    unsigned int number;
+    unsigned int sixteenth_points = num_points / 16;
+
+    int8x16x2_t input_vector;
+    for (number = 0; number < sixteenth_points; ++number) {
+        input_vector = vld2q_s8((const int8_t*)complexVector);
+        vst1q_s8(iBuffer, input_vector.val[0]);
+        iBuffer += 16;
+        complexVector += 16;
+    }
+
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
+    int8_t* iBufferPtr = iBuffer;
+    for (number = sixteenth_points * 16; number < num_points; number++) {
+        *iBufferPtr++ = *complexVectorPtr++;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_NEON */
+
+#ifdef LV_HAVE_NEONV8
+#include <arm_neon.h>
+
+static inline void volk_8ic_deinterleave_real_8i_neonv8(int8_t* iBuffer,
+                                                        const lv_8sc_t* complexVector,
+                                                        unsigned int num_points)
+{
+    const unsigned int thirtysecondPoints = num_points / 32;
+
+    for (unsigned int number = 0; number < thirtysecondPoints; number++) {
+        int8x16x2_t cplx0 = vld2q_s8((const int8_t*)complexVector);
+        int8x16x2_t cplx1 = vld2q_s8((const int8_t*)complexVector + 32);
+        __VOLK_PREFETCH((const int8_t*)complexVector + 64);
+
+        vst1q_s8(iBuffer, cplx0.val[0]);
+        vst1q_s8(iBuffer + 16, cplx1.val[0]);
+
+        iBuffer += 32;
+        complexVector += 32;
+    }
+
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
+    for (unsigned int number = thirtysecondPoints * 32; number < num_points; number++) {
+        *iBuffer++ = *complexVectorPtr++;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_NEONV8 */
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_8ic_deinterleave_real_8i_rvv(int8_t* iBuffer,
+                                                     const lv_8sc_t* complexVector,
+                                                     unsigned int num_points)
+{
+    const uint16_t* in = (const uint16_t*)complexVector;
+    size_t n = num_points;
+    for (size_t vl; n > 0; n -= vl, in += vl, iBuffer += vl) {
+        vl = __riscv_vsetvl_e16m8(n);
+        vuint16m8_t vc = __riscv_vle16_v_u16m8(in, vl);
+        __riscv_vse8((uint8_t*)iBuffer, __riscv_vnsrl(vc, 0, vl), vl);
+    }
+}
+#endif /* LV_HAVE_RVV */
+
+
+#endif /* INCLUDED_volk_8ic_deinterleave_real_8i_u_H */
+
+#ifndef INCLUDED_volk_8ic_deinterleave_real_8i_a_H
+#define INCLUDED_volk_8ic_deinterleave_real_8i_a_H
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#ifdef LV_HAVE_SSSE3
+#include <tmmintrin.h>
+
+static inline void volk_8ic_deinterleave_real_8i_a_ssse3(int8_t* iBuffer,
+                                                         const lv_8sc_t* complexVector,
+                                                         unsigned int num_points)
+{
+    unsigned int number = 0;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
+    int8_t* iBufferPtr = iBuffer;
+    __m128i moveMask1 = _mm_set_epi8(
+        0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
+    __m128i moveMask2 = _mm_set_epi8(
+        14, 12, 10, 8, 6, 4, 2, 0, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80);
+    __m128i complexVal1, complexVal2, outputVal;
+
+    unsigned int sixteenthPoints = num_points / 16;
+
+    for (number = 0; number < sixteenthPoints; number++) {
+        complexVal1 = _mm_load_si128((const __m128i*)complexVectorPtr);
+        complexVectorPtr += 16;
+        complexVal2 = _mm_load_si128((const __m128i*)complexVectorPtr);
+        complexVectorPtr += 16;
+
+        complexVal1 = _mm_shuffle_epi8(complexVal1, moveMask1);
+        complexVal2 = _mm_shuffle_epi8(complexVal2, moveMask2);
+
+        outputVal = _mm_or_si128(complexVal1, complexVal2);
+
+        _mm_store_si128((__m128i*)iBufferPtr, outputVal);
+        iBufferPtr += 16;
+    }
+
+    number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = *complexVectorPtr++;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_SSSE3 */
+
+
+#ifdef LV_HAVE_AVX
+#include <immintrin.h>
+
+static inline void volk_8ic_deinterleave_real_8i_a_avx(int8_t* iBuffer,
+                                                       const lv_8sc_t* complexVector,
+                                                       unsigned int num_points)
+{
+    unsigned int number = 0;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
+    int8_t* iBufferPtr = iBuffer;
+    __m128i moveMaskL = _mm_set_epi8(
+        0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
+    __m128i moveMaskH = _mm_set_epi8(
+        14, 12, 10, 8, 6, 4, 2, 0, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80);
+    __m256i complexVal1, complexVal2, outputVal;
+    __m128i complexVal1H, complexVal1L, complexVal2H, complexVal2L, outputVal1,
+        outputVal2;
+
+    unsigned int thirtysecondPoints = num_points / 32;
+
+    for (number = 0; number < thirtysecondPoints; number++) {
+
+        complexVal1 = _mm256_load_si256((const __m256i*)complexVectorPtr);
+        complexVectorPtr += 32;
+        complexVal2 = _mm256_load_si256((const __m256i*)complexVectorPtr);
+        complexVectorPtr += 32;
+
+        complexVal1H = _mm256_extractf128_si256(complexVal1, 1);
+        complexVal1L = _mm256_extractf128_si256(complexVal1, 0);
+        complexVal2H = _mm256_extractf128_si256(complexVal2, 1);
+        complexVal2L = _mm256_extractf128_si256(complexVal2, 0);
+
+        complexVal1H = _mm_shuffle_epi8(complexVal1H, moveMaskH);
+        complexVal1L = _mm_shuffle_epi8(complexVal1L, moveMaskL);
+        outputVal1 = _mm_or_si128(complexVal1H, complexVal1L);
+
+
+        complexVal2H = _mm_shuffle_epi8(complexVal2H, moveMaskH);
+        complexVal2L = _mm_shuffle_epi8(complexVal2L, moveMaskL);
+        outputVal2 = _mm_or_si128(complexVal2H, complexVal2L);
+
+        __m256i dummy = _mm256_setzero_si256();
+        outputVal = _mm256_insertf128_si256(dummy, outputVal1, 0);
+        outputVal = _mm256_insertf128_si256(outputVal, outputVal2, 1);
+
+
+        _mm256_store_si256((__m256i*)iBufferPtr, outputVal);
+        iBufferPtr += 32;
+    }
+
+    number = thirtysecondPoints * 32;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = *complexVectorPtr++;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_AVX */
+
 
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
@@ -146,306 +449,4 @@ static inline void volk_8ic_deinterleave_real_8i_a_avx2(int8_t* iBuffer,
 #endif /* LV_HAVE_AVX2 */
 
 
-#ifdef LV_HAVE_SSSE3
-#include <tmmintrin.h>
-
-static inline void volk_8ic_deinterleave_real_8i_a_ssse3(int8_t* iBuffer,
-                                                         const lv_8sc_t* complexVector,
-                                                         unsigned int num_points)
-{
-    unsigned int number = 0;
-    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
-    int8_t* iBufferPtr = iBuffer;
-    __m128i moveMask1 = _mm_set_epi8(
-        0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
-    __m128i moveMask2 = _mm_set_epi8(
-        14, 12, 10, 8, 6, 4, 2, 0, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80);
-    __m128i complexVal1, complexVal2, outputVal;
-
-    unsigned int sixteenthPoints = num_points / 16;
-
-    for (number = 0; number < sixteenthPoints; number++) {
-        complexVal1 = _mm_load_si128((const __m128i*)complexVectorPtr);
-        complexVectorPtr += 16;
-        complexVal2 = _mm_load_si128((const __m128i*)complexVectorPtr);
-        complexVectorPtr += 16;
-
-        complexVal1 = _mm_shuffle_epi8(complexVal1, moveMask1);
-        complexVal2 = _mm_shuffle_epi8(complexVal2, moveMask2);
-
-        outputVal = _mm_or_si128(complexVal1, complexVal2);
-
-        _mm_store_si128((__m128i*)iBufferPtr, outputVal);
-        iBufferPtr += 16;
-    }
-
-    number = sixteenthPoints * 16;
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = *complexVectorPtr++;
-        complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_SSSE3 */
-
-
-#ifdef LV_HAVE_AVX
-#include <immintrin.h>
-
-static inline void volk_8ic_deinterleave_real_8i_a_avx(int8_t* iBuffer,
-                                                       const lv_8sc_t* complexVector,
-                                                       unsigned int num_points)
-{
-    unsigned int number = 0;
-    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
-    int8_t* iBufferPtr = iBuffer;
-    __m128i moveMaskL = _mm_set_epi8(
-        0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
-    __m128i moveMaskH = _mm_set_epi8(
-        14, 12, 10, 8, 6, 4, 2, 0, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80);
-    __m256i complexVal1, complexVal2, outputVal;
-    __m128i complexVal1H, complexVal1L, complexVal2H, complexVal2L, outputVal1,
-        outputVal2;
-
-    unsigned int thirtysecondPoints = num_points / 32;
-
-    for (number = 0; number < thirtysecondPoints; number++) {
-
-        complexVal1 = _mm256_load_si256((const __m256i*)complexVectorPtr);
-        complexVectorPtr += 32;
-        complexVal2 = _mm256_load_si256((const __m256i*)complexVectorPtr);
-        complexVectorPtr += 32;
-
-        complexVal1H = _mm256_extractf128_si256(complexVal1, 1);
-        complexVal1L = _mm256_extractf128_si256(complexVal1, 0);
-        complexVal2H = _mm256_extractf128_si256(complexVal2, 1);
-        complexVal2L = _mm256_extractf128_si256(complexVal2, 0);
-
-        complexVal1H = _mm_shuffle_epi8(complexVal1H, moveMaskH);
-        complexVal1L = _mm_shuffle_epi8(complexVal1L, moveMaskL);
-        outputVal1 = _mm_or_si128(complexVal1H, complexVal1L);
-
-
-        complexVal2H = _mm_shuffle_epi8(complexVal2H, moveMaskH);
-        complexVal2L = _mm_shuffle_epi8(complexVal2L, moveMaskL);
-        outputVal2 = _mm_or_si128(complexVal2H, complexVal2L);
-
-        __m256i dummy = _mm256_setzero_si256();
-        outputVal = _mm256_insertf128_si256(dummy, outputVal1, 0);
-        outputVal = _mm256_insertf128_si256(outputVal, outputVal2, 1);
-
-
-        _mm256_store_si256((__m256i*)iBufferPtr, outputVal);
-        iBufferPtr += 32;
-    }
-
-    number = thirtysecondPoints * 32;
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = *complexVectorPtr++;
-        complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_AVX */
-
-
-#ifdef LV_HAVE_GENERIC
-
-static inline void volk_8ic_deinterleave_real_8i_generic(int8_t* iBuffer,
-                                                         const lv_8sc_t* complexVector,
-                                                         unsigned int num_points)
-{
-    unsigned int number = 0;
-    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
-    int8_t* iBufferPtr = iBuffer;
-    for (number = 0; number < num_points; number++) {
-        *iBufferPtr++ = *complexVectorPtr++;
-        complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_GENERIC */
-
-
-#ifdef LV_HAVE_NEON
-#include <arm_neon.h>
-
-static inline void volk_8ic_deinterleave_real_8i_neon(int8_t* iBuffer,
-                                                      const lv_8sc_t* complexVector,
-                                                      unsigned int num_points)
-{
-    unsigned int number;
-    unsigned int sixteenth_points = num_points / 16;
-
-    int8x16x2_t input_vector;
-    for (number = 0; number < sixteenth_points; ++number) {
-        input_vector = vld2q_s8((const int8_t*)complexVector);
-        vst1q_s8(iBuffer, input_vector.val[0]);
-        iBuffer += 16;
-        complexVector += 16;
-    }
-
-    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
-    int8_t* iBufferPtr = iBuffer;
-    for (number = sixteenth_points * 16; number < num_points; number++) {
-        *iBufferPtr++ = *complexVectorPtr++;
-        complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_NEON */
-
-#ifdef LV_HAVE_NEONV8
-#include <arm_neon.h>
-
-static inline void volk_8ic_deinterleave_real_8i_neonv8(int8_t* iBuffer,
-                                                        const lv_8sc_t* complexVector,
-                                                        unsigned int num_points)
-{
-    const unsigned int thirtysecondPoints = num_points / 32;
-
-    for (unsigned int number = 0; number < thirtysecondPoints; number++) {
-        int8x16x2_t cplx0 = vld2q_s8((const int8_t*)complexVector);
-        int8x16x2_t cplx1 = vld2q_s8((const int8_t*)complexVector + 32);
-        __VOLK_PREFETCH((const int8_t*)complexVector + 64);
-
-        vst1q_s8(iBuffer, cplx0.val[0]);
-        vst1q_s8(iBuffer + 16, cplx1.val[0]);
-
-        iBuffer += 32;
-        complexVector += 32;
-    }
-
-    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
-    for (unsigned int number = thirtysecondPoints * 32; number < num_points; number++) {
-        *iBuffer++ = *complexVectorPtr++;
-        complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_NEONV8 */
-
-
-#endif /* INCLUDED_VOLK_8sc_DEINTERLEAVE_REAL_8s_ALIGNED8_H */
-
-#ifndef INCLUDED_VOLK_8sc_DEINTERLEAVE_REAL_8s_UNALIGNED8_H
-#define INCLUDED_VOLK_8sc_DEINTERLEAVE_REAL_8s_UNALIGNED8_H
-
-#include <inttypes.h>
-#include <stdio.h>
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-
-static inline void volk_8ic_deinterleave_real_8i_u_avx2(int8_t* iBuffer,
-                                                        const lv_8sc_t* complexVector,
-                                                        unsigned int num_points)
-{
-    unsigned int number = 0;
-    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
-    int8_t* iBufferPtr = iBuffer;
-    __m256i moveMask1 = _mm256_set_epi8(0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        14,
-                                        12,
-                                        10,
-                                        8,
-                                        6,
-                                        4,
-                                        2,
-                                        0,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        14,
-                                        12,
-                                        10,
-                                        8,
-                                        6,
-                                        4,
-                                        2,
-                                        0);
-    __m256i moveMask2 = _mm256_set_epi8(14,
-                                        12,
-                                        10,
-                                        8,
-                                        6,
-                                        4,
-                                        2,
-                                        0,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        14,
-                                        12,
-                                        10,
-                                        8,
-                                        6,
-                                        4,
-                                        2,
-                                        0,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80);
-    __m256i complexVal1, complexVal2, outputVal;
-
-    unsigned int thirtysecondPoints = num_points / 32;
-
-    for (number = 0; number < thirtysecondPoints; number++) {
-
-        complexVal1 = _mm256_loadu_si256((const __m256i*)complexVectorPtr);
-        complexVectorPtr += 32;
-        complexVal2 = _mm256_loadu_si256((const __m256i*)complexVectorPtr);
-        complexVectorPtr += 32;
-
-        complexVal1 = _mm256_shuffle_epi8(complexVal1, moveMask1);
-        complexVal2 = _mm256_shuffle_epi8(complexVal2, moveMask2);
-        outputVal = _mm256_or_si256(complexVal1, complexVal2);
-        outputVal = _mm256_permute4x64_epi64(outputVal, 0xd8);
-
-        _mm256_storeu_si256((__m256i*)iBufferPtr, outputVal);
-        iBufferPtr += 32;
-    }
-
-    number = thirtysecondPoints * 32;
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = *complexVectorPtr++;
-        complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_AVX2 */
-
-#ifdef LV_HAVE_RVV
-#include <riscv_vector.h>
-
-static inline void volk_8ic_deinterleave_real_8i_rvv(int8_t* iBuffer,
-                                                     const lv_8sc_t* complexVector,
-                                                     unsigned int num_points)
-{
-    const uint16_t* in = (const uint16_t*)complexVector;
-    size_t n = num_points;
-    for (size_t vl; n > 0; n -= vl, in += vl, iBuffer += vl) {
-        vl = __riscv_vsetvl_e16m8(n);
-        vuint16m8_t vc = __riscv_vle16_v_u16m8(in, vl);
-        __riscv_vse8((uint8_t*)iBuffer, __riscv_vnsrl(vc, 0, vl), vl);
-    }
-}
-#endif /*LV_HAVE_RVV*/
-
-#endif /* INCLUDED_VOLK_8sc_DEINTERLEAVE_REAL_8s_UNALIGNED8_H */
+#endif /* INCLUDED_volk_8ic_deinterleave_real_8i_a_H */

--- a/kernels/volk/volk_8ic_deinterleave_real_8i.h
+++ b/kernels/volk/volk_8ic_deinterleave_real_8i.h
@@ -51,7 +51,7 @@ static inline void volk_8ic_deinterleave_real_8i_a_avx2(int8_t* iBuffer,
                                                         unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int8_t* iBufferPtr = iBuffer;
     __m256i moveMask1 = _mm256_set_epi8(0x80,
                                         0x80,
@@ -123,9 +123,9 @@ static inline void volk_8ic_deinterleave_real_8i_a_avx2(int8_t* iBuffer,
 
     for (number = 0; number < thirtysecondPoints; number++) {
 
-        complexVal1 = _mm256_load_si256((__m256i*)complexVectorPtr);
+        complexVal1 = _mm256_load_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
-        complexVal2 = _mm256_load_si256((__m256i*)complexVectorPtr);
+        complexVal2 = _mm256_load_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
 
         complexVal1 = _mm256_shuffle_epi8(complexVal1, moveMask1);
@@ -154,7 +154,7 @@ static inline void volk_8ic_deinterleave_real_8i_a_ssse3(int8_t* iBuffer,
                                                          unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int8_t* iBufferPtr = iBuffer;
     __m128i moveMask1 = _mm_set_epi8(
         0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
@@ -165,9 +165,9 @@ static inline void volk_8ic_deinterleave_real_8i_a_ssse3(int8_t* iBuffer,
     unsigned int sixteenthPoints = num_points / 16;
 
     for (number = 0; number < sixteenthPoints; number++) {
-        complexVal1 = _mm_load_si128((__m128i*)complexVectorPtr);
+        complexVal1 = _mm_load_si128((const __m128i*)complexVectorPtr);
         complexVectorPtr += 16;
-        complexVal2 = _mm_load_si128((__m128i*)complexVectorPtr);
+        complexVal2 = _mm_load_si128((const __m128i*)complexVectorPtr);
         complexVectorPtr += 16;
 
         complexVal1 = _mm_shuffle_epi8(complexVal1, moveMask1);
@@ -196,7 +196,7 @@ static inline void volk_8ic_deinterleave_real_8i_a_avx(int8_t* iBuffer,
                                                        unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int8_t* iBufferPtr = iBuffer;
     __m128i moveMaskL = _mm_set_epi8(
         0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
@@ -210,9 +210,9 @@ static inline void volk_8ic_deinterleave_real_8i_a_avx(int8_t* iBuffer,
 
     for (number = 0; number < thirtysecondPoints; number++) {
 
-        complexVal1 = _mm256_load_si256((__m256i*)complexVectorPtr);
+        complexVal1 = _mm256_load_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
-        complexVal2 = _mm256_load_si256((__m256i*)complexVectorPtr);
+        complexVal2 = _mm256_load_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
 
         complexVal1H = _mm256_extractf128_si256(complexVal1, 1);
@@ -254,7 +254,7 @@ static inline void volk_8ic_deinterleave_real_8i_generic(int8_t* iBuffer,
                                                          unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int8_t* iBufferPtr = iBuffer;
     for (number = 0; number < num_points; number++) {
         *iBufferPtr++ = *complexVectorPtr++;
@@ -276,13 +276,13 @@ static inline void volk_8ic_deinterleave_real_8i_neon(int8_t* iBuffer,
 
     int8x16x2_t input_vector;
     for (number = 0; number < sixteenth_points; ++number) {
-        input_vector = vld2q_s8((int8_t*)complexVector);
+        input_vector = vld2q_s8((const int8_t*)complexVector);
         vst1q_s8(iBuffer, input_vector.val[0]);
         iBuffer += 16;
         complexVector += 16;
     }
 
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int8_t* iBufferPtr = iBuffer;
     for (number = sixteenth_points * 16; number < num_points; number++) {
         *iBufferPtr++ = *complexVectorPtr++;
@@ -337,7 +337,7 @@ static inline void volk_8ic_deinterleave_real_8i_u_avx2(int8_t* iBuffer,
                                                         unsigned int num_points)
 {
     unsigned int number = 0;
-    const int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
     int8_t* iBufferPtr = iBuffer;
     __m256i moveMask1 = _mm256_set_epi8(0x80,
                                         0x80,
@@ -409,9 +409,9 @@ static inline void volk_8ic_deinterleave_real_8i_u_avx2(int8_t* iBuffer,
 
     for (number = 0; number < thirtysecondPoints; number++) {
 
-        complexVal1 = _mm256_loadu_si256((__m256i*)complexVectorPtr);
+        complexVal1 = _mm256_loadu_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
-        complexVal2 = _mm256_loadu_si256((__m256i*)complexVectorPtr);
+        complexVal2 = _mm256_loadu_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
 
         complexVal1 = _mm256_shuffle_epi8(complexVal1, moveMask1);

--- a/kernels/volk/volk_8ic_s32f_deinterleave_32f_x2.h
+++ b/kernels/volk/volk_8ic_s32f_deinterleave_32f_x2.h
@@ -68,7 +68,7 @@ volk_8ic_s32f_deinterleave_32f_x2_a_sse4_1(float* iBuffer,
     const float iScalar = 1.0 / scalar;
     __m128 invScalar = _mm_set_ps1(iScalar);
     __m128i complexVal, iIntVal, qIntVal, iComplexVal, qComplexVal;
-    int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
 
     __m128i iMoveMask = _mm_set_epi8(
         0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
@@ -76,7 +76,7 @@ volk_8ic_s32f_deinterleave_32f_x2_a_sse4_1(float* iBuffer,
         0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 15, 13, 11, 9, 7, 5, 3, 1);
 
     for (; number < eighthPoints; number++) {
-        complexVal = _mm_load_si128((__m128i*)complexVectorPtr);
+        complexVal = _mm_load_si128((const __m128i*)complexVectorPtr);
         complexVectorPtr += 16;
         iComplexVal = _mm_shuffle_epi8(complexVal, iMoveMask);
         qComplexVal = _mm_shuffle_epi8(complexVal, qMoveMask);
@@ -137,7 +137,7 @@ static inline void volk_8ic_s32f_deinterleave_32f_x2_a_sse(float* iBuffer,
     __m128 cplxValue1, cplxValue2, iValue, qValue;
 
     __m128 invScalar = _mm_set_ps1(1.0 / scalar);
-    int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
 
     __VOLK_ATTR_ALIGNED(16) float floatBuffer[8];
 
@@ -172,7 +172,7 @@ static inline void volk_8ic_s32f_deinterleave_32f_x2_a_sse(float* iBuffer,
     }
 
     number = quarterPoints * 4;
-    complexVectorPtr = (int8_t*)&complexVector[number];
+    complexVectorPtr = (const int8_t*)&complexVector[number];
     for (; number < num_points; number++) {
         *iBufferPtr++ = (float)(*complexVectorPtr++) / scalar;
         *qBufferPtr++ = (float)(*complexVectorPtr++) / scalar;
@@ -200,7 +200,7 @@ static inline void volk_8ic_s32f_deinterleave_32f_x2_a_avx2(float* iBuffer,
     const float iScalar = 1.0 / scalar;
     __m256 invScalar = _mm256_set1_ps(iScalar);
     __m256i complexVal, iIntVal, qIntVal, iComplexVal, qComplexVal;
-    int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
 
     __m256i iMoveMask = _mm256_set_epi8(0x80,
                                         0x80,
@@ -268,7 +268,7 @@ static inline void volk_8ic_s32f_deinterleave_32f_x2_a_avx2(float* iBuffer,
                                         1);
 
     for (; number < sixteenthPoints; number++) {
-        complexVal = _mm256_load_si256((__m256i*)complexVectorPtr);
+        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
         iComplexVal = _mm256_shuffle_epi8(complexVal, iMoveMask);
         qComplexVal = _mm256_shuffle_epi8(complexVal, qMoveMask);
@@ -361,7 +361,7 @@ static inline void volk_8ic_s32f_deinterleave_32f_x2_u_avx2(float* iBuffer,
     __m256 invScalar = _mm256_set1_ps(iScalar);
     __m256i complexVal, iIntVal, qIntVal;
     __m128i iComplexVal, qComplexVal;
-    int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
 
     __m256i MoveMask = _mm256_set_epi8(15,
                                        13,
@@ -397,7 +397,7 @@ static inline void volk_8ic_s32f_deinterleave_32f_x2_u_avx2(float* iBuffer,
                                        0);
 
     for (; number < sixteenthPoints; number++) {
-        complexVal = _mm256_loadu_si256((__m256i*)complexVectorPtr);
+        complexVal = _mm256_loadu_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
         complexVal = _mm256_shuffle_epi8(complexVal, MoveMask);
         complexVal = _mm256_permute4x64_epi64(complexVal, 0xd8);

--- a/kernels/volk/volk_8ic_s32f_deinterleave_32f_x2.h
+++ b/kernels/volk/volk_8ic_s32f_deinterleave_32f_x2.h
@@ -40,273 +40,12 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_8ic_s32f_deinterleave_32f_x2_a_H
-#define INCLUDED_volk_8ic_s32f_deinterleave_32f_x2_a_H
+#ifndef INCLUDED_volk_8ic_s32f_deinterleave_32f_x2_u_H
+#define INCLUDED_volk_8ic_s32f_deinterleave_32f_x2_u_H
 
 #include <inttypes.h>
 #include <stdio.h>
 #include <volk/volk_common.h>
-
-
-#ifdef LV_HAVE_SSE4_1
-#include <smmintrin.h>
-
-static inline void
-volk_8ic_s32f_deinterleave_32f_x2_a_sse4_1(float* iBuffer,
-                                           float* qBuffer,
-                                           const lv_8sc_t* complexVector,
-                                           const float scalar,
-                                           unsigned int num_points)
-{
-    float* iBufferPtr = iBuffer;
-    float* qBufferPtr = qBuffer;
-
-    unsigned int number = 0;
-    const unsigned int eighthPoints = num_points / 8;
-    __m128 iFloatValue, qFloatValue;
-
-    const float iScalar = 1.0 / scalar;
-    __m128 invScalar = _mm_set_ps1(iScalar);
-    __m128i complexVal, iIntVal, qIntVal, iComplexVal, qComplexVal;
-    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
-
-    __m128i iMoveMask = _mm_set_epi8(
-        0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
-    __m128i qMoveMask = _mm_set_epi8(
-        0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 15, 13, 11, 9, 7, 5, 3, 1);
-
-    for (; number < eighthPoints; number++) {
-        complexVal = _mm_load_si128((const __m128i*)complexVectorPtr);
-        complexVectorPtr += 16;
-        iComplexVal = _mm_shuffle_epi8(complexVal, iMoveMask);
-        qComplexVal = _mm_shuffle_epi8(complexVal, qMoveMask);
-
-        iIntVal = _mm_cvtepi8_epi32(iComplexVal);
-        iFloatValue = _mm_cvtepi32_ps(iIntVal);
-        iFloatValue = _mm_mul_ps(iFloatValue, invScalar);
-        _mm_store_ps(iBufferPtr, iFloatValue);
-        iBufferPtr += 4;
-
-        iComplexVal = _mm_srli_si128(iComplexVal, 4);
-
-        iIntVal = _mm_cvtepi8_epi32(iComplexVal);
-        iFloatValue = _mm_cvtepi32_ps(iIntVal);
-        iFloatValue = _mm_mul_ps(iFloatValue, invScalar);
-        _mm_store_ps(iBufferPtr, iFloatValue);
-        iBufferPtr += 4;
-
-        qIntVal = _mm_cvtepi8_epi32(qComplexVal);
-        qFloatValue = _mm_cvtepi32_ps(qIntVal);
-        qFloatValue = _mm_mul_ps(qFloatValue, invScalar);
-        _mm_store_ps(qBufferPtr, qFloatValue);
-        qBufferPtr += 4;
-
-        qComplexVal = _mm_srli_si128(qComplexVal, 4);
-
-        qIntVal = _mm_cvtepi8_epi32(qComplexVal);
-        qFloatValue = _mm_cvtepi32_ps(qIntVal);
-        qFloatValue = _mm_mul_ps(qFloatValue, invScalar);
-        _mm_store_ps(qBufferPtr, qFloatValue);
-
-        qBufferPtr += 4;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = (float)(*complexVectorPtr++) * iScalar;
-        *qBufferPtr++ = (float)(*complexVectorPtr++) * iScalar;
-    }
-}
-#endif /* LV_HAVE_SSE4_1 */
-
-
-#ifdef LV_HAVE_SSE
-#include <xmmintrin.h>
-
-static inline void volk_8ic_s32f_deinterleave_32f_x2_a_sse(float* iBuffer,
-                                                           float* qBuffer,
-                                                           const lv_8sc_t* complexVector,
-                                                           const float scalar,
-                                                           unsigned int num_points)
-{
-    float* iBufferPtr = iBuffer;
-    float* qBufferPtr = qBuffer;
-
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-    __m128 cplxValue1, cplxValue2, iValue, qValue;
-
-    __m128 invScalar = _mm_set_ps1(1.0 / scalar);
-    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
-
-    __VOLK_ATTR_ALIGNED(16) float floatBuffer[8];
-
-    for (; number < quarterPoints; number++) {
-        floatBuffer[0] = (float)(complexVectorPtr[0]);
-        floatBuffer[1] = (float)(complexVectorPtr[1]);
-        floatBuffer[2] = (float)(complexVectorPtr[2]);
-        floatBuffer[3] = (float)(complexVectorPtr[3]);
-
-        floatBuffer[4] = (float)(complexVectorPtr[4]);
-        floatBuffer[5] = (float)(complexVectorPtr[5]);
-        floatBuffer[6] = (float)(complexVectorPtr[6]);
-        floatBuffer[7] = (float)(complexVectorPtr[7]);
-
-        cplxValue1 = _mm_load_ps(&floatBuffer[0]);
-        cplxValue2 = _mm_load_ps(&floatBuffer[4]);
-
-        complexVectorPtr += 8;
-
-        cplxValue1 = _mm_mul_ps(cplxValue1, invScalar);
-        cplxValue2 = _mm_mul_ps(cplxValue2, invScalar);
-
-        // Arrange in i1i2i3i4 format
-        iValue = _mm_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(2, 0, 2, 0));
-        qValue = _mm_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(3, 1, 3, 1));
-
-        _mm_store_ps(iBufferPtr, iValue);
-        _mm_store_ps(qBufferPtr, qValue);
-
-        iBufferPtr += 4;
-        qBufferPtr += 4;
-    }
-
-    number = quarterPoints * 4;
-    complexVectorPtr = (const int8_t*)&complexVector[number];
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = (float)(*complexVectorPtr++) / scalar;
-        *qBufferPtr++ = (float)(*complexVectorPtr++) / scalar;
-    }
-}
-#endif /* LV_HAVE_SSE */
-
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-
-static inline void volk_8ic_s32f_deinterleave_32f_x2_a_avx2(float* iBuffer,
-                                                            float* qBuffer,
-                                                            const lv_8sc_t* complexVector,
-                                                            const float scalar,
-                                                            unsigned int num_points)
-{
-    float* iBufferPtr = iBuffer;
-    float* qBufferPtr = qBuffer;
-
-    unsigned int number = 0;
-    const unsigned int sixteenthPoints = num_points / 16;
-    __m256 iFloatValue, qFloatValue;
-
-    const float iScalar = 1.0 / scalar;
-    __m256 invScalar = _mm256_set1_ps(iScalar);
-    __m256i complexVal, iIntVal, qIntVal, iComplexVal, qComplexVal;
-    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
-
-    __m256i iMoveMask = _mm256_set_epi8(0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        14,
-                                        12,
-                                        10,
-                                        8,
-                                        6,
-                                        4,
-                                        2,
-                                        0,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        14,
-                                        12,
-                                        10,
-                                        8,
-                                        6,
-                                        4,
-                                        2,
-                                        0);
-    __m256i qMoveMask = _mm256_set_epi8(0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        15,
-                                        13,
-                                        11,
-                                        9,
-                                        7,
-                                        5,
-                                        3,
-                                        1,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        0x80,
-                                        15,
-                                        13,
-                                        11,
-                                        9,
-                                        7,
-                                        5,
-                                        3,
-                                        1);
-
-    for (; number < sixteenthPoints; number++) {
-        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
-        complexVectorPtr += 32;
-        iComplexVal = _mm256_shuffle_epi8(complexVal, iMoveMask);
-        qComplexVal = _mm256_shuffle_epi8(complexVal, qMoveMask);
-
-        iIntVal = _mm256_cvtepi8_epi32(_mm256_castsi256_si128(iComplexVal));
-        iFloatValue = _mm256_cvtepi32_ps(iIntVal);
-        iFloatValue = _mm256_mul_ps(iFloatValue, invScalar);
-        _mm256_store_ps(iBufferPtr, iFloatValue);
-        iBufferPtr += 8;
-
-        iComplexVal = _mm256_permute4x64_epi64(iComplexVal, 0b11000110);
-        iIntVal = _mm256_cvtepi8_epi32(_mm256_castsi256_si128(iComplexVal));
-        iFloatValue = _mm256_cvtepi32_ps(iIntVal);
-        iFloatValue = _mm256_mul_ps(iFloatValue, invScalar);
-        _mm256_store_ps(iBufferPtr, iFloatValue);
-        iBufferPtr += 8;
-
-        qIntVal = _mm256_cvtepi8_epi32(_mm256_castsi256_si128(qComplexVal));
-        qFloatValue = _mm256_cvtepi32_ps(qIntVal);
-        qFloatValue = _mm256_mul_ps(qFloatValue, invScalar);
-        _mm256_store_ps(qBufferPtr, qFloatValue);
-        qBufferPtr += 8;
-
-        qComplexVal = _mm256_permute4x64_epi64(qComplexVal, 0b11000110);
-        qIntVal = _mm256_cvtepi8_epi32(_mm256_castsi256_si128(qComplexVal));
-        qFloatValue = _mm256_cvtepi32_ps(qIntVal);
-        qFloatValue = _mm256_mul_ps(qFloatValue, invScalar);
-        _mm256_store_ps(qBufferPtr, qFloatValue);
-        qBufferPtr += 8;
-    }
-
-    number = sixteenthPoints * 16;
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = (float)(*complexVectorPtr++) * iScalar;
-        *qBufferPtr++ = (float)(*complexVectorPtr++) * iScalar;
-    }
-}
-#endif /* LV_HAVE_AVX2 */
 
 
 #ifdef LV_HAVE_GENERIC
@@ -330,16 +69,6 @@ volk_8ic_s32f_deinterleave_32f_x2_generic(float* iBuffer,
 }
 #endif /* LV_HAVE_GENERIC */
 
-
-#endif /* INCLUDED_volk_8ic_s32f_deinterleave_32f_x2_a_H */
-
-
-#ifndef INCLUDED_volk_8ic_s32f_deinterleave_32f_x2_u_H
-#define INCLUDED_volk_8ic_s32f_deinterleave_32f_x2_u_H
-
-#include <inttypes.h>
-#include <stdio.h>
-#include <volk/volk_common.h>
 
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
@@ -523,3 +252,275 @@ static inline void volk_8ic_s32f_deinterleave_32f_x2_rvv(float* iBuffer,
 #endif /*LV_HAVE_RVV*/
 
 #endif /* INCLUDED_volk_8ic_s32f_deinterleave_32f_x2_u_H */
+
+
+#ifndef INCLUDED_volk_8ic_s32f_deinterleave_32f_x2_a_H
+#define INCLUDED_volk_8ic_s32f_deinterleave_32f_x2_a_H
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <volk/volk_common.h>
+
+
+#ifdef LV_HAVE_SSE
+#include <xmmintrin.h>
+
+static inline void volk_8ic_s32f_deinterleave_32f_x2_a_sse(float* iBuffer,
+                                                           float* qBuffer,
+                                                           const lv_8sc_t* complexVector,
+                                                           const float scalar,
+                                                           unsigned int num_points)
+{
+    float* iBufferPtr = iBuffer;
+    float* qBufferPtr = qBuffer;
+
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+    __m128 cplxValue1, cplxValue2, iValue, qValue;
+
+    __m128 invScalar = _mm_set_ps1(1.0 / scalar);
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
+
+    __VOLK_ATTR_ALIGNED(16) float floatBuffer[8];
+
+    for (; number < quarterPoints; number++) {
+        floatBuffer[0] = (float)(complexVectorPtr[0]);
+        floatBuffer[1] = (float)(complexVectorPtr[1]);
+        floatBuffer[2] = (float)(complexVectorPtr[2]);
+        floatBuffer[3] = (float)(complexVectorPtr[3]);
+
+        floatBuffer[4] = (float)(complexVectorPtr[4]);
+        floatBuffer[5] = (float)(complexVectorPtr[5]);
+        floatBuffer[6] = (float)(complexVectorPtr[6]);
+        floatBuffer[7] = (float)(complexVectorPtr[7]);
+
+        cplxValue1 = _mm_load_ps(&floatBuffer[0]);
+        cplxValue2 = _mm_load_ps(&floatBuffer[4]);
+
+        complexVectorPtr += 8;
+
+        cplxValue1 = _mm_mul_ps(cplxValue1, invScalar);
+        cplxValue2 = _mm_mul_ps(cplxValue2, invScalar);
+
+        // Arrange in i1i2i3i4 format
+        iValue = _mm_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(2, 0, 2, 0));
+        qValue = _mm_shuffle_ps(cplxValue1, cplxValue2, _MM_SHUFFLE(3, 1, 3, 1));
+
+        _mm_store_ps(iBufferPtr, iValue);
+        _mm_store_ps(qBufferPtr, qValue);
+
+        iBufferPtr += 4;
+        qBufferPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    complexVectorPtr = (const int8_t*)&complexVector[number];
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = (float)(*complexVectorPtr++) / scalar;
+        *qBufferPtr++ = (float)(*complexVectorPtr++) / scalar;
+    }
+}
+#endif /* LV_HAVE_SSE */
+
+
+#ifdef LV_HAVE_SSE4_1
+#include <smmintrin.h>
+
+static inline void
+volk_8ic_s32f_deinterleave_32f_x2_a_sse4_1(float* iBuffer,
+                                           float* qBuffer,
+                                           const lv_8sc_t* complexVector,
+                                           const float scalar,
+                                           unsigned int num_points)
+{
+    float* iBufferPtr = iBuffer;
+    float* qBufferPtr = qBuffer;
+
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+    __m128 iFloatValue, qFloatValue;
+
+    const float iScalar = 1.0 / scalar;
+    __m128 invScalar = _mm_set_ps1(iScalar);
+    __m128i complexVal, iIntVal, qIntVal, iComplexVal, qComplexVal;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
+
+    __m128i iMoveMask = _mm_set_epi8(
+        0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
+    __m128i qMoveMask = _mm_set_epi8(
+        0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 15, 13, 11, 9, 7, 5, 3, 1);
+
+    for (; number < eighthPoints; number++) {
+        complexVal = _mm_load_si128((const __m128i*)complexVectorPtr);
+        complexVectorPtr += 16;
+        iComplexVal = _mm_shuffle_epi8(complexVal, iMoveMask);
+        qComplexVal = _mm_shuffle_epi8(complexVal, qMoveMask);
+
+        iIntVal = _mm_cvtepi8_epi32(iComplexVal);
+        iFloatValue = _mm_cvtepi32_ps(iIntVal);
+        iFloatValue = _mm_mul_ps(iFloatValue, invScalar);
+        _mm_store_ps(iBufferPtr, iFloatValue);
+        iBufferPtr += 4;
+
+        iComplexVal = _mm_srli_si128(iComplexVal, 4);
+
+        iIntVal = _mm_cvtepi8_epi32(iComplexVal);
+        iFloatValue = _mm_cvtepi32_ps(iIntVal);
+        iFloatValue = _mm_mul_ps(iFloatValue, invScalar);
+        _mm_store_ps(iBufferPtr, iFloatValue);
+        iBufferPtr += 4;
+
+        qIntVal = _mm_cvtepi8_epi32(qComplexVal);
+        qFloatValue = _mm_cvtepi32_ps(qIntVal);
+        qFloatValue = _mm_mul_ps(qFloatValue, invScalar);
+        _mm_store_ps(qBufferPtr, qFloatValue);
+        qBufferPtr += 4;
+
+        qComplexVal = _mm_srli_si128(qComplexVal, 4);
+
+        qIntVal = _mm_cvtepi8_epi32(qComplexVal);
+        qFloatValue = _mm_cvtepi32_ps(qIntVal);
+        qFloatValue = _mm_mul_ps(qFloatValue, invScalar);
+        _mm_store_ps(qBufferPtr, qFloatValue);
+
+        qBufferPtr += 4;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = (float)(*complexVectorPtr++) * iScalar;
+        *qBufferPtr++ = (float)(*complexVectorPtr++) * iScalar;
+    }
+}
+#endif /* LV_HAVE_SSE4_1 */
+
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void volk_8ic_s32f_deinterleave_32f_x2_a_avx2(float* iBuffer,
+                                                            float* qBuffer,
+                                                            const lv_8sc_t* complexVector,
+                                                            const float scalar,
+                                                            unsigned int num_points)
+{
+    float* iBufferPtr = iBuffer;
+    float* qBufferPtr = qBuffer;
+
+    unsigned int number = 0;
+    const unsigned int sixteenthPoints = num_points / 16;
+    __m256 iFloatValue, qFloatValue;
+
+    const float iScalar = 1.0 / scalar;
+    __m256 invScalar = _mm256_set1_ps(iScalar);
+    __m256i complexVal, iIntVal, qIntVal, iComplexVal, qComplexVal;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
+
+    __m256i iMoveMask = _mm256_set_epi8(0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        14,
+                                        12,
+                                        10,
+                                        8,
+                                        6,
+                                        4,
+                                        2,
+                                        0,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        14,
+                                        12,
+                                        10,
+                                        8,
+                                        6,
+                                        4,
+                                        2,
+                                        0);
+    __m256i qMoveMask = _mm256_set_epi8(0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        15,
+                                        13,
+                                        11,
+                                        9,
+                                        7,
+                                        5,
+                                        3,
+                                        1,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        0x80,
+                                        15,
+                                        13,
+                                        11,
+                                        9,
+                                        7,
+                                        5,
+                                        3,
+                                        1);
+
+    for (; number < sixteenthPoints; number++) {
+        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
+        complexVectorPtr += 32;
+        iComplexVal = _mm256_shuffle_epi8(complexVal, iMoveMask);
+        qComplexVal = _mm256_shuffle_epi8(complexVal, qMoveMask);
+
+        iIntVal = _mm256_cvtepi8_epi32(_mm256_castsi256_si128(iComplexVal));
+        iFloatValue = _mm256_cvtepi32_ps(iIntVal);
+        iFloatValue = _mm256_mul_ps(iFloatValue, invScalar);
+        _mm256_store_ps(iBufferPtr, iFloatValue);
+        iBufferPtr += 8;
+
+        iComplexVal = _mm256_permute4x64_epi64(iComplexVal, 0b11000110);
+        iIntVal = _mm256_cvtepi8_epi32(_mm256_castsi256_si128(iComplexVal));
+        iFloatValue = _mm256_cvtepi32_ps(iIntVal);
+        iFloatValue = _mm256_mul_ps(iFloatValue, invScalar);
+        _mm256_store_ps(iBufferPtr, iFloatValue);
+        iBufferPtr += 8;
+
+        qIntVal = _mm256_cvtepi8_epi32(_mm256_castsi256_si128(qComplexVal));
+        qFloatValue = _mm256_cvtepi32_ps(qIntVal);
+        qFloatValue = _mm256_mul_ps(qFloatValue, invScalar);
+        _mm256_store_ps(qBufferPtr, qFloatValue);
+        qBufferPtr += 8;
+
+        qComplexVal = _mm256_permute4x64_epi64(qComplexVal, 0b11000110);
+        qIntVal = _mm256_cvtepi8_epi32(_mm256_castsi256_si128(qComplexVal));
+        qFloatValue = _mm256_cvtepi32_ps(qIntVal);
+        qFloatValue = _mm256_mul_ps(qFloatValue, invScalar);
+        _mm256_store_ps(qBufferPtr, qFloatValue);
+        qBufferPtr += 8;
+    }
+
+    number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = (float)(*complexVectorPtr++) * iScalar;
+        *qBufferPtr++ = (float)(*complexVectorPtr++) * iScalar;
+    }
+}
+#endif /* LV_HAVE_AVX2 */
+
+
+#endif /* INCLUDED_volk_8ic_s32f_deinterleave_32f_x2_a_H */

--- a/kernels/volk/volk_8ic_s32f_deinterleave_real_32f.h
+++ b/kernels/volk/volk_8ic_s32f_deinterleave_real_32f.h
@@ -64,7 +64,7 @@ volk_8ic_s32f_deinterleave_real_32f_a_avx2(float* iBuffer,
     const float iScalar = 1.0 / scalar;
     __m256 invScalar = _mm256_set1_ps(iScalar);
     __m256i complexVal, iIntVal;
-    int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
 
     __m256i moveMask = _mm256_set_epi8(0x80,
                                        0x80,
@@ -99,7 +99,7 @@ volk_8ic_s32f_deinterleave_real_32f_a_avx2(float* iBuffer,
                                        2,
                                        0);
     for (; number < sixteenthPoints; number++) {
-        complexVal = _mm256_load_si256((__m256i*)complexVectorPtr);
+        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
         complexVal = _mm256_shuffle_epi8(complexVal, moveMask);
 
@@ -144,13 +144,13 @@ volk_8ic_s32f_deinterleave_real_32f_a_sse4_1(float* iBuffer,
     const float iScalar = 1.0 / scalar;
     __m128 invScalar = _mm_set_ps1(iScalar);
     __m128i complexVal, iIntVal;
-    int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
 
     __m128i moveMask = _mm_set_epi8(
         0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
 
     for (; number < eighthPoints; number++) {
-        complexVal = _mm_load_si128((__m128i*)complexVectorPtr);
+        complexVal = _mm_load_si128((const __m128i*)complexVectorPtr);
         complexVectorPtr += 16;
         complexVal = _mm_shuffle_epi8(complexVal, moveMask);
 
@@ -200,7 +200,7 @@ volk_8ic_s32f_deinterleave_real_32f_a_sse(float* iBuffer,
 
     const float iScalar = 1.0 / scalar;
     __m128 invScalar = _mm_set_ps1(iScalar);
-    int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
 
     __VOLK_ATTR_ALIGNED(16) float floatBuffer[4];
 
@@ -280,7 +280,7 @@ volk_8ic_s32f_deinterleave_real_32f_u_avx2(float* iBuffer,
     __m256 invScalar = _mm256_set1_ps(iScalar);
     __m256i complexVal, iIntVal;
     __m128i hcomplexVal;
-    int8_t* complexVectorPtr = (int8_t*)complexVector;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
 
     __m256i moveMask = _mm256_set_epi8(0x80,
                                        0x80,
@@ -316,7 +316,7 @@ volk_8ic_s32f_deinterleave_real_32f_u_avx2(float* iBuffer,
                                        0);
 
     for (; number < sixteenthPoints; number++) {
-        complexVal = _mm256_loadu_si256((__m256i*)complexVectorPtr);
+        complexVal = _mm256_loadu_si256((const __m256i*)complexVectorPtr);
         complexVectorPtr += 32;
         complexVal = _mm256_shuffle_epi8(complexVal, moveMask);
 

--- a/kernels/volk/volk_8ic_s32f_deinterleave_real_32f.h
+++ b/kernels/volk/volk_8ic_s32f_deinterleave_real_32f.h
@@ -39,198 +39,12 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_8ic_s32f_deinterleave_real_32f_a_H
-#define INCLUDED_volk_8ic_s32f_deinterleave_real_32f_a_H
+#ifndef INCLUDED_volk_8ic_s32f_deinterleave_real_32f_u_H
+#define INCLUDED_volk_8ic_s32f_deinterleave_real_32f_u_H
 
 #include <inttypes.h>
 #include <stdio.h>
 #include <volk/volk_common.h>
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-
-static inline void
-volk_8ic_s32f_deinterleave_real_32f_a_avx2(float* iBuffer,
-                                           const lv_8sc_t* complexVector,
-                                           const float scalar,
-                                           unsigned int num_points)
-{
-    float* iBufferPtr = iBuffer;
-
-    unsigned int number = 0;
-    const unsigned int sixteenthPoints = num_points / 16;
-    __m256 iFloatValue;
-
-    const float iScalar = 1.0 / scalar;
-    __m256 invScalar = _mm256_set1_ps(iScalar);
-    __m256i complexVal, iIntVal;
-    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
-
-    __m256i moveMask = _mm256_set_epi8(0x80,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       14,
-                                       12,
-                                       10,
-                                       8,
-                                       6,
-                                       4,
-                                       2,
-                                       0,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       0x80,
-                                       14,
-                                       12,
-                                       10,
-                                       8,
-                                       6,
-                                       4,
-                                       2,
-                                       0);
-    for (; number < sixteenthPoints; number++) {
-        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
-        complexVectorPtr += 32;
-        complexVal = _mm256_shuffle_epi8(complexVal, moveMask);
-
-        iIntVal = _mm256_cvtepi8_epi32(_mm256_castsi256_si128(complexVal));
-        iFloatValue = _mm256_cvtepi32_ps(iIntVal);
-        iFloatValue = _mm256_mul_ps(iFloatValue, invScalar);
-        _mm256_store_ps(iBufferPtr, iFloatValue);
-        iBufferPtr += 8;
-
-        complexVal = _mm256_permute4x64_epi64(complexVal, 0b11000110);
-        iIntVal = _mm256_cvtepi8_epi32(_mm256_castsi256_si128(complexVal));
-        iFloatValue = _mm256_cvtepi32_ps(iIntVal);
-        iFloatValue = _mm256_mul_ps(iFloatValue, invScalar);
-        _mm256_store_ps(iBufferPtr, iFloatValue);
-        iBufferPtr += 8;
-    }
-
-    number = sixteenthPoints * 16;
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = (float)(*complexVectorPtr++) * iScalar;
-        complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_AVX2 */
-
-
-#ifdef LV_HAVE_SSE4_1
-#include <smmintrin.h>
-
-static inline void
-volk_8ic_s32f_deinterleave_real_32f_a_sse4_1(float* iBuffer,
-                                             const lv_8sc_t* complexVector,
-                                             const float scalar,
-                                             unsigned int num_points)
-{
-    float* iBufferPtr = iBuffer;
-
-    unsigned int number = 0;
-    const unsigned int eighthPoints = num_points / 8;
-    __m128 iFloatValue;
-
-    const float iScalar = 1.0 / scalar;
-    __m128 invScalar = _mm_set_ps1(iScalar);
-    __m128i complexVal, iIntVal;
-    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
-
-    __m128i moveMask = _mm_set_epi8(
-        0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
-
-    for (; number < eighthPoints; number++) {
-        complexVal = _mm_load_si128((const __m128i*)complexVectorPtr);
-        complexVectorPtr += 16;
-        complexVal = _mm_shuffle_epi8(complexVal, moveMask);
-
-        iIntVal = _mm_cvtepi8_epi32(complexVal);
-        iFloatValue = _mm_cvtepi32_ps(iIntVal);
-
-        iFloatValue = _mm_mul_ps(iFloatValue, invScalar);
-
-        _mm_store_ps(iBufferPtr, iFloatValue);
-
-        iBufferPtr += 4;
-
-        complexVal = _mm_srli_si128(complexVal, 4);
-        iIntVal = _mm_cvtepi8_epi32(complexVal);
-        iFloatValue = _mm_cvtepi32_ps(iIntVal);
-
-        iFloatValue = _mm_mul_ps(iFloatValue, invScalar);
-
-        _mm_store_ps(iBufferPtr, iFloatValue);
-
-        iBufferPtr += 4;
-    }
-
-    number = eighthPoints * 8;
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = (float)(*complexVectorPtr++) * iScalar;
-        complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_SSE4_1 */
-
-
-#ifdef LV_HAVE_SSE
-#include <xmmintrin.h>
-
-static inline void
-volk_8ic_s32f_deinterleave_real_32f_a_sse(float* iBuffer,
-                                          const lv_8sc_t* complexVector,
-                                          const float scalar,
-                                          unsigned int num_points)
-{
-    float* iBufferPtr = iBuffer;
-
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-    __m128 iValue;
-
-    const float iScalar = 1.0 / scalar;
-    __m128 invScalar = _mm_set_ps1(iScalar);
-    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
-
-    __VOLK_ATTR_ALIGNED(16) float floatBuffer[4];
-
-    for (; number < quarterPoints; number++) {
-        floatBuffer[0] = (float)(*complexVectorPtr);
-        complexVectorPtr += 2;
-        floatBuffer[1] = (float)(*complexVectorPtr);
-        complexVectorPtr += 2;
-        floatBuffer[2] = (float)(*complexVectorPtr);
-        complexVectorPtr += 2;
-        floatBuffer[3] = (float)(*complexVectorPtr);
-        complexVectorPtr += 2;
-
-        iValue = _mm_load_ps(floatBuffer);
-
-        iValue = _mm_mul_ps(iValue, invScalar);
-
-        _mm_store_ps(iBufferPtr, iValue);
-
-        iBufferPtr += 4;
-    }
-
-    number = quarterPoints * 4;
-    for (; number < num_points; number++) {
-        *iBufferPtr++ = (float)(*complexVectorPtr++) * iScalar;
-        complexVectorPtr++;
-    }
-}
-#endif /* LV_HAVE_SSE */
-
 
 #ifdef LV_HAVE_GENERIC
 
@@ -251,15 +65,6 @@ volk_8ic_s32f_deinterleave_real_32f_generic(float* iBuffer,
 }
 #endif /* LV_HAVE_GENERIC */
 
-
-#endif /* INCLUDED_volk_8ic_s32f_deinterleave_real_32f_a_H */
-
-#ifndef INCLUDED_volk_8ic_s32f_deinterleave_real_32f_u_H
-#define INCLUDED_volk_8ic_s32f_deinterleave_real_32f_u_H
-
-#include <inttypes.h>
-#include <stdio.h>
-#include <volk/volk_common.h>
 
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
@@ -410,6 +215,201 @@ static inline void volk_8ic_s32f_deinterleave_real_32f_rvv(float* iBuffer,
         __riscv_vse32(iBuffer, __riscv_vfmul(vrf, 1.0f / scalar, vl), vl);
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
 
 #endif /* INCLUDED_volk_8ic_s32f_deinterleave_real_32f_u_H */
+
+#ifndef INCLUDED_volk_8ic_s32f_deinterleave_real_32f_a_H
+#define INCLUDED_volk_8ic_s32f_deinterleave_real_32f_a_H
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <volk/volk_common.h>
+
+#ifdef LV_HAVE_SSE
+#include <xmmintrin.h>
+
+static inline void
+volk_8ic_s32f_deinterleave_real_32f_a_sse(float* iBuffer,
+                                          const lv_8sc_t* complexVector,
+                                          const float scalar,
+                                          unsigned int num_points)
+{
+    float* iBufferPtr = iBuffer;
+
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+    __m128 iValue;
+
+    const float iScalar = 1.0 / scalar;
+    __m128 invScalar = _mm_set_ps1(iScalar);
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
+
+    __VOLK_ATTR_ALIGNED(16) float floatBuffer[4];
+
+    for (; number < quarterPoints; number++) {
+        floatBuffer[0] = (float)(*complexVectorPtr);
+        complexVectorPtr += 2;
+        floatBuffer[1] = (float)(*complexVectorPtr);
+        complexVectorPtr += 2;
+        floatBuffer[2] = (float)(*complexVectorPtr);
+        complexVectorPtr += 2;
+        floatBuffer[3] = (float)(*complexVectorPtr);
+        complexVectorPtr += 2;
+
+        iValue = _mm_load_ps(floatBuffer);
+
+        iValue = _mm_mul_ps(iValue, invScalar);
+
+        _mm_store_ps(iBufferPtr, iValue);
+
+        iBufferPtr += 4;
+    }
+
+    number = quarterPoints * 4;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = (float)(*complexVectorPtr++) * iScalar;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_SSE */
+
+
+#ifdef LV_HAVE_SSE4_1
+#include <smmintrin.h>
+
+static inline void
+volk_8ic_s32f_deinterleave_real_32f_a_sse4_1(float* iBuffer,
+                                             const lv_8sc_t* complexVector,
+                                             const float scalar,
+                                             unsigned int num_points)
+{
+    float* iBufferPtr = iBuffer;
+
+    unsigned int number = 0;
+    const unsigned int eighthPoints = num_points / 8;
+    __m128 iFloatValue;
+
+    const float iScalar = 1.0 / scalar;
+    __m128 invScalar = _mm_set_ps1(iScalar);
+    __m128i complexVal, iIntVal;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
+
+    __m128i moveMask = _mm_set_epi8(
+        0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 14, 12, 10, 8, 6, 4, 2, 0);
+
+    for (; number < eighthPoints; number++) {
+        complexVal = _mm_load_si128((const __m128i*)complexVectorPtr);
+        complexVectorPtr += 16;
+        complexVal = _mm_shuffle_epi8(complexVal, moveMask);
+
+        iIntVal = _mm_cvtepi8_epi32(complexVal);
+        iFloatValue = _mm_cvtepi32_ps(iIntVal);
+
+        iFloatValue = _mm_mul_ps(iFloatValue, invScalar);
+
+        _mm_store_ps(iBufferPtr, iFloatValue);
+
+        iBufferPtr += 4;
+
+        complexVal = _mm_srli_si128(complexVal, 4);
+        iIntVal = _mm_cvtepi8_epi32(complexVal);
+        iFloatValue = _mm_cvtepi32_ps(iIntVal);
+
+        iFloatValue = _mm_mul_ps(iFloatValue, invScalar);
+
+        _mm_store_ps(iBufferPtr, iFloatValue);
+
+        iBufferPtr += 4;
+    }
+
+    number = eighthPoints * 8;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = (float)(*complexVectorPtr++) * iScalar;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_SSE4_1 */
+
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void
+volk_8ic_s32f_deinterleave_real_32f_a_avx2(float* iBuffer,
+                                           const lv_8sc_t* complexVector,
+                                           const float scalar,
+                                           unsigned int num_points)
+{
+    float* iBufferPtr = iBuffer;
+
+    unsigned int number = 0;
+    const unsigned int sixteenthPoints = num_points / 16;
+    __m256 iFloatValue;
+
+    const float iScalar = 1.0 / scalar;
+    __m256 invScalar = _mm256_set1_ps(iScalar);
+    __m256i complexVal, iIntVal;
+    const int8_t* complexVectorPtr = (const int8_t*)complexVector;
+
+    __m256i moveMask = _mm256_set_epi8(0x80,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       14,
+                                       12,
+                                       10,
+                                       8,
+                                       6,
+                                       4,
+                                       2,
+                                       0,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       0x80,
+                                       14,
+                                       12,
+                                       10,
+                                       8,
+                                       6,
+                                       4,
+                                       2,
+                                       0);
+    for (; number < sixteenthPoints; number++) {
+        complexVal = _mm256_load_si256((const __m256i*)complexVectorPtr);
+        complexVectorPtr += 32;
+        complexVal = _mm256_shuffle_epi8(complexVal, moveMask);
+
+        iIntVal = _mm256_cvtepi8_epi32(_mm256_castsi256_si128(complexVal));
+        iFloatValue = _mm256_cvtepi32_ps(iIntVal);
+        iFloatValue = _mm256_mul_ps(iFloatValue, invScalar);
+        _mm256_store_ps(iBufferPtr, iFloatValue);
+        iBufferPtr += 8;
+
+        complexVal = _mm256_permute4x64_epi64(complexVal, 0b11000110);
+        iIntVal = _mm256_cvtepi8_epi32(_mm256_castsi256_si128(complexVal));
+        iFloatValue = _mm256_cvtepi32_ps(iIntVal);
+        iFloatValue = _mm256_mul_ps(iFloatValue, invScalar);
+        _mm256_store_ps(iBufferPtr, iFloatValue);
+        iBufferPtr += 8;
+    }
+
+    number = sixteenthPoints * 16;
+    for (; number < num_points; number++) {
+        *iBufferPtr++ = (float)(*complexVectorPtr++) * iScalar;
+        complexVectorPtr++;
+    }
+}
+#endif /* LV_HAVE_AVX2 */
+
+
+#endif /* INCLUDED_volk_8ic_s32f_deinterleave_real_32f_a_H */

--- a/kernels/volk/volk_8ic_x2_multiply_conjugate_16ic.h
+++ b/kernels/volk/volk_8ic_x2_multiply_conjugate_16ic.h
@@ -7,157 +7,13 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-#ifndef INCLUDED_volk_8ic_x2_multiply_conjugate_16ic_a_H
-#define INCLUDED_volk_8ic_x2_multiply_conjugate_16ic_a_H
+#ifndef INCLUDED_volk_8ic_x2_multiply_conjugate_16ic_u_H
+#define INCLUDED_volk_8ic_x2_multiply_conjugate_16ic_u_H
 
 #include <inttypes.h>
 #include <limits.h>
 #include <stdio.h>
 #include <volk/volk_complex.h>
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-/*!
-  \brief Multiplys the one complex vector with the complex conjugate of the second complex
-  vector and stores their results in the third vector \param cVector The complex vector
-  where the results will be stored \param aVector One of the complex vectors to be
-  multiplied \param bVector The complex vector which will be converted to complex
-  conjugate and multiplied \param num_points The number of complex values in aVector and
-  bVector to be multiplied together and stored into cVector
-*/
-static inline void volk_8ic_x2_multiply_conjugate_16ic_a_avx2(lv_16sc_t* cVector,
-                                                              const lv_8sc_t* aVector,
-                                                              const lv_8sc_t* bVector,
-                                                              unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 8;
-
-    __m256i x, y, realz, imagz;
-    lv_16sc_t* c = cVector;
-    const lv_8sc_t* a = aVector;
-    const lv_8sc_t* b = bVector;
-    __m256i conjugateSign =
-        _mm256_set_epi16(-1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1);
-
-    for (; number < quarterPoints; number++) {
-        // Convert 8 bit values into 16 bit values
-        x = _mm256_cvtepi8_epi16(_mm_load_si128((const __m128i*)a));
-        y = _mm256_cvtepi8_epi16(_mm_load_si128((const __m128i*)b));
-
-        // Calculate the ar*cr - ai*(-ci) portions
-        realz = _mm256_madd_epi16(x, y);
-
-        // Calculate the complex conjugate of the cr + ci j values
-        y = _mm256_sign_epi16(y, conjugateSign);
-
-        // Shift the order of the cr and ci values
-        y = _mm256_shufflehi_epi16(_mm256_shufflelo_epi16(y, _MM_SHUFFLE(2, 3, 0, 1)),
-                                   _MM_SHUFFLE(2, 3, 0, 1));
-
-        // Calculate the ar*(-ci) + cr*(ai)
-        imagz = _mm256_madd_epi16(x, y);
-
-        // Perform the addition of products
-
-        _mm256_store_si256((__m256i*)c,
-                           _mm256_packs_epi32(_mm256_unpacklo_epi32(realz, imagz),
-                                              _mm256_unpackhi_epi32(realz, imagz)));
-
-        a += 8;
-        b += 8;
-        c += 8;
-    }
-
-    number = quarterPoints * 8;
-    int16_t* c16Ptr = (int16_t*)&cVector[number];
-    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
-    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
-    for (; number < num_points; number++) {
-        float aReal = (float)*a8Ptr++;
-        float aImag = (float)*a8Ptr++;
-        lv_32fc_t aVal = lv_cmake(aReal, aImag);
-        float bReal = (float)*b8Ptr++;
-        float bImag = (float)*b8Ptr++;
-        lv_32fc_t bVal = lv_cmake(bReal, -bImag);
-        lv_32fc_t temp = aVal * bVal;
-
-        *c16Ptr++ = (int16_t)(lv_creal(temp) > SHRT_MAX ? SHRT_MAX : lv_creal(temp));
-        *c16Ptr++ = (int16_t)lv_cimag(temp);
-    }
-}
-#endif /* LV_HAVE_AVX2 */
-
-
-#ifdef LV_HAVE_SSE4_1
-#include <smmintrin.h>
-/*!
-  \brief Multiplys the one complex vector with the complex conjugate of the second complex
-  vector and stores their results in the third vector \param cVector The complex vector
-  where the results will be stored \param aVector One of the complex vectors to be
-  multiplied \param bVector The complex vector which will be converted to complex
-  conjugate and multiplied \param num_points The number of complex values in aVector and
-  bVector to be multiplied together and stored into cVector
-*/
-static inline void volk_8ic_x2_multiply_conjugate_16ic_a_sse4_1(lv_16sc_t* cVector,
-                                                                const lv_8sc_t* aVector,
-                                                                const lv_8sc_t* bVector,
-                                                                unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-
-    __m128i x, y, realz, imagz;
-    lv_16sc_t* c = cVector;
-    const lv_8sc_t* a = aVector;
-    const lv_8sc_t* b = bVector;
-    __m128i conjugateSign = _mm_set_epi16(-1, 1, -1, 1, -1, 1, -1, 1);
-
-    for (; number < quarterPoints; number++) {
-        // Convert into 8 bit values into 16 bit values
-        x = _mm_cvtepi8_epi16(_mm_loadl_epi64((const __m128i*)a));
-        y = _mm_cvtepi8_epi16(_mm_loadl_epi64((const __m128i*)b));
-
-        // Calculate the ar*cr - ai*(-ci) portions
-        realz = _mm_madd_epi16(x, y);
-
-        // Calculate the complex conjugate of the cr + ci j values
-        y = _mm_sign_epi16(y, conjugateSign);
-
-        // Shift the order of the cr and ci values
-        y = _mm_shufflehi_epi16(_mm_shufflelo_epi16(y, _MM_SHUFFLE(2, 3, 0, 1)),
-                                _MM_SHUFFLE(2, 3, 0, 1));
-
-        // Calculate the ar*(-ci) + cr*(ai)
-        imagz = _mm_madd_epi16(x, y);
-
-        _mm_store_si128((__m128i*)c,
-                        _mm_packs_epi32(_mm_unpacklo_epi32(realz, imagz),
-                                        _mm_unpackhi_epi32(realz, imagz)));
-
-        a += 4;
-        b += 4;
-        c += 4;
-    }
-
-    number = quarterPoints * 4;
-    int16_t* c16Ptr = (int16_t*)&cVector[number];
-    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
-    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
-    for (; number < num_points; number++) {
-        float aReal = (float)*a8Ptr++;
-        float aImag = (float)*a8Ptr++;
-        lv_32fc_t aVal = lv_cmake(aReal, aImag);
-        float bReal = (float)*b8Ptr++;
-        float bImag = (float)*b8Ptr++;
-        lv_32fc_t bVal = lv_cmake(bReal, -bImag);
-        lv_32fc_t temp = aVal * bVal;
-
-        *c16Ptr++ = (int16_t)(lv_creal(temp) > SHRT_MAX ? SHRT_MAX : lv_creal(temp));
-        *c16Ptr++ = (int16_t)lv_cimag(temp);
-    }
-}
-#endif /* LV_HAVE_SSE4_1 */
 
 #ifdef LV_HAVE_GENERIC
 /*!
@@ -191,6 +47,80 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_generic(lv_16sc_t* cVecto
     }
 }
 #endif /* LV_HAVE_GENERIC */
+
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+/*!
+  \brief Multiplys the one complex vector with the complex conjugate of the second complex
+  vector and stores their results in the third vector \param cVector The complex vector
+  where the results will be stored \param aVector One of the complex vectors to be
+  multiplied \param bVector The complex vector which will be converted to complex
+  conjugate and multiplied \param num_points The number of complex values in aVector and
+  bVector to be multiplied together and stored into cVector
+*/
+static inline void volk_8ic_x2_multiply_conjugate_16ic_u_avx2(lv_16sc_t* cVector,
+                                                              const lv_8sc_t* aVector,
+                                                              const lv_8sc_t* bVector,
+                                                              unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int oneEigthPoints = num_points / 8;
+
+    __m256i x, y, realz, imagz;
+    lv_16sc_t* c = cVector;
+    const lv_8sc_t* a = aVector;
+    const lv_8sc_t* b = bVector;
+    __m256i conjugateSign =
+        _mm256_set_epi16(-1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1);
+
+    for (; number < oneEigthPoints; number++) {
+        // Convert 8 bit values into 16 bit values
+        x = _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)a));
+        y = _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)b));
+
+        // Calculate the ar*cr - ai*(-ci) portions
+        realz = _mm256_madd_epi16(x, y);
+
+        // Calculate the complex conjugate of the cr + ci j values
+        y = _mm256_sign_epi16(y, conjugateSign);
+
+        // Shift the order of the cr and ci values
+        y = _mm256_shufflehi_epi16(_mm256_shufflelo_epi16(y, _MM_SHUFFLE(2, 3, 0, 1)),
+                                   _MM_SHUFFLE(2, 3, 0, 1));
+
+        // Calculate the ar*(-ci) + cr*(ai)
+        imagz = _mm256_madd_epi16(x, y);
+
+        // Perform the addition of products
+
+        _mm256_storeu_si256((__m256i*)c,
+                            _mm256_packs_epi32(_mm256_unpacklo_epi32(realz, imagz),
+                                               _mm256_unpackhi_epi32(realz, imagz)));
+
+        a += 8;
+        b += 8;
+        c += 8;
+    }
+
+    number = oneEigthPoints * 8;
+    int16_t* c16Ptr = (int16_t*)&cVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
+    for (; number < num_points; number++) {
+        float aReal = (float)*a8Ptr++;
+        float aImag = (float)*a8Ptr++;
+        lv_32fc_t aVal = lv_cmake(aReal, aImag);
+        float bReal = (float)*b8Ptr++;
+        float bImag = (float)*b8Ptr++;
+        lv_32fc_t bVal = lv_cmake(bReal, -bImag);
+        lv_32fc_t temp = aVal * bVal;
+
+        *c16Ptr++ = (int16_t)(lv_creal(temp) > SHRT_MAX ? SHRT_MAX : lv_creal(temp));
+        *c16Ptr++ = (int16_t)lv_cimag(temp);
+    }
+}
+#endif /* LV_HAVE_AVX2 */
 
 
 #ifdef LV_HAVE_NEON
@@ -285,88 +215,6 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_neon(lv_16sc_t* cVector,
 #endif /* LV_HAVE_NEON */
 
 
-#endif /* INCLUDED_volk_8ic_x2_multiply_conjugate_16ic_a_H */
-
-#ifndef INCLUDED_volk_8ic_x2_multiply_conjugate_16ic_u_H
-#define INCLUDED_volk_8ic_x2_multiply_conjugate_16ic_u_H
-
-#include <inttypes.h>
-#include <stdio.h>
-#include <volk/volk_complex.h>
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-/*!
-  \brief Multiplys the one complex vector with the complex conjugate of the second complex
-  vector and stores their results in the third vector \param cVector The complex vector
-  where the results will be stored \param aVector One of the complex vectors to be
-  multiplied \param bVector The complex vector which will be converted to complex
-  conjugate and multiplied \param num_points The number of complex values in aVector and
-  bVector to be multiplied together and stored into cVector
-*/
-static inline void volk_8ic_x2_multiply_conjugate_16ic_u_avx2(lv_16sc_t* cVector,
-                                                              const lv_8sc_t* aVector,
-                                                              const lv_8sc_t* bVector,
-                                                              unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int oneEigthPoints = num_points / 8;
-
-    __m256i x, y, realz, imagz;
-    lv_16sc_t* c = cVector;
-    const lv_8sc_t* a = aVector;
-    const lv_8sc_t* b = bVector;
-    __m256i conjugateSign =
-        _mm256_set_epi16(-1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1);
-
-    for (; number < oneEigthPoints; number++) {
-        // Convert 8 bit values into 16 bit values
-        x = _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)a));
-        y = _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)b));
-
-        // Calculate the ar*cr - ai*(-ci) portions
-        realz = _mm256_madd_epi16(x, y);
-
-        // Calculate the complex conjugate of the cr + ci j values
-        y = _mm256_sign_epi16(y, conjugateSign);
-
-        // Shift the order of the cr and ci values
-        y = _mm256_shufflehi_epi16(_mm256_shufflelo_epi16(y, _MM_SHUFFLE(2, 3, 0, 1)),
-                                   _MM_SHUFFLE(2, 3, 0, 1));
-
-        // Calculate the ar*(-ci) + cr*(ai)
-        imagz = _mm256_madd_epi16(x, y);
-
-        // Perform the addition of products
-
-        _mm256_storeu_si256((__m256i*)c,
-                            _mm256_packs_epi32(_mm256_unpacklo_epi32(realz, imagz),
-                                               _mm256_unpackhi_epi32(realz, imagz)));
-
-        a += 8;
-        b += 8;
-        c += 8;
-    }
-
-    number = oneEigthPoints * 8;
-    int16_t* c16Ptr = (int16_t*)&cVector[number];
-    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
-    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
-    for (; number < num_points; number++) {
-        float aReal = (float)*a8Ptr++;
-        float aImag = (float)*a8Ptr++;
-        lv_32fc_t aVal = lv_cmake(aReal, aImag);
-        float bReal = (float)*b8Ptr++;
-        float bImag = (float)*b8Ptr++;
-        lv_32fc_t bVal = lv_cmake(bReal, -bImag);
-        lv_32fc_t temp = aVal * bVal;
-
-        *c16Ptr++ = (int16_t)(lv_creal(temp) > SHRT_MAX ? SHRT_MAX : lv_creal(temp));
-        *c16Ptr++ = (int16_t)lv_cimag(temp);
-    }
-}
-#endif /* LV_HAVE_AVX2 */
-
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 
@@ -391,7 +239,7 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_rvv(lv_16sc_t* cVector,
         __riscv_vse32((uint32_t*)cVector, v, vl);
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
 
 #ifdef LV_HAVE_RVVSEG
 #include <riscv_vector.h>
@@ -415,7 +263,160 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_rvvseg(lv_16sc_t* cVector
             (int16_t*)cVector, __riscv_vcreate_v_i16m4x2(vr, vi), vl);
     }
 }
-
-#endif /*LV_HAVE_RVVSEG*/
+#endif /* LV_HAVE_RVVSEG */
 
 #endif /* INCLUDED_volk_8ic_x2_multiply_conjugate_16ic_u_H */
+
+#ifndef INCLUDED_volk_8ic_x2_multiply_conjugate_16ic_a_H
+#define INCLUDED_volk_8ic_x2_multiply_conjugate_16ic_a_H
+
+#include <inttypes.h>
+#include <limits.h>
+#include <stdio.h>
+#include <volk/volk_complex.h>
+
+#ifdef LV_HAVE_SSE4_1
+#include <smmintrin.h>
+/*!
+  \brief Multiplys the one complex vector with the complex conjugate of the second complex
+  vector and stores their results in the third vector \param cVector The complex vector
+  where the results will be stored \param aVector One of the complex vectors to be
+  multiplied \param bVector The complex vector which will be converted to complex
+  conjugate and multiplied \param num_points The number of complex values in aVector and
+  bVector to be multiplied together and stored into cVector
+*/
+static inline void volk_8ic_x2_multiply_conjugate_16ic_a_sse4_1(lv_16sc_t* cVector,
+                                                                const lv_8sc_t* aVector,
+                                                                const lv_8sc_t* bVector,
+                                                                unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    __m128i x, y, realz, imagz;
+    lv_16sc_t* c = cVector;
+    const lv_8sc_t* a = aVector;
+    const lv_8sc_t* b = bVector;
+    __m128i conjugateSign = _mm_set_epi16(-1, 1, -1, 1, -1, 1, -1, 1);
+
+    for (; number < quarterPoints; number++) {
+        // Convert into 8 bit values into 16 bit values
+        x = _mm_cvtepi8_epi16(_mm_loadl_epi64((const __m128i*)a));
+        y = _mm_cvtepi8_epi16(_mm_loadl_epi64((const __m128i*)b));
+
+        // Calculate the ar*cr - ai*(-ci) portions
+        realz = _mm_madd_epi16(x, y);
+
+        // Calculate the complex conjugate of the cr + ci j values
+        y = _mm_sign_epi16(y, conjugateSign);
+
+        // Shift the order of the cr and ci values
+        y = _mm_shufflehi_epi16(_mm_shufflelo_epi16(y, _MM_SHUFFLE(2, 3, 0, 1)),
+                                _MM_SHUFFLE(2, 3, 0, 1));
+
+        // Calculate the ar*(-ci) + cr*(ai)
+        imagz = _mm_madd_epi16(x, y);
+
+        _mm_store_si128((__m128i*)c,
+                        _mm_packs_epi32(_mm_unpacklo_epi32(realz, imagz),
+                                        _mm_unpackhi_epi32(realz, imagz)));
+
+        a += 4;
+        b += 4;
+        c += 4;
+    }
+
+    number = quarterPoints * 4;
+    int16_t* c16Ptr = (int16_t*)&cVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
+    for (; number < num_points; number++) {
+        float aReal = (float)*a8Ptr++;
+        float aImag = (float)*a8Ptr++;
+        lv_32fc_t aVal = lv_cmake(aReal, aImag);
+        float bReal = (float)*b8Ptr++;
+        float bImag = (float)*b8Ptr++;
+        lv_32fc_t bVal = lv_cmake(bReal, -bImag);
+        lv_32fc_t temp = aVal * bVal;
+
+        *c16Ptr++ = (int16_t)(lv_creal(temp) > SHRT_MAX ? SHRT_MAX : lv_creal(temp));
+        *c16Ptr++ = (int16_t)lv_cimag(temp);
+    }
+}
+#endif /* LV_HAVE_SSE4_1 */
+
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+/*!
+  \brief Multiplys the one complex vector with the complex conjugate of the second complex
+  vector and stores their results in the third vector \param cVector The complex vector
+  where the results will be stored \param aVector One of the complex vectors to be
+  multiplied \param bVector The complex vector which will be converted to complex
+  conjugate and multiplied \param num_points The number of complex values in aVector and
+  bVector to be multiplied together and stored into cVector
+*/
+static inline void volk_8ic_x2_multiply_conjugate_16ic_a_avx2(lv_16sc_t* cVector,
+                                                              const lv_8sc_t* aVector,
+                                                              const lv_8sc_t* bVector,
+                                                              unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 8;
+
+    __m256i x, y, realz, imagz;
+    lv_16sc_t* c = cVector;
+    const lv_8sc_t* a = aVector;
+    const lv_8sc_t* b = bVector;
+    __m256i conjugateSign =
+        _mm256_set_epi16(-1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1);
+
+    for (; number < quarterPoints; number++) {
+        // Convert 8 bit values into 16 bit values
+        x = _mm256_cvtepi8_epi16(_mm_load_si128((const __m128i*)a));
+        y = _mm256_cvtepi8_epi16(_mm_load_si128((const __m128i*)b));
+
+        // Calculate the ar*cr - ai*(-ci) portions
+        realz = _mm256_madd_epi16(x, y);
+
+        // Calculate the complex conjugate of the cr + ci j values
+        y = _mm256_sign_epi16(y, conjugateSign);
+
+        // Shift the order of the cr and ci values
+        y = _mm256_shufflehi_epi16(_mm256_shufflelo_epi16(y, _MM_SHUFFLE(2, 3, 0, 1)),
+                                   _MM_SHUFFLE(2, 3, 0, 1));
+
+        // Calculate the ar*(-ci) + cr*(ai)
+        imagz = _mm256_madd_epi16(x, y);
+
+        // Perform the addition of products
+
+        _mm256_store_si256((__m256i*)c,
+                           _mm256_packs_epi32(_mm256_unpacklo_epi32(realz, imagz),
+                                              _mm256_unpackhi_epi32(realz, imagz)));
+
+        a += 8;
+        b += 8;
+        c += 8;
+    }
+
+    number = quarterPoints * 8;
+    int16_t* c16Ptr = (int16_t*)&cVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
+    for (; number < num_points; number++) {
+        float aReal = (float)*a8Ptr++;
+        float aImag = (float)*a8Ptr++;
+        lv_32fc_t aVal = lv_cmake(aReal, aImag);
+        float bReal = (float)*b8Ptr++;
+        float bImag = (float)*b8Ptr++;
+        lv_32fc_t bVal = lv_cmake(bReal, -bImag);
+        lv_32fc_t temp = aVal * bVal;
+
+        *c16Ptr++ = (int16_t)(lv_creal(temp) > SHRT_MAX ? SHRT_MAX : lv_creal(temp));
+        *c16Ptr++ = (int16_t)lv_cimag(temp);
+    }
+}
+#endif /* LV_HAVE_AVX2 */
+
+#endif /* INCLUDED_volk_8ic_x2_multiply_conjugate_16ic_a_H */

--- a/kernels/volk/volk_8ic_x2_multiply_conjugate_16ic.h
+++ b/kernels/volk/volk_8ic_x2_multiply_conjugate_16ic.h
@@ -42,8 +42,8 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_a_avx2(lv_16sc_t* cVector
 
     for (; number < quarterPoints; number++) {
         // Convert 8 bit values into 16 bit values
-        x = _mm256_cvtepi8_epi16(_mm_load_si128((__m128i*)a));
-        y = _mm256_cvtepi8_epi16(_mm_load_si128((__m128i*)b));
+        x = _mm256_cvtepi8_epi16(_mm_load_si128((const __m128i*)a));
+        y = _mm256_cvtepi8_epi16(_mm_load_si128((const __m128i*)b));
 
         // Calculate the ar*cr - ai*(-ci) portions
         realz = _mm256_madd_epi16(x, y);
@@ -71,8 +71,8 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_a_avx2(lv_16sc_t* cVector
 
     number = quarterPoints * 8;
     int16_t* c16Ptr = (int16_t*)&cVector[number];
-    int8_t* a8Ptr = (int8_t*)&aVector[number];
-    int8_t* b8Ptr = (int8_t*)&bVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
     for (; number < num_points; number++) {
         float aReal = (float)*a8Ptr++;
         float aImag = (float)*a8Ptr++;
@@ -115,8 +115,8 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_a_sse4_1(lv_16sc_t* cVect
 
     for (; number < quarterPoints; number++) {
         // Convert into 8 bit values into 16 bit values
-        x = _mm_cvtepi8_epi16(_mm_loadl_epi64((__m128i*)a));
-        y = _mm_cvtepi8_epi16(_mm_loadl_epi64((__m128i*)b));
+        x = _mm_cvtepi8_epi16(_mm_loadl_epi64((const __m128i*)a));
+        y = _mm_cvtepi8_epi16(_mm_loadl_epi64((const __m128i*)b));
 
         // Calculate the ar*cr - ai*(-ci) portions
         realz = _mm_madd_epi16(x, y);
@@ -142,8 +142,8 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_a_sse4_1(lv_16sc_t* cVect
 
     number = quarterPoints * 4;
     int16_t* c16Ptr = (int16_t*)&cVector[number];
-    int8_t* a8Ptr = (int8_t*)&aVector[number];
-    int8_t* b8Ptr = (int8_t*)&bVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
     for (; number < num_points; number++) {
         float aReal = (float)*a8Ptr++;
         float aImag = (float)*a8Ptr++;
@@ -175,8 +175,8 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_generic(lv_16sc_t* cVecto
 {
     unsigned int number = 0;
     int16_t* c16Ptr = (int16_t*)cVector;
-    int8_t* a8Ptr = (int8_t*)aVector;
-    int8_t* b8Ptr = (int8_t*)bVector;
+    const int8_t* a8Ptr = (const int8_t*)aVector;
+    const int8_t* b8Ptr = (const int8_t*)bVector;
     for (number = 0; number < num_points; number++) {
         float aReal = (float)*a8Ptr++;
         float aImag = (float)*a8Ptr++;
@@ -267,8 +267,8 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_neon(lv_16sc_t* cVector,
 
     number = eighthPoints * 8;
     int16_t* c16Ptr = (int16_t*)&cVector[number];
-    int8_t* a8Ptr = (int8_t*)&aVector[number];
-    int8_t* b8Ptr = (int8_t*)&bVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
     for (; number < num_points; number++) {
         float aReal_f = (float)*a8Ptr++;
         float aImag_f = (float)*a8Ptr++;
@@ -321,8 +321,8 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_u_avx2(lv_16sc_t* cVector
 
     for (; number < oneEigthPoints; number++) {
         // Convert 8 bit values into 16 bit values
-        x = _mm256_cvtepi8_epi16(_mm_loadu_si128((__m128i*)a));
-        y = _mm256_cvtepi8_epi16(_mm_loadu_si128((__m128i*)b));
+        x = _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)a));
+        y = _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)b));
 
         // Calculate the ar*cr - ai*(-ci) portions
         realz = _mm256_madd_epi16(x, y);
@@ -350,8 +350,8 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_u_avx2(lv_16sc_t* cVector
 
     number = oneEigthPoints * 8;
     int16_t* c16Ptr = (int16_t*)&cVector[number];
-    int8_t* a8Ptr = (int8_t*)&aVector[number];
-    int8_t* b8Ptr = (int8_t*)&bVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
     for (; number < num_points; number++) {
         float aReal = (float)*a8Ptr++;
         float aImag = (float)*a8Ptr++;

--- a/kernels/volk/volk_8ic_x2_s32f_multiply_conjugate_32fc.h
+++ b/kernels/volk/volk_8ic_x2_s32f_multiply_conjugate_32fc.h
@@ -73,8 +73,8 @@ volk_8ic_x2_s32f_multiply_conjugate_32fc_a_avx2(lv_32fc_t* cVector,
 
     for (; number < oneEigthPoints; number++) {
         // Convert  8 bit values into 16 bit values
-        x = _mm256_cvtepi8_epi16(_mm_load_si128((__m128i*)a));
-        y = _mm256_cvtepi8_epi16(_mm_load_si128((__m128i*)b));
+        x = _mm256_cvtepi8_epi16(_mm_load_si128((const __m128i*)a));
+        y = _mm256_cvtepi8_epi16(_mm_load_si128((const __m128i*)b));
 
         // Calculate the ar*cr - ai*(-ci) portions
         realz = _mm256_madd_epi16(x, y);
@@ -115,8 +115,8 @@ volk_8ic_x2_s32f_multiply_conjugate_32fc_a_avx2(lv_32fc_t* cVector,
 
     number = oneEigthPoints * 8;
     float* cFloatPtr = (float*)&cVector[number];
-    int8_t* a8Ptr = (int8_t*)&aVector[number];
-    int8_t* b8Ptr = (int8_t*)&bVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
     for (; number < num_points; number++) {
         float aReal = (float)*a8Ptr++;
         float aImag = (float)*a8Ptr++;
@@ -157,8 +157,8 @@ volk_8ic_x2_s32f_multiply_conjugate_32fc_a_sse4_1(lv_32fc_t* cVector,
 
     for (; number < quarterPoints; number++) {
         // Convert into 8 bit values into 16 bit values
-        x = _mm_cvtepi8_epi16(_mm_loadl_epi64((__m128i*)a));
-        y = _mm_cvtepi8_epi16(_mm_loadl_epi64((__m128i*)b));
+        x = _mm_cvtepi8_epi16(_mm_loadl_epi64((const __m128i*)a));
+        y = _mm_cvtepi8_epi16(_mm_loadl_epi64((const __m128i*)b));
 
         // Calculate the ar*cr - ai*(-ci) portions
         realz = _mm_madd_epi16(x, y);
@@ -199,8 +199,8 @@ volk_8ic_x2_s32f_multiply_conjugate_32fc_a_sse4_1(lv_32fc_t* cVector,
 
     number = quarterPoints * 4;
     float* cFloatPtr = (float*)&cVector[number];
-    int8_t* a8Ptr = (int8_t*)&aVector[number];
-    int8_t* b8Ptr = (int8_t*)&bVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
     for (; number < num_points; number++) {
         float aReal = (float)*a8Ptr++;
         float aImag = (float)*a8Ptr++;
@@ -229,8 +229,8 @@ volk_8ic_x2_s32f_multiply_conjugate_32fc_generic(lv_32fc_t* cVector,
     unsigned int number = 0;
     float* cPtr = (float*)cVector;
     const float invScalar = 1.0 / scalar;
-    int8_t* a8Ptr = (int8_t*)aVector;
-    int8_t* b8Ptr = (int8_t*)bVector;
+    const int8_t* a8Ptr = (const int8_t*)aVector;
+    const int8_t* b8Ptr = (const int8_t*)bVector;
     for (number = 0; number < num_points; number++) {
         float aReal = (float)*a8Ptr++;
         float aImag = (float)*a8Ptr++;
@@ -327,8 +327,8 @@ static inline void volk_8ic_x2_s32f_multiply_conjugate_32fc_neon(lv_32fc_t* cVec
 
     number = eighthPoints * 8;
     float* cFloatPtr = (float*)&cVector[number];
-    int8_t* a8Ptr = (int8_t*)&aVector[number];
-    int8_t* b8Ptr = (int8_t*)&bVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
     for (; number < num_points; number++) {
         float aReal_f = (float)*a8Ptr++;
         float aImag_f = (float)*a8Ptr++;
@@ -379,8 +379,8 @@ volk_8ic_x2_s32f_multiply_conjugate_32fc_u_avx2(lv_32fc_t* cVector,
 
     for (; number < oneEigthPoints; number++) {
         // Convert  8 bit values into 16 bit values
-        x = _mm256_cvtepi8_epi16(_mm_loadu_si128((__m128i*)a));
-        y = _mm256_cvtepi8_epi16(_mm_loadu_si128((__m128i*)b));
+        x = _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)a));
+        y = _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)b));
 
         // Calculate the ar*cr - ai*(-ci) portions
         realz = _mm256_madd_epi16(x, y);
@@ -421,8 +421,8 @@ volk_8ic_x2_s32f_multiply_conjugate_32fc_u_avx2(lv_32fc_t* cVector,
 
     number = oneEigthPoints * 8;
     float* cFloatPtr = (float*)&cVector[number];
-    int8_t* a8Ptr = (int8_t*)&aVector[number];
-    int8_t* b8Ptr = (int8_t*)&bVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
     for (; number < num_points; number++) {
         float aReal = (float)*a8Ptr++;
         float aImag = (float)*a8Ptr++;

--- a/kernels/volk/volk_8ic_x2_s32f_multiply_conjugate_32fc.h
+++ b/kernels/volk/volk_8ic_x2_s32f_multiply_conjugate_32fc.h
@@ -41,181 +41,12 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_8ic_x2_s32f_multiply_conjugate_32fc_a_H
-#define INCLUDED_volk_8ic_x2_s32f_multiply_conjugate_32fc_a_H
+#ifndef INCLUDED_volk_8ic_x2_s32f_multiply_conjugate_32fc_u_H
+#define INCLUDED_volk_8ic_x2_s32f_multiply_conjugate_32fc_u_H
 
 #include <inttypes.h>
 #include <stdio.h>
 #include <volk/volk_complex.h>
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-
-static inline void
-volk_8ic_x2_s32f_multiply_conjugate_32fc_a_avx2(lv_32fc_t* cVector,
-                                                const lv_8sc_t* aVector,
-                                                const lv_8sc_t* bVector,
-                                                const float scalar,
-                                                unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int oneEigthPoints = num_points / 8;
-
-    __m256i x, y, realz, imagz;
-    __m256 ret, retlo, rethi;
-    lv_32fc_t* c = cVector;
-    const lv_8sc_t* a = aVector;
-    const lv_8sc_t* b = bVector;
-    __m256i conjugateSign =
-        _mm256_set_epi16(-1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1);
-
-    __m256 invScalar = _mm256_set1_ps(1.0 / scalar);
-
-    for (; number < oneEigthPoints; number++) {
-        // Convert  8 bit values into 16 bit values
-        x = _mm256_cvtepi8_epi16(_mm_load_si128((const __m128i*)a));
-        y = _mm256_cvtepi8_epi16(_mm_load_si128((const __m128i*)b));
-
-        // Calculate the ar*cr - ai*(-ci) portions
-        realz = _mm256_madd_epi16(x, y);
-
-        // Calculate the complex conjugate of the cr + ci j values
-        y = _mm256_sign_epi16(y, conjugateSign);
-
-        // Shift the order of the cr and ci values
-        y = _mm256_shufflehi_epi16(_mm256_shufflelo_epi16(y, _MM_SHUFFLE(2, 3, 0, 1)),
-                                   _MM_SHUFFLE(2, 3, 0, 1));
-
-        // Calculate the ar*(-ci) + cr*(ai)
-        imagz = _mm256_madd_epi16(x, y);
-
-        // Interleave real and imaginary and then convert to float values
-        retlo = _mm256_cvtepi32_ps(_mm256_unpacklo_epi32(realz, imagz));
-
-        // Normalize the floating point values
-        retlo = _mm256_mul_ps(retlo, invScalar);
-
-        // Interleave real and imaginary and then convert to float values
-        rethi = _mm256_cvtepi32_ps(_mm256_unpackhi_epi32(realz, imagz));
-
-        // Normalize the floating point values
-        rethi = _mm256_mul_ps(rethi, invScalar);
-
-        ret = _mm256_permute2f128_ps(retlo, rethi, 0b00100000);
-        _mm256_store_ps((float*)c, ret);
-        c += 4;
-
-        ret = _mm256_permute2f128_ps(retlo, rethi, 0b00110001);
-        _mm256_store_ps((float*)c, ret);
-        c += 4;
-
-        a += 8;
-        b += 8;
-    }
-
-    number = oneEigthPoints * 8;
-    float* cFloatPtr = (float*)&cVector[number];
-    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
-    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
-    for (; number < num_points; number++) {
-        float aReal = (float)*a8Ptr++;
-        float aImag = (float)*a8Ptr++;
-        lv_32fc_t aVal = lv_cmake(aReal, aImag);
-        float bReal = (float)*b8Ptr++;
-        float bImag = (float)*b8Ptr++;
-        lv_32fc_t bVal = lv_cmake(bReal, -bImag);
-        lv_32fc_t temp = aVal * bVal;
-
-        *cFloatPtr++ = lv_creal(temp) / scalar;
-        *cFloatPtr++ = lv_cimag(temp) / scalar;
-    }
-}
-#endif /* LV_HAVE_AVX2*/
-
-
-#ifdef LV_HAVE_SSE4_1
-#include <smmintrin.h>
-
-static inline void
-volk_8ic_x2_s32f_multiply_conjugate_32fc_a_sse4_1(lv_32fc_t* cVector,
-                                                  const lv_8sc_t* aVector,
-                                                  const lv_8sc_t* bVector,
-                                                  const float scalar,
-                                                  unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int quarterPoints = num_points / 4;
-
-    __m128i x, y, realz, imagz;
-    __m128 ret;
-    lv_32fc_t* c = cVector;
-    const lv_8sc_t* a = aVector;
-    const lv_8sc_t* b = bVector;
-    __m128i conjugateSign = _mm_set_epi16(-1, 1, -1, 1, -1, 1, -1, 1);
-
-    __m128 invScalar = _mm_set_ps1(1.0 / scalar);
-
-    for (; number < quarterPoints; number++) {
-        // Convert into 8 bit values into 16 bit values
-        x = _mm_cvtepi8_epi16(_mm_loadl_epi64((const __m128i*)a));
-        y = _mm_cvtepi8_epi16(_mm_loadl_epi64((const __m128i*)b));
-
-        // Calculate the ar*cr - ai*(-ci) portions
-        realz = _mm_madd_epi16(x, y);
-
-        // Calculate the complex conjugate of the cr + ci j values
-        y = _mm_sign_epi16(y, conjugateSign);
-
-        // Shift the order of the cr and ci values
-        y = _mm_shufflehi_epi16(_mm_shufflelo_epi16(y, _MM_SHUFFLE(2, 3, 0, 1)),
-                                _MM_SHUFFLE(2, 3, 0, 1));
-
-        // Calculate the ar*(-ci) + cr*(ai)
-        imagz = _mm_madd_epi16(x, y);
-
-        // Interleave real and imaginary and then convert to float values
-        ret = _mm_cvtepi32_ps(_mm_unpacklo_epi32(realz, imagz));
-
-        // Normalize the floating point values
-        ret = _mm_mul_ps(ret, invScalar);
-
-        // Store the floating point values
-        _mm_store_ps((float*)c, ret);
-        c += 2;
-
-        // Interleave real and imaginary and then convert to float values
-        ret = _mm_cvtepi32_ps(_mm_unpackhi_epi32(realz, imagz));
-
-        // Normalize the floating point values
-        ret = _mm_mul_ps(ret, invScalar);
-
-        // Store the floating point values
-        _mm_store_ps((float*)c, ret);
-        c += 2;
-
-        a += 4;
-        b += 4;
-    }
-
-    number = quarterPoints * 4;
-    float* cFloatPtr = (float*)&cVector[number];
-    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
-    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
-    for (; number < num_points; number++) {
-        float aReal = (float)*a8Ptr++;
-        float aImag = (float)*a8Ptr++;
-        lv_32fc_t aVal = lv_cmake(aReal, aImag);
-        float bReal = (float)*b8Ptr++;
-        float bImag = (float)*b8Ptr++;
-        lv_32fc_t bVal = lv_cmake(bReal, -bImag);
-        lv_32fc_t temp = aVal * bVal;
-
-        *cFloatPtr++ = lv_creal(temp) / scalar;
-        *cFloatPtr++ = lv_cimag(temp) / scalar;
-    }
-}
-#endif /* LV_HAVE_SSE4_1 */
-
 
 #ifdef LV_HAVE_GENERIC
 
@@ -245,6 +76,91 @@ volk_8ic_x2_s32f_multiply_conjugate_32fc_generic(lv_32fc_t* cVector,
     }
 }
 #endif /* LV_HAVE_GENERIC */
+
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void
+volk_8ic_x2_s32f_multiply_conjugate_32fc_u_avx2(lv_32fc_t* cVector,
+                                                const lv_8sc_t* aVector,
+                                                const lv_8sc_t* bVector,
+                                                const float scalar,
+                                                unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int oneEigthPoints = num_points / 8;
+
+    __m256i x, y, realz, imagz;
+    __m256 ret, retlo, rethi;
+    lv_32fc_t* c = cVector;
+    const lv_8sc_t* a = aVector;
+    const lv_8sc_t* b = bVector;
+    __m256i conjugateSign =
+        _mm256_set_epi16(-1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1);
+
+    __m256 invScalar = _mm256_set1_ps(1.0 / scalar);
+
+    for (; number < oneEigthPoints; number++) {
+        // Convert  8 bit values into 16 bit values
+        x = _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)a));
+        y = _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)b));
+
+        // Calculate the ar*cr - ai*(-ci) portions
+        realz = _mm256_madd_epi16(x, y);
+
+        // Calculate the complex conjugate of the cr + ci j values
+        y = _mm256_sign_epi16(y, conjugateSign);
+
+        // Shift the order of the cr and ci values
+        y = _mm256_shufflehi_epi16(_mm256_shufflelo_epi16(y, _MM_SHUFFLE(2, 3, 0, 1)),
+                                   _MM_SHUFFLE(2, 3, 0, 1));
+
+        // Calculate the ar*(-ci) + cr*(ai)
+        imagz = _mm256_madd_epi16(x, y);
+
+        // Interleave real and imaginary and then convert to float values
+        retlo = _mm256_cvtepi32_ps(_mm256_unpacklo_epi32(realz, imagz));
+
+        // Normalize the floating point values
+        retlo = _mm256_mul_ps(retlo, invScalar);
+
+        // Interleave real and imaginary and then convert to float values
+        rethi = _mm256_cvtepi32_ps(_mm256_unpackhi_epi32(realz, imagz));
+
+        // Normalize the floating point values
+        rethi = _mm256_mul_ps(rethi, invScalar);
+
+        ret = _mm256_permute2f128_ps(retlo, rethi, 0b00100000);
+        _mm256_storeu_ps((float*)c, ret);
+        c += 4;
+
+        ret = _mm256_permute2f128_ps(retlo, rethi, 0b00110001);
+        _mm256_storeu_ps((float*)c, ret);
+        c += 4;
+
+        a += 8;
+        b += 8;
+    }
+
+    number = oneEigthPoints * 8;
+    float* cFloatPtr = (float*)&cVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
+    for (; number < num_points; number++) {
+        float aReal = (float)*a8Ptr++;
+        float aImag = (float)*a8Ptr++;
+        lv_32fc_t aVal = lv_cmake(aReal, aImag);
+        float bReal = (float)*b8Ptr++;
+        float bImag = (float)*b8Ptr++;
+        lv_32fc_t bVal = lv_cmake(bReal, -bImag);
+        lv_32fc_t temp = aVal * bVal;
+
+        *cFloatPtr++ = lv_creal(temp) / scalar;
+        *cFloatPtr++ = lv_cimag(temp) / scalar;
+    }
+}
+#endif /* LV_HAVE_AVX2 */
 
 
 #ifdef LV_HAVE_NEON
@@ -345,100 +261,6 @@ static inline void volk_8ic_x2_s32f_multiply_conjugate_32fc_neon(lv_32fc_t* cVec
 #endif /* LV_HAVE_NEON */
 
 
-#endif /* INCLUDED_volk_8ic_x2_s32f_multiply_conjugate_32fc_a_H */
-
-#ifndef INCLUDED_volk_8ic_x2_s32f_multiply_conjugate_32fc_u_H
-#define INCLUDED_volk_8ic_x2_s32f_multiply_conjugate_32fc_u_H
-
-#include <inttypes.h>
-#include <stdio.h>
-#include <volk/volk_complex.h>
-
-#ifdef LV_HAVE_AVX2
-#include <immintrin.h>
-
-static inline void
-volk_8ic_x2_s32f_multiply_conjugate_32fc_u_avx2(lv_32fc_t* cVector,
-                                                const lv_8sc_t* aVector,
-                                                const lv_8sc_t* bVector,
-                                                const float scalar,
-                                                unsigned int num_points)
-{
-    unsigned int number = 0;
-    const unsigned int oneEigthPoints = num_points / 8;
-
-    __m256i x, y, realz, imagz;
-    __m256 ret, retlo, rethi;
-    lv_32fc_t* c = cVector;
-    const lv_8sc_t* a = aVector;
-    const lv_8sc_t* b = bVector;
-    __m256i conjugateSign =
-        _mm256_set_epi16(-1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1);
-
-    __m256 invScalar = _mm256_set1_ps(1.0 / scalar);
-
-    for (; number < oneEigthPoints; number++) {
-        // Convert  8 bit values into 16 bit values
-        x = _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)a));
-        y = _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)b));
-
-        // Calculate the ar*cr - ai*(-ci) portions
-        realz = _mm256_madd_epi16(x, y);
-
-        // Calculate the complex conjugate of the cr + ci j values
-        y = _mm256_sign_epi16(y, conjugateSign);
-
-        // Shift the order of the cr and ci values
-        y = _mm256_shufflehi_epi16(_mm256_shufflelo_epi16(y, _MM_SHUFFLE(2, 3, 0, 1)),
-                                   _MM_SHUFFLE(2, 3, 0, 1));
-
-        // Calculate the ar*(-ci) + cr*(ai)
-        imagz = _mm256_madd_epi16(x, y);
-
-        // Interleave real and imaginary and then convert to float values
-        retlo = _mm256_cvtepi32_ps(_mm256_unpacklo_epi32(realz, imagz));
-
-        // Normalize the floating point values
-        retlo = _mm256_mul_ps(retlo, invScalar);
-
-        // Interleave real and imaginary and then convert to float values
-        rethi = _mm256_cvtepi32_ps(_mm256_unpackhi_epi32(realz, imagz));
-
-        // Normalize the floating point values
-        rethi = _mm256_mul_ps(rethi, invScalar);
-
-        ret = _mm256_permute2f128_ps(retlo, rethi, 0b00100000);
-        _mm256_storeu_ps((float*)c, ret);
-        c += 4;
-
-        ret = _mm256_permute2f128_ps(retlo, rethi, 0b00110001);
-        _mm256_storeu_ps((float*)c, ret);
-        c += 4;
-
-        a += 8;
-        b += 8;
-    }
-
-    number = oneEigthPoints * 8;
-    float* cFloatPtr = (float*)&cVector[number];
-    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
-    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
-    for (; number < num_points; number++) {
-        float aReal = (float)*a8Ptr++;
-        float aImag = (float)*a8Ptr++;
-        lv_32fc_t aVal = lv_cmake(aReal, aImag);
-        float bReal = (float)*b8Ptr++;
-        float bImag = (float)*b8Ptr++;
-        lv_32fc_t bVal = lv_cmake(bReal, -bImag);
-        lv_32fc_t temp = aVal * bVal;
-
-        *cFloatPtr++ = lv_creal(temp) / scalar;
-        *cFloatPtr++ = lv_cimag(temp) / scalar;
-    }
-}
-#endif /* LV_HAVE_AVX2*/
-
-
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 
@@ -467,7 +289,7 @@ static inline void volk_8ic_x2_s32f_multiply_conjugate_32fc_rvv(lv_32fc_t* cVect
         __riscv_vse64((uint64_t*)cVector, v, vl);
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
 
 #ifdef LV_HAVE_RVVSEG
 #include <riscv_vector.h>
@@ -496,6 +318,184 @@ volk_8ic_x2_s32f_multiply_conjugate_32fc_rvvseg(lv_32fc_t* cVector,
     }
 }
 
-#endif /*LV_HAVE_RVVSEG*/
+#endif /* LV_HAVE_RVVSEG */
 
 #endif /* INCLUDED_volk_8ic_x2_s32f_multiply_conjugate_32fc_u_H */
+
+#ifndef INCLUDED_volk_8ic_x2_s32f_multiply_conjugate_32fc_a_H
+#define INCLUDED_volk_8ic_x2_s32f_multiply_conjugate_32fc_a_H
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <volk/volk_complex.h>
+
+#ifdef LV_HAVE_SSE4_1
+#include <smmintrin.h>
+
+static inline void
+volk_8ic_x2_s32f_multiply_conjugate_32fc_a_sse4_1(lv_32fc_t* cVector,
+                                                  const lv_8sc_t* aVector,
+                                                  const lv_8sc_t* bVector,
+                                                  const float scalar,
+                                                  unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int quarterPoints = num_points / 4;
+
+    __m128i x, y, realz, imagz;
+    __m128 ret;
+    lv_32fc_t* c = cVector;
+    const lv_8sc_t* a = aVector;
+    const lv_8sc_t* b = bVector;
+    __m128i conjugateSign = _mm_set_epi16(-1, 1, -1, 1, -1, 1, -1, 1);
+
+    __m128 invScalar = _mm_set_ps1(1.0 / scalar);
+
+    for (; number < quarterPoints; number++) {
+        // Convert into 8 bit values into 16 bit values
+        x = _mm_cvtepi8_epi16(_mm_loadl_epi64((const __m128i*)a));
+        y = _mm_cvtepi8_epi16(_mm_loadl_epi64((const __m128i*)b));
+
+        // Calculate the ar*cr - ai*(-ci) portions
+        realz = _mm_madd_epi16(x, y);
+
+        // Calculate the complex conjugate of the cr + ci j values
+        y = _mm_sign_epi16(y, conjugateSign);
+
+        // Shift the order of the cr and ci values
+        y = _mm_shufflehi_epi16(_mm_shufflelo_epi16(y, _MM_SHUFFLE(2, 3, 0, 1)),
+                                _MM_SHUFFLE(2, 3, 0, 1));
+
+        // Calculate the ar*(-ci) + cr*(ai)
+        imagz = _mm_madd_epi16(x, y);
+
+        // Interleave real and imaginary and then convert to float values
+        ret = _mm_cvtepi32_ps(_mm_unpacklo_epi32(realz, imagz));
+
+        // Normalize the floating point values
+        ret = _mm_mul_ps(ret, invScalar);
+
+        // Store the floating point values
+        _mm_store_ps((float*)c, ret);
+        c += 2;
+
+        // Interleave real and imaginary and then convert to float values
+        ret = _mm_cvtepi32_ps(_mm_unpackhi_epi32(realz, imagz));
+
+        // Normalize the floating point values
+        ret = _mm_mul_ps(ret, invScalar);
+
+        // Store the floating point values
+        _mm_store_ps((float*)c, ret);
+        c += 2;
+
+        a += 4;
+        b += 4;
+    }
+
+    number = quarterPoints * 4;
+    float* cFloatPtr = (float*)&cVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
+    for (; number < num_points; number++) {
+        float aReal = (float)*a8Ptr++;
+        float aImag = (float)*a8Ptr++;
+        lv_32fc_t aVal = lv_cmake(aReal, aImag);
+        float bReal = (float)*b8Ptr++;
+        float bImag = (float)*b8Ptr++;
+        lv_32fc_t bVal = lv_cmake(bReal, -bImag);
+        lv_32fc_t temp = aVal * bVal;
+
+        *cFloatPtr++ = lv_creal(temp) / scalar;
+        *cFloatPtr++ = lv_cimag(temp) / scalar;
+    }
+}
+#endif /* LV_HAVE_SSE4_1 */
+
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void
+volk_8ic_x2_s32f_multiply_conjugate_32fc_a_avx2(lv_32fc_t* cVector,
+                                                const lv_8sc_t* aVector,
+                                                const lv_8sc_t* bVector,
+                                                const float scalar,
+                                                unsigned int num_points)
+{
+    unsigned int number = 0;
+    const unsigned int oneEigthPoints = num_points / 8;
+
+    __m256i x, y, realz, imagz;
+    __m256 ret, retlo, rethi;
+    lv_32fc_t* c = cVector;
+    const lv_8sc_t* a = aVector;
+    const lv_8sc_t* b = bVector;
+    __m256i conjugateSign =
+        _mm256_set_epi16(-1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1);
+
+    __m256 invScalar = _mm256_set1_ps(1.0 / scalar);
+
+    for (; number < oneEigthPoints; number++) {
+        // Convert  8 bit values into 16 bit values
+        x = _mm256_cvtepi8_epi16(_mm_load_si128((const __m128i*)a));
+        y = _mm256_cvtepi8_epi16(_mm_load_si128((const __m128i*)b));
+
+        // Calculate the ar*cr - ai*(-ci) portions
+        realz = _mm256_madd_epi16(x, y);
+
+        // Calculate the complex conjugate of the cr + ci j values
+        y = _mm256_sign_epi16(y, conjugateSign);
+
+        // Shift the order of the cr and ci values
+        y = _mm256_shufflehi_epi16(_mm256_shufflelo_epi16(y, _MM_SHUFFLE(2, 3, 0, 1)),
+                                   _MM_SHUFFLE(2, 3, 0, 1));
+
+        // Calculate the ar*(-ci) + cr*(ai)
+        imagz = _mm256_madd_epi16(x, y);
+
+        // Interleave real and imaginary and then convert to float values
+        retlo = _mm256_cvtepi32_ps(_mm256_unpacklo_epi32(realz, imagz));
+
+        // Normalize the floating point values
+        retlo = _mm256_mul_ps(retlo, invScalar);
+
+        // Interleave real and imaginary and then convert to float values
+        rethi = _mm256_cvtepi32_ps(_mm256_unpackhi_epi32(realz, imagz));
+
+        // Normalize the floating point values
+        rethi = _mm256_mul_ps(rethi, invScalar);
+
+        ret = _mm256_permute2f128_ps(retlo, rethi, 0b00100000);
+        _mm256_store_ps((float*)c, ret);
+        c += 4;
+
+        ret = _mm256_permute2f128_ps(retlo, rethi, 0b00110001);
+        _mm256_store_ps((float*)c, ret);
+        c += 4;
+
+        a += 8;
+        b += 8;
+    }
+
+    number = oneEigthPoints * 8;
+    float* cFloatPtr = (float*)&cVector[number];
+    const int8_t* a8Ptr = (const int8_t*)&aVector[number];
+    const int8_t* b8Ptr = (const int8_t*)&bVector[number];
+    for (; number < num_points; number++) {
+        float aReal = (float)*a8Ptr++;
+        float aImag = (float)*a8Ptr++;
+        lv_32fc_t aVal = lv_cmake(aReal, aImag);
+        float bReal = (float)*b8Ptr++;
+        float bImag = (float)*b8Ptr++;
+        lv_32fc_t bVal = lv_cmake(bReal, -bImag);
+        lv_32fc_t temp = aVal * bVal;
+
+        *cFloatPtr++ = lv_creal(temp) / scalar;
+        *cFloatPtr++ = lv_cimag(temp) / scalar;
+    }
+}
+#endif /* LV_HAVE_AVX2 */
+
+
+#endif /* INCLUDED_volk_8ic_x2_s32f_multiply_conjugate_32fc_a_H */

--- a/kernels/volk/volk_8u_x2_encodeframepolar_8u.h
+++ b/kernels/volk/volk_8u_x2_encodeframepolar_8u.h
@@ -610,6 +610,88 @@ static inline void volk_8u_x2_encodeframepolar_8u_u_avx2(unsigned char* frame,
 }
 #endif /* LV_HAVE_AVX2 */
 
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_8u_x2_encodeframepolar_8u_rvv(unsigned char* frame,
+                                                      unsigned char* temp,
+                                                      unsigned int frame_size)
+{
+    unsigned int stage = log2_of_power_of_2(frame_size);
+    unsigned int frame_half = frame_size >> 1;
+    unsigned int num_branches = 1;
+
+    while (stage) {
+        // encode stage
+        if (frame_half < 8) {
+            encodepolar_single_stage(frame, temp, num_branches, frame_half);
+        } else {
+            const unsigned char* in = temp;
+            unsigned char* out = frame;
+            for (size_t branch = 0; branch < num_branches; ++branch) {
+                size_t n = frame_half;
+                for (size_t vl; n > 0; n -= vl, in += vl * 2, out += vl) {
+                    vl = __riscv_vsetvl_e8m1(n);
+                    vuint16m2_t vc = __riscv_vle16_v_u16m2((const uint16_t*)in, vl);
+                    vuint8m1_t v1 = __riscv_vnsrl(vc, 0, vl);
+                    vuint8m1_t v2 = __riscv_vnsrl(vc, 8, vl);
+                    __riscv_vse8(out, __riscv_vxor(v1, v2, vl), vl);
+                    __riscv_vse8(out + frame_half, v2, vl);
+                }
+                out += frame_half;
+            }
+        }
+        memcpy(temp, frame, sizeof(unsigned char) * frame_size);
+
+        // update all the parameters.
+        num_branches = num_branches << 1;
+        frame_half = frame_half >> 1;
+        --stage;
+    }
+}
+#endif /* LV_HAVE_RVV */
+
+#ifdef LV_HAVE_RVVSEG
+#include <riscv_vector.h>
+
+static inline void volk_8u_x2_encodeframepolar_8u_rvvseg(unsigned char* frame,
+                                                         unsigned char* temp,
+                                                         unsigned int frame_size)
+{
+    unsigned int stage = log2_of_power_of_2(frame_size);
+    unsigned int frame_half = frame_size >> 1;
+    unsigned int num_branches = 1;
+
+    while (stage) {
+        // encode stage
+        if (frame_half < 8) {
+            encodepolar_single_stage(frame, temp, num_branches, frame_half);
+        } else {
+            const unsigned char* in = temp;
+            unsigned char* out = frame;
+            for (size_t branch = 0; branch < num_branches; ++branch) {
+                size_t n = frame_half;
+                for (size_t vl; n > 0; n -= vl, in += vl * 2, out += vl) {
+                    vl = __riscv_vsetvl_e8m1(n);
+                    vuint8m1x2_t vc = __riscv_vlseg2e8_v_u8m1x2(in, vl);
+                    vuint8m1_t v1 = __riscv_vget_u8m1(vc, 0);
+                    vuint8m1_t v2 = __riscv_vget_u8m1(vc, 1);
+                    __riscv_vse8(out, __riscv_vxor(v1, v2, vl), vl);
+                    __riscv_vse8(out + frame_half, v2, vl);
+                }
+                out += frame_half;
+            }
+        }
+        memcpy(temp, frame, sizeof(unsigned char) * frame_size);
+
+        // update all the parameters.
+        num_branches = num_branches << 1;
+        frame_half = frame_half >> 1;
+        --stage;
+    }
+}
+#endif /* LV_HAVE_RVVSEG */
+
 #endif /* VOLK_KERNELS_VOLK_VOLK_8U_X2_ENCODEFRAMEPOLAR_8U_U_H_ */
 
 #ifndef VOLK_KERNELS_VOLK_VOLK_8U_X2_ENCODEFRAMEPOLAR_8U_A_H_
@@ -1152,87 +1234,5 @@ static inline void volk_8u_x2_encodeframepolar_8u_a_avx2(unsigned char* frame,
     }
 }
 #endif /* LV_HAVE_AVX2 */
-
-#ifdef LV_HAVE_RVV
-#include <riscv_vector.h>
-
-static inline void volk_8u_x2_encodeframepolar_8u_rvv(unsigned char* frame,
-                                                      unsigned char* temp,
-                                                      unsigned int frame_size)
-{
-    unsigned int stage = log2_of_power_of_2(frame_size);
-    unsigned int frame_half = frame_size >> 1;
-    unsigned int num_branches = 1;
-
-    while (stage) {
-        // encode stage
-        if (frame_half < 8) {
-            encodepolar_single_stage(frame, temp, num_branches, frame_half);
-        } else {
-            const unsigned char* in = temp;
-            unsigned char* out = frame;
-            for (size_t branch = 0; branch < num_branches; ++branch) {
-                size_t n = frame_half;
-                for (size_t vl; n > 0; n -= vl, in += vl * 2, out += vl) {
-                    vl = __riscv_vsetvl_e8m1(n);
-                    vuint16m2_t vc = __riscv_vle16_v_u16m2((const uint16_t*)in, vl);
-                    vuint8m1_t v1 = __riscv_vnsrl(vc, 0, vl);
-                    vuint8m1_t v2 = __riscv_vnsrl(vc, 8, vl);
-                    __riscv_vse8(out, __riscv_vxor(v1, v2, vl), vl);
-                    __riscv_vse8(out + frame_half, v2, vl);
-                }
-                out += frame_half;
-            }
-        }
-        memcpy(temp, frame, sizeof(unsigned char) * frame_size);
-
-        // update all the parameters.
-        num_branches = num_branches << 1;
-        frame_half = frame_half >> 1;
-        --stage;
-    }
-}
-#endif /*LV_HAVE_RVV*/
-
-#ifdef LV_HAVE_RVVSEG
-#include <riscv_vector.h>
-
-static inline void volk_8u_x2_encodeframepolar_8u_rvvseg(unsigned char* frame,
-                                                         unsigned char* temp,
-                                                         unsigned int frame_size)
-{
-    unsigned int stage = log2_of_power_of_2(frame_size);
-    unsigned int frame_half = frame_size >> 1;
-    unsigned int num_branches = 1;
-
-    while (stage) {
-        // encode stage
-        if (frame_half < 8) {
-            encodepolar_single_stage(frame, temp, num_branches, frame_half);
-        } else {
-            const unsigned char* in = temp;
-            unsigned char* out = frame;
-            for (size_t branch = 0; branch < num_branches; ++branch) {
-                size_t n = frame_half;
-                for (size_t vl; n > 0; n -= vl, in += vl * 2, out += vl) {
-                    vl = __riscv_vsetvl_e8m1(n);
-                    vuint8m1x2_t vc = __riscv_vlseg2e8_v_u8m1x2(in, vl);
-                    vuint8m1_t v1 = __riscv_vget_u8m1(vc, 0);
-                    vuint8m1_t v2 = __riscv_vget_u8m1(vc, 1);
-                    __riscv_vse8(out, __riscv_vxor(v1, v2, vl), vl);
-                    __riscv_vse8(out + frame_half, v2, vl);
-                }
-                out += frame_half;
-            }
-        }
-        memcpy(temp, frame, sizeof(unsigned char) * frame_size);
-
-        // update all the parameters.
-        num_branches = num_branches << 1;
-        frame_half = frame_half >> 1;
-        --stage;
-    }
-}
-#endif /*LV_HAVE_RVVSEG*/
 
 #endif /* VOLK_KERNELS_VOLK_VOLK_8U_X2_ENCODEFRAMEPOLAR_8U_A_H_ */

--- a/kernels/volk/volk_8u_x2_encodeframepolar_8u.h
+++ b/kernels/volk/volk_8u_x2_encodeframepolar_8u.h
@@ -86,7 +86,7 @@ static inline void volk_8u_x2_encodeframepolar_8u_u_ssse3(unsigned char* frame,
 
     unsigned int stage = po2;
     unsigned char* frame_ptr = frame;
-    unsigned char* temp_ptr = temp;
+    const unsigned char* temp_ptr = temp;
 
     unsigned int frame_half = frame_size >> 1;
     unsigned int num_branches = 1;
@@ -126,9 +126,9 @@ static inline void volk_8u_x2_encodeframepolar_8u_u_ssse3(unsigned char* frame,
             // for stage = 5 a branch has 32 elements. So upper stages are even bigger.
             for (branch = 0; branch < num_branches; ++branch) {
                 for (bit = 0; bit < frame_half; bit += 16) {
-                    r_temp0 = _mm_loadu_si128((__m128i*)temp_ptr);
+                    r_temp0 = _mm_loadu_si128((const __m128i*)temp_ptr);
                     temp_ptr += 16;
-                    r_temp1 = _mm_loadu_si128((__m128i*)temp_ptr);
+                    r_temp1 = _mm_loadu_si128((const __m128i*)temp_ptr);
                     temp_ptr += 16;
 
                     shifted = _mm_srli_si128(r_temp0, 1);
@@ -221,7 +221,7 @@ static inline void volk_8u_x2_encodeframepolar_8u_u_ssse3(unsigned char* frame,
                                              0xFF);
 
     for (branch = 0; branch < num_branches; ++branch) {
-        r_temp0 = _mm_loadu_si128((__m128i*)temp_ptr);
+        r_temp0 = _mm_loadu_si128((const __m128i*)temp_ptr);
 
         // prefetch next chunk
         temp_ptr += 16;
@@ -270,7 +270,7 @@ static inline void volk_8u_x2_encodeframepolar_8u_u_avx2(unsigned char* frame,
 
     unsigned int stage = po2;
     unsigned char* frame_ptr = frame;
-    unsigned char* temp_ptr = temp;
+    const unsigned char* temp_ptr = temp;
 
     unsigned int frame_half = frame_size >> 1;
     unsigned int num_branches = 1;
@@ -378,9 +378,9 @@ static inline void volk_8u_x2_encodeframepolar_8u_u_avx2(unsigned char* frame,
                     if ((frame_half - bit) <
                         32) // if only 16 bits remaining in frame, not 32
                     {
-                        r_temp2 = _mm_loadu_si128((__m128i*)temp_ptr);
+                        r_temp2 = _mm_loadu_si128((const __m128i*)temp_ptr);
                         temp_ptr += 16;
-                        r_temp3 = _mm_loadu_si128((__m128i*)temp_ptr);
+                        r_temp3 = _mm_loadu_si128((const __m128i*)temp_ptr);
                         temp_ptr += 16;
 
                         shifted2 = _mm_srli_si128(r_temp2, 1);
@@ -401,9 +401,9 @@ static inline void volk_8u_x2_encodeframepolar_8u_u_avx2(unsigned char* frame,
                         frame_ptr += 16;
                         break;
                     }
-                    r_temp0 = _mm256_loadu_si256((__m256i*)temp_ptr);
+                    r_temp0 = _mm256_loadu_si256((const __m256i*)temp_ptr);
                     temp_ptr += 32;
-                    r_temp1 = _mm256_loadu_si256((__m256i*)temp_ptr);
+                    r_temp1 = _mm256_loadu_si256((const __m256i*)temp_ptr);
                     temp_ptr += 32;
 
                     shifted = _mm256_srli_si256(r_temp0, 1); // operate on 128 bit lanes
@@ -577,7 +577,7 @@ static inline void volk_8u_x2_encodeframepolar_8u_u_avx2(unsigned char* frame,
                                                 0xFF);
 
     for (branch = 0; branch < num_branches / 2; ++branch) {
-        r_temp0 = _mm256_loadu_si256((__m256i*)temp_ptr);
+        r_temp0 = _mm256_loadu_si256((const __m256i*)temp_ptr);
 
         // prefetch next chunk
         temp_ptr += 32;
@@ -631,7 +631,7 @@ static inline void volk_8u_x2_encodeframepolar_8u_a_ssse3(unsigned char* frame,
 
     unsigned int stage = po2;
     unsigned char* frame_ptr = frame;
-    unsigned char* temp_ptr = temp;
+    const unsigned char* temp_ptr = temp;
 
     unsigned int frame_half = frame_size >> 1;
     unsigned int num_branches = 1;
@@ -671,9 +671,9 @@ static inline void volk_8u_x2_encodeframepolar_8u_a_ssse3(unsigned char* frame,
             // for stage = 5 a branch has 32 elements. So upper stages are even bigger.
             for (branch = 0; branch < num_branches; ++branch) {
                 for (bit = 0; bit < frame_half; bit += 16) {
-                    r_temp0 = _mm_load_si128((__m128i*)temp_ptr);
+                    r_temp0 = _mm_load_si128((const __m128i*)temp_ptr);
                     temp_ptr += 16;
-                    r_temp1 = _mm_load_si128((__m128i*)temp_ptr);
+                    r_temp1 = _mm_load_si128((const __m128i*)temp_ptr);
                     temp_ptr += 16;
 
                     shifted = _mm_srli_si128(r_temp0, 1);
@@ -766,7 +766,7 @@ static inline void volk_8u_x2_encodeframepolar_8u_a_ssse3(unsigned char* frame,
                                              0xFF);
 
     for (branch = 0; branch < num_branches; ++branch) {
-        r_temp0 = _mm_load_si128((__m128i*)temp_ptr);
+        r_temp0 = _mm_load_si128((const __m128i*)temp_ptr);
 
         // prefetch next chunk
         temp_ptr += 16;
@@ -814,7 +814,7 @@ static inline void volk_8u_x2_encodeframepolar_8u_a_avx2(unsigned char* frame,
 
     unsigned int stage = po2;
     unsigned char* frame_ptr = frame;
-    unsigned char* temp_ptr = temp;
+    const unsigned char* temp_ptr = temp;
 
     unsigned int frame_half = frame_size >> 1;
     unsigned int num_branches = 1;
@@ -922,9 +922,9 @@ static inline void volk_8u_x2_encodeframepolar_8u_a_avx2(unsigned char* frame,
                     if ((frame_half - bit) <
                         32) // if only 16 bits remaining in frame, not 32
                     {
-                        r_temp2 = _mm_load_si128((__m128i*)temp_ptr);
+                        r_temp2 = _mm_load_si128((const __m128i*)temp_ptr);
                         temp_ptr += 16;
-                        r_temp3 = _mm_load_si128((__m128i*)temp_ptr);
+                        r_temp3 = _mm_load_si128((const __m128i*)temp_ptr);
                         temp_ptr += 16;
 
                         shifted2 = _mm_srli_si128(r_temp2, 1);
@@ -945,9 +945,9 @@ static inline void volk_8u_x2_encodeframepolar_8u_a_avx2(unsigned char* frame,
                         frame_ptr += 16;
                         break;
                     }
-                    r_temp0 = _mm256_load_si256((__m256i*)temp_ptr);
+                    r_temp0 = _mm256_load_si256((const __m256i*)temp_ptr);
                     temp_ptr += 32;
-                    r_temp1 = _mm256_load_si256((__m256i*)temp_ptr);
+                    r_temp1 = _mm256_load_si256((const __m256i*)temp_ptr);
                     temp_ptr += 32;
 
                     shifted = _mm256_srli_si256(r_temp0, 1); // operate on 128 bit lanes
@@ -1121,7 +1121,7 @@ static inline void volk_8u_x2_encodeframepolar_8u_a_avx2(unsigned char* frame,
                                                 0xFF);
 
     for (branch = 0; branch < num_branches / 2; ++branch) {
-        r_temp0 = _mm256_load_si256((__m256i*)temp_ptr);
+        r_temp0 = _mm256_load_si256((const __m256i*)temp_ptr);
 
         // prefetch next chunk
         temp_ptr += 32;
@@ -1169,12 +1169,13 @@ static inline void volk_8u_x2_encodeframepolar_8u_rvv(unsigned char* frame,
         if (frame_half < 8) {
             encodepolar_single_stage(frame, temp, num_branches, frame_half);
         } else {
-            unsigned char *in = temp, *out = frame;
+            const unsigned char* in = temp;
+            unsigned char* out = frame;
             for (size_t branch = 0; branch < num_branches; ++branch) {
                 size_t n = frame_half;
                 for (size_t vl; n > 0; n -= vl, in += vl * 2, out += vl) {
                     vl = __riscv_vsetvl_e8m1(n);
-                    vuint16m2_t vc = __riscv_vle16_v_u16m2((uint16_t*)in, vl);
+                    vuint16m2_t vc = __riscv_vle16_v_u16m2((const uint16_t*)in, vl);
                     vuint8m1_t v1 = __riscv_vnsrl(vc, 0, vl);
                     vuint8m1_t v2 = __riscv_vnsrl(vc, 8, vl);
                     __riscv_vse8(out, __riscv_vxor(v1, v2, vl), vl);
@@ -1209,7 +1210,8 @@ static inline void volk_8u_x2_encodeframepolar_8u_rvvseg(unsigned char* frame,
         if (frame_half < 8) {
             encodepolar_single_stage(frame, temp, num_branches, frame_half);
         } else {
-            unsigned char *in = temp, *out = frame;
+            const unsigned char* in = temp;
+            unsigned char* out = frame;
             for (size_t branch = 0; branch < num_branches; ++branch) {
                 size_t n = frame_half;
                 for (size_t vl; n > 0; n -= vl, in += vl * 2, out += vl) {

--- a/kernels/volk/volk_8u_x4_conv_k7_r2_8u.h
+++ b/kernels/volk/volk_8u_x4_conv_k7_r2_8u.h
@@ -77,11 +77,11 @@ static inline void renormalize(unsigned char* X)
 // helper BFLY for GENERIC version
 static inline void BFLY(int i,
                         int s,
-                        unsigned char* syms,
+                        const unsigned char* syms,
                         unsigned char* Y,
-                        unsigned char* X,
+                        const unsigned char* X,
                         decision_t* d,
-                        unsigned char* Branchtab)
+                        const unsigned char* Branchtab)
 {
     int j;
     unsigned int decision0, decision1;
@@ -125,11 +125,11 @@ static inline void BFLY(int i,
 
 static inline void volk_8u_x4_conv_k7_r2_8u_avx2(unsigned char* Y,
                                                  unsigned char* X,
-                                                 unsigned char* syms,
+                                                 const unsigned char* syms,
                                                  unsigned char* dec,
                                                  unsigned int framebits,
                                                  unsigned int excess,
-                                                 unsigned char* Branchtab)
+                                                 const unsigned char* Branchtab)
 {
     unsigned int i;
     for (i = 0; i < framebits + excess; i++) {
@@ -142,10 +142,10 @@ static inline void volk_8u_x4_conv_k7_r2_8u_avx2(unsigned char* Y,
         s18 = ((__m256i*)X)[0];
         s19 = ((__m256i*)X)[1];
         a76 = _mm256_set1_epi8(syms[2 * i]);
-        a78 = ((__m256i*)Branchtab)[0];
+        a78 = ((const __m256i*)Branchtab)[0];
         a79 = _mm256_xor_si256(a76, a78);
         a82 = _mm256_set1_epi8(syms[2 * i + 1]);
-        a84 = ((__m256i*)Branchtab)[1];
+        a84 = ((const __m256i*)Branchtab)[1];
         a85 = _mm256_xor_si256(a82, a84);
         a86 = _mm256_avg_epu8(a79, a85);
         a88 = _mm256_srli_epi16(a86, 2);
@@ -211,11 +211,11 @@ static inline void volk_8u_x4_conv_k7_r2_8u_avx2(unsigned char* Y,
 
 static inline void volk_8u_x4_conv_k7_r2_8u_spiral(unsigned char* Y,
                                                    unsigned char* X,
-                                                   unsigned char* syms,
+                                                   const unsigned char* syms,
                                                    unsigned char* dec,
                                                    unsigned int framebits,
                                                    unsigned int excess,
-                                                   unsigned char* Branchtab)
+                                                   const unsigned char* Branchtab)
 {
     unsigned int i;
     for (i = 0; i < framebits + excess; i++) {
@@ -229,10 +229,10 @@ static inline void volk_8u_x4_conv_k7_r2_8u_spiral(unsigned char* Y,
         s18 = ((__m128i*)X)[0];
         s19 = ((__m128i*)X)[2];
         a76 = _mm_set1_epi8(syms[2 * i]);
-        a78 = ((__m128i*)Branchtab)[0];
+        a78 = ((const __m128i*)Branchtab)[0];
         a79 = _mm_xor_si128(a76, a78);
         a82 = _mm_set1_epi8(syms[2 * i + 1]);
-        a84 = ((__m128i*)Branchtab)[2];
+        a84 = ((const __m128i*)Branchtab)[2];
         a85 = _mm_xor_si128(a82, a84);
         a86 = _mm_avg_epu8(a79, a85);
         a88 = _mm_srli_epi16(a86, 2);
@@ -254,9 +254,9 @@ static inline void volk_8u_x4_conv_k7_r2_8u_spiral(unsigned char* Y,
         // Second half of butterfly
         s24 = ((__m128i*)X)[1];
         s25 = ((__m128i*)X)[3];
-        a100 = ((__m128i*)Branchtab)[1];
+        a100 = ((const __m128i*)Branchtab)[1];
         a101 = _mm_xor_si128(a76, a100);
-        a103 = ((__m128i*)Branchtab)[3];
+        a103 = ((const __m128i*)Branchtab)[3];
         a104 = _mm_xor_si128(a82, a103);
         a105 = _mm_avg_epu8(a101, a104);
         a107 = _mm_srli_epi16(a105, 2);
@@ -309,11 +309,11 @@ static inline void volk_8u_x4_conv_k7_r2_8u_spiral(unsigned char* Y,
 
 static inline void volk_8u_x4_conv_k7_r2_8u_neonspiral(unsigned char* Y,
                                                        unsigned char* X,
-                                                       unsigned char* syms,
+                                                       const unsigned char* syms,
                                                        unsigned char* dec,
                                                        unsigned int framebits,
                                                        unsigned int excess,
-                                                       unsigned char* Branchtab)
+                                                       const unsigned char* Branchtab)
 {
     unsigned int i;
     for (i = 0; i < framebits + excess; i++) {
@@ -332,10 +332,10 @@ static inline void volk_8u_x4_conv_k7_r2_8u_neonspiral(unsigned char* Y,
         s18 = ((uint8x16_t*)X)[0];
         s19 = ((uint8x16_t*)X)[2];
         a76 = vdupq_n_u8(syms[2 * i]);
-        a78 = ((uint8x16_t*)Branchtab)[0];
+        a78 = ((const uint8x16_t*)Branchtab)[0];
         a79 = veorq_u8(a76, a78);
         a82 = vdupq_n_u8(syms[2 * i + 1]);
-        a84 = ((uint8x16_t*)Branchtab)[2];
+        a84 = ((const uint8x16_t*)Branchtab)[2];
         a85 = veorq_u8(a82, a84);
         a86 = vrhaddq_u8(a79, a85);
         t14 = vshrq_n_u8(a86, 2);
@@ -374,9 +374,9 @@ static inline void volk_8u_x4_conv_k7_r2_8u_neonspiral(unsigned char* Y,
         // Second half of butterfly
         s24 = ((uint8x16_t*)X)[1];
         s25 = ((uint8x16_t*)X)[3];
-        a100 = ((uint8x16_t*)Branchtab)[1];
+        a100 = ((const uint8x16_t*)Branchtab)[1];
         a101 = veorq_u8(a76, a100);
-        a103 = ((uint8x16_t*)Branchtab)[3];
+        a103 = ((const uint8x16_t*)Branchtab)[3];
         a104 = veorq_u8(a82, a103);
         a105 = vrhaddq_u8(a101, a104);
         t17 = vshrq_n_u8(a105, 2);
@@ -442,11 +442,11 @@ static inline void volk_8u_x4_conv_k7_r2_8u_neonspiral(unsigned char* Y,
 
 static inline void volk_8u_x4_conv_k7_r2_8u_generic(unsigned char* Y,
                                                     unsigned char* X,
-                                                    unsigned char* syms,
+                                                    const unsigned char* syms,
                                                     unsigned char* dec,
                                                     unsigned int framebits,
                                                     unsigned int excess,
-                                                    unsigned char* Branchtab)
+                                                    const unsigned char* Branchtab)
 {
     int nbits = framebits + excess;
     int NUMSTATES = 64;
@@ -474,11 +474,11 @@ static inline void volk_8u_x4_conv_k7_r2_8u_generic(unsigned char* Y,
 
 static inline void volk_8u_x4_conv_k7_r2_8u_rvv(unsigned char* Y,
                                                 unsigned char* X,
-                                                unsigned char* syms,
+                                                const unsigned char* syms,
                                                 unsigned char* dec,
                                                 unsigned int framebits,
                                                 unsigned int excess,
-                                                unsigned char* Branchtab)
+                                                const unsigned char* Branchtab)
 {
     size_t vl = 256 / 8;
 

--- a/kernels/volk/volk_8u_x4_conv_k7_r2_8u.h
+++ b/kernels/volk/volk_8u_x4_conv_k7_r2_8u.h
@@ -42,8 +42,8 @@
  * \endcode
  */
 
-#ifndef INCLUDED_volk_8u_x4_conv_k7_r2_8u_H
-#define INCLUDED_volk_8u_x4_conv_k7_r2_8u_H
+#ifndef INCLUDED_volk_8u_x4_conv_k7_r2_8u_u_H
+#define INCLUDED_volk_8u_x4_conv_k7_r2_8u_u_H
 
 typedef union {
     unsigned char /*DECISIONTYPE*/ t[64 /*NUMSTATES*/ / 8 /*DECISIONTYPE_BITSIZE*/];
@@ -118,87 +118,36 @@ static inline void BFLY(int i,
 }
 
 
-#if LV_HAVE_AVX2
+#if LV_HAVE_GENERIC
 
-#include <immintrin.h>
-#include <stdio.h>
-
-static inline void volk_8u_x4_conv_k7_r2_8u_avx2(unsigned char* Y,
-                                                 unsigned char* X,
-                                                 const unsigned char* syms,
-                                                 unsigned char* dec,
-                                                 unsigned int framebits,
-                                                 unsigned int excess,
-                                                 const unsigned char* Branchtab)
+static inline void volk_8u_x4_conv_k7_r2_8u_generic(unsigned char* Y,
+                                                    unsigned char* X,
+                                                    const unsigned char* syms,
+                                                    unsigned char* dec,
+                                                    unsigned int framebits,
+                                                    unsigned int excess,
+                                                    const unsigned char* Branchtab)
 {
-    unsigned int i;
-    for (i = 0; i < framebits + excess; i++) {
-        unsigned char* tmp;
-        unsigned int* dec_int = (unsigned int*)dec;
-        __m256i a76, a78, a79, a82, a84, a85, a86, a88, a89, a90, d10, d9, m23, m24, m25,
-            m26, s18, s19, s22, s23, t14, t15;
+    int nbits = framebits + excess;
+    int NUMSTATES = 64;
 
-        // Butterfly
-        s18 = ((__m256i*)X)[0];
-        s19 = ((__m256i*)X)[1];
-        a76 = _mm256_set1_epi8(syms[2 * i]);
-        a78 = ((const __m256i*)Branchtab)[0];
-        a79 = _mm256_xor_si256(a76, a78);
-        a82 = _mm256_set1_epi8(syms[2 * i + 1]);
-        a84 = ((const __m256i*)Branchtab)[1];
-        a85 = _mm256_xor_si256(a82, a84);
-        a86 = _mm256_avg_epu8(a79, a85);
-        a88 = _mm256_srli_epi16(a86, 2);
-        t14 = _mm256_and_si256(a88, _mm256_set1_epi8(63));
-        t15 = _mm256_subs_epu8(_mm256_set1_epi8(63), t14);
-        m23 = _mm256_adds_epu8(s18, t14);
-        m24 = _mm256_adds_epu8(s19, t15);
-        m25 = _mm256_adds_epu8(s18, t15);
-        m26 = _mm256_adds_epu8(s19, t14);
-        a89 = _mm256_min_epu8(m24, m23);
-        d9 = _mm256_cmpeq_epi8(a89, m24);
-        a90 = _mm256_min_epu8(m26, m25);
-        d10 = _mm256_cmpeq_epi8(a90, m26);
-        s22 = _mm256_unpacklo_epi8(d9, d10);
-        s23 = _mm256_unpackhi_epi8(d9, d10);
-        dec_int[2 * i] = _mm256_movemask_epi8(_mm256_permute2x128_si256(s22, s23, 0x20));
-        dec_int[2 * i + 1] =
-            _mm256_movemask_epi8(_mm256_permute2x128_si256(s22, s23, 0x31));
-        s22 = _mm256_unpacklo_epi8(a89, a90);
-        s23 = _mm256_unpackhi_epi8(a89, a90);
-        ((__m256i*)Y)[0] = _mm256_permute2x128_si256(s22, s23, 0x20);
-        ((__m256i*)Y)[1] = _mm256_permute2x128_si256(s22, s23, 0x31);
+    int s, i;
+    for (s = 0; s < nbits; s++) {
+        void* tmp;
+        for (i = 0; i < NUMSTATES / 2; i++) {
+            BFLY(i, s, syms, Y, X, (decision_t*)dec, Branchtab);
+        }
 
-        // Renormalize
-        __m256i m5, m6;
-        m5 = ((__m256i*)Y)[0];
-        m5 = _mm256_min_epu8(m5, ((__m256i*)Y)[1]);
-        m5 = ((__m256i)_mm256_min_epu8(_mm256_permute2x128_si256(m5, m5, 0x21), m5));
-        __m256i m7;
-        m7 = _mm256_min_epu8(_mm256_srli_si256(m5, 8), m5);
-        m7 = ((__m256i)_mm256_min_epu8(((__m256i)_mm256_srli_epi64(m7, 32)),
-                                       ((__m256i)m7)));
-        m7 = ((__m256i)_mm256_min_epu8(((__m256i)_mm256_srli_epi64(m7, 16)),
-                                       ((__m256i)m7)));
-        m7 = ((__m256i)_mm256_min_epu8(((__m256i)_mm256_srli_epi64(m7, 8)),
-                                       ((__m256i)m7)));
-        m7 = _mm256_unpacklo_epi8(m7, m7);
-        m7 = _mm256_shufflelo_epi16(m7, 0);
-        m6 = _mm256_unpacklo_epi64(m7, m7);
-        m6 = _mm256_permute2x128_si256(
-            m6, m6, 0); // copy lower half of m6 to upper half, since above ops
-                        // operate on 128 bit lanes
-        ((__m256i*)Y)[0] = _mm256_subs_epu8(((__m256i*)Y)[0], m6);
-        ((__m256i*)Y)[1] = _mm256_subs_epu8(((__m256i*)Y)[1], m6);
+        renormalize(Y);
 
-        // Swap pointers to old and new metrics
-        tmp = X;
+        ///     Swap pointers to old and new metrics
+        tmp = (void*)X;
         X = Y;
-        Y = tmp;
+        Y = (unsigned char*)tmp;
     }
 }
 
-#endif /*LV_HAVE_AVX2*/
+#endif /* LV_HAVE_GENERIC */
 
 
 #if LV_HAVE_SSE3
@@ -301,7 +250,91 @@ static inline void volk_8u_x4_conv_k7_r2_8u_spiral(unsigned char* Y,
     }
 }
 
-#endif /*LV_HAVE_SSE3*/
+#endif /* LV_HAVE_SSE3 */
+
+
+#if LV_HAVE_AVX2
+
+#include <immintrin.h>
+#include <stdio.h>
+
+static inline void volk_8u_x4_conv_k7_r2_8u_avx2(unsigned char* Y,
+                                                 unsigned char* X,
+                                                 const unsigned char* syms,
+                                                 unsigned char* dec,
+                                                 unsigned int framebits,
+                                                 unsigned int excess,
+                                                 const unsigned char* Branchtab)
+{
+    unsigned int i;
+    for (i = 0; i < framebits + excess; i++) {
+        unsigned char* tmp;
+        unsigned int* dec_int = (unsigned int*)dec;
+        __m256i a76, a78, a79, a82, a84, a85, a86, a88, a89, a90, d10, d9, m23, m24, m25,
+            m26, s18, s19, s22, s23, t14, t15;
+
+        // Butterfly
+        s18 = ((__m256i*)X)[0];
+        s19 = ((__m256i*)X)[1];
+        a76 = _mm256_set1_epi8(syms[2 * i]);
+        a78 = ((const __m256i*)Branchtab)[0];
+        a79 = _mm256_xor_si256(a76, a78);
+        a82 = _mm256_set1_epi8(syms[2 * i + 1]);
+        a84 = ((const __m256i*)Branchtab)[1];
+        a85 = _mm256_xor_si256(a82, a84);
+        a86 = _mm256_avg_epu8(a79, a85);
+        a88 = _mm256_srli_epi16(a86, 2);
+        t14 = _mm256_and_si256(a88, _mm256_set1_epi8(63));
+        t15 = _mm256_subs_epu8(_mm256_set1_epi8(63), t14);
+        m23 = _mm256_adds_epu8(s18, t14);
+        m24 = _mm256_adds_epu8(s19, t15);
+        m25 = _mm256_adds_epu8(s18, t15);
+        m26 = _mm256_adds_epu8(s19, t14);
+        a89 = _mm256_min_epu8(m24, m23);
+        d9 = _mm256_cmpeq_epi8(a89, m24);
+        a90 = _mm256_min_epu8(m26, m25);
+        d10 = _mm256_cmpeq_epi8(a90, m26);
+        s22 = _mm256_unpacklo_epi8(d9, d10);
+        s23 = _mm256_unpackhi_epi8(d9, d10);
+        dec_int[2 * i] = _mm256_movemask_epi8(_mm256_permute2x128_si256(s22, s23, 0x20));
+        dec_int[2 * i + 1] =
+            _mm256_movemask_epi8(_mm256_permute2x128_si256(s22, s23, 0x31));
+        s22 = _mm256_unpacklo_epi8(a89, a90);
+        s23 = _mm256_unpackhi_epi8(a89, a90);
+        ((__m256i*)Y)[0] = _mm256_permute2x128_si256(s22, s23, 0x20);
+        ((__m256i*)Y)[1] = _mm256_permute2x128_si256(s22, s23, 0x31);
+
+        // Renormalize
+        __m256i m5, m6;
+        m5 = ((__m256i*)Y)[0];
+        m5 = _mm256_min_epu8(m5, ((__m256i*)Y)[1]);
+        m5 = ((__m256i)_mm256_min_epu8(_mm256_permute2x128_si256(m5, m5, 0x21), m5));
+        __m256i m7;
+        m7 = _mm256_min_epu8(_mm256_srli_si256(m5, 8), m5);
+        m7 = ((__m256i)_mm256_min_epu8(((__m256i)_mm256_srli_epi64(m7, 32)),
+                                       ((__m256i)m7)));
+        m7 = ((__m256i)_mm256_min_epu8(((__m256i)_mm256_srli_epi64(m7, 16)),
+                                       ((__m256i)m7)));
+        m7 = ((__m256i)_mm256_min_epu8(((__m256i)_mm256_srli_epi64(m7, 8)),
+                                       ((__m256i)m7)));
+        m7 = _mm256_unpacklo_epi8(m7, m7);
+        m7 = _mm256_shufflelo_epi16(m7, 0);
+        m6 = _mm256_unpacklo_epi64(m7, m7);
+        m6 = _mm256_permute2x128_si256(
+            m6, m6, 0); // copy lower half of m6 to upper half, since above ops
+                        // operate on 128 bit lanes
+        ((__m256i*)Y)[0] = _mm256_subs_epu8(((__m256i*)Y)[0], m6);
+        ((__m256i*)Y)[1] = _mm256_subs_epu8(((__m256i*)Y)[1], m6);
+
+        // Swap pointers to old and new metrics
+        tmp = X;
+        X = Y;
+        Y = tmp;
+    }
+}
+
+#endif /* LV_HAVE_AVX2 */
+
 
 #if LV_HAVE_NEON
 
@@ -436,38 +469,7 @@ static inline void volk_8u_x4_conv_k7_r2_8u_neonspiral(unsigned char* Y,
     }
 }
 
-#endif /*LV_HAVE_NEON*/
-
-#if LV_HAVE_GENERIC
-
-static inline void volk_8u_x4_conv_k7_r2_8u_generic(unsigned char* Y,
-                                                    unsigned char* X,
-                                                    const unsigned char* syms,
-                                                    unsigned char* dec,
-                                                    unsigned int framebits,
-                                                    unsigned int excess,
-                                                    const unsigned char* Branchtab)
-{
-    int nbits = framebits + excess;
-    int NUMSTATES = 64;
-
-    int s, i;
-    for (s = 0; s < nbits; s++) {
-        void* tmp;
-        for (i = 0; i < NUMSTATES / 2; i++) {
-            BFLY(i, s, syms, Y, X, (decision_t*)dec, Branchtab);
-        }
-
-        renormalize(Y);
-
-        ///     Swap pointers to old and new metrics
-        tmp = (void*)X;
-        X = Y;
-        Y = (unsigned char*)tmp;
-    }
-}
-
-#endif /* LV_HAVE_GENERIC */
+#endif /* LV_HAVE_NEON */
 
 #if LV_HAVE_RVV
 #include <riscv_vector.h>
@@ -673,6 +675,11 @@ static inline void volk_8u_x4_conv_k7_r2_8u_rvv(unsigned char* Y,
         }
     }
 }
-#endif /*LV_HAVE_RVV*/
+#endif /* LV_HAVE_RVV */
 
-#endif /*INCLUDED_volk_8u_x4_conv_k7_r2_8u_H*/
+#endif /* INCLUDED_volk_8u_x4_conv_k7_r2_8u_u_H */
+
+#ifndef INCLUDED_volk_8u_x4_conv_k7_r2_8u_a_H
+#define INCLUDED_volk_8u_x4_conv_k7_r2_8u_a_H
+
+#endif /* INCLUDED_volk_8u_x4_conv_k7_r2_8u_a_H */


### PR DESCRIPTION
## Summary

Companion to #826 — standardizes the internal structure of the remaining 50 kernel headers that also received const-correctness fixes in #827.

**Depends on #827** (`fix/const-correctness-casts`). The diff will look clean once #827 is merged; until then, this PR includes both commits.

Same mechanical transformation as #826:

1. **Unaligned section (`_u_H`) before aligned section (`_a_H`)** — sections swapped where reversed
2. **Proper `_u_H` / `_a_H` include guard pairs** — bare `_H` guards split into the required pair
3. **ISA ordering within sections** — implementations reordered: `GENERIC` → `SSE` → `SSE2` → `SSE3` → `SSE4_1` → `AVX` → `AVX2` → `AVX512F` → `NEON` → `NEONV8` → `RVV` → `ORC`

### What did NOT change

- No implementation code was added, removed, or modified — only moved
- No behavioral change — dispatcher selects by ISA bitmask, not file position

### Together with #826

The two section-ordering PRs (#826 + this one) cover all 139 non-puppet kernel headers in the project.

## Test plan

- [ ] CI builds pass (no code changes, only reordering)
- [ ] `volk_profile` produces identical results before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)