### PR TITLE
mod_range: Add proper include guard for every implementation

### DIFF
--- a/kernels/volk/volk_32f_s32f_s32f_mod_range_32f.h
+++ b/kernels/volk/volk_32f_s32f_s32f_mod_range_32f.h
@@ -113,6 +113,10 @@ static inline void volk_32f_s32f_s32f_mod_range_32f_u_avx(float* outputVector,
     volk_32f_s32f_s32f_mod_range_32f_generic(
         outPtr, inPtr, lower_bound, upper_bound, num_points - eight_points * 8);
 }
+#endif /* LV_HAVE_AVX */
+
+#ifdef LV_HAVE_AVX
+#include <xmmintrin.h>
 static inline void volk_32f_s32f_s32f_mod_range_32f_a_avx(float* outputVector,
                                                           const float* inputVector,
                                                           const float lower_bound,
@@ -212,6 +216,10 @@ static inline void volk_32f_s32f_s32f_mod_range_32f_u_sse2(float* outputVector,
     volk_32f_s32f_s32f_mod_range_32f_generic(
         outPtr, inPtr, lower_bound, upper_bound, num_points - quarter_points * 4);
 }
+#endif /* LV_HAVE_SSE2 */
+
+#ifdef LV_HAVE_SSE2
+#include <xmmintrin.h>
 static inline void volk_32f_s32f_s32f_mod_range_32f_a_sse2(float* outputVector,
                                                            const float* inputVector,
                                                            const float lower_bound,
@@ -310,6 +318,11 @@ static inline void volk_32f_s32f_s32f_mod_range_32f_u_sse(float* outputVector,
     volk_32f_s32f_s32f_mod_range_32f_generic(
         outPtr, inPtr, lower_bound, upper_bound, num_points - quarter_points * 4);
 }
+#endif /* LV_HAVE_SSE */
+
+#ifdef LV_HAVE_SSE
+#include <xmmintrin.h>
+
 static inline void volk_32f_s32f_s32f_mod_range_32f_a_sse(float* outputVector,
                                                           const float* inputVector,
                                                           const float lower_bound,


### PR DESCRIPTION
Previously, multiple implementations, specifically the aligned and unaligned versions, were smashed into one block. While not a bug per-se, it lead some scripts to believe that there's only one implementation instead of an aligned and unaligned version.

In the build folder, previously one could find:
```bash
$ grep -A 1 mod_range lib/volk_machine_avx512f_64_mmx_orc.c
    "volk_32f_s32f_s32f_mod_range_32f",
    {"generic", "u_avx", "u_sse2", "u_sse"},
```
but now:
```bash
$ grep -A 1 mod_range lib/volk_machine_avx512f_64_mmx_orc.c
    "volk_32f_s32f_mod_rangepuppet_32f",
    {"generic", "u_sse", "a_sse", "u_sse2", "a_sse2", "u_avx", "a_avx"},
```

Fixes: #862