### PR TITLE
CI: Update actions to latest major releases

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: 
+        arch:
           - { name: armeabi-v7a, allow_fail: false }
           - { name: arm64-v8a, allow_fail: false }
           - { name: x86, allow_fail: false }
@@ -26,38 +26,38 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: 'recursive'
+      - uses: actions/checkout@v6
+        with:
+          submodules: "recursive"
 
-    - name: Update repositories
-      run: sudo apt update 
-    
-    # All dependencies
-    - name: Install dependencies
-      run: sudo apt install -y cmake python3-mako
+      - name: Update repositories
+        run: sudo apt update
 
-    # Setup Java
-    - uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '17'
+      # All dependencies
+      - name: Install dependencies
+        run: sudo apt install -y cmake python3-mako
 
-    # Setup Android SDK, and auto-accept licenses
-    - name: Install Android SDK
-      run: wget --quiet --output-document=android-sdk.zip https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip && mkdir android-sdk-linux && unzip -qq android-sdk.zip -d android-sdk-linux && export ANDROID_HOME=./android-sdk-linux && echo y | $ANDROID_HOME/cmdline-tools/bin/sdkmanager --sdk_root=android-sdk-linux --update && (echo y; echo y; echo y; echo y; echo y; echo y; echo y; echo y) | $ANDROID_HOME/cmdline-tools/bin/sdkmanager --sdk_root=android-sdk-linux --licenses
+      # Setup Java
+      - uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "17"
 
-    # Call SDKManager to install the Android NDK
-    - name: Install Android NDK
-      run: $GITHUB_WORKSPACE/android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=$GITHUB_WORKSPACE/android-sdk-linux --install "ndk;27.2.12479018" --channel=3
+      # Setup Android SDK, and auto-accept licenses
+      - name: Install Android SDK
+        run: wget --quiet --output-document=android-sdk.zip https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip && mkdir android-sdk-linux && unzip -qq android-sdk.zip -d android-sdk-linux && export ANDROID_HOME=./android-sdk-linux && echo y | $ANDROID_HOME/cmdline-tools/bin/sdkmanager --sdk_root=android-sdk-linux --update && (echo y; echo y; echo y; echo y; echo y; echo y; echo y; echo y) | $ANDROID_HOME/cmdline-tools/bin/sdkmanager --sdk_root=android-sdk-linux --licenses
 
-    # Setup build directory
-    - name: Setup ${{ matrix.arch.name }}
-      shell: bash
-      run: cd $GITHUB_WORKSPACE/ && mkdir build && cd build && cmake -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/android-sdk-linux/ndk/27.2.12479018/build/cmake/android.toolchain.cmake -DANDROID_ABI=${{ matrix.arch.name }} -DANDROID_PLATFORM=android-34 ..
+      # Call SDKManager to install the Android NDK
+      - name: Install Android NDK
+        run: $GITHUB_WORKSPACE/android-sdk-linux/cmdline-tools/bin/sdkmanager --sdk_root=$GITHUB_WORKSPACE/android-sdk-linux --install "ndk;27.2.12479018" --channel=3
 
-    # Build
-    - name: Build ${{ matrix.arch.name }}
-      shell: bash
-      run: cd $GITHUB_WORKSPACE/build && make
-      continue-on-error: ${{ matrix.arch.allow_fail }}
+      # Setup build directory
+      - name: Setup ${{ matrix.arch.name }}
+        shell: bash
+        run: cd $GITHUB_WORKSPACE/ && mkdir build && cd build && cmake -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/android-sdk-linux/ndk/27.2.12479018/build/cmake/android.toolchain.cmake -DANDROID_ABI=${{ matrix.arch.name }} -DANDROID_PLATFORM=android-34 ..
+
+      # Build
+      - name: Build ${{ matrix.arch.name }}
+        shell: bash
+        run: cd $GITHUB_WORKSPACE/build && make
+        continue-on-error: ${{ matrix.arch.allow_fail }}

--- a/.github/workflows/check-pr-formatting.yml
+++ b/.github/workflows/check-pr-formatting.yml
@@ -11,22 +11,21 @@ name: Check PR Formatting
 on:
   push:
     paths-ignore:
-      - 'tmpl/'
-      - 'include/volk/sse2neon.h'
+      - "tmpl/"
+      - "include/volk/sse2neon.h"
   pull_request:
     paths-ignore:
-      - 'tmpl/'
-      - 'include/volk/sse2neon.h'
+      - "tmpl/"
+      - "include/volk/sse2neon.h"
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: gnuradio/clang-format-lint-action@v0.5-4
-      with:
-        source: '.'
-        exclude: './tmpl,./include/volk/sse2neon.h'
-        extensions: 'c,cc,cpp,cxx,h,hh'
-
+      - uses: actions/checkout@v6
+      - uses: gnuradio/clang-format-lint-action@v0.5-4
+        with:
+          source: "."
+          exclude: "./tmpl,./include/volk/sse2neon.h"
+          extensions: "c,cc,cpp,cxx,h,hh"

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: "recursive"
       - name: Install dependencies
@@ -29,7 +29,7 @@ jobs:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
           TARGET_DIR: "${{ github.ref_type }}/${{ github.ref_name }}"
         run: 'tar -cz build/html/ | ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_SERVER }} "mkdir -p /www/${{ env.TARGET_DIR }}/$(date +%Y.%m.%d); cd /www/${{ env.TARGET_DIR }}/$(date +%Y.%m.%d); tar --strip-components=2 -xzf -; rm -f /www/${{ env.TARGET_DIR }}/live; cd /www/${{ env.TARGET_DIR }}; ln -sf $(date +%Y.%m.%d) live;"'
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: volk_docs
           path: build/html/

--- a/.github/workflows/run-tests-rvv.yml
+++ b/.github/workflows/run-tests-rvv.yml
@@ -14,42 +14,40 @@ jobs:
   Tests:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: "recursive"
-    - name: Install packages
-      run: |
-        sudo apt-get update -q -y
-        sudo apt-get install -y python3-mako cmake qemu-user-static g++-14-riscv64-linux-gnu clang-18
-        mkdir build
-        cd build
-    - name: Test gcc-14 VLEN=128
-      run: |
-        cd build; rm -rf *
-        CXX=riscv64-linux-gnu-g++-14 CC=riscv64-linux-gnu-gcc-14 VLEN=128 \
-        cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/rv64gcv-linux-gnu.cmake ..
-        make -j$(nproc)
-        ARGS=-V make test
-    - name: Test gcc-14 VLEN=256
-      run: |
-        cd build; rm -rf *
-        CXX=riscv64-linux-gnu-g++-14 CC=riscv64-linux-gnu-gcc-14 VLEN=256 \
-        cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/rv64gcv-linux-gnu.cmake .. -DCMAKE_BUILD_TYPE=Release
-        make -j$(nproc)
-        ARGS=-V make test
-    - name: Test clang-18 VLEN=512
-      run: |
-        cd build; rm -rf *
-        CXX=clang++-18 CC=clang-18 CFLAGS=--target=riscv64-linux-gnu VLEN=512 \
-        cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/rv64gcv-linux-gnu.cmake ..
-        make -j$(nproc)
-        ARGS=-V make test
-    - name: Test clang-18 VLEN=1024
-      run: |
-        cd build; rm -rf *
-        CXX=clang++-18 CC=clang-18 CFLAGS=--target=riscv64-linux-gnu VLEN=1024 \
-        cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/rv64gcv-linux-gnu.cmake .. -DCMAKE_BUILD_TYPE=Release
-        make -j$(nproc)
-        ARGS=-V make test
-
-
+      - uses: actions/checkout@v6
+        with:
+          submodules: "recursive"
+      - name: Install packages
+        run: |
+          sudo apt-get update -q -y
+          sudo apt-get install -y python3-mako cmake qemu-user-static g++-14-riscv64-linux-gnu clang-18
+          mkdir build
+          cd build
+      - name: Test gcc-14 VLEN=128
+        run: |
+          cd build; rm -rf *
+          CXX=riscv64-linux-gnu-g++-14 CC=riscv64-linux-gnu-gcc-14 VLEN=128 \
+          cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/rv64gcv-linux-gnu.cmake ..
+          make -j$(nproc)
+          ARGS=-V make test
+      - name: Test gcc-14 VLEN=256
+        run: |
+          cd build; rm -rf *
+          CXX=riscv64-linux-gnu-g++-14 CC=riscv64-linux-gnu-gcc-14 VLEN=256 \
+          cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/rv64gcv-linux-gnu.cmake .. -DCMAKE_BUILD_TYPE=Release
+          make -j$(nproc)
+          ARGS=-V make test
+      - name: Test clang-18 VLEN=512
+        run: |
+          cd build; rm -rf *
+          CXX=clang++-18 CC=clang-18 CFLAGS=--target=riscv64-linux-gnu VLEN=512 \
+          cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/rv64gcv-linux-gnu.cmake ..
+          make -j$(nproc)
+          ARGS=-V make test
+      - name: Test clang-18 VLEN=1024
+        run: |
+          cd build; rm -rf *
+          CXX=clang++-18 CC=clang-18 CFLAGS=--target=riscv64-linux-gnu VLEN=1024 \
+          cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/rv64gcv-linux-gnu.cmake .. -DCMAKE_BUILD_TYPE=Release
+          make -j$(nproc)
+          ARGS=-V make test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         compiler:
           - { name: g++-11, cc: gcc-11, cxx: g++-11, distro: ubuntu-22.04 }
