### PR TITLE
docs: write missing/FIXME examples in Doxygen doc blocks

### DIFF
--- a/kernels/volk/volk_16i_32fc_dot_prod_32fc.h
+++ b/kernels/volk/volk_16i_32fc_dot_prod_32fc.h
@@ -12,33 +12,59 @@
  *
  * \b Overview
  *
- * This block computes the dot product (or inner product) between two
- * vectors, the \p input and \p taps vectors. Given a set of \p
- * num_points taps, the result is the sum of products between the two
- * vectors. The result is a single value stored in the \p result
- * address and will be complex.
+ * Computes the dot product between a vector of 16-bit integers and a
+ * vector of complex floats. Each short input is converted to float,
+ * multiplied by the corresponding complex tap, and the products are
+ * summed into a single complex result.
  *
  * <b>Dispatcher Prototype</b>
  * \code
- * void volk_16i_32fc_dot_prod_32fc(lv_32fc_t* result, const short* input, const lv_32fc_t
- * * taps, unsigned int num_points) \endcode
+ * void volk_16i_32fc_dot_prod_32fc(lv_32fc_t* result, const short* input, const
+ * lv_32fc_t* taps, unsigned int num_points) \endcode
  *
  * \b Inputs
- * \li input: vector of shorts.
- * \li taps:  complex taps.
- * \li num_points: number of samples in both \p input and \p taps.
+ * \li input: vector of 16-bit integer samples (short).
+ * \li taps: vector of complex float taps (lv_32fc_t).
+ * \li num_points: number of elements in both \p input and \p taps.
  *
  * \b Outputs
- * \li result: pointer to a complex value to hold the dot product result.
+ * \li result: pointer to a complex float to store the dot product result (lv_32fc_t).
  *
  * \b Example
+ * Compute a weighted sum of short-valued samples with complex coefficients.
  * \code
- * int N = 10000;
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
  *
- * <FIXME>
+ *   int main() {
+ *     unsigned int num_points = 8;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_16i_32fc_dot_prod_32fc();
+ *     // Allocate aligned memory
+ *     short* input = (short*)volk_malloc(sizeof(short) * num_points, alignment);
+ *     lv_32fc_t* taps =
+ *         (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t) * num_points, alignment);
+ *     lv_32fc_t result;
  *
+ *     // Initialize input samples (e.g., a short ramp)
+ *     for (unsigned int i = 0; i < num_points; i++) {
+ *       input[i] = (short)(i * 100);
+ *     }
+ *
+ *     // Initialize complex taps (e.g., a simple low-pass-like filter)
+ *     for (unsigned int i = 0; i < num_points; i++) {
+ *       taps[i] = lv_cmake(0.125f, 0.0f);
+ *     }
+ *
+ *     // Compute the dot product: result = sum(input[i] * taps[i])
+ *     volk_16i_32fc_dot_prod_32fc(&result, input, taps, num_points);
+ *
+ *     printf("Dot product = (%f, %f)\n", lv_creal(result), lv_cimag(result));
+ *
+ *     volk_free(input);
+ *     volk_free(taps);
+ *     return 0;
+ *   }
  * \endcode
  */
 

--- a/kernels/volk/volk_16i_convert_8i.h
+++ b/kernels/volk/volk_16i_convert_8i.h
@@ -12,7 +12,8 @@
  *
  * \b Overview
  *
- * Converts 16-bit shorts to 8-bit chars.
+ * Converts 16-bit signed integers to 8-bit signed integers by arithmetic
+ * right-shifting each input value by 8 bits (keeping the high byte).
  *
  * <b>Dispatcher Prototype</b>
  * \code
@@ -20,20 +21,51 @@
  * num_points) \endcode
  *
  * \b Inputs
- * \li inputVector: The input vector of 16-bit shorts.
- * \li num_points: The number of complex data points.
+ * \li inputVector: The input vector of 16-bit signed integers (int16_t).
+ * \li num_points: The number of data points.
  *
  * \b Outputs
- * \li outputVector: The output vector of 8-bit chars.
+ * \li outputVector: The output vector of 8-bit signed integers (int8_t).
  *
  * \b Example
+ * Convert 16-bit samples to 8-bit by extracting the high byte.
  * \code
- * int N = 10000;
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
  *
- * volk_16i_convert_8i();
+ *   int main() {
+ *     unsigned int num_points = 8;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
- * volk_free(t);
+ *     // Allocate aligned memory
+ *     int16_t* input =
+ *         (int16_t*)volk_malloc(sizeof(int16_t) * num_points, alignment);
+ *     int8_t* output =
+ *         (int8_t*)volk_malloc(sizeof(int8_t) * num_points, alignment);
+ *
+ *     // Initialize with values whose high byte is meaningful
+ *     // Right-shifting by 8 keeps the upper byte: 0x0100 >> 8 = 1, etc.
+ *     input[0] = 0x0100;  // 256  -> 1
+ *     input[1] = 0x0200;  // 512  -> 2
+ *     input[2] = 0x0A00;  // 2560 -> 10
+ *     input[3] = 0x7F00;  // 32512 -> 127
+ *     input[4] = -256;    // 0xFF00 -> -1 (sign-preserving)
+ *     input[5] = -512;    // 0xFE00 -> -2
+ *     input[6] = 0x0050;  // 80   -> 0 (low byte discarded)
+ *     input[7] = 0x03C0;  // 960  -> 3
+ *
+ *     // Convert 16-bit to 8-bit: output[i] = (int8_t)(input[i] >> 8)
+ *     volk_16i_convert_8i(output, input, num_points);
+ *
+ *     for (unsigned int i = 0; i < num_points; i++) {
+ *       printf("input[%u] = %6d  ->  output[%u] = %4d\n",
+ *              i, input[i], i, output[i]);
+ *     }
+ *
+ *     volk_free(input);
+ *     volk_free(output);
+ *     return 0;
+ *   }
  * \endcode
  */
 

--- a/kernels/volk/volk_16i_s32f_convert_32f.h
+++ b/kernels/volk/volk_16i_s32f_convert_32f.h
@@ -12,29 +12,58 @@
  *
  * \b Overview
  *
- * Converts 16-bit shorts to scaled 32-bit floating point values.
+ * Converts 16-bit integers to 32-bit floats, dividing each value by a scalar.
+ * The output is: outputVector[i] = (float)inputVector[i] / scalar.
  *
  * <b>Dispatcher Prototype</b>
  * \code
  * void volk_16i_s32f_convert_32f(float* outputVector, const int16_t* inputVector, const
- * float scalar, unsigned int num_points); \endcode
+ * float scalar, unsigned int num_points) \endcode
  *
  * \b Inputs
- * \li inputVector: The input vector of 16-bit shorts.
- * \li scalar: The value divided against each point in the output buffer.
- * \li num_points: The number of complex data points.
+ * \li inputVector: The input vector of 16-bit integers (int16_t).
+ * \li scalar: The divisor applied to each converted value.
+ * \li num_points: The number of data points to convert.
  *
  * \b Outputs
- * \li outputVector: The output vector of 8-bit chars.
+ * \li outputVector: The output vector of 32-bit floats.
  *
  * \b Example
+ * Convert 16-bit ADC samples to normalized floating point values.
  * \code
- * int N = 10000;
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
  *
- * volk_16i_s32f_convert_32f();
+ *   int main() {
+ *     unsigned int N = 8;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
- * volk_free(t);
+ *     // Simulate 16-bit ADC samples with a full-scale range of +/- 32767
+ *     int16_t* input = (int16_t*)volk_malloc(N * sizeof(int16_t), alignment);
+ *     float* output = (float*)volk_malloc(N * sizeof(float), alignment);
+ *
+ *     // Fill with sample values spanning the int16 range
+ *     input[0] = 32767;   // max positive
+ *     input[1] = 16384;   // half scale
+ *     input[2] = 8192;
+ *     input[3] = 0;
+ *     input[4] = -8192;
+ *     input[5] = -16384;
+ *     input[6] = -32767;  // max negative
+ *     input[7] = 1000;
+ *
+ *     // Divide by 32768.0 to normalize to approximately [-1.0, 1.0]
+ *     float scalar = 32768.0f;
+ *     volk_16i_s32f_convert_32f(output, input, scalar, N);
+ *
+ *     for (unsigned int i = 0; i < N; i++) {
+ *       printf("input[%u] = %6d  ->  output[%u] = %9.6f\n", i, input[i], i, output[i]);
+ *     }
+ *
+ *     volk_free(input);
+ *     volk_free(output);
+ *     return 0;
+ *   }
  * \endcode
  */
 

--- a/kernels/volk/volk_16ic_deinterleave_16i_x2.h
+++ b/kernels/volk/volk_16ic_deinterleave_16i_x2.h
@@ -12,29 +12,63 @@
  *
  * \b Overview
  *
- * Deinterleaves the complex 16 bit vector into I & Q vector data.
+ * Deinterleaves a complex 16-bit integer vector into separate I (real) and Q
+ * (imaginary) output vectors.
  *
  * <b>Dispatcher Prototype</b>
  * \code
- * void volk_16ic_deinterleave_16i_x2(int16_t* iBuffer, int16_t* qBuffer, const lv_16sc_t*
- * complexVector, unsigned int num_points) \endcode
+ * void volk_16ic_deinterleave_16i_x2(int16_t* iBuffer, int16_t* qBuffer, const
+ * lv_16sc_t* complexVector, unsigned int num_points) \endcode
  *
  * \b Inputs
- * \li complexVector: The complex input vector.
+ * \li complexVector: The complex input vector (lv_16sc_t).
  * \li num_points: The number of complex data values to be deinterleaved.
  *
  * \b Outputs
- * \li iBuffer: The I buffer output data.
- * \li qBuffer: The Q buffer output data.
+ * \li iBuffer: The in-phase (real) output vector (int16_t).
+ * \li qBuffer: The quadrature (imaginary) output vector (int16_t).
  *
  * \b Example
+ * Deinterleave a complex signal into its I and Q components.
  * \code
- * int N = 10000;
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
  *
- * volk_16ic_deinterleave_16i_x2();
+ *   int main() {
+ *     unsigned int N = 8;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
- * volk_free(t);
+ *     // Allocate input complex vector and output I/Q buffers
+ *     lv_16sc_t* complexVector =
+ *         (lv_16sc_t*)volk_malloc(N * sizeof(lv_16sc_t), alignment);
+ *     int16_t* iBuffer = (int16_t*)volk_malloc(N * sizeof(int16_t), alignment);
+ *     int16_t* qBuffer = (int16_t*)volk_malloc(N * sizeof(int16_t), alignment);
+ *
+ *     // Fill with complex samples representing a signal
+ *     complexVector[0] = lv_cmake((int16_t)100, (int16_t)200);
+ *     complexVector[1] = lv_cmake((int16_t)-300, (int16_t)400);
+ *     complexVector[2] = lv_cmake((int16_t)500, (int16_t)-600);
+ *     complexVector[3] = lv_cmake((int16_t)-700, (int16_t)-800);
+ *     complexVector[4] = lv_cmake((int16_t)1000, (int16_t)2000);
+ *     complexVector[5] = lv_cmake((int16_t)-3000, (int16_t)4000);
+ *     complexVector[6] = lv_cmake((int16_t)5000, (int16_t)-6000);
+ *     complexVector[7] = lv_cmake((int16_t)32767, (int16_t)-32768);
+ *
+ *     // Deinterleave into separate I and Q vectors
+ *     volk_16ic_deinterleave_16i_x2(iBuffer, qBuffer, complexVector, N);
+ *
+ *     // Print results
+ *     for (unsigned int i = 0; i < N; i++) {
+ *       printf("complex(%d, %d) -> I: %d  Q: %d\n",
+ *              lv_creal(complexVector[i]), lv_cimag(complexVector[i]),
+ *              iBuffer[i], qBuffer[i]);
+ *     }
+ *
+ *     volk_free(complexVector);
+ *     volk_free(iBuffer);
+ *     volk_free(qBuffer);
+ *     return 0;
+ *   }
  * \endcode
  */
 

--- a/kernels/volk/volk_16ic_deinterleave_real_16i.h
+++ b/kernels/volk/volk_16ic_deinterleave_real_16i.h
@@ -12,8 +12,8 @@
  *
  * \b Overview
  *
- * Deinterleaves the complex 16 bit vector and returns the real (inphase) part of the
- * signal.
+ * Deinterleaves a complex 16-bit integer vector and returns only the real
+ * (in-phase) component of each sample.
  *
  * <b>Dispatcher Prototype</b>
  * \code
@@ -21,20 +21,50 @@
  * unsigned int num_points) \endcode
  *
  * \b Inputs
- * \li complexVector: The complex input vector.
+ * \li complexVector: The complex input vector (lv_16sc_t).
  * \li num_points: The number of complex data values to be deinterleaved.
  *
  * \b Outputs
- * \li iBuffer: The I buffer output data.
+ * \li iBuffer: The in-phase (real) output vector (int16_t).
  *
  * \b Example
+ * Extract the real part of a complex signal.
  * \code
- * int N = 10000;
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
  *
