### PR TITLE
docs: write complete docs for deprecated kernels

### DIFF
--- a/kernels/volk/volk_16i_branch_4_state_8.h
+++ b/kernels/volk/volk_16i_branch_4_state_8.h
@@ -12,11 +12,15 @@
  *
  * \b Deprecation
  *
- * This kernel is deprecated.
+ * This kernel is deprecated. No replacement has been identified.
  *
  * \b Overview
  *
- * <FIXME>
+ * Computes branch metrics for a Viterbi decoder with 4 branch types and 8 trellis
+ * states. For each of the 4 groups, the source state metrics are permuted according to
+ * the trellis connectivity, group-specific scalar offsets are added (the 4 combinations
+ * of scalars[0] and scalars[1]), and masked control values from two control arrays are
+ * accumulated into the result.
  *
  * <b>Dispatcher Prototype</b>
  * \code
@@ -24,23 +28,85 @@
  * cntl2, short* cntl3, short* scalars) \endcode
  *
  * \b Inputs
- * \li src0: <FIXME>
- * \li permuters: <FIXME>
- * \li cntl2: <FIXME>
- * \li cntl3: <FIXME>
- * \li scalars: <FIXME>
+ * \li src0: The 8 source state metrics as 16-bit shorts (8 values, aligned).
+ * \li permuters: Array of 4 char pointers, each pointing to a 16-byte aligned permutation
+ * table that maps source state metrics to output positions via byte-level shuffling.
+ * \li cntl2: Control array of 32 shorts (4 groups x 8 states). Each value is bitwise-ANDed
+ * with scalars[2] before being added to the output.
+ * \li cntl3: Control array of 32 shorts (4 groups x 8 states). Each value is bitwise-ANDed
+ * with scalars[3] before being added to the output.
+ * \li scalars: Array of at least 4 shorts. scalars[0] and scalars[1] are group-specific
+ * branch offsets; scalars[2] and scalars[3] are masks applied to cntl2 and cntl3.
  *
  * \b Outputs
- * \li target: <FIXME>
+ * \li target: The 32 computed branch metrics as 16-bit shorts (4 groups x 8 states,
+ * aligned).
  *
  * \b Example
  * \code
- * int N = 10000;
+ * #include <volk/volk.h>
+ * #include <stdio.h>
+ * #include <string.h>
  *
- * volk_16i_branch_4_state_8();
+ * int main() {
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
- * volk_free(t);
+ *     short* src0 = (short*)volk_malloc(8 * sizeof(short), alignment);
+ *     short* target = (short*)volk_malloc(32 * sizeof(short), alignment);
+ *     char* perm0 = (char*)volk_malloc(16, alignment);
+ *     char* perm1 = (char*)volk_malloc(16, alignment);
+ *     char* perm2 = (char*)volk_malloc(16, alignment);
+ *     char* perm3 = (char*)volk_malloc(16, alignment);
+ *     char* permuters[4] = {perm0, perm1, perm2, perm3};
+ *     short* cntl2 = (short*)volk_malloc(32 * sizeof(short), alignment);
+ *     short* cntl3 = (short*)volk_malloc(32 * sizeof(short), alignment);
+ *     short* scalars = (short*)volk_malloc(8 * sizeof(short), alignment);
+ *
+ *     // Initialize 8 source state metrics
+ *     for (unsigned int i = 0; i < 8; i++) {
+ *         src0[i] = (short)(100 * (i + 1));
+ *     }
+ *
+ *     // Identity permutation: each output maps to the same-index source
+ *     for (unsigned int p = 0; p < 4; p++) {
+ *         for (unsigned int i = 0; i < 16; i++) {
+ *             permuters[p][i] = (char)i;
+ *         }
+ *     }
+ *
+ *     // Branch offsets and control masks
+ *     scalars[0] = 10;  // added to groups 0 and 2
+ *     scalars[1] = 20;  // added to groups 0 and 1
+ *     scalars[2] = 0;   // mask for cntl2 (disabled)
+ *     scalars[3] = 0;   // mask for cntl3 (disabled)
+ *     for (unsigned int i = 4; i < 8; i++) {
+ *         scalars[i] = 0;
+ *     }
+ *
+ *     memset(cntl2, 0, 32 * sizeof(short));
+ *     memset(cntl3, 0, 32 * sizeof(short));
+ *
+ *     volk_16i_branch_4_state_8(target, src0, permuters, cntl2, cntl3, scalars);
+ *
+ *     // Group 0: src0[j]+30, Group 1: src0[j]+20, Group 2: src0[j]+10, Group 3: src0[j]
+ *     for (unsigned int g = 0; g < 4; g++) {
+ *         printf("Group %u:", g);
+ *         for (unsigned int j = 0; j < 8; j++) {
+ *             printf(" %d", target[g * 8 + j]);
+ *         }
+ *         printf("\n");
+ *     }
+ *
+ *     volk_free(target);
+ *     volk_free(src0);
+ *     volk_free(perm0);
+ *     volk_free(perm1);
+ *     volk_free(perm2);
+ *     volk_free(perm3);
+ *     volk_free(cntl2);
+ *     volk_free(cntl3);
+ *     volk_free(scalars);
+ * }
  * \endcode
  */
 