-          - { name: g++-11, cc: gcc-11, cxx: g++-11, distro: ubuntu-22.04-arm }
+          # - { name: g++-11, cc: gcc-11, cxx: g++-11, distro: ubuntu-22.04-arm }
           - { name: g++-12, cc: gcc-12, cxx: g++-12, distro: ubuntu-22.04 }
-          - { name: g++-12, cc: gcc-12, cxx: g++-12, distro: ubuntu-22.04-arm }
+          # - { name: g++-12, cc: gcc-12, cxx: g++-12, distro: ubuntu-22.04-arm }
           - { name: g++-13, cc: gcc-13, cxx: g++-13, distro: ubuntu-24.04 }
           - { name: g++-13, cc: gcc-13, cxx: g++-13, distro: ubuntu-24.04-arm }
           - { name: g++-14, cc: gcc-14, cxx: g++-14, distro: ubuntu-24.04 }
@@ -29,7 +29,7 @@ jobs:
           - { name: clang-14, cc: clang-14, cxx: clang++-14, distro: ubuntu-22.04 }
           # - { name: clang-14, cc: clang-14, cxx: clang++-14, distro: ubuntu-22.04-arm } # possibly broken runner: https://github.com/actions/runner-images/issues/8659
           - { name: clang-15, cc: clang-15, cxx: clang++-15, distro: ubuntu-22.04 }
-          - { name: clang-15, cc: clang-15, cxx: clang++-15, distro: ubuntu-22.04-arm }
+          # - { name: clang-15, cc: clang-15, cxx: clang++-15, distro: ubuntu-22.04-arm }
           - { name: clang-16, cc: clang-16, cxx: clang++-16, distro: ubuntu-24.04 }
           - { name: clang-16, cc: clang-16, cxx: clang++-16, distro: ubuntu-24.04-arm }
           - { name: clang-17, cc: clang-17, cxx: clang++-17, distro: ubuntu-24.04 }

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ matrix.compiler.distro }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: "recursive"
       - name: Install dependencies
@@ -97,7 +97,7 @@ jobs:
             compiler: { name: g++-12, cc: gcc-12, cxx: g++-12 }
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: "recursive"
       - uses: uraimo/run-on-arch-action@v3
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: "recursive"
       - name: dependencies
@@ -179,10 +179,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: "recursive"
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: dependencies
@@ -212,7 +212,7 @@ jobs:
   #           python-six
   #           mingw-w64-x86_64-gcc
   #           mingw-w64-x86_64-cmake
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v6
   #     - name: Checkout submodules
   #       run: git submodule update --init --recursive
   #     - name: Configure
@@ -235,7 +235,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: "recursive"
       - name: dependencies


### PR DESCRIPTION
This should help to avoid warnings and eventually broken CI because of missing actions.