- * volk_16ic_deinterleave_real_16i();
+ *   int main() {
+ *     unsigned int N = 8;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
- * volk_free(t);
+ *     // Allocate input complex vector and output I buffer
+ *     lv_16sc_t* complexVector =
+ *         (lv_16sc_t*)volk_malloc(N * sizeof(lv_16sc_t), alignment);
+ *     int16_t* iBuffer = (int16_t*)volk_malloc(N * sizeof(int16_t), alignment);
+ *
+ *     // Fill with complex samples: (real, imag)
+ *     complexVector[0] = lv_cmake((int16_t)100, (int16_t)200);
+ *     complexVector[1] = lv_cmake((int16_t)-300, (int16_t)400);
+ *     complexVector[2] = lv_cmake((int16_t)500, (int16_t)-600);
+ *     complexVector[3] = lv_cmake((int16_t)700, (int16_t)800);
+ *     complexVector[4] = lv_cmake((int16_t)-900, (int16_t)1000);
+ *     complexVector[5] = lv_cmake((int16_t)1100, (int16_t)-1200);
+ *     complexVector[6] = lv_cmake((int16_t)-1300, (int16_t)1400);
+ *     complexVector[7] = lv_cmake((int16_t)1500, (int16_t)-1600);
+ *
+ *     // Extract the real (in-phase) component
+ *     volk_16ic_deinterleave_real_16i(iBuffer, complexVector, N);
+ *
+ *     // Verify: output should contain only the real parts
+ *     for (unsigned int i = 0; i < N; i++) {
+ *       printf("Sample %u: complex=(%d, %d) -> real=%d\n",
+ *              i, lv_creal(complexVector[i]), lv_cimag(complexVector[i]), iBuffer[i]);
+ *     }
+ *
+ *     volk_free(complexVector);
+ *     volk_free(iBuffer);
+ *     return 0;
+ *   }
  * \endcode
  */
 

--- a/kernels/volk/volk_16ic_deinterleave_real_8i.h
+++ b/kernels/volk/volk_16ic_deinterleave_real_8i.h
@@ -12,8 +12,9 @@
  *
  * \b Overview
  *
- * Deinterleaves the complex 16 bit vector and returns the real
- * (inphase) part of the signal as an 8-bit value.
+ * Deinterleaves a complex 16-bit integer vector and returns only the real
+ * (in-phase) component of each sample, right-shifted by 8 bits to produce
+ * an 8-bit result.
  *
  * <b>Dispatcher Prototype</b>
  * \code
@@ -21,20 +22,51 @@
  * unsigned int num_points) \endcode
  *
  * \b Inputs
- * \li complexVector: The complex input vector.
+ * \li complexVector: The complex input vector (lv_16sc_t).
  * \li num_points: The number of complex data values to be deinterleaved.
  *
  * \b Outputs
- * \li iBuffer: The I buffer output data with 8-bit precision.
+ * \li iBuffer: The in-phase (real) output vector, right-shifted by 8 (int8_t).
  *
  * \b Example
+ * Extract the real part of a complex signal, reduced to 8-bit precision.
  * \code
- * int N = 10000;
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
  *
- * volk_16ic_deinterleave_real_8i();
+ *   int main() {
+ *     unsigned int N = 8;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
- * volk_free(t);
+ *     // Allocate input complex vector and output I buffer
+ *     lv_16sc_t* complexVector =
+ *         (lv_16sc_t*)volk_malloc(N * sizeof(lv_16sc_t), alignment);
+ *     int8_t* iBuffer = (int8_t*)volk_malloc(N * sizeof(int8_t), alignment);
+ *
+ *     // Fill with complex samples: (real, imag)
+ *     // Real parts are chosen as multiples of 256 so the >> 8 result is clear
+ *     complexVector[0] = lv_cmake((int16_t)256, (int16_t)100);
+ *     complexVector[1] = lv_cmake((int16_t)512, (int16_t)-200);
+ *     complexVector[2] = lv_cmake((int16_t)-768, (int16_t)300);
+ *     complexVector[3] = lv_cmake((int16_t)1024, (int16_t)-400);
+ *     complexVector[4] = lv_cmake((int16_t)-1280, (int16_t)500);
+ *     complexVector[5] = lv_cmake((int16_t)1536, (int16_t)-600);
+ *     complexVector[6] = lv_cmake((int16_t)-1792, (int16_t)700);
+ *     complexVector[7] = lv_cmake((int16_t)2048, (int16_t)-800);
+ *
+ *     // Extract real parts, right-shifted by 8 to produce 8-bit output
+ *     volk_16ic_deinterleave_real_8i(iBuffer, complexVector, N);
+ *
+ *     // Expected: 1, 2, -3, 4, -5, 6, -7, 8
+ *     for (unsigned int i = 0; i < N; i++) {
+ *       printf("Complex[%u] real=%d -> iBuffer=%d\n",
+ *              i, lv_creal(complexVector[i]), iBuffer[i]);
+ *     }
+ *
+ *     volk_free(complexVector);
+ *     volk_free(iBuffer);
+ *     return 0;
+ *   }
  * \endcode
  */
 

--- a/kernels/volk/volk_16ic_magnitude_16i.h
+++ b/kernels/volk/volk_16ic_magnitude_16i.h
@@ -12,8 +12,9 @@
  *
  * \b Overview
  *
- * Computes the magnitude of the complexVector and stores the results
- * in the magnitudeVector.
+ * Computes the magnitude of each complex 16-bit integer sample and stores
+ * the results as 16-bit integers. Values are internally normalized by
+ * SHRT_MAX before computing sqrt(I^2 + Q^2), then scaled back.
  *
  * <b>Dispatcher Prototype</b>
  * \code
@@ -21,20 +22,45 @@
  * unsigned int num_points) \endcode
  *
  * \b Inputs
- * \li complexVector: The complex input vector.
- * \li num_points: The number of samples.
+ * \li complexVector: The complex input vector (lv_16sc_t).
+ * \li num_points: The number of complex samples.
  *
  * \b Outputs
- * \li magnitudeVector: The magnitude of the complex values.
+ * \li magnitudeVector: The magnitude of each complex value (int16_t).
  *
  * \b Example
+ * Compute the magnitude of several complex samples with known I/Q values.
  * \code
- * int N = 10000;
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
  *
- * volk_16ic_magnitude_16i();
+ *   int main() {
+ *     unsigned int N = 4;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
- * volk_free(t);
+ *     // Allocate input and output vectors
+ *     lv_16sc_t* complexVector =
+ *         (lv_16sc_t*)volk_malloc(N * sizeof(lv_16sc_t), alignment);
+ *     int16_t* magnitudeVector =
+ *         (int16_t*)volk_malloc(N * sizeof(int16_t), alignment);
+ *
+ *     // Fill with complex samples whose magnitudes are easy to verify
+ *     complexVector[0] = lv_cmake((int16_t)3000, (int16_t)4000);   // mag ~ 5000
+ *     complexVector[1] = lv_cmake((int16_t)0, (int16_t)10000);     // mag ~ 10000
+ *     complexVector[2] = lv_cmake((int16_t)-7000, (int16_t)0);     // mag ~ 7000
+ *     complexVector[3] = lv_cmake((int16_t)20000, (int16_t)20000); // mag ~ 28284
+ *
+ *     // Compute magnitudes
+ *     volk_16ic_magnitude_16i(magnitudeVector, complexVector, N);
+ *
+ *     for (unsigned int i = 0; i < N; i++) {
+ *       printf("mag[%u] = %d\n", i, magnitudeVector[i]);
+ *     }
+ *
+ *     volk_free(magnitudeVector);
+ *     volk_free(complexVector);
+ *     return 0;
+ *   }
  * \endcode
  */
 

--- a/kernels/volk/volk_16ic_s32f_deinterleave_real_32f.h
+++ b/kernels/volk/volk_16ic_s32f_deinterleave_real_32f.h
@@ -12,31 +12,55 @@
  *
  * \b Overview
  *
- * Deinterleaves the complex 16 bit vector and returns just the real
- * part (inphase) of the data as a vector of floats that have been
- * scaled.
+ * Deinterleaves a complex 16-bit integer vector and returns just the real
+ * (in-phase) component as floating-point values, divided by a scalar.
  *
  * <b>Dispatcher Prototype</b>
  * \code
- *  void volk_16ic_s32f_deinterleave_real_32f(float* iBuffer, const lv_16sc_t*
- * complexVector, const float scalar, unsigned int num_points){ \endcode
+ * void volk_16ic_s32f_deinterleave_real_32f(float* iBuffer, const lv_16sc_t*
+ * complexVector, const float scalar, unsigned int num_points) \endcode
  *
  * \b Inputs
- * \li complexVector: The complex input vector of 16-bit shorts.
- * \li scalar: The value to be divided against each sample of the input complex vector.
- * \li num_points: The number of complex data values to be deinterleaved.
+ * \li complexVector: The complex input vector (lv_16sc_t).
+ * \li scalar: The value to divide each real sample by.
+ * \li num_points: The number of complex samples to process.
  *
  * \b Outputs
- * \li iBuffer: The floating point I buffer output data.
+ * \li iBuffer: The scaled real (in-phase) output values (float).
  *
  * \b Example
+ * Extract and scale the real part of complex 16-bit samples.
  * \code
- * int N = 10000;
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
  *
- * volk_16ic_s32f_deinterleave_real_32f();
+ *   int main() {
+ *     unsigned int N = 4;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
- * volk_free(t);
+ *     // Allocate input and output vectors
+ *     lv_16sc_t* complexVector =
+ *         (lv_16sc_t*)volk_malloc(N * sizeof(lv_16sc_t), alignment);
+ *     float* iBuffer = (float*)volk_malloc(N * sizeof(float), alignment);
+ *
+ *     // Fill with complex samples: (real, imag)
+ *     complexVector[0] = lv_cmake((int16_t)1000, (int16_t)2000);
+ *     complexVector[1] = lv_cmake((int16_t)-500, (int16_t)3000);
+ *     complexVector[2] = lv_cmake((int16_t)4000, (int16_t)-1000);
+ *     complexVector[3] = lv_cmake((int16_t)0, (int16_t)7000);
+ *
+ *     // Divide real part by scalar (e.g. normalize 16-bit range to +/-1.0)
+ *     float scalar = 32768.0f;
+ *     volk_16ic_s32f_deinterleave_real_32f(iBuffer, complexVector, scalar, N);
+ *
+ *     for (unsigned int i = 0; i < N; i++) {
+ *       printf("iBuffer[%u] = %f\n", i, iBuffer[i]);
+ *     }
+ *
+ *     volk_free(complexVector);
+ *     volk_free(iBuffer);
+ *     return 0;
+ *   }
  * \endcode
  */
 

--- a/kernels/volk/volk_16ic_s32f_magnitude_32f.h
+++ b/kernels/volk/volk_16ic_s32f_magnitude_32f.h
@@ -12,8 +12,9 @@
  *
  * \b Overview
  *
- * Computes the magnitude of the complexVector and stores the results
- * in the magnitudeVector as a scaled floating point number.
+ * Computes the magnitude of each complex 16-bit integer sample, dividing
+ * real and imaginary parts by the scalar before computing
+ * sqrt(real^2 + imag^2). Results are stored as 32-bit floats.
  *
  * <b>Dispatcher Prototype</b>
  * \code
@@ -21,21 +22,47 @@
  * complexVector, const float scalar, unsigned int num_points) \endcode
  *
  * \b Inputs
- * \li complexVector: The complex input vector of complex 16-bit shorts.
- * \li scalar: The value to be divided against each sample of the input complex vector.
- * \li num_points: The number of samples.
+ * \li complexVector: The complex input vector (lv_16sc_t).
+ * \li scalar: The value to divide each sample's real and imaginary parts by.
+ * \li num_points: The number of complex samples to process.
  *
  * \b Outputs
- * \li magnitudeVector: The magnitude of the complex values.
+ * \li magnitudeVector: The scaled magnitude of each complex sample (float).
  *
  * \b Example
+ * Compute the magnitude of complex 16-bit samples normalized to +/-1.0.
  * \code
- * int N = 10000;
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
  *
- * volk_16ic_s32f_magnitude_32f();
+ *   int main() {
+ *     unsigned int N = 4;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
- * volk_free(t);
+ *     // Allocate input and output vectors
+ *     lv_16sc_t* complexVector =
+ *         (lv_16sc_t*)volk_malloc(N * sizeof(lv_16sc_t), alignment);
+ *     float* magnitudeVector =
+ *         (float*)volk_malloc(N * sizeof(float), alignment);
+ *
+ *     // Fill with complex samples: (real, imag)
+ *     complexVector[0] = lv_cmake((int16_t)3000, (int16_t)4000);   // mag ~ 5000
+ *     complexVector[1] = lv_cmake((int16_t)-10000, (int16_t)0);    // mag ~ 10000
+ *     complexVector[2] = lv_cmake((int16_t)0, (int16_t)32767);     // mag ~ 32767
+ *     complexVector[3] = lv_cmake((int16_t)23170, (int16_t)23170); // mag ~ 32767
+ *
+ *     // Divide by scalar before computing magnitude (e.g. normalize to +/-1.0)
+ *     float scalar = 32768.0f;
+ *     volk_16ic_s32f_magnitude_32f(magnitudeVector, complexVector, scalar, N);
+ *
+ *     for (unsigned int i = 0; i < N; i++) {
+ *       printf("magnitudeVector[%u] = %f\n", i, magnitudeVector[i]);
+ *     }
+ *
+ *     volk_free(complexVector);
+ *     volk_free(magnitudeVector);
+ *     return 0;
+ *   }
  * \endcode
  */
 