--- a/kernels/volk/volk_16i_max_star_16i.h
+++ b/kernels/volk/volk_16i_max_star_16i.h
@@ -12,11 +12,14 @@
  *
  * \b Deprecation
  *
- * This kernel is deprecated.
+ * This kernel is deprecated. No replacement has been identified.
  *
  * \b Overview
  *
- * <FIXME>
+ * Computes the max* (max-star) operation over a vector of 16-bit signed integers,
+ * returning the maximum value. In log-MAP decoding the max* operation selects the
+ * dominant path metric; this implementation performs the max selection without the
+ * log-domain correction term.
  *
  * <b>Dispatcher Prototype</b>
  * \code
@@ -24,20 +27,39 @@
  * \endcode
  *
  * \b Inputs
- * \li src0: The input vector.
- * \li num_points: The number of complex data points.
+ * \li src0: The input vector of 16-bit signed integers (short).
+ * \li num_points: The number of data points in the input vector.
  *
  * \b Outputs
- * \li target: The output value of the max* operation.
+ * \li target: The maximum value found in the input vector (single short value).
  *
  * \b Example
  * \code
- * int N = 10000;
+ *   #include <volk/volk.h>
+ *   #include <stdio.h>
  *
- * volk_16i_max_star_16i();
+ *   int main() {
+ *     unsigned int N = 10;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
- * volk_free(t);
+ *     short* src0 = (short*)volk_malloc(sizeof(short) * N, alignment);
+ *     short* target = (short*)volk_malloc(sizeof(short), alignment);
+ *
+ *     // Initialize with sample path metrics
+ *     for (unsigned int i = 0; i < N; ++i) {
+ *       src0[i] = (short)(100 - (int)(i * 20));
+ *     }
+ *     // src0 = {100, 80, 60, 40, 20, 0, -20, -40, -60, -80}
+ *
+ *     volk_16i_max_star_16i(target, src0, N);
+ *
+ *     printf("max* = %d\n", target[0]);
+ *     // Expected output: max* = 100
+ *
+ *     volk_free(src0);
+ *     volk_free(target);
+ *     return 0;
+ *   }
  * \endcode
  */
 

--- a/kernels/volk/volk_16i_max_star_horizontal_16i.h
+++ b/kernels/volk/volk_16i_max_star_horizontal_16i.h
@@ -13,11 +13,14 @@
  *
  * \b Deprecation
  *
- * This kernel is deprecated.
+ * This kernel is deprecated, no replacement has been identified.
  *
  * \b Overview
  *
- * <FIXME>
+ * Computes the maximum of each consecutive pair of 16-bit integers in the input
+ * vector. For every two adjacent elements (src0[2k], src0[2k+1]), the larger value is
+ * written to the output, producing num_points/2 results. This is a simplified max*
+ * (max-star) operation used in log-MAP decoding for communications applications.
  *
  * <b>Dispatcher Prototype</b>
  * \code
@@ -25,20 +28,48 @@
  * num_points); \endcode
  *
  * \b Inputs
- * \li src0: The input vector.
- * \li num_points: The number of complex data points.
+ * \li src0: The input vector of 16-bit integers. Must contain num_points elements, where
+ * num_points is even.
+ * \li num_points: The number of 16-bit integer data points in the input vector (must be
+ * even).
  *
  * \b Outputs
- * \li target: The output value of the max* operation.
+ * \li target: The output vector containing num_points/2 maximum values, one per
+ * consecutive input pair.
  *
  * \b Example
  * \code
- * int N = 10000;
+ * #include <volk/volk.h>
+ * #include <stdio.h>
  *
- * volk_16i_max_star_horizontal_16i();
+ * int main() {
+ *     unsigned int num_points = 8;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
- * volk_free(t);
+ *     short* src0 = (short*)volk_malloc(sizeof(short) * num_points, alignment);
+ *     short* target = (short*)volk_malloc(sizeof(short) * (num_points / 2), alignment);
+ *
+ *     // Initialize with pairs of values
+ *     src0[0] = 10;  src0[1] = 5;
+ *     src0[2] = -3;  src0[3] = 7;
+ *     src0[4] = 15;  src0[5] = 15;
+ *     src0[6] = -8;  src0[7] = -2;
+ *
+ *     volk_16i_max_star_horizontal_16i(target, src0, num_points);
+ *
+ *     // Expected: max of each pair
+ *     // target[0] = max(10, 5)   = 10
+ *     // target[1] = max(-3, 7)   = 7
+ *     // target[2] = max(15, 15)  = 15
+ *     // target[3] = max(-8, -2)  = -2
+ *     for (unsigned int i = 0; i < num_points / 2; i++) {
+ *         printf("target[%u] = %d\n", i, target[i]);
+ *     }
+ *
+ *     volk_free(src0);
+ *     volk_free(target);
+ *     return 0;
+ * }
  * \endcode
  */
 

--- a/kernels/volk/volk_16i_permute_and_scalar_add.h
+++ b/kernels/volk/volk_16i_permute_and_scalar_add.h
@@ -12,38 +12,93 @@
  *
  * \b Deprecation
  *
