### PR TITLE
prefs: Global struct can only store 128 kernel names, we have 155 kernels

### DIFF
--- a/include/volk/volk_prefs.h
+++ b/include/volk/volk_prefs.h
@@ -17,9 +17,9 @@
 __VOLK_DECL_BEGIN
 
 typedef struct volk_arch_pref {
-    char name[128];   // name of the kernel
-    char impl_a[128]; // best aligned impl
-    char impl_u[128]; // best unaligned impl
+    char name[256];   // name of the kernel
+    char impl_a[256]; // best aligned impl
+    char impl_u[256]; // best unaligned impl
 } volk_arch_pref_t;
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Granted, not all of these are enabled in volk_profile, so for most
users, you'll not see more than 117 kernels being used, but a) we
explicitly allow people to add their own kernels, and kind of encourage
that as FOSS project, so we do *not* control that and b) people might
just be updating their volk_config since they first installed it with
GNU Radio in 2012, and then there's easily more than 8 that we retired
since then that pollute this structure.

This probably calls for a completely different data structure
alltogether.