--- a/kernels/volk/volk_16ic_x2_dot_prod_16ic.h
+++ b/kernels/volk/volk_16ic_x2_dot_prod_16ic.h
@@ -12,24 +12,62 @@
  *
  * \b Overview
  *
- * Multiplies two input complex vectors (16-bit integer each component) and accumulates
- * them, storing the result. Results are saturated so never go beyond the limits of the
- * data type.
+ * Computes the dot product of two complex 16-bit integer vectors. Each
+ * element-wise complex multiplication is accumulated into a single complex
+ * result using saturated arithmetic to prevent overflow.
  *
  * <b>Dispatcher Prototype</b>
  * \code
  * void volk_16ic_x2_dot_prod_16ic(lv_16sc_t* result, const lv_16sc_t* in_a, const
- * lv_16sc_t* in_b, unsigned int num_points); \endcode
+ * lv_16sc_t* in_b, unsigned int num_points)
+ * \endcode
  *
  * \b Inputs
- * \li in_a:          One of the vectors to be multiplied and accumulated.
- * \li in_b:          The other vector to be multiplied and accumulated.
- * \li num_points:    Number of complex values to be multiplied together, accumulated and
- * stored into \p result
+ * \li in_a: The first complex input vector (lv_16sc_t).
+ * \li in_b: The second complex input vector (lv_16sc_t).
+ * \li num_points: The number of complex samples to multiply and accumulate.
  *
  * \b Outputs
- * \li result:        Value of the accumulated result.
+ * \li result: The complex dot product of the two input vectors (lv_16sc_t).
  *
+ * \b Example
+ * Compute the complex dot product of two short vectors.
+ * \code
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
+ *
+ *   int main() {
+ *     unsigned int N = 4;
+ *     unsigned int alignment = volk_get_alignment();
+ *
+ *     // Allocate input and output buffers
+ *     lv_16sc_t* in_a =
+ *         (lv_16sc_t*)volk_malloc(N * sizeof(lv_16sc_t), alignment);
+ *     lv_16sc_t* in_b =
+ *         (lv_16sc_t*)volk_malloc(N * sizeof(lv_16sc_t), alignment);
+ *     lv_16sc_t result;
+ *
+ *     // Fill with complex samples: (real, imag)
+ *     in_a[0] = lv_cmake((int16_t)100, (int16_t)200);
+ *     in_a[1] = lv_cmake((int16_t)-50, (int16_t)300);
+ *     in_a[2] = lv_cmake((int16_t)400, (int16_t)-100);
+ *     in_a[3] = lv_cmake((int16_t)150, (int16_t)250);
+ *
+ *     in_b[0] = lv_cmake((int16_t)10, (int16_t)-20);
+ *     in_b[1] = lv_cmake((int16_t)30, (int16_t)40);
+ *     in_b[2] = lv_cmake((int16_t)-10, (int16_t)50);
+ *     in_b[3] = lv_cmake((int16_t)20, (int16_t)-30);
+ *
+ *     // Compute complex dot product: sum(in_a[i] * in_b[i])
+ *     volk_16ic_x2_dot_prod_16ic(&result, in_a, in_b, N);
+ *
+ *     printf("Dot product: (%d, %d)\n", lv_creal(result), lv_cimag(result));
+ *
+ *     volk_free(in_a);
+ *     volk_free(in_b);
+ *     return 0;
+ *   }
+ * \endcode
  */
 
 #ifndef INCLUDED_volk_16ic_x2_dot_prod_16ic_H

--- a/kernels/volk/volk_16ic_x2_multiply_16ic.h
+++ b/kernels/volk/volk_16ic_x2_multiply_16ic.h
@@ -12,23 +12,67 @@
  *
  * \b Overview
  *
- * Multiplies two input complex vectors, point-by-point, storing the result in the third
- * vector. WARNING: Saturation is not checked.
+ * Multiplies two complex 16-bit integer vectors element-wise, storing the
+ * result in the output vector. Saturation is not checked, so results may
+ * overflow for large input values.
  *
  * <b>Dispatcher Prototype</b>
  * \code
  * void volk_16ic_x2_multiply_16ic(lv_16sc_t* result, const lv_16sc_t* in_a, const
- * lv_16sc_t* in_b, unsigned int num_points); \endcode
+ * lv_16sc_t* in_b, unsigned int num_points)
+ * \endcode
  *
  * \b Inputs
- * \li in_a: One of the vectors to be multiplied.
- * \li in_b: The other vector to be multiplied.
- * \li num_points: The number of complex data points to be multiplied from both input
- * vectors.
+ * \li in_a: The first complex input vector (lv_16sc_t).
+ * \li in_b: The second complex input vector (lv_16sc_t).
+ * \li num_points: The number of complex samples to multiply.
  *
  * \b Outputs
- * \li result: The vector where the results will be stored.
+ * \li result: The element-wise complex product of the two input vectors (lv_16sc_t).
  *
+ * \b Example
+ * Multiply two complex 16-bit integer vectors element-wise.
+ * \code
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
+ *
+ *   int main() {
+ *     unsigned int N = 4;
+ *     unsigned int alignment = volk_get_alignment();
+ *
+ *     // Allocate input and output buffers
+ *     lv_16sc_t* in_a =
+ *         (lv_16sc_t*)volk_malloc(N * sizeof(lv_16sc_t), alignment);
+ *     lv_16sc_t* in_b =
+ *         (lv_16sc_t*)volk_malloc(N * sizeof(lv_16sc_t), alignment);
+ *     lv_16sc_t* result =
+ *         (lv_16sc_t*)volk_malloc(N * sizeof(lv_16sc_t), alignment);
+ *
+ *     // Fill with complex samples: (real, imag)
+ *     in_a[0] = lv_cmake((int16_t)100, (int16_t)200);
+ *     in_a[1] = lv_cmake((int16_t)-50, (int16_t)300);
+ *     in_a[2] = lv_cmake((int16_t)400, (int16_t)-100);
+ *     in_a[3] = lv_cmake((int16_t)150, (int16_t)250);
+ *
+ *     in_b[0] = lv_cmake((int16_t)10, (int16_t)-20);
+ *     in_b[1] = lv_cmake((int16_t)30, (int16_t)40);
+ *     in_b[2] = lv_cmake((int16_t)-10, (int16_t)50);
+ *     in_b[3] = lv_cmake((int16_t)20, (int16_t)-30);
+ *
+ *     // Compute element-wise complex product: result[i] = in_a[i] * in_b[i]
+ *     volk_16ic_x2_multiply_16ic(result, in_a, in_b, N);
+ *
+ *     for (unsigned int i = 0; i < N; i++) {
+ *       printf("result[%u] = (%d, %d)\n", i,
+ *              lv_creal(result[i]), lv_cimag(result[i]));
+ *     }
+ *
+ *     volk_free(in_a);
+ *     volk_free(in_b);
+ *     volk_free(result);
+ *     return 0;
+ *   }
+ * \endcode
  */
 
 #ifndef INCLUDED_volk_16ic_x2_multiply_16ic_H

--- a/kernels/volk/volk_16u_byteswap.h
+++ b/kernels/volk/volk_16u_byteswap.h
@@ -12,7 +12,9 @@
  *
  * \b Overview
  *
- * Byteswaps (in-place) an aligned vector of int16_t's.
+ * Swaps the high and low bytes of each 16-bit unsigned integer in the input
+ * vector, in-place. This is useful for converting between big-endian and
+ * little-endian byte order.
  *
  * <b>Dispatcher Prototype</b>
  * \code
@@ -20,20 +22,48 @@
  * \endcode
  *
  * \b Inputs
- * \li intsToSwap: The vector of data to byte swap.
- * \li num_points: The number of data points.
+ * \li intsToSwap: The vector of uint16_t values to byte swap.
+ * \li num_points: The number of 16-bit values to process.
  *
  * \b Outputs
- * \li intsToSwap: returns as an in-place calculation.
+ * \li intsToSwap: The byte-swapped values, written in-place.
  *
  * \b Example
+ * Byte-swap a small vector of 16-bit unsigned integers.
  * \code
- * int N = 10000;
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
  *
- * <FIXME>
+ *   int main() {
+ *     unsigned int N = 4;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_16u_byteswap(x, N);
+ *     // Allocate aligned buffer
+ *     uint16_t* data =
+ *         (uint16_t*)volk_malloc(N * sizeof(uint16_t), alignment);
  *
+ *     // Initialize with values whose bytes are easy to verify after swapping
+ *     // 0x0102 -> 0x0201, 0xAABB -> 0xBBAA, etc.
+ *     data[0] = 0x0102;
+ *     data[1] = 0xAABB;
+ *     data[2] = 0xFF00;
+ *     data[3] = 0x1234;
+ *
+ *     // Byte-swap each 16-bit element in-place
+ *     volk_16u_byteswap(data, N);
+ *
+ *     for (unsigned int i = 0; i < N; i++) {
+ *       printf("data[%u] = 0x%04X\n", i, data[i]);
+ *     }
+ *     // Expected output:
+ *     // data[0] = 0x0201
+ *     // data[1] = 0xBBAA
+ *     // data[2] = 0x00FF
+ *     // data[3] = 0x3412
+ *
+ *     volk_free(data);
+ *     return 0;
+ *   }
  * \endcode
  */
 

--- a/kernels/volk/volk_32f_null_32f.h
+++ b/kernels/volk/volk_32f_null_32f.h
@@ -7,6 +7,63 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
+/*!
+ * \page volk_32f_null_32f
+ *
+ * \b Overview
+ *
+ * Copies 32-bit floating-point values from the input vector to the output
+ * vector. This is a null (pass-through) kernel useful as a baseline for
+ * benchmarking memory bandwidth.
+ *
+ * <b>Dispatcher Prototype</b>
+ * \code
+ * void volk_32f_null_32f(float* bVector, const float* aVector, unsigned int num_points)
+ * \endcode
+ *
+ * \b Inputs
+ * \li aVector: The input vector of floats.
+ * \li num_points: The number of float values to copy.
+ *
+ * \b Outputs
+ * \li bVector: The output vector where values are copied to.
+ *
+ * \b Example
+ * Copy a small vector of floats through the null kernel.
+ * \code
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
+ *
+ *   int main() {
+ *     unsigned int N = 5;
+ *     unsigned int alignment = volk_get_alignment();
+ *
+ *     // Allocate aligned input and output buffers
+ *     float* input = (float*)volk_malloc(N * sizeof(float), alignment);
+ *     float* output = (float*)volk_malloc(N * sizeof(float), alignment);
+ *
+ *     // Fill input with sample values
+ *     input[0] = 1.5f;
+ *     input[1] = -3.14f;
+ *     input[2] = 0.0f;
+ *     input[3] = 42.0f;
+ *     input[4] = 7.77f;
+ *
+ *     // Copy input to output
+ *     volk_32f_null_32f(output, input, N);
+ *
+ *     // Verify the copy
+ *     for (unsigned int i = 0; i < N; i++) {
+ *       printf("output[%u] = %f\n", i, output[i]);
+ *     }
+ *
+ *     volk_free(input);
+ *     volk_free(output);
+ *     return 0;
+ *   }
+ * \endcode
+ */
+
 #include <inttypes.h>
 #include <math.h>
 #include <stdio.h>

--- a/kernels/volk/volk_32f_s32f_32f_fm_detect_32f.h
+++ b/kernels/volk/volk_32f_s32f_32f_fm_detect_32f.h
@@ -12,32 +12,65 @@
  *
  * \b Overview
  *
- * Performs FM-detect differentiation on the input vector and stores
- * the results in the output vector.
+ * Computes the instantaneous frequency of an FM signal by differentiating consecutive
+ * phase samples with modular wrapping. Each output sample is the difference between
+ * adjacent input samples, wrapped to the interval (-bound, bound]. The saveValue
+ * parameter provides continuity across successive calls by storing the last input sample.
  *
  * <b>Dispatcher Prototype</b>
  * \code
  * void volk_32f_s32f_32f_fm_detect_32f(float* outputVector, const float* inputVector,
- * const float bound, float* saveValue, unsigned int num_points) \endcode
+ * const float bound, float* saveValue, unsigned int num_points)
+ * \endcode
  *
  * \b Inputs
- * \li inputVector: The input vector containing phase data (must be on the interval
- * (-bound, bound]). \li bound: The interval that the input phase data is in, which is
- * used to modulo the differentiation. \li saveValue: A pointer to a float which contains
- * the phase value of the sample before the first input sample. \li num_points The number
- * of data points.
+ * \li inputVector: The input vector of phase samples as floats.
+ * \li bound: The wrapping bound for the phase interval; differences outside
+ * (-bound, bound] are wrapped by adding or subtracting 2*bound.
+ * \li saveValue: Pointer to a float holding the phase value of the sample before the
+ * first input sample (updated to the last input sample on return).
+ * \li num_points: The number of input samples.
  *
  * \b Outputs
- * \li outputVector: The vector where the results will be stored.
+ * \li outputVector: The vector of wrapped phase differences (instantaneous frequency).
  *
  * \b Example
+ * Detect instantaneous frequency from a phase ramp that wraps around PI.
  * \code
- * int N = 10000;
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
+ *   #include <math.h>
  *
- * <FIXME>
+ *   unsigned int N = 10;
+ *   unsigned int alignment = volk_get_alignment();
+ *   float bound = (float)M_PI;
  *