- * This kernel is deprecated.
+ * This kernel is deprecated, no replacement has been identified.
  *
  * \b Overview
  *
- * <FIXME>
+ * Gathers elements from a source vector using an index array, then adds
+ * scalar-masked contributions from four control vectors. For each element i,
+ * computes: target[i] = src0[permute_indexes[i]] + (cntl0[i] & scalars[0]) +
+ * (cntl1[i] & scalars[1]) + (cntl2[i] & scalars[2]) + (cntl3[i] & scalars[3]).
+ * The control vectors act as bitwise masks that selectively pass or block each scalar
+ * value on a per-element basis.
  *
  * <b>Dispatcher Prototype</b>
  * \code
- * void volk_16i_permute_and_scalar_add(short* target,  short* src0, short*
+ * void volk_16i_permute_and_scalar_add(short* target, short* src0, short*
  * permute_indexes, short* cntl0, short* cntl1, short* cntl2, short* cntl3, short*
- * scalars, unsigned int num_points) \endcode
+ * scalars, unsigned int num_points)
+ * \endcode
  *
  * \b Inputs
- * \li src0: The input vector.
- * \li permute_indexes: <FIXME>
- * \li cntl0: <FIXME>
- * \li cntl1: <FIXME>
- * \li cntl2: <FIXME>
- * \li cntl3: <FIXME>
- * \li scalars: <FIXME>
- * \li num_points: The number of complex data points.
+ * \li src0: The source vector of short values to gather from.
+ * \li permute_indexes: Vector of short indices used to look up elements in src0.
+ * \li cntl0: First control mask vector of short values (num_points elements).
+ * \li cntl1: Second control mask vector of short values (num_points elements).
+ * \li cntl2: Third control mask vector of short values (num_points elements).
+ * \li cntl3: Fourth control mask vector of short values (num_points elements).
+ * \li scalars: Array of 4 short values, each bitwise ANDed with the corresponding
+ * control vector.
+ * \li num_points: The number of short values to process.
  *
  * \b Outputs
- * \li target: The output value.
+ * \li target: The output vector of short values (num_points elements).
  *
  * \b Example
  * \code
- * int N = 10000;
+ * #include <volk/volk.h>
+ * #include <stdio.h>
  *
- * volk_16i_permute_and_scalar_add();
+ * int N = 8;
+ * unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
+ * short* src0 = (short*)volk_malloc(sizeof(short) * N, alignment);
+ * short* permute_indexes = (short*)volk_malloc(sizeof(short) * N, alignment);
+ * short* cntl0 = (short*)volk_malloc(sizeof(short) * N, alignment);
+ * short* cntl1 = (short*)volk_malloc(sizeof(short) * N, alignment);
+ * short* cntl2 = (short*)volk_malloc(sizeof(short) * N, alignment);
+ * short* cntl3 = (short*)volk_malloc(sizeof(short) * N, alignment);
+ * short* scalars = (short*)volk_malloc(sizeof(short) * 4, alignment);
+ * short* target = (short*)volk_malloc(sizeof(short) * N, alignment);
+ *
+ * for (unsigned int ii = 0; ii < N; ++ii) {
+ *     src0[ii] = (short)(ii * 10);
+ * }
+ *
+ * // Reverse permutation: read src0 in reverse order
+ * for (unsigned int ii = 0; ii < N; ++ii) {
+ *     permute_indexes[ii] = (short)(N - 1 - ii);
+ * }
+ *
+ * // Control masks: -1 (all bits set) passes the scalar through, 0 blocks it
+ * for (unsigned int ii = 0; ii < N; ++ii) {
+ *     cntl0[ii] = -1;
+ *     cntl1[ii] = 0;
+ *     cntl2[ii] = 0;
+ *     cntl3[ii] = 0;
+ * }
+ *
+ * scalars[0] = 1;
+ * scalars[1] = 2;
+ * scalars[2] = 3;
+ * scalars[3] = 4;
+ *
+ * // target[i] = src0[7-i] + (-1 & 1) + 0 + 0 + 0 = src0[7-i] + 1
+ * volk_16i_permute_and_scalar_add(target, src0, permute_indexes, cntl0, cntl1, cntl2,
+ *                                 cntl3, scalars, N);
+ *
+ * for (unsigned int ii = 0; ii < N; ++ii) {
+ *     printf("target[%u] = %d\n", ii, target[ii]);
+ * }
+ *
+ * volk_free(src0);
+ * volk_free(permute_indexes);
+ * volk_free(cntl0);
+ * volk_free(cntl1);
+ * volk_free(cntl2);
+ * volk_free(cntl3);
+ * volk_free(scalars);
+ * volk_free(target);
  * \endcode
  */
 

--- a/kernels/volk/volk_16i_x4_quad_max_star_16i.h
+++ b/kernels/volk/volk_16i_x4_quad_max_star_16i.h
@@ -12,34 +12,69 @@
  *
  * \b Deprecation
  *
- * This kernel is deprecated.
+ * This kernel is deprecated, no replacement has been identified.
  *
  * \b Overview
  *