- * volk_32f_s32f_32f_fm_detect_32f();
+ *   float* input = (float*)volk_malloc(sizeof(float) * N, alignment);
+ *   float* output = (float*)volk_malloc(sizeof(float) * N, alignment);
  *
+ *   // Simulate a phase ramp that wraps around PI (as in FM demodulation)
+ *   float phase = 0.0f;
+ *   float freq = 0.8f; // radians per sample
+ *   for (unsigned int i = 0; i < N; i++) {
+ *       phase += freq;
+ *       // Wrap phase to (-PI, PI]
+ *       while (phase > bound) phase -= 2.0f * bound;
+ *       while (phase <= -bound) phase += 2.0f * bound;
+ *       input[i] = phase;
+ *   }
+ *
+ *   // saveValue holds the "previous" phase sample (0 for the first call)
+ *   float saveValue = 0.0f;
+ *
+ *   volk_32f_s32f_32f_fm_detect_32f(output, input, bound, &saveValue, N);
+ *
+ *   // Each output should recover the original frequency (~0.8 rad/sample)
+ *   for (unsigned int i = 0; i < N; i++) {
+ *       printf("output[%u] = %f\n", i, output[i]);
+ *   }
+ *
+ *   volk_free(input);
+ *   volk_free(output);
  * \endcode
  */
 

--- a/kernels/volk/volk_32f_s32f_calc_spectral_noise_floor_32f.h
+++ b/kernels/volk/volk_32f_s32f_calc_spectral_noise_floor_32f.h
@@ -17,7 +17,7 @@
  * Calculates the spectral noise floor of an input power spectrum by
  * determining the mean of the input power spectrum, then
  * recalculating the mean excluding any power spectrum values that
- * exceed the mean by the spectralExclusionValue (in dB).  Provides a
+ * exceed the mean by the spectralExclusionValue (in dB). Provides a
  * rough estimation of the signal noise floor.
  *
  * <b>Dispatcher Prototype</b>
@@ -29,19 +29,43 @@
  * \b Inputs
  * \li realDataPoints: The input power spectrum.
  * \li spectralExclusionValue: The number of dB above the noise floor that a data point
- * must be to be excluded from the noise floor calculation - default value is 20. \li
- * num_points: The number of data points.
+ * must be to be excluded from the noise floor calculation - default value is 20.
+ * \li num_points: The number of data points.
  *
  * \b Outputs
  * \li noiseFloorAmplitude: The noise floor of the input spectrum, in dB.
  *
  * \b Example
+ * Estimate the noise floor of a power spectrum with two strong signals above the noise.
  * \code
- * int N = 10000;
+ * #include <volk/volk.h>
+ * #include <stdio.h>
  *
- * volk_32f_s32f_calc_spectral_noise_floor_32f
+ * int main() {
+ *     unsigned int N = 256;
+ *     size_t alignment = volk_get_alignment();
  *
- * volk_free(x);
+ *     float* powerSpectrum = (float*)volk_malloc(sizeof(float) * N, alignment);
+ *     float noiseFloor = 0.0f;
+ *
+ *     // Fill spectrum with a noise floor around -100 dB
+ *     for (unsigned int i = 0; i < N; i++) {
+ *         powerSpectrum[i] = -100.0f + (float)(i % 3) * 0.5f;
+ *     }
+ *     // Insert two strong signals well above the noise floor
+ *     powerSpectrum[64] = -30.0f;
+ *     powerSpectrum[192] = -40.0f;
+ *
+ *     // Estimate noise floor, excluding bins more than 20 dB above the mean
+ *     float spectralExclusionValue = 20.0f;
+ *     volk_32f_s32f_calc_spectral_noise_floor_32f(
+ *         &noiseFloor, powerSpectrum, spectralExclusionValue, N);
+ *
+ *     printf("Estimated noise floor: %f dB\n", noiseFloor);
+ *
+ *     volk_free(powerSpectrum);
+ *     return 0;
+ * }
  * \endcode
  */
 

--- a/kernels/volk/volk_32f_s32f_s32f_mod_range_32f.h
+++ b/kernels/volk/volk_32f_s32f_s32f_mod_range_32f.h
@@ -10,22 +10,64 @@
 /*!
  * \page volk_32f_s32f_s32f_mod_range_32f
  *
- * \b wraps floating point numbers to stay within a defined [min,max] range
+ * \b Overview
+ *
+ * Wraps floating point numbers to stay within a defined [lower_bound, upper_bound]
+ * range. Values outside the range are shifted by integer multiples of the range width
+ * until they fall within bounds.
  *
  * <b>Dispatcher Prototype</b>
  * \code
  * void volk_32f_s32f_s32f_mod_range_32f(float* outputVector, const float* inputVector,
- * const float lower_bound, const float upper_bound, unsigned int num_points) \endcode
+ * const float lower_bound, const float upper_bound, unsigned int num_points)
+ * \endcode
  *
  * \b Inputs
- * \li inputVector: The input vector
- * \li lower_bound: The lower output boundary
- * \li upper_bound: The upper output boundary
- * \li num_points The number of data points.
+ * \li inputVector: The input vector of floats to be wrapped.
+ * \li lower_bound: The lower output boundary.
+ * \li upper_bound: The upper output boundary.
+ * \li num_points: The number of data points.
  *
  * \b Outputs
- * \li outputVector: The vector where the results will be stored.
+ * \li outputVector: The vector where the wrapped results will be stored.
  *
+ * \b Example
+ * Wrap phase values into the range [-pi, pi].
+ * \code
+ * #include <volk/volk.h>
+ * #include <math.h>
+ * #include <stdio.h>
+ *
+ * int main() {
+ *     unsigned int N = 8;
+ *     size_t alignment = volk_get_alignment();
+ *
+ *     float* input = (float*)volk_malloc(sizeof(float) * N, alignment);
+ *     float* output = (float*)volk_malloc(sizeof(float) * N, alignment);
+ *
+ *     // Simulate accumulated phase values that have drifted outside [-pi, pi]
+ *     input[0] = 0.5f;
+ *     input[1] = 3.5f;       // slightly above pi
+ *     input[2] = -3.5f;      // slightly below -pi
+ *     input[3] = 7.0f;       // more than one full wrap above pi
+ *     input[4] = -7.0f;      // more than one full wrap below -pi
+ *     input[5] = (float)M_PI;
+ *     input[6] = (float)-M_PI;
+ *     input[7] = 12.566f;    // approximately 4*pi
+ *
+ *     float lower_bound = (float)-M_PI;
+ *     float upper_bound = (float)M_PI;
+ *
+ *     volk_32f_s32f_s32f_mod_range_32f(output, input, lower_bound, upper_bound, N);
+ *
+ *     for (unsigned int i = 0; i < N; i++) {
+ *         printf("input: %8.3f  ->  output: %8.3f\n", input[i], output[i]);
+ *     }
+ *
+ *     volk_free(input);
+ *     volk_free(output);
+ *     return 0;
+ * }
  * \endcode
  */
 

--- a/kernels/volk/volk_32f_x2_dot_prod_16i.h
+++ b/kernels/volk/volk_32f_x2_dot_prod_16i.h
@@ -12,33 +12,57 @@
  *
  * \b Overview
  *
- * This block computes the dot product (or inner product) between two
- * vectors, the \p input and \p taps vectors. Given a set of \p
- * num_points taps, the result is the sum of products between the two
- * vectors. The result is a single value stored in the \p result
- * address and is conerted to a fixed-point short.
+ * Computes the dot product (inner product) between two float vectors and
+ * stores the result as a rounded 16-bit integer (int16_t). The floating-point
+ * sum of element-wise products is converted to fixed-point via rintf().
  *
  * <b>Dispatcher Prototype</b>
  * \code
- * void volk_32f_x2_dot_prod_16i(int16_t* result, const float* input, const float* taps,
- * unsigned int num_points) \endcode
+ * void volk_32f_x2_dot_prod_16i(int16_t* result, const float* input, const float*
+ * taps, unsigned int num_points)
+ * \endcode
  *
  * \b Inputs
  * \li input: vector of floats.
- * \li taps:  float taps.
+ * \li taps: vector of float taps.
  * \li num_points: number of samples in both \p input and \p taps.
  *
  * \b Outputs
- * \li result: pointer to a short value to hold the dot product result.
+ * \li result: pointer to an int16_t value to hold the dot product result.
  *
  * \b Example
+ * Compute the dot product of a short signal with a simple averaging filter.
  * \code
- * int N = 10000;
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
  *
- * <FIXME>
+ *   int main() {
+ *     unsigned int N = 8;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_32f_x2_dot_prod_16i();
+ *     float* input = (float*)volk_malloc(sizeof(float) * N, alignment);
+ *     float* taps  = (float*)volk_malloc(sizeof(float) * N, alignment);
+ *     int16_t result = 0;
  *
+ *     // Fill input with sample signal values
+ *     input[0] = 10.0f;  input[1] = 20.0f;  input[2] = 30.0f;  input[3] = 40.0f;
+ *     input[4] = 50.0f;  input[5] = 60.0f;  input[6] = 70.0f;  input[7] = 80.0f;
+ *
+ *     // Fill taps with uniform weights (averaging filter)
+ *     for (unsigned int i = 0; i < N; i++) {
+ *       taps[i] = 0.125f;  // 1/8
+ *     }
+ *
+ *     // Compute dot product: sum(input[i] * taps[i]) rounded to int16_t
+ *     volk_32f_x2_dot_prod_16i(&result, input, taps, N);
+ *
+ *     // Expected: (10+20+30+40+50+60+70+80)*0.125 = 45.0 -> 45
+ *     printf("Dot product result: %d\n", result);
+ *
+ *     volk_free(input);
+ *     volk_free(taps);
+ *     return 0;
+ *   }
  * \endcode
  */
 

--- a/kernels/volk/volk_32fc_32f_multiply_32fc.h
+++ b/kernels/volk/volk_32fc_32f_multiply_32fc.h
@@ -12,13 +12,15 @@
  *
  * \b Overview
  *
- * Multiplies a complex vector by a floating point vector and returns
- * the complex result.
+ * Multiplies each element of a complex float vector by the corresponding
+ * element of a real float vector. Both the real and imaginary parts of each
+ * complex input are scaled by the real value.
  *
  * <b>Dispatcher Prototype</b>
  * \code
- * void volk_32fc_32f_multiply_32fc(lv_32fc_t* cVector, const lv_32fc_t* aVector, const
- * float* bVector, unsigned int num_points); \endcode
+ * void volk_32fc_32f_multiply_32fc(lv_32fc_t* cVector, const lv_32fc_t* aVector,
+ * const float* bVector, unsigned int num_points)
+ * \endcode
  *
  * \b Inputs
  * \li aVector: The input vector of complex floats.
@@ -26,16 +28,47 @@
  * \li num_points: The number of data points.
  *
  * \b Outputs
- * \li outputVector: The output vector complex floats.
+ * \li cVector: The output vector of complex floats.
  *
  * \b Example
+ * Scale a complex signal by a real-valued gain ramp.
  * \code
- * int N = 10000;
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
  *
- * volk_32fc_32f_multiply_32fc();
+ *   int main() {
+ *     unsigned int N = 4;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
- * volk_free(t);
+ *     lv_32fc_t* aVector = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t) * N, alignment);
+ *     float* bVector     = (float*)volk_malloc(sizeof(float) * N, alignment);
+ *     lv_32fc_t* cVector = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t) * N, alignment);
+ *
+ *     // Complex signal: (1+2j, 3+4j, 5+6j, 7+8j)
+ *     aVector[0] = lv_cmake(1.0f, 2.0f);
+ *     aVector[1] = lv_cmake(3.0f, 4.0f);
+ *     aVector[2] = lv_cmake(5.0f, 6.0f);
+ *     aVector[3] = lv_cmake(7.0f, 8.0f);
+ *
+ *     // Real gain ramp: 0.5, 1.0, 1.5, 2.0
+ *     bVector[0] = 0.5f;
+ *     bVector[1] = 1.0f;
+ *     bVector[2] = 1.5f;
+ *     bVector[3] = 2.0f;
+ *
+ *     volk_32fc_32f_multiply_32fc(cVector, aVector, bVector, N);
+ *
+ *     // Expected: (0.5+1j, 3+4j, 7.5+9j, 14+16j)
+ *     for (unsigned int i = 0; i < N; i++) {
+ *       printf("cVector[%u] = (%.1f, %.1f)\n",
+ *              i, lv_creal(cVector[i]), lv_cimag(cVector[i]));
+ *     }
+ *
+ *     volk_free(aVector);
+ *     volk_free(bVector);
+ *     volk_free(cVector);
+ *     return 0;
+ *   }
  * \endcode
  */
 

--- a/kernels/volk/volk_32fc_convert_16ic.h
+++ b/kernels/volk/volk_32fc_convert_16ic.h
@@ -12,22 +12,54 @@
  *
  * \b Overview
  *
- * Converts a complex vector of 32-bits float each component into
- * a complex vector of 16-bits integer each component.
+ * Converts a complex vector of 32-bit float each component into
+ * a complex vector of 16-bit integer each component.
  * Values are saturated to the limit values of the output data type.
  *
  * <b>Dispatcher Prototype</b>
  * \code
  * void volk_32fc_convert_16ic(lv_16sc_t* outputVector, const lv_32fc_t* inputVector,
- * unsigned int num_points); \endcode
+ * unsigned int num_points)
+ * \endcode
  *
  * \b Inputs
- * \li inputVector:  The complex 32-bit float input data buffer.
- * \li num_points:   The number of data values to be converted.
+ * \li inputVector: The complex 32-bit float input data buffer.
+ * \li num_points: The number of data values to be converted.
  *
  * \b Outputs
  * \li outputVector: The complex 16-bit integer output data buffer.
  *
+ * \b Example
+ * Convert complex float samples to 16-bit integer representation with saturation.
+ * \code
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
+ *
+ *   int main(){
+ *     unsigned int N = 4;
+ *     unsigned int alignment = volk_get_alignment();
+ *
+ *     lv_32fc_t* input = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t) * N, alignment);
+ *     lv_16sc_t* output = (lv_16sc_t*)volk_malloc(sizeof(lv_16sc_t) * N, alignment);
+ *
+ *     // Mix of normal values and values that will saturate
+ *     input[0] = lv_cmake(100.0f, -200.0f);
+ *     input[1] = lv_cmake(16000.5f, -16000.5f);
+ *     input[2] = lv_cmake(50000.0f, -50000.0f);   // will saturate to SHRT_MAX/SHRT_MIN
+ *     input[3] = lv_cmake(-1234.7f, 5678.3f);
+ *
+ *     volk_32fc_convert_16ic(output, input, N);
+ *
+ *     // Expected output: (100,-200) (16000,-16000) (32767,-32768) (-1235,5678)
+ *     for (unsigned int i = 0; i < N; i++) {
+ *       printf("(%d,%d)\n", lv_creal(output[i]), lv_cimag(output[i]));
+ *     }
+ *
+ *     volk_free(input);
+ *     volk_free(output);
+ *     return 0;
+ *   }
+ * \endcode
  */
 
 #ifndef INCLUDED_volk_32fc_convert_16ic_a_H

--- a/kernels/volk/volk_32fc_s32f_power_32fc.h
+++ b/kernels/volk/volk_32fc_s32f_power_32fc.h
@@ -12,9 +12,8 @@
  *
  * \b Overview
  *
- * Takes each the input complex vector value to the specified power
- * and stores the results in the return vector. The output is scaled
- * and converted to 16-bit shorts.
+ * Raises each complex input value to the specified real-valued power and stores
+ * the results in the output vector. The computation is performed in polar form.
  *
  * <b>Dispatcher Prototype</b>
  * \code
@@ -22,20 +21,45 @@
  * float power, unsigned int num_points) \endcode
  *
  * \b Inputs
- * \li aVector: The complex input vector.
- * \li power: The power value to be applied to each data point.
- * \li num_points: The number of samples.
+ * \li aVector: The complex float input vector.
+ * \li power: The real-valued exponent applied to each element.
+ * \li num_points: The number of complex values to process.
  *
  * \b Outputs
- * \li cVector: The output value as 16-bit shorts.
+ * \li cVector: The complex float output vector.
  *
  * \b Example
+ * Raise a vector of complex values to the power of 2.
  * \code
- * int N = 10000;
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
  *
- * volk_32fc_s32f_power_32fc();
+ *   int main(){
+ *     unsigned int N = 4;
+ *     unsigned int alignment = volk_get_alignment();
+ *     float power = 2.0f;
  *
- * volk_free(x);
+ *     lv_32fc_t* input  = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t) * N, alignment);
+ *     lv_32fc_t* output = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t) * N, alignment);
+ *
+ *     // Initialize with some complex values
+ *     input[0] = lv_cmake(1.0f, 0.0f);
+ *     input[1] = lv_cmake(0.0f, 1.0f);
+ *     input[2] = lv_cmake(1.0f, 1.0f);
+ *     input[3] = lv_cmake(2.0f, -1.0f);
+ *
+ *     volk_32fc_s32f_power_32fc(output, input, power, N);
+ *
+ *     for (unsigned int i = 0; i < N; i++) {
+ *       printf("(%1.2f, %1.2f)^%1.1f = (%1.4f, %1.4f)\n",
+ *              lv_creal(input[i]), lv_cimag(input[i]), power,
+ *              lv_creal(output[i]), lv_cimag(output[i]));
+ *     }
+ *
+ *     volk_free(input);
+ *     volk_free(output);
+ *     return 0;
+ *   }
  * \endcode
  */
 

--- a/kernels/volk/volk_32fc_s32f_power_spectrum_32f.h
+++ b/kernels/volk/volk_32fc_s32f_power_spectrum_32f.h
@@ -12,7 +12,9 @@
  *
  * \b Overview
  *
- * Calculates the log10 power value for each input point.
+ * Computes the log power spectrum of complex FFT data. Each output sample is
+ * 10 * log10((real/norm)^2 + (imag/norm)^2), where norm is the normalization factor.
+ * This is useful for converting complex FFT output into a power spectral density in dB.
  *
  * <b>Dispatcher Prototype</b>
  * \code
@@ -20,20 +22,49 @@
  * complexFFTInput, const float normalizationFactor, unsigned int num_points) \endcode
  *
  * \b Inputs
- * \li complexFFTInput The complex data output from the FFT point.
- * \li normalizationFactor: This value is divided against all the input values before the
- * power is calculated. \li num_points: The number of fft data points.
+ * \li complexFFTInput: The complex data output from the FFT.
+ * \li normalizationFactor: Each input value is divided by this factor before the power is
+ * calculated.
+ * \li num_points: The number of FFT data points.
  *
  * \b Outputs
- * \li logPowerOutput: The 10.0 * log10(r*r + i*i) for each data point.
+ * \li logPowerOutput: The 10.0 * log10(r*r + i*i) for each data point, where r and i are
+ * the normalized real and imaginary components.
  *
  * \b Example
+ * Compute the power spectrum in dB from simulated FFT output.
  * \code
- * int N = 10000;
+ * #include <volk/volk.h>
+ * #include <stdio.h>
+ * #include <math.h>
  *
- * volk_32fc_s32f_power_spectrum_32f();
+ * int main() {
+ *     unsigned int N = 8;
+ *     unsigned int alignment = volk_get_alignment();
+ *     float normalizationFactor = (float)N;
  *
- * volk_free(x);
+ *     lv_32fc_t* fftOutput =
+ *         (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t) * N, alignment);
+ *     float* powerSpectrum =
+ *         (float*)volk_malloc(sizeof(float) * N, alignment);
+ *
+ *     // Simulate FFT output with a strong bin at index 1
+ *     for (unsigned int i = 0; i < N; i++) {
+ *         fftOutput[i] = lv_cmake(0.01f, 0.01f);
+ *     }
+ *     fftOutput[1] = lv_cmake(4.0f, 3.0f); // magnitude 5.0
+ *
+ *     volk_32fc_s32f_power_spectrum_32f(
+ *         powerSpectrum, fftOutput, normalizationFactor, N);
+ *
+ *     for (unsigned int i = 0; i < N; i++) {
+ *         printf("bin[%u] = %+.2f dB\n", i, powerSpectrum[i]);
+ *     }
+ *
+ *     volk_free(fftOutput);
+ *     volk_free(powerSpectrum);
+ *     return 0;
+ * }
  * \endcode
  */
 

--- a/kernels/volk/volk_32fc_s32f_x2_power_spectral_density_32f.h
+++ b/kernels/volk/volk_32fc_s32f_x2_power_spectral_density_32f.h
@@ -12,7 +12,10 @@
  *
  * \b Overview
  *
- * Calculates the log10 power value divided by the RBW for each input point.
+ * Computes the power spectral density (PSD) of complex FFT data. Each output sample is
+ * 10 * log10((real/norm)^2 + (imag/norm)^2) normalized by the resolution bandwidth (RBW).
+ * When RBW is not 1.0, the normalization factor is scaled by sqrt(RBW) so that the result
+ * represents power per unit bandwidth in dB.
  *
  * <b>Dispatcher Prototype</b>
  * \code
@@ -21,21 +24,51 @@
  * int num_points) \endcode
  *
  * \b Inputs
- * \li complexFFTInput The complex data output from the FFT point.
- * \li normalizationFactor: This value is divided against all the input values before the
- * power is calculated. \li rbw: The resolution bandwidth of the fft spectrum \li
- * num_points: The number of fft data points.
+ * \li complexFFTInput: The complex data output from the FFT.
+ * \li normalizationFactor: Each input value is divided by this factor before the power is
+ * calculated.
+ * \li rbw: The resolution bandwidth of the FFT spectrum.
+ * \li num_points: The number of FFT data points.
  *
  * \b Outputs
- * \li logPowerOutput: The 10.0 * log10((r*r + i*i)/RBW) for each data point.
+ * \li logPowerOutput: The 10.0 * log10((r*r + i*i) / (norm*norm * rbw)) for each data
+ * point.
  *
  * \b Example
+ * Compute the power spectral density in dB/Hz from simulated FFT output.
  * \code
- * int N = 10000;
+ * #include <volk/volk.h>
+ * #include <stdio.h>
+ * #include <math.h>
  *
- * volk_32fc_s32f_x2_power_spectral_density_32f();
+ * int main() {
+ *     unsigned int N = 8;
+ *     unsigned int alignment = volk_get_alignment();
+ *     float normalizationFactor = (float)N;
+ *     // RBW = sample_rate / N; e.g. 1000 Hz / 8 = 125 Hz
+ *     float rbw = 125.0f;
  *
- * volk_free(x);
+ *     lv_32fc_t* fftOutput =
+ *         (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t) * N, alignment);
+ *     float* psd = (float*)volk_malloc(sizeof(float) * N, alignment);
+ *
+ *     // Simulate FFT output with a strong bin at index 1
+ *     for (unsigned int i = 0; i < N; i++) {
+ *         fftOutput[i] = lv_cmake(0.01f, 0.01f);
+ *     }
+ *     fftOutput[1] = lv_cmake(4.0f, 3.0f); // magnitude 5.0
+ *
+ *     volk_32fc_s32f_x2_power_spectral_density_32f(
+ *         psd, fftOutput, normalizationFactor, rbw, N);
+ *
+ *     for (unsigned int i = 0; i < N; i++) {
+ *         printf("bin[%u] = %+.2f dB/Hz\n", i, psd[i]);
+ *     }
+ *
+ *     volk_free(fftOutput);
+ *     volk_free(psd);
+ *     return 0;
+ * }
  * \endcode
  */
 

--- a/kernels/volk/volk_32fc_x2_dot_prod_32fc.h
+++ b/kernels/volk/volk_32fc_x2_dot_prod_32fc.h
@@ -12,11 +12,9 @@
  *
  * \b Overview
  *
- * This block computes the dot product (or inner product) between two
- * vectors, the \p input and \p taps vectors. Given a set of \p
- * num_points taps, the result is the sum of products between the two
- * vectors. The result is a single value stored in the \p result
- * address and is returned as a complex float.
+ * Computes the complex dot product (inner product) of two complex float vectors.
+ * The result is the sum of element-wise complex multiplications, returned as a
+ * single complex float value.
  *
  * <b>Dispatcher Prototype</b>
  * \code
@@ -24,21 +22,47 @@
  * lv_32fc_t* taps, unsigned int num_points) \endcode
  *
  * \b Inputs
- * \li input: vector of complex floats.
- * \li taps:  complex float taps.
- * \li num_points: number of samples in both \p input and \p taps.
+ * \li input: The complex float input vector.
+ * \li taps: The complex float taps vector.
+ * \li num_points: The number of complex values in both \p input and \p taps.
  *
  * \b Outputs
- * \li result: pointer to a complex float value to hold the dot product result.
+ * \li result: Pointer to a complex float value to hold the dot product result.
  *
  * \b Example
+ * Compute the dot product of two short complex vectors.
  * \code
- * int N = 10000;
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
  *
- * <FIXME>
+ *   int main(){
+ *     unsigned int N = 4;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_32fc_x2_dot_prod_32fc();
+ *     lv_32fc_t* input = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t) * N, alignment);
+ *     lv_32fc_t* taps  = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t) * N, alignment);
+ *     lv_32fc_t result;
  *
+ *     // Initialize input: complex sinusoid samples
+ *     input[0] = lv_cmake(1.0f,  0.0f);
+ *     input[1] = lv_cmake(0.0f,  1.0f);
+ *     input[2] = lv_cmake(-1.0f, 0.0f);
+ *     input[3] = lv_cmake(0.0f, -1.0f);
+ *
+ *     // Initialize taps: simple FIR filter coefficients
+ *     taps[0] = lv_cmake(0.5f, 0.0f);
+ *     taps[1] = lv_cmake(0.25f, 0.1f);
+ *     taps[2] = lv_cmake(0.25f, -0.1f);
+ *     taps[3] = lv_cmake(0.5f, 0.0f);
+ *
+ *     volk_32fc_x2_dot_prod_32fc(&result, input, taps, N);
+ *
+ *     printf("Dot product = (%1.4f, %1.4f)\n", lv_creal(result), lv_cimag(result));
+ *
+ *     volk_free(input);
+ *     volk_free(taps);
+ *     return 0;
+ *   }
  * \endcode
  */
 

--- a/kernels/volk/volk_32u_reverse_32u.h
+++ b/kernels/volk/volk_32u_reverse_32u.h
@@ -10,21 +10,54 @@
 /*!
  * \page volk_32u_reverse_32u
  *
- * \b bit reversal of the input 32 bit word
-
+ * \b Overview
+ *
+ * Reverses the bit order of each 32-bit unsigned integer in the input vector. For each
+ * element, bit 0 becomes bit 31, bit 1 becomes bit 30, and so on.
+ *
  * <b>Dispatcher Prototype</b>
- * \code volk_32u_reverse_32u(uint32_t *outputVector, uint32_t *inputVector; unsigned int
- num_points);
+ * \code
+ * void volk_32u_reverse_32u(uint32_t* out, const uint32_t* in, unsigned int num_points)
  * \endcode
  *
  * \b Inputs
- * \li inputVector: The input vector
- * \li num_points The number of data points.
+ * \li in: Vector of 32-bit unsigned integers to bit-reverse (uint32_t).
+ * \li num_points: The number of data points.
  *
  * \b Outputs
- * \li outputVector: The vector where the results will be stored, which is the
- bit-reversed input
+ * \li out: Vector of 32-bit unsigned integers containing the bit-reversed results
+ * (uint32_t).
  *
+ * \b Example
+ * Bit-reverse several 32-bit values and print the results in hex.
+ * \code
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
+ *   #include <stdint.h>
+ *
+ *   int main() {
+ *     unsigned int num_points = 4;
+ *     unsigned int alignment = volk_get_alignment();
+ *
+ *     uint32_t* in = (uint32_t*)volk_malloc(sizeof(uint32_t) * num_points, alignment);
+ *     uint32_t* out = (uint32_t*)volk_malloc(sizeof(uint32_t) * num_points, alignment);
+ *
+ *     // Initialize with values that have recognizable bit patterns
+ *     in[0] = 0x00000001; // only LSB set -> expect only MSB set: 0x80000000
+ *     in[1] = 0x80000000; // only MSB set -> expect only LSB set: 0x00000001
+ *     in[2] = 0x0F0F0F0F; // alternating nibbles
+ *     in[3] = 0xAAAAAAAA; // alternating bits: 1010... -> 0101...: 0x55555555
+ *
+ *     volk_32u_reverse_32u(out, in, num_points);
+ *
+ *     for (unsigned int i = 0; i < num_points; i++) {
+ *       printf("in: 0x%08X  ->  out: 0x%08X\n", in[i], out[i]);
+ *     }
+ *
+ *     volk_free(in);
+ *     volk_free(out);
+ *     return 0;
+ *   }
  * \endcode
  */
 #ifndef INCLUDED_VOLK_32u_REVERSE_32u_U_H

--- a/kernels/volk/volk_8i_convert_16i.h
+++ b/kernels/volk/volk_8i_convert_16i.h
@@ -12,8 +12,8 @@
  *
  * \b Overview
  *
- * Convert the input vector of 8-bit chars to a vector of 16-bit
- * shorts.
+ * Converts 8-bit signed integers to 16-bit signed integers by scaling each value
+ * by 256 (i.e. shifting left by 8 bits into the upper byte of the 16-bit output).
  *
  * <b>Dispatcher Prototype</b>
  * \code
@@ -21,19 +21,46 @@
  * num_points) \endcode
  *
  * \b Inputs
- * \li inputVector: The input vector of 8-bit chars.
- * \li num_points: The number of values.
+ * \li inputVector: The input vector of 8-bit signed chars (int8_t).
+ * \li num_points: The number of values to convert.
  *
  * \b Outputs
- * \li outputVector: The output 16-bit shorts.
+ * \li outputVector: The output vector of 16-bit signed shorts (int16_t).
  *
  * \b Example
+ * Convert a small array of 8-bit values to 16-bit and verify the scaling.
  * \code
- * int N = 10000;
+ * #include <volk/volk.h>
+ * #include <stdio.h>
  *
- * volk_8i_convert_16i();
+ * int main() {
+ *     unsigned int N = 8;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
+ *     int8_t* input = (int8_t*)volk_malloc(sizeof(int8_t) * N, alignment);
+ *     int16_t* output = (int16_t*)volk_malloc(sizeof(int16_t) * N, alignment);
+ *
+ *     // Initialize with sample signed 8-bit values
+ *     input[0] = 1;
+ *     input[1] = -1;
+ *     input[2] = 127;
+ *     input[3] = -128;
+ *     input[4] = 0;
+ *     input[5] = 42;
+ *     input[6] = -50;
+ *     input[7] = 100;
+ *
+ *     // Each output value equals the input value multiplied by 256
+ *     volk_8i_convert_16i(output, input, N);
+ *
+ *     for (unsigned int i = 0; i < N; i++) {
+ *         printf("in: %4d  out: %6d\n", input[i], output[i]);
+ *     }
+ *
+ *     volk_free(input);
+ *     volk_free(output);
+ *     return 0;
+ * }
  * \endcode
  */
 

--- a/kernels/volk/volk_8i_s32f_convert_32f.h
+++ b/kernels/volk/volk_8i_s32f_convert_32f.h
@@ -12,8 +12,8 @@
  *
  * \b Overview
  *
- * Convert the input vector of 8-bit chars to a vector of floats. The
- * floats are then divided by the scalar factor.  shorts.
+ * Converts 8-bit signed integers to 32-bit floats, dividing each value by
+ * the scalar factor. This is useful for normalizing quantized samples.
  *
  * <b>Dispatcher Prototype</b>
  * \code
@@ -21,20 +21,48 @@
  * float scalar, unsigned int num_points) \endcode
  *
  * \b Inputs
- * \li inputVector: The input vector of 8-bit chars.
- * \li scalar: the scaling factor used to divide the results of the conversion.
- * \li num_points: The number of values.
+ * \li inputVector: The input vector of 8-bit signed chars (int8_t).
+ * \li scalar: The scaling factor used to divide the results of the conversion.
+ * \li num_points: The number of values to convert.
  *
  * \b Outputs
- * \li outputVector: The output 16-bit shorts.
+ * \li outputVector: The output vector of 32-bit floats (float).
  *
  * \b Example
+ * Convert 8-bit ADC samples to normalized floats in the range [-1.0, 1.0].
  * \code
- * int N = 10000;
+ * #include <volk/volk.h>
+ * #include <stdio.h>
  *
- * volk_8i_s32f_convert_32f();
+ * int main() {
+ *     unsigned int N = 8;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
+ *     int8_t* input = (int8_t*)volk_malloc(sizeof(int8_t) * N, alignment);
+ *     float* output = (float*)volk_malloc(sizeof(float) * N, alignment);
+ *
+ *     // Simulate 8-bit ADC samples
+ *     input[0] = 127;   // max positive
+ *     input[1] = -128;  // max negative
+ *     input[2] = 64;
+ *     input[3] = -64;
+ *     input[4] = 0;
+ *     input[5] = 32;
+ *     input[6] = -32;
+ *     input[7] = 1;
+ *
+ *     // Divide by 128 to normalize to approximately [-1.0, 1.0]
+ *     float scalar = 128.0f;
+ *     volk_8i_s32f_convert_32f(output, input, scalar, N);
+ *
+ *     for (unsigned int i = 0; i < N; i++) {
+ *         printf("input[%u] = %4d  ->  output[%u] = %+.4f\n", i, input[i], i, output[i]);
+ *     }
+ *
+ *     volk_free(input);
+ *     volk_free(output);
+ *     return 0;
+ * }
  * \endcode
  */
 

--- a/kernels/volk/volk_8ic_deinterleave_16i_x2.h
+++ b/kernels/volk/volk_8ic_deinterleave_16i_x2.h
@@ -12,8 +12,9 @@
  *
  * \b Overview
  *
- * Deinterleaves the complex 8-bit char vector into I & Q vector data
- * and converts them to 16-bit shorts.
+ * Deinterleaves a complex 8-bit char vector into separate I and Q vectors
+ * of 16-bit shorts. Each 8-bit component is sign-extended to 16 bits and
+ * shifted left by 8, scaling the values by 256.
  *
  * <b>Dispatcher Prototype</b>
  * \code
@@ -21,20 +22,48 @@
  * complexVector, unsigned int num_points) \endcode
  *
  * \b Inputs
- * \li complexVector: The complex input vector.
+ * \li complexVector: The complex input vector of interleaved 8-bit I/Q pairs (lv_8sc_t).
  * \li num_points: The number of complex data values to be deinterleaved.
  *
  * \b Outputs
- * \li iBuffer: The I buffer output data.
- * \li qBuffer: The Q buffer output data.
+ * \li iBuffer: The in-phase (I) output vector of 16-bit shorts (int16_t).
+ * \li qBuffer: The quadrature (Q) output vector of 16-bit shorts (int16_t).
  *
  * \b Example
+ * Deinterleave complex 8-bit samples into separate I and Q 16-bit vectors.
  * \code
- * int N = 10000;
+ * #include <volk/volk.h>
+ * #include <stdio.h>
  *
- * volk_8ic_deinterleave_16i_x2();
+ * int main() {
+ *     unsigned int N = 4;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
+ *     lv_8sc_t* complexVector =
+ *         (lv_8sc_t*)volk_malloc(sizeof(lv_8sc_t) * N, alignment);
+ *     int16_t* iBuffer = (int16_t*)volk_malloc(sizeof(int16_t) * N, alignment);
+ *     int16_t* qBuffer = (int16_t*)volk_malloc(sizeof(int16_t) * N, alignment);
+ *
+ *     // Simulate complex 8-bit samples: (I, Q) pairs
+ *     complexVector[0] = lv_cmake((int8_t)127, (int8_t)-128);
+ *     complexVector[1] = lv_cmake((int8_t)50, (int8_t)-50);
+ *     complexVector[2] = lv_cmake((int8_t)0, (int8_t)100);
+ *     complexVector[3] = lv_cmake((int8_t)-30, (int8_t)30);
+ *
+ *     volk_8ic_deinterleave_16i_x2(iBuffer, qBuffer, complexVector, N);
+ *
+ *     // Each 8-bit value is scaled by 256 (left-shifted by 8 bits)
+ *     for (unsigned int i = 0; i < N; i++) {
+ *         printf("complex[%u] = (%4d, %4d)  ->  I = %6d, Q = %6d\n",
+ *                i, lv_creal(complexVector[i]), lv_cimag(complexVector[i]),
+ *                iBuffer[i], qBuffer[i]);
+ *     }
+ *
+ *     volk_free(complexVector);
+ *     volk_free(iBuffer);
+ *     volk_free(qBuffer);
+ *     return 0;
+ * }
  * \endcode
  */
 

--- a/kernels/volk/volk_8ic_deinterleave_real_16i.h
+++ b/kernels/volk/volk_8ic_deinterleave_real_16i.h
@@ -12,8 +12,9 @@
  *
  * \b Overview
  *
- * Deinterleaves the complex 8-bit char vector into just the I (real)
- * vector and converts it to 16-bit shorts.
+ * Deinterleaves the complex 8-bit char vector into just the real (I)
+ * component and converts it to 16-bit shorts. Each 8-bit value is
+ * sign-extended to 16 bits and scaled by 128 (left-shifted by 7).
  *
  * <b>Dispatcher Prototype</b>
  * \code
@@ -21,19 +22,45 @@
  * unsigned int num_points) \endcode
  *
  * \b Inputs
- * \li complexVector: The complex input vector.
+ * \li complexVector: The complex input vector of interleaved 8-bit I/Q pairs (lv_8sc_t).
  * \li num_points: The number of complex data values to be deinterleaved.
  *
  * \b Outputs
- * \li iBuffer: The I buffer output data.
+ * \li iBuffer: The real (I) output vector of 16-bit shorts (int16_t).
  *
  * \b Example
+ * Extract the real component from complex 8-bit samples into a 16-bit vector.
  * \code
- * int N = 10000;
+ * #include <volk/volk.h>
+ * #include <stdio.h>
  *
- * volk_8ic_deinterleave_real_16i();
+ * int main() {
+ *     unsigned int N = 4;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
+ *     lv_8sc_t* complexVector =
+ *         (lv_8sc_t*)volk_malloc(sizeof(lv_8sc_t) * N, alignment);
+ *     int16_t* iBuffer = (int16_t*)volk_malloc(sizeof(int16_t) * N, alignment);
+ *
+ *     // Simulate complex 8-bit samples: (I, Q) pairs
+ *     complexVector[0] = lv_cmake((int8_t)127, (int8_t)-128);
+ *     complexVector[1] = lv_cmake((int8_t)50, (int8_t)-50);
+ *     complexVector[2] = lv_cmake((int8_t)0, (int8_t)100);
+ *     complexVector[3] = lv_cmake((int8_t)-30, (int8_t)30);
+ *
+ *     // Extract real (I) component, scaled by 128
+ *     volk_8ic_deinterleave_real_16i(iBuffer, complexVector, N);
+ *
+ *     for (unsigned int i = 0; i < N; i++) {
+ *         printf("complex[%u] = (%4d, %4d)  ->  I = %6d\n",
+ *                i, lv_creal(complexVector[i]), lv_cimag(complexVector[i]),
+ *                iBuffer[i]);
+ *     }
+ *
+ *     volk_free(complexVector);
+ *     volk_free(iBuffer);
+ *     return 0;
+ * }
  * \endcode
  */
 

--- a/kernels/volk/volk_8ic_deinterleave_real_8i.h
+++ b/kernels/volk/volk_8ic_deinterleave_real_8i.h
@@ -12,8 +12,8 @@
  *
  * \b Overview
  *