- * <FIXME>
+ * Computes the element-wise maximum across four 16-bit integer input vectors using a
+ * tournament-style comparison. For each element index, the kernel first selects the
+ * larger value from each pair (src0 vs src1, and src2 vs src3), then selects the larger
+ * of those two results. This implements the max-log-MAP approximation of the max-star
+ * operation used in turbo and Viterbi decoding.
  *
  * <b>Dispatcher Prototype</b>
  * \code
  * void volk_16i_x4_quad_max_star_16i(short* target, short* src0, short* src1, short*
- * src2, short* src3, unsigned int num_points) \endcode
+ * src2, short* src3, unsigned int num_points)
+ * \endcode
  *
  * \b Inputs
- * \li src0: The input vector 0.
- * \li src1: The input vector 1.
- * \li src2: The input vector 2.
- * \li src3: The input vector 3.
- * \li num_points: The number of data points.
+ * \li src0: First input vector of 16-bit integers (short).
+ * \li src1: Second input vector of 16-bit integers (short).
+ * \li src2: Third input vector of 16-bit integers (short).
+ * \li src3: Fourth input vector of 16-bit integers (short).
+ * \li num_points: The number of elements in each input/output vector.
  *
  * \b Outputs
- * \li target: The output value.
+ * \li target: Output vector of 16-bit integers (short) containing
+ * max(max(src0[i], src1[i]), max(src2[i], src3[i])) for each element.
  *
  * \b Example
  * \code
- * int N = 10000;
+ * #include <volk/volk.h>
+ * #include <stdio.h>
  *
- * volk_16i_x4_quad_max_star_16i();
+ * int main() {
+ *     unsigned int N = 16;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
+ *     short* src0 = (short*)volk_malloc(N * sizeof(short), alignment);
+ *     short* src1 = (short*)volk_malloc(N * sizeof(short), alignment);
+ *     short* src2 = (short*)volk_malloc(N * sizeof(short), alignment);
+ *     short* src3 = (short*)volk_malloc(N * sizeof(short), alignment);
+ *     short* target = (short*)volk_malloc(N * sizeof(short), alignment);
+ *
+ *     // Initialize with sample trellis metric values
+ *     for (unsigned int i = 0; i < N; i++) {
+ *         src0[i] = (short)(100 - 10 * (int)i);
+ *         src1[i] = (short)(5 * (int)i - 30);
+ *         src2[i] = (short)(50 + 3 * (int)i);
+ *         src3[i] = (short)(80 - 7 * (int)i);
+ *     }
+ *
+ *     volk_16i_x4_quad_max_star_16i(target, src0, src1, src2, src3, N);
+ *
+ *     for (unsigned int i = 0; i < N; i++) {
+ *         printf("target[%u] = %d\n", i, target[i]);
+ *     }
+ *
+ *     volk_free(src0);
+ *     volk_free(src1);
+ *     volk_free(src2);
+ *     volk_free(src3);
+ *     volk_free(target);
+ *     return 0;
+ * }
  * \endcode
  */
 

--- a/kernels/volk/volk_16i_x5_add_quad_16i_x4.h
+++ b/kernels/volk/volk_16i_x5_add_quad_16i_x4.h
@@ -12,39 +12,82 @@
  *
  * \b Deprecation
  *
- * This kernel is deprecated.
+ * This kernel is deprecated, no replacement has been identified.
  *
  * \b Overview
  *
- * <FIXME>
+ * Adds a common 16-bit integer base vector (src0) to each of four other 16-bit integer
+ * vectors (src1, src2, src3, src4), producing four output vectors. Computes target0 =
+ * src0 + src1, target1 = src0 + src2, target2 = src0 + src3, and target3 = src0 + src4
+ * element-wise.
  *
  * <b>Dispatcher Prototype</b>
  * \code
- * void volk_16i_x5_add_quad_16i_x4(short* target0, short* target1, short* target2, short*
- * target3, short* src0, short* src1, short* src2, short* src3, short* src4, unsigned int
- * num_points); \endcode
+ * void volk_16i_x5_add_quad_16i_x4(short* target0, short* target1, short* target2,
+ * short* target3, short* src0, short* src1, short* src2, short* src3, short* src4,
+ * unsigned int num_points)
+ * \endcode
  *
  * \b Inputs
- * \li src0: The input vector 0.
- * \li src1: The input vector 1.
- * \li src2: The input vector 2.
- * \li src3: The input vector 3.
- * \li src4: The input vector 4.
- * \li num_points: The number of data points.
+ * \li src0: Common base vector of 16-bit integers added to each of the other inputs.
+ * \li src1: Input vector of 16-bit integers added to src0 to produce target0.
+ * \li src2: Input vector of 16-bit integers added to src0 to produce target1.
+ * \li src3: Input vector of 16-bit integers added to src0 to produce target2.
+ * \li src4: Input vector of 16-bit integers added to src0 to produce target3.
+ * \li num_points: The number of elements in each vector.
  *
  * \b Outputs
- * \li target0: The output value 0.
- * \li target1: The output value 1.
- * \li target2: The output value 2.
- * \li target3: The output value 3.
+ * \li target0: Output vector of 16-bit integers: src0 + src1.
+ * \li target1: Output vector of 16-bit integers: src0 + src2.
+ * \li target2: Output vector of 16-bit integers: src0 + src3.
+ * \li target3: Output vector of 16-bit integers: src0 + src4.
  *
  * \b Example
  * \code