- * Deinterleaves the complex 8-bit char vector into just the I (real)
- * vector.
+ * Deinterleaves the complex 8-bit char vector into just the real (I)
+ * component as 8-bit chars. The imaginary (Q) values are discarded.
  *
  * <b>Dispatcher Prototype</b>
  * \code
@@ -21,19 +21,45 @@
  * unsigned int num_points) \endcode
  *
  * \b Inputs
- * \li complexVector: The complex input vector.
+ * \li complexVector: The complex input vector of interleaved 8-bit I/Q pairs (lv_8sc_t).
  * \li num_points: The number of complex data values to be deinterleaved.
  *
  * \b Outputs
- * \li iBuffer: The I buffer output data.
+ * \li iBuffer: The real (I) output vector of 8-bit chars (int8_t).
  *
  * \b Example
+ * Extract the real component from complex 8-bit samples.
  * \code
- * int N = 10000;
+ * #include <volk/volk.h>
+ * #include <stdio.h>
  *
- * volk_8ic_deinterleave_real_8i();
+ * int main() {
+ *     unsigned int N = 4;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
+ *     lv_8sc_t* complexVector =
+ *         (lv_8sc_t*)volk_malloc(sizeof(lv_8sc_t) * N, alignment);
+ *     int8_t* iBuffer = (int8_t*)volk_malloc(sizeof(int8_t) * N, alignment);
+ *
+ *     // Simulate complex 8-bit samples: (I, Q) pairs
+ *     complexVector[0] = lv_cmake((int8_t)127, (int8_t)-128);
+ *     complexVector[1] = lv_cmake((int8_t)50, (int8_t)-50);
+ *     complexVector[2] = lv_cmake((int8_t)0, (int8_t)100);
+ *     complexVector[3] = lv_cmake((int8_t)-30, (int8_t)30);
+ *
+ *     // Extract real (I) component, discarding Q
+ *     volk_8ic_deinterleave_real_8i(iBuffer, complexVector, N);
+ *
+ *     for (unsigned int i = 0; i < N; i++) {
+ *         printf("complex[%u] = (%4d, %4d)  ->  I = %4d\n",
+ *                i, lv_creal(complexVector[i]), lv_cimag(complexVector[i]),
+ *                iBuffer[i]);
+ *     }
+ *
+ *     volk_free(complexVector);
+ *     volk_free(iBuffer);
+ *     return 0;
+ * }
  * \endcode
  */
 

--- a/kernels/volk/volk_8ic_s32f_deinterleave_32f_x2.h
+++ b/kernels/volk/volk_8ic_s32f_deinterleave_32f_x2.h
@@ -12,31 +12,56 @@
  *
  * \b Overview
  *
- * Deinterleaves the complex 8-bit char vector into I & Q vector data,
- * converts them to floats, and divides the results by the scalar
- * factor.
+ * Deinterleaves the complex 8-bit char vector into separate I and Q
+ * float vectors, dividing each component by the scalar factor.
  *
  * <b>Dispatcher Prototype</b>
  * \code
- * void volk_8ic_s32f_deinterleave_32f_x2(float* iBuffer, float* qBuffer, const lv_8sc_t*
- * complexVector, const float scalar, unsigned int num_points) \endcode
+ * void volk_8ic_s32f_deinterleave_32f_x2(float* iBuffer, float* qBuffer, const
+ * lv_8sc_t* complexVector, const float scalar, unsigned int num_points) \endcode
  *
  * \b Inputs
- * \li complexVector: The complex input vector.
- * \li scalar: The scalar value used to divide the floating point results.
+ * \li complexVector: The complex input vector of interleaved 8-bit I/Q pairs (lv_8sc_t).
+ * \li scalar: The scalar divisor applied to each output value.
  * \li num_points: The number of complex data values to be deinterleaved.
  *
  * \b Outputs
- * \li iBuffer: The I buffer output data.
- * \li qBuffer: The Q buffer output data.
+ * \li iBuffer: The in-phase (I) output vector of floats.
+ * \li qBuffer: The quadrature (Q) output vector of floats.
  *
  * \b Example
+ * Deinterleave complex 8-bit samples and scale to normalized floats.
  * \code
- * int N = 10000;
+ * #include <volk/volk.h>
+ * #include <stdio.h>
  *
- * volk_8ic_s32f_deinterleave_32f_x2();
+ * int main() {
+ *     unsigned int N = 4;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
+ *     lv_8sc_t* complexVector =
+ *         (lv_8sc_t*)volk_malloc(sizeof(lv_8sc_t) * N, alignment);
+ *     float* iBuffer = (float*)volk_malloc(sizeof(float) * N, alignment);
+ *     float* qBuffer = (float*)volk_malloc(sizeof(float) * N, alignment);
+ *
+ *     // Simulate complex 8-bit samples: (I, Q) pairs
+ *     complexVector[0] = lv_cmake((int8_t)127, (int8_t)-128);
+ *     complexVector[1] = lv_cmake((int8_t)50, (int8_t)-50);
+ *     complexVector[2] = lv_cmake((int8_t)0, (int8_t)100);
+ *     complexVector[3] = lv_cmake((int8_t)-30, (int8_t)30);
+ *
+ *     // Divide by 128 to normalize to approximately [-1.0, 1.0]
+ *     float scalar = 128.0f;
+ *     volk_8ic_s32f_deinterleave_32f_x2(iBuffer, qBuffer, complexVector, scalar, N);
+ *
+ *     for (unsigned int i = 0; i < N; i++) {
+ *         printf("Sample %u: I = %+.4f  Q = %+.4f\n", i, iBuffer[i], qBuffer[i]);
+ *     }
+ *
+ *     volk_free(complexVector);
+ *     volk_free(iBuffer);
+ *     volk_free(qBuffer);
+ * }
  * \endcode
  */
 

--- a/kernels/volk/volk_8ic_s32f_deinterleave_real_32f.h
+++ b/kernels/volk/volk_8ic_s32f_deinterleave_real_32f.h
@@ -18,8 +18,8 @@
  *
  * <b>Dispatcher Prototype</b>
  * \code
- * void volk_8ic_s32f_deinterleave_real_32f(float* iBuffer, const lv_8sc_t* complexVector,
- * const float scalar, unsigned int num_points) \endcode
+ * void volk_8ic_s32f_deinterleave_real_32f(float* iBuffer, const lv_8sc_t*
+ * complexVector, const float scalar, unsigned int num_points) \endcode
  *
  * \b Inputs
  * \li complexVector: The complex input vector.
@@ -30,12 +30,41 @@
  * \li iBuffer: The I buffer output data.
  *
  * \b Example
+ * Extract and scale the real (I) component from 8-bit complex samples.
  * \code
- * int N = 10000;
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
  *
- * volk_8ic_s32f_deinterleave_real_32f();
+ *   int main(){
+ *     unsigned int N = 8;
+ *     float scalar = 127.0f; // normalize to [-1.0, 1.0] range
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
+ *     // Allocate aligned memory
+ *     lv_8sc_t* complexVector = (lv_8sc_t*)volk_malloc(sizeof(lv_8sc_t) * N, alignment);
+ *     float* iBuffer = (float*)volk_malloc(sizeof(float) * N, alignment);
+ *
+ *     // Fill with sample complex data (I, Q pairs)
+ *     complexVector[0] = lv_cmake((int8_t)127,  (int8_t)0);
+ *     complexVector[1] = lv_cmake((int8_t)90,   (int8_t)90);
+ *     complexVector[2] = lv_cmake((int8_t)0,    (int8_t)127);
+ *     complexVector[3] = lv_cmake((int8_t)-90,  (int8_t)90);
+ *     complexVector[4] = lv_cmake((int8_t)-127, (int8_t)0);
+ *     complexVector[5] = lv_cmake((int8_t)-90,  (int8_t)-90);
+ *     complexVector[6] = lv_cmake((int8_t)0,    (int8_t)-127);
+ *     complexVector[7] = lv_cmake((int8_t)90,   (int8_t)-90);
+ *
+ *     // Deinterleave real part and divide by scalar
+ *     volk_8ic_s32f_deinterleave_real_32f(iBuffer, complexVector, scalar, N);
+ *
+ *     for(unsigned int i = 0; i < N; i++){
+ *       printf("I[%u] = %1.4f\n", i, iBuffer[i]);
+ *     }
+ *
+ *     volk_free(complexVector);
+ *     volk_free(iBuffer);
+ *     return 0;
+ *   }
  * \endcode
  */
 

--- a/kernels/volk/volk_8ic_x2_multiply_conjugate_16ic.h
+++ b/kernels/volk/volk_8ic_x2_multiply_conjugate_16ic.h
@@ -18,13 +18,69 @@
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
 /*!
-  \brief Multiplys the one complex vector with the complex conjugate of the second complex
-  vector and stores their results in the third vector \param cVector The complex vector
-  where the results will be stored \param aVector One of the complex vectors to be
-  multiplied \param bVector The complex vector which will be converted to complex
-  conjugate and multiplied \param num_points The number of complex values in aVector and
-  bVector to be multiplied together and stored into cVector
-*/
+ * \page volk_8ic_x2_multiply_conjugate_16ic
+ *
+ * \b Overview
+ *
+ * Multiplies each element of one complex 8-bit integer vector by the complex
+ * conjugate of the corresponding element in a second complex 8-bit integer
+ * vector. The results are stored as complex 16-bit integers to accommodate
+ * the wider product range.
+ *
+ * <b>Dispatcher Prototype</b>
+ * \code
+ * void volk_8ic_x2_multiply_conjugate_16ic(lv_16sc_t* cVector, const lv_8sc_t*
+ * aVector, const lv_8sc_t* bVector, unsigned int num_points) \endcode
+ *
+ * \b Inputs
+ * \li aVector: The first complex 8-bit input vector.
+ * \li bVector: The second complex 8-bit input vector whose conjugate is used.
+ * \li num_points: The number of complex values to process.
+ *
+ * \b Outputs
+ * \li cVector: The complex 16-bit output vector.
+ *
+ * \b Example
+ * Multiply a complex signal by the conjugate of a reference to compute correlation.
+ * \code
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
+ *
+ *   int main(){
+ *     unsigned int N = 4;
+ *     unsigned int alignment = volk_get_alignment();
+ *
+ *     // Allocate aligned memory
+ *     lv_8sc_t* aVector = (lv_8sc_t*)volk_malloc(sizeof(lv_8sc_t) * N, alignment);
+ *     lv_8sc_t* bVector = (lv_8sc_t*)volk_malloc(sizeof(lv_8sc_t) * N, alignment);
+ *     lv_16sc_t* cVector = (lv_16sc_t*)volk_malloc(sizeof(lv_16sc_t) * N, alignment);
+ *
+ *     // Fill with sample complex data representing received signal
+ *     aVector[0] = lv_cmake((int8_t)10,  (int8_t)20);
+ *     aVector[1] = lv_cmake((int8_t)-5,  (int8_t)15);
+ *     aVector[2] = lv_cmake((int8_t)30,  (int8_t)-10);
+ *     aVector[3] = lv_cmake((int8_t)-20, (int8_t)-25);
+ *
+ *     // Fill with reference signal
+ *     bVector[0] = lv_cmake((int8_t)3,   (int8_t)4);
+ *     bVector[1] = lv_cmake((int8_t)-2,  (int8_t)7);
+ *     bVector[2] = lv_cmake((int8_t)6,   (int8_t)-3);
+ *     bVector[3] = lv_cmake((int8_t)-4,  (int8_t)1);
+ *
+ *     // Compute a[i] * conj(b[i]) for each element
+ *     volk_8ic_x2_multiply_conjugate_16ic(cVector, aVector, bVector, N);
+ *
+ *     for(unsigned int i = 0; i < N; i++){
+ *       printf("c[%u] = (%d, %d)\n", i, lv_creal(cVector[i]), lv_cimag(cVector[i]));
+ *     }
+ *
+ *     volk_free(aVector);
+ *     volk_free(bVector);
+ *     volk_free(cVector);
+ *     return 0;
+ *   }
+ * \endcode
+ */
 static inline void volk_8ic_x2_multiply_conjugate_16ic_a_avx2(lv_16sc_t* cVector,
                                                               const lv_8sc_t* aVector,
                                                               const lv_8sc_t* bVector,
@@ -92,7 +148,7 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_a_avx2(lv_16sc_t* cVector
 #ifdef LV_HAVE_SSE4_1
 #include <smmintrin.h>
 /*!
-  \brief Multiplys the one complex vector with the complex conjugate of the second complex
+  \brief Multiplies the one complex vector with the complex conjugate of the second complex
   vector and stores their results in the third vector \param cVector The complex vector
   where the results will be stored \param aVector One of the complex vectors to be
   multiplied \param bVector The complex vector which will be converted to complex
@@ -161,7 +217,7 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_a_sse4_1(lv_16sc_t* cVect
 
 #ifdef LV_HAVE_GENERIC
 /*!
-  \brief Multiplys the one complex vector with the complex conjugate of the second complex
+  \brief Multiplies the one complex vector with the complex conjugate of the second complex
   vector and stores their results in the third vector \param cVector The complex vector
   where the results will be stored \param aVector One of the complex vectors to be
   multiplied \param bVector The complex vector which will be converted to complex
@@ -297,7 +353,7 @@ static inline void volk_8ic_x2_multiply_conjugate_16ic_neon(lv_16sc_t* cVector,
 #ifdef LV_HAVE_AVX2
 #include <immintrin.h>
 /*!
-  \brief Multiplys the one complex vector with the complex conjugate of the second complex
+  \brief Multiplies the one complex vector with the complex conjugate of the second complex
   vector and stores their results in the third vector \param cVector The complex vector
   where the results will be stored \param aVector One of the complex vectors to be
   multiplied \param bVector The complex vector which will be converted to complex

--- a/kernels/volk/volk_8ic_x2_s32f_multiply_conjugate_32fc.h
+++ b/kernels/volk/volk_8ic_x2_s32f_multiply_conjugate_32fc.h
@@ -12,8 +12,9 @@
  *
  * \b Overview
  *
- * Multiplys the one complex vector with the complex conjugate of the
- * second complex vector and stores their results in the third vector
+ * Multiplies each element of one complex 8-bit integer vector by the complex
+ * conjugate of the corresponding element in a second complex 8-bit integer
+ * vector, producing complex 32-bit float results scaled by 1/scalar.
  *
  * <b>Dispatcher Prototype</b>
  * \code
@@ -21,23 +22,54 @@
  * aVector, const lv_8sc_t* bVector, const float scalar, unsigned int num_points) \endcode
  *
  * \b Inputs
- * \li aVector: One of the complex vectors to be multiplied.
- * \li bVector: The complex vector which will be converted to complex conjugate and
- * multiplied. \li scalar: each output value is scaled by 1/scalar. \li num_points: The
- * number of complex values in aVector and bVector to be multiplied together and stored
- * into cVector.
+ * \li aVector: The first complex 8-bit input vector.
+ * \li bVector: The second complex 8-bit input vector whose conjugate is used.
+ * \li scalar: Each output value is scaled by 1/scalar.
+ * \li num_points: The number of complex values to process.
  *
  * \b Outputs
- * \li cVector: The complex vector where the results will be stored.
+ * \li cVector: The complex 32-bit float output vector.
  *
  * \b Example
+ * Multiply a complex signal by the conjugate of a reference and scale the result.
  * \code
- * int N = 10000;
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
  *
- * <FIXME>
+ *   int main(){
+ *     unsigned int N = 4;
+ *     unsigned int alignment = volk_get_alignment();
+ *     float scalar = 2.0f;
  *
- * volk_8ic_x2_s32f_multiply_conjugate_32fc();
+ *     // Allocate aligned memory
+ *     lv_8sc_t* aVector = (lv_8sc_t*)volk_malloc(sizeof(lv_8sc_t) * N, alignment);
+ *     lv_8sc_t* bVector = (lv_8sc_t*)volk_malloc(sizeof(lv_8sc_t) * N, alignment);
+ *     lv_32fc_t* cVector = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t) * N, alignment);
  *
+ *     // Initialize input: signal samples as complex 8-bit integers
+ *     aVector[0] = lv_cmake((int8_t)3, (int8_t)4);
+ *     aVector[1] = lv_cmake((int8_t)-2, (int8_t)5);
+ *     aVector[2] = lv_cmake((int8_t)7, (int8_t)-1);
+ *     aVector[3] = lv_cmake((int8_t)1, (int8_t)6);
+ *
+ *     // Initialize reference: complex 8-bit integers
+ *     bVector[0] = lv_cmake((int8_t)1, (int8_t)2);
+ *     bVector[1] = lv_cmake((int8_t)3, (int8_t)-1);
+ *     bVector[2] = lv_cmake((int8_t)2, (int8_t)4);
+ *     bVector[3] = lv_cmake((int8_t)-3, (int8_t)2);
+ *
+ *     // Compute: cVector[i] = aVector[i] * conj(bVector[i]) / scalar
+ *     volk_8ic_x2_s32f_multiply_conjugate_32fc(cVector, aVector, bVector, scalar, N);
+ *
+ *     for (unsigned int i = 0; i < N; i++) {
+ *       printf("result[%u] = (%f, %f)\n", i, lv_creal(cVector[i]), lv_cimag(cVector[i]));
+ *     }
+ *
+ *     volk_free(aVector);
+ *     volk_free(bVector);
+ *     volk_free(cVector);
+ *     return 0;
+ *   }
  * \endcode
  */
 

--- a/kernels/volk/volk_8u_x4_conv_k7_r2_8u.h
+++ b/kernels/volk/volk_8u_x4_conv_k7_r2_8u.h
@@ -12,33 +12,102 @@
  *
  * \b Overview
  *
- * Performs convolutional decoding for a K=7, rate 1/2 convolutional
- * code. The polynomials user defined.
+ * Performs convolutional decoding for a K=7, rate 1/2 convolutional code
+ * using the Viterbi algorithm (add-compare-select butterfly with
+ * renormalization). The code polynomials are user-defined via the Branchtab
+ * lookup table.
  *
  * <b>Dispatcher Prototype</b>
  * \code
- * void volk_8u_x4_conv_k7_r2_8u(unsigned char* Y, unsigned char* X, unsigned char* syms,
- * unsigned char* dec, unsigned int framebits, unsigned int excess, unsigned char*
+ * void volk_8u_x4_conv_k7_r2_8u(unsigned char* Y, unsigned char* X, unsigned char*
+ * syms, unsigned char* dec, unsigned int framebits, unsigned int excess, unsigned char*
  * Branchtab) \endcode
  *
  * \b Inputs
- * \li X: <FIXME>
- * \li syms: <FIXME>
- * \li dec: <FIXME>
- * \li framebits: size of the frame to decode in bits.
- * \li excess: <FIXME>
- * \li Branchtab: <FIXME>
+ * \li X: Current path metrics for all 64 trellis states. Initialize state 0 to 0 and
+ * all others to a large value (e.g. 63). Array of 64 unsigned chars, aligned.
+ * \li syms: Soft-decision input symbols. Two symbols per bit (rate 1/2), so the length
+ * is 2 * (framebits + excess). Values range from 0 to 255.
+ * \li dec: Decision buffer for storing trellis traceback decisions. Must be at least
+ * 8 * (framebits + excess) bytes and cleared to zero before calling. Aligned.
+ * \li framebits: Size of the frame to decode in bits.
+ * \li excess: Number of additional tail bits beyond the frame, typically K-1 = 6.
+ * \li Branchtab: Branch metric lookup table encoding the convolutional code polynomials.
+ * Array of 64 unsigned chars (RATE * NUMSTATES/2 = 2 * 32), aligned. Each entry is 0 or
+ * 255 representing the expected parity output for each half-state.
  *
  * \b Outputs
- * \li Y: The decoded output bits.
+ * \li Y: Alternate path metrics buffer used as workspace. After the call, final path
+ * metrics reside in Y or X depending on the parity of (framebits + excess). Array of 64
+ * unsigned chars, aligned.
  *
  * \b Example
+ * Set up and run the Viterbi ACS butterfly for a short frame using CCSDS-standard
+ * polynomials.
  * \code
- * int N = 10000;
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
+ *   #include <string.h>
  *
- * volk_8u_x4_conv_k7_r2_8u();
+ *   int main(){
+ *     unsigned int framebits = 16;
+ *     unsigned int excess = 6;       // Tail bits (K-1) to flush the encoder
+ *     unsigned int numstates = 64;   // 2^(K-1) for K=7
+ *     unsigned int total_bits = framebits + excess;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
+ *     // Path metric buffers: NUMSTATES bytes each
+ *     unsigned char* Y = (unsigned char*)volk_malloc(numstates, alignment);
+ *     unsigned char* X = (unsigned char*)volk_malloc(numstates, alignment);
+ *
+ *     // Soft-decision symbols: 2 per bit (rate 1/2)
+ *     unsigned char* syms = (unsigned char*)volk_malloc(2 * total_bits, alignment);
+ *
+ *     // Decision buffer: 8 bytes per trellis step
+ *     unsigned char* dec = (unsigned char*)volk_malloc(8 * total_bits, alignment);
+ *
+ *     // Branch metric table: RATE * NUMSTATES/2 = 64 bytes
+ *     unsigned char* Branchtab = (unsigned char*)volk_malloc(numstates, alignment);
+ *
+ *     // Initialize path metrics: state 0 starts at 0, all others at max cost
+ *     memset(X, 63, numstates);
+ *     X[0] = 0;
+ *     memset(Y, 0, numstates);
+ *
+ *     // Build branch table for CCSDS polynomials (171o = 0x79, 133o = 0x5B)
+ *     unsigned char polys[2] = {0x79, 0x5B};
+ *     unsigned int p, s;
+ *     for (p = 0; p < 2; p++) {
+ *       for (s = 0; s < numstates / 2; s++) {
+ *         unsigned int bits = s & (polys[p] >> 1);
+ *         unsigned char parity = 0;
+ *         while (bits) { parity ^= bits & 1; bits >>= 1; }
+ *         Branchtab[s + p * (numstates / 2)] = parity ? 255 : 0;
+ *       }
+ *     }
+ *
+ *     // Simulated received soft-decision symbols (noisy channel output)
+ *     unsigned int i;
+ *     for (i = 0; i < 2 * total_bits; i++) {
+ *       syms[i] = (i % 5 < 2) ? 200 : 55;
+ *     }
+ *
+ *     // Clear decision buffer
+ *     memset(dec, 0, 8 * total_bits);
+ *
+ *     // Run Viterbi ACS butterfly and renormalization for all trellis steps
+ *     volk_8u_x4_conv_k7_r2_8u(Y, X, syms, dec, framebits, excess, Branchtab);
+ *
+ *     // The dec buffer now contains traceback decisions for the decoded path
+ *     printf("Viterbi decoding complete for %u-bit frame.\n", framebits);
+ *
+ *     volk_free(Y);
+ *     volk_free(X);
+ *     volk_free(syms);
+ *     volk_free(dec);
+ *     volk_free(Branchtab);
+ *     return 0;
+ *   }
  * \endcode
  */
 


### PR DESCRIPTION
## Summary

- Write complete, working examples for 34 kernels that had broken/FIXME/missing example code
- Fix associated prose issues: wrong type descriptions, typos, missing markup, stray `\endcode` tags, `<FIXME>` placeholders in parameter descriptions
- All new examples follow the standard pattern: `volk_malloc`/`volk_free`, proper alignment, meaningful data initialization, correct function calls, and memory cleanup

All changes are strictly within `/*! ... */` Doxygen comment blocks — no implementation code changes.

### Kernels modified

| Kernel | Fix |
|--------|-----|
| `volk_16i_32fc_dot_prod_32fc` | Replace `<FIXME>` example |
| `volk_16i_convert_8i` | Rewrite broken example + fix "complex data points" description |
| `volk_16i_s32f_convert_32f` | Rewrite broken example + fix wrong type descriptions |
| `volk_16ic_deinterleave_16i_x2` | Rewrite broken example |
| `volk_16ic_deinterleave_real_16i` | Rewrite broken example |
| `volk_16ic_deinterleave_real_8i` | Rewrite broken example |
| `volk_16ic_magnitude_16i` | Rewrite broken example |
| `volk_16ic_s32f_deinterleave_real_32f` | Rewrite broken example |
| `volk_16ic_s32f_magnitude_32f` | Rewrite broken example |
| `volk_16ic_x2_dot_prod_16ic` | Write missing example |
| `volk_16ic_x2_multiply_16ic` | Write missing example |
| `volk_16u_byteswap` | Replace `<FIXME>` example |
| `volk_32f_null_32f` | Write entire doc block from scratch |
| `volk_32f_s32f_32f_fm_detect_32f` | Replace `<FIXME>` example |
| `volk_32f_s32f_calc_spectral_noise_floor_32f` | Rewrite broken example |
| `volk_32f_s32f_s32f_mod_range_32f` | Write missing example + fix markup |
| `volk_32f_x2_dot_prod_16i` | Replace `<FIXME>` example + fix typo |
| `volk_32fc_32f_multiply_32fc` | Rewrite broken example + fix output param name |
| `volk_32fc_convert_16ic` | Write missing example |
| `volk_32fc_s32f_power_32fc` | Rewrite broken example + fix wrong descriptions |
| `volk_32fc_s32f_power_spectrum_32f` | Rewrite broken example |
| `volk_32fc_s32f_x2_power_spectral_density_32f` | Rewrite broken example |
| `volk_32fc_x2_dot_prod_32fc` | Replace `<FIXME>` example |
| `volk_32u_reverse_32u` | Write missing example + fix prototype markup |
| `volk_8i_convert_16i` | Rewrite broken example |
| `volk_8i_s32f_convert_32f` | Rewrite broken example + fix wrong descriptions |
| `volk_8ic_deinterleave_16i_x2` | Rewrite broken example |
| `volk_8ic_deinterleave_real_16i` | Rewrite broken example |
| `volk_8ic_deinterleave_real_8i` | Rewrite broken example |
| `volk_8ic_s32f_deinterleave_32f_x2` | Rewrite broken example |
| `volk_8ic_s32f_deinterleave_real_32f` | Rewrite broken example |
| `volk_8ic_x2_multiply_conjugate_16ic` | Write missing example + fix "Multiplys" typo |
| `volk_8ic_x2_s32f_multiply_conjugate_32fc` | Replace `<FIXME>` example + fix "Multiplys" typo |
| `volk_8u_x4_conv_k7_r2_8u` | Rewrite broken example + fix `<FIXME>` params |

## Test plan

- [ ] Verify Doxygen builds without warnings for modified files
- [ ] Spot-check that new examples use correct function signatures and types
- [ ] Confirm no implementation code was modified (doc blocks only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)