- * int N = 10000;
+ * #include <volk/volk.h>
+ * #include <stdio.h>
  *
- * volk_16i_x5_add_quad_16i_x4();
+ * int main() {
+ *     unsigned int N = 10;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * volk_free(x);
+ *     short* src0 = (short*)volk_malloc(sizeof(short) * N, alignment);
+ *     short* src1 = (short*)volk_malloc(sizeof(short) * N, alignment);
+ *     short* src2 = (short*)volk_malloc(sizeof(short) * N, alignment);
+ *     short* src3 = (short*)volk_malloc(sizeof(short) * N, alignment);
+ *     short* src4 = (short*)volk_malloc(sizeof(short) * N, alignment);
+ *     short* target0 = (short*)volk_malloc(sizeof(short) * N, alignment);
+ *     short* target1 = (short*)volk_malloc(sizeof(short) * N, alignment);
+ *     short* target2 = (short*)volk_malloc(sizeof(short) * N, alignment);
+ *     short* target3 = (short*)volk_malloc(sizeof(short) * N, alignment);
+ *
+ *     for (unsigned int i = 0; i < N; i++) {
+ *         src0[i] = (short)i;       // common base: 0, 1, 2, ...
+ *         src1[i] = (short)(i * 2); // 0, 2, 4, ...
+ *         src2[i] = (short)(i * 3); // 0, 3, 6, ...
+ *         src3[i] = (short)(i * 4); // 0, 4, 8, ...
+ *         src4[i] = (short)(i * 5); // 0, 5, 10, ...
+ *     }
+ *
+ *     volk_16i_x5_add_quad_16i_x4(
+ *         target0, target1, target2, target3,
+ *         src0, src1, src2, src3, src4, N);
+ *
+ *     for (unsigned int i = 0; i < N; i++) {
+ *         printf("i=%u: t0=%d t1=%d t2=%d t3=%d\n",
+ *                i, target0[i], target1[i], target2[i], target3[i]);
+ *     }
+ *
+ *     volk_free(src0);
+ *     volk_free(src1);
+ *     volk_free(src2);
+ *     volk_free(src3);
+ *     volk_free(src4);
+ *     volk_free(target0);
+ *     volk_free(target1);
+ *     volk_free(target2);
+ *     volk_free(target3);
+ * }
  * \endcode
  */
 

--- a/kernels/volk/volk_32fc_s32fc_multiply_32fc.h
+++ b/kernels/volk/volk_32fc_s32fc_multiply_32fc.h
@@ -12,57 +12,69 @@
  *
  * \b Deprecation
  *
- * This kernel is deprecated, because passing in `lv_32fc_t` by value results in
- * Undefined Behaviour, causing a segmentation fault on some architectures.
- * Use `volk_32fc_s32fc_multiply2_32fc` instead.
+ * This kernel is deprecated, because passing in \p lv_32fc_t by value results in
+ * undefined behavior, causing a segmentation fault on some architectures.
+ * Use \ref volk_32fc_s32fc_multiply2_32fc instead.
  *
  * \b Overview
  *
- * Multiplies the input complex vector by a complex scalar and returns
- * the results.
+ * Multiplies each element of a complex floating-point vector by a complex scalar.
+ * For each element, computes cVector[i] = aVector[i] * scalar using standard complex
+ * multiplication.
  *
  * <b>Dispatcher Prototype</b>
  * \code
- * void volk_32fc_s32fc_multiply_32fc(lv_32fc_t* cVector, const lv_32fc_t* aVector, const
- * lv_32fc_t scalar, unsigned int num_points); \endcode
+ * void volk_32fc_s32fc_multiply_32fc(lv_32fc_t* cVector, const lv_32fc_t* aVector,
+ * const lv_32fc_t scalar, unsigned int num_points)
+ * \endcode
  *
  * \b Inputs
- * \li aVector: The input vector to be multiplied.
- * \li scalar The complex scalar to multiply against aVector.
- * \li num_points: The number of complex values in aVector.
+ * \li aVector: Complex input vector of length \p num_points (lv_32fc_t).
+ * \li scalar: The complex scalar multiplier (lv_32fc_t, passed by value).
+ * \li num_points: The number of complex elements in \p aVector.
  *
  * \b Outputs
- * \li cVector: The vector where the results will be stored.
+ * \li cVector: Complex output vector of length \p num_points (lv_32fc_t).
  *
  * \b Example
- * Generate points around the unit circle and shift the phase pi/3 rad.
+ * Generate points around the unit circle and shift the phase by pi/3 radians.
  * \code
- *   int N = 10;
- *   unsigned int alignment = volk_get_alignment();
- *   lv_32fc_t* in  = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t)*N, alignment);
- *   lv_32fc_t* out = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t)*N, alignment);
- *   lv_32fc_t scalar = lv_cmake((float)std::cos(M_PI/3.f), (float)std::sin(M_PI/3.f));
+ * #include <volk/volk.h>
+ * #include <stdio.h>
+ * #include <math.h>
+ * #include <complex>
  *
- *   float delta = 2.f*M_PI / (float)N;
- *   for(unsigned int ii = 0; ii < N/2; ++ii){
- *       // Generate points around the unit circle
- *       float real = std::cos(delta * (float)ii);
- *       float imag = std::sin(delta * (float)ii);
- *       in[ii] = lv_cmake(real, imag);
- *       in[ii+N/2] = lv_cmake(-real, -imag);
- *   }
+ * int main() {
+ *     unsigned int N = 10;
+ *     unsigned int alignment = volk_get_alignment();
+ *     lv_32fc_t* in  = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t) * N, alignment);
+ *     lv_32fc_t* out = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t) * N, alignment);
  *
- *   volk_32fc_s32fc_multiply_32fc(out, in, scalar, N);
+ *     // Scalar rotates phase by pi/3
+ *     lv_32fc_t scalar = lv_cmake((float)cos(M_PI / 3.0), (float)sin(M_PI / 3.0));
  *
- *   printf(" mag   phase  |   mag   phase\n");
- *   for(unsigned int ii = 0; ii < N; ++ii){
- *       printf("%+1.2f  %+1.2f  |  %+1.2f   %+1.2f\n",
- *           std::abs(in[ii]), std::arg(in[ii]),
- *           std::abs(out[ii]), std::arg(out[ii]));
- *   }
+ *     // Generate points around the unit circle
+ *     float delta = 2.0f * (float)M_PI / (float)N;
+ *     for (unsigned int i = 0; i < N / 2; ++i) {
+ *         float real = cosf(delta * (float)i);
+ *         float imag = sinf(delta * (float)i);
+ *         in[i]         = lv_cmake(real, imag);
+ *         in[i + N / 2] = lv_cmake(-real, -imag);
+ *     }
  *
- *   volk_free(in);
- *   volk_free(out);
+ *     volk_32fc_s32fc_multiply_32fc(out, in, scalar, N);
+ *
+ *     printf("  in mag   in phase  |  out mag  out phase\n");
+ *     for (unsigned int i = 0; i < N; ++i) {
+ *         printf("  %+1.2f    %+1.2f    |   %+1.2f    %+1.2f\n",
+ *                std::abs(in[i]),  std::arg(in[i]),
+ *                std::abs(out[i]), std::arg(out[i]));
+ *     }
+ *
+ *     volk_free(in);
+ *     volk_free(out);
+ *     return 0;
+ * }
  * \endcode
  */
 

--- a/kernels/volk/volk_32fc_s32fc_x2_rotator_32fc.h
+++ b/kernels/volk/volk_32fc_s32fc_x2_rotator_32fc.h
@@ -12,62 +12,73 @@
  *
  * \b Deprecation
  *
- * This kernel is deprecated, because passing in `lv_32fc_t` by value results in
- * Undefined Behaviour, causing a segmentation fault on some architectures.
- * Use `volk_32fc_s32fc_x2_rotator2_32fc` instead.
+ * This kernel is deprecated, because passing in \p lv_32fc_t by value results in
+ * undefined behavior, causing a segmentation fault on some architectures.
+ * Use \ref volk_32fc_s32fc_x2_rotator2_32fc instead.
  *
  * \b Overview
  *
- * Rotate input vector at fixed rate per sample from initial phase
- * offset.
+ * Applies a complex phase rotation to each element of a complex floating-point input
+ * vector. The rotation advances by a fixed phase increment per sample, starting from
+ * a caller-supplied initial phase. On return, the phase accumulator is updated to
+ * reflect the final phase, allowing back-to-back calls for continuous rotation across
+ * blocks.
  *
  * <b>Dispatcher Prototype</b>
  * \code
  * void volk_32fc_s32fc_x2_rotator_32fc(lv_32fc_t* outVector, const lv_32fc_t* inVector,
- * const lv_32fc_t phase_inc, lv_32fc_t* phase, unsigned int num_points) \endcode
+ * const lv_32fc_t phase_inc, lv_32fc_t* phase, unsigned int num_points)
+ * \endcode
  *
  * \b Inputs
- * \li inVector: Vector to be rotated.
- * \li phase_inc: rotational velocity.
- * \li phase: initial phase offset.
- * \li num_points: The number of values in inVector to be rotated and stored into
- * outVector.
+ * \li inVector: Complex input vector of length \p num_points (lv_32fc_t).
+ * \li phase_inc: Per-sample phase increment as a unit-magnitude complex number
+ *     (lv_32fc_t, passed by value).
+ * \li phase: Pointer to the complex phase accumulator; provides the initial phase and
+ *     is updated on return (lv_32fc_t*).
+ * \li num_points: The number of complex elements to process.
  *
  * \b Outputs
- * \li outVector: The vector where the results will be stored.
+ * \li outVector: Complex output vector of length \p num_points (lv_32fc_t).
+ * \li phase: Updated to the phase value after the last sample.
  *
  * \b Example
- * Generate a tone at f=0.3 (normalized frequency) and use the rotator with
- * f=0.1 to shift the tone to f=0.4. Change this example to start with a DC
- * tone (initialize in with lv_cmake(1, 0)) to observe rotator signal generation.
+ * Generate a tone at normalized frequency f = 0.3 and use the rotator with
+ * f = 0.1 to shift the tone to f = 0.4.
  * \code
- *   int N = 10;
- *   unsigned int alignment = volk_get_alignment();
- *   lv_32fc_t* in  = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t)*N, alignment);
- *   lv_32fc_t* out = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t)*N, alignment);
+ * #include <volk/volk.h>
+ * #include <math.h>
+ * #include <stdio.h>
  *
- *   for(unsigned int ii = 0; ii < N; ++ii){
- *       // Generate a tone at f=0.3
- *       float real = std::cos(0.3f * (float)ii);
- *       float imag = std::sin(0.3f * (float)ii);
- *       in[ii] = lv_cmake(real, imag);
- *   }
- *   // The oscillator rotates at f=0.1
- *   float frequency = 0.1f;
- *   lv_32fc_t phase_increment = lv_cmake(std::cos(frequency), std::sin(frequency));
- *   lv_32fc_t phase= lv_cmake(1.f, 0.0f); // start at 1 (0 rad phase)
+ * int main() {
+ *     unsigned int N = 10;
+ *     unsigned int alignment = volk_get_alignment();
+ *     lv_32fc_t* in  = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t) * N, alignment);
+ *     lv_32fc_t* out = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t) * N, alignment);
  *
- *   // rotate so the output is a tone at f=0.4
- *   volk_32fc_s32fc_x2_rotator_32fc(out, in, phase_increment, &phase, N);
+ *     // Generate a tone at f = 0.3
+ *     for (unsigned int i = 0; i < N; ++i) {
+ *         float angle = 0.3f * (float)i;
+ *         in[i] = lv_cmake(cosf(angle), sinf(angle));
+ *     }
  *
- *   // print results for inspection
- *   for(unsigned int ii = 0; ii < N; ++ii){
- *       printf("out[%u] = %+1.2f %+1.2fj\n",
- *           ii, lv_creal(out[ii]), lv_cimag(out[ii]));
- *   }
+ *     // Phase increment corresponding to f = 0.1
+ *     float freq = 0.1f;
+ *     lv_32fc_t phase_inc = lv_cmake(cosf(freq), sinf(freq));
+ *     lv_32fc_t phase     = lv_cmake(1.0f, 0.0f); // start at 0 rad
  *
- *   volk_free(in);
- *   volk_free(out);
+ *     // Rotate so the output is a tone at f = 0.4
+ *     volk_32fc_s32fc_x2_rotator_32fc(out, in, phase_inc, &phase, N);
+ *
+ *     for (unsigned int i = 0; i < N; ++i) {
+ *         printf("out[%u] = %+1.4f %+1.4fj\n",
+ *                i, lv_creal(out[i]), lv_cimag(out[i]));
+ *     }
+ *
+ *     volk_free(in);
+ *     volk_free(out);
+ *     return 0;
+ * }
  * \endcode
  */
 

--- a/kernels/volk/volk_32fc_x2_s32fc_multiply_conjugate_add_32fc.h
+++ b/kernels/volk/volk_32fc_x2_s32fc_multiply_conjugate_add_32fc.h
@@ -12,67 +12,77 @@
  *
  * \b Deprecation
  *
- * This kernel is deprecated, because passing in `lv_32fc_t` by value results in
- * Undefined Behaviour, causing a segmentation fault on some architectures.
- * Use `volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc` instead.
+ * This kernel is deprecated, because passing in \p lv_32fc_t by value results in
+ * undefined behavior, causing a segmentation fault on some architectures.
+ * Use \ref volk_32fc_x2_s32fc_multiply_conjugate_add2_32fc instead.
  *
  * \b Overview
  *
- * Conjugate the input complex vector, multiply them by a complex scalar,
- * add the another input complex vector and returns the results.
+ * Computes the conjugate of each element in a complex input vector, multiplies
+ * by a complex scalar, and adds the result to a second complex input vector.
+ * For each element the operation is:
  *
- * c[i] = a[i] + conj(b[i]) * scalar
+ * \f[
+ * c[i] = a[i] + \operatorname{conj}(b[i]) \times \text{scalar}
+ * \f]
+ *
+ * This pattern appears in adaptive filtering algorithms such as LMS (Least Mean
+ * Squares), where filter weights are updated using the conjugate of the input
+ * signal.
  *
  * <b>Dispatcher Prototype</b>
  * \code
- * void volk_32fc_x2_s32fc_multiply_conjugate_add_32fc(lv_32fc_t* cVector, const
- * lv_32fc_t* aVector, const lv_32fc_t* bVector, const lv_32fc_t scalar, unsigned int
- * num_points); \endcode
+ * void volk_32fc_x2_s32fc_multiply_conjugate_add_32fc(lv_32fc_t* cVector,
+ *     const lv_32fc_t* aVector, const lv_32fc_t* bVector, const lv_32fc_t scalar,
+ *     unsigned int num_points)
+ * \endcode
  *
  * \b Inputs
- * \li aVector: The input vector to be added.
- * \li bVector: The input vector to be conjugate and multiplied.
- * \li scalar: The complex scalar to multiply against conjugated bVector.
- * \li num_points: The number of complex values in aVector and bVector to be conjugate,
- * multiplied and stored into cVector.
+ * \li aVector: Complex input vector to be added, of length \p num_points (lv_32fc_t).
+ * \li bVector: Complex input vector to be conjugated and multiplied, of length
+ *     \p num_points (lv_32fc_t).
+ * \li scalar: Complex scalar multiplied against the conjugated elements of \p bVector
+ *     (lv_32fc_t, passed by value).
+ * \li num_points: The number of complex elements to process.
  *
  * \b Outputs
- * \li cVector: The vector where the results will be stored.
+ * \li cVector: Complex output vector of length \p num_points (lv_32fc_t).
  *
  * \b Example
- * Calculate coefficients.
- *
+ * Conjugate-multiply a vector by a scalar and add to another vector.
  * \code
- * int n_filter = 2 * N + 1;
- * unsigned int alignment = volk_get_alignment();
+ * #include <volk/volk.h>
+ * #include <stdio.h>
  *
- * // state is a queue of input IQ data.
- * lv_32fc_t* state = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t) * n_filter, alignment);
- * // weight and next one.
- * lv_32fc_t* weight = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t) * n_filter, alignment);
- * lv_32fc_t* next = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t) * n_filter, alignment);
- * ...
- * // push back input IQ data into state.
- * foo_push_back_queue(state, input);
+ * int main() {
+ *     unsigned int N = 4;
+ *     unsigned int alignment = volk_get_alignment();
  *
- * // get filtered output.
- * lv_32fc_t output = lv_cmake(0.f,0.f);
- * for (int i = 0; i < n_filter; i++) {
- *   output += state[i] * weight[i];
+ *     lv_32fc_t* aVector = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t) * N, alignment);
+ *     lv_32fc_t* bVector = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t) * N, alignment);
+ *     lv_32fc_t* cVector = (lv_32fc_t*)volk_malloc(sizeof(lv_32fc_t) * N, alignment);
+ *
+ *     // Initialize inputs
+ *     for (unsigned int i = 0; i < N; ++i) {
+ *         aVector[i] = lv_cmake(1.0f, 0.5f);
+ *         bVector[i] = lv_cmake(2.0f, -1.0f);
+ *     }
+ *     lv_32fc_t scalar = lv_cmake(0.5f, 0.0f);
+ *
+ *     // c[i] = a[i] + conj(b[i]) * scalar
+ *     volk_32fc_x2_s32fc_multiply_conjugate_add_32fc(cVector, aVector, bVector,
+ *         scalar, N);
+ *
+ *     for (unsigned int i = 0; i < N; ++i) {
+ *         printf("c[%u] = %+1.4f %+1.4fj\n",
+ *             i, lv_creal(cVector[i]), lv_cimag(cVector[i]));
+ *     }
+ *
+ *     volk_free(aVector);
+ *     volk_free(bVector);
+ *     volk_free(cVector);
+ *     return 0;
  * }
- *
- * // update weight using output.
- * float real = lv_creal(output) * (1.0 - std::norm(output)) * MU;
- * lv_32fc_t factor = lv_cmake(real, 0.f);
- * volk_32fc_x2_s32fc_multiply_conjugate_add_32fc(next, weight, state, factor, n_filter);
- * lv_32fc_t *tmp = next;
- * next = weight;
- * weight = tmp;
- * weight[N + 1] = lv_cmake(lv_creal(weight[N + 1]), 0.f);
- * ...
- * volk_free(state);
- * volk_free(weight);
- * volk_free(next);
  * \endcode
  */
 


### PR DESCRIPTION
## Summary

- Write complete documentation for 9 deprecated kernels that had `<FIXME>` overviews, broken examples, and incorrect parameter descriptions
- Each kernel gets a full doc block: `\b Deprecation` notice, `\b Overview`, correct dispatcher prototype, accurate `\b Inputs`/`\b Outputs`, and a working `\b Example`
- All new examples follow the standard pattern: `volk_malloc`/`volk_free`, proper alignment, meaningful data initialization, correct function calls, and memory cleanup

All changes are strictly within `/*! ... */` Doxygen comment blocks — no implementation code changes.

### Kernels modified

| Kernel | Fix |
|--------|-----|
| `volk_16i_branch_4_state_8` | `<FIXME>` overview + all params + broken example |
| `volk_16i_max_star_16i` | `<FIXME>` overview + wrong "complex" description + broken example |
| `volk_16i_max_star_horizontal_16i` | `<FIXME>` overview + wrong "complex" description + broken example |
| `volk_16i_permute_and_scalar_add` | `<FIXME>` overview + wrong "complex" description + broken example |
| `volk_16i_x4_quad_max_star_16i` | `<FIXME>` overview + broken example |
| `volk_16i_x5_add_quad_16i_x4` | `<FIXME>` overview + broken example |
| `volk_32fc_s32fc_multiply_32fc` | Complete documentation rewrite |
| `volk_32fc_s32fc_x2_rotator_32fc` | Complete documentation rewrite |
| `volk_32fc_x2_s32fc_multiply_conjugate_add_32fc` | Complete documentation rewrite |

## Test plan

- [ ] Verify Doxygen builds without warnings for modified files
- [ ] Spot-check that new examples use correct function signatures and types
- [ ] Confirm no implementation code was modified (doc blocks only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)