### PR TITLE
CI: cache builds

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -31,11 +31,11 @@ jobs:
           submodules: "recursive"
 
       - name: Update repositories
-        run: sudo apt update
+        run: sudo DEBIAN_FRONTEND=noninteractive apt-get update > /dev/null
 
       # All dependencies
       - name: Install dependencies
-        run: sudo apt install -y cmake python3-mako curl
+        run: sudo DEBIAN_FRONTEND=noninteractive apt-get install -y cmake python3-mako curl
 
       - name: Install sccache
         shell: bash

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -35,7 +35,16 @@ jobs:
 
       # All dependencies
       - name: Install dependencies
-        run: sudo apt install -y cmake python3-mako
+        run: sudo apt install -y cmake python3-mako curl
+
+      - name: Install sccache
+        shell: bash
+        run: sudo scripts/ci/install_sccache.bash "${{ matrix.arch.name }}"
+        continue-on-error: true
+
+      - name: Prepare sccache usage
+        id: enable_sccache
+        run: scripts/ci/setup_cmake_cache_flags.bash "${{ matrix.name }}"
 
       # Setup Java
       - uses: actions/setup-java@v5
@@ -54,10 +63,24 @@ jobs:
       # Setup build directory
       - name: Setup ${{ matrix.arch.name }}
         shell: bash
-        run: cd $GITHUB_WORKSPACE/ && mkdir build && cd build && cmake -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/android-sdk-linux/ndk/27.2.12479018/build/cmake/android.toolchain.cmake -DANDROID_ABI=${{ matrix.arch.name }} -DANDROID_PLATFORM=android-34 ..
+        run: |
+          cd $GITHUB_WORKSPACE/ \
+          && mkdir build \
+          && cmake -S . -B build \
+          -DCMAKE_TOOLCHAIN_FILE=$GITHUB_WORKSPACE/android-sdk-linux/ndk/27.2.12479018/build/cmake/android.toolchain.cmake \
+          -DANDROID_ABI=${{ matrix.arch.name }} \
+          -DANDROID_PLATFORM=android-34 \
+          ${{ steps.enable_sccache.outputs.CXX_LAUNCHER }} \
+          ${{ steps.enable_sccache.outputs.C_LAUNCHER }}
 
       # Build
       - name: Build ${{ matrix.arch.name }}
         shell: bash
-        run: cd $GITHUB_WORKSPACE/build && make
+        run: cmake --build build -j $(nproc)
         continue-on-error: ${{ matrix.arch.allow_fail }}
+
+      - name: Show final sccache and build directory stats
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: scripts/ci/build-summary.sh "${{ matrix.arch.name }}" "./build/"

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,6 +1,12 @@
 name: Publish docs
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+      - maint
+      - master
+
 jobs:
   build-docs:
     name: Build VOLK docs

--- a/.github/workflows/run-tests-rvv.yml
+++ b/.github/workflows/run-tests-rvv.yml
@@ -19,8 +19,8 @@ jobs:
           submodules: "recursive"
       - name: Install packages
         run: |
-          sudo apt-get update -q -y
-          sudo apt-get install -y python3-mako cmake qemu-user-static g++-14-riscv64-linux-gnu clang-18 curl
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update -q -y
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python3-mako cmake qemu-user-static g++-14-riscv64-linux-gnu clang-18 curl
           sudo scripts/ci/install_sccache.bash
           mkdir build
           cd build

--- a/.github/workflows/run-tests-rvv.yml
+++ b/.github/workflows/run-tests-rvv.yml
@@ -20,34 +20,55 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update -q -y
-          sudo apt-get install -y python3-mako cmake qemu-user-static g++-14-riscv64-linux-gnu clang-18
+          sudo apt-get install -y python3-mako cmake qemu-user-static g++-14-riscv64-linux-gnu clang-18 curl
+          sudo scripts/ci/install_sccache.bash
           mkdir build
           cd build
+      - name: Prepare sccache usage
+        id: enable_sccache
+        run: scripts/ci/setup_cmake_cache_flags.bash "RVV tests"
       - name: Test gcc-14 VLEN=128
         run: |
           cd build; rm -rf *
           CXX=riscv64-linux-gnu-g++-14 CC=riscv64-linux-gnu-gcc-14 VLEN=128 \
-          cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/rv64gcv-linux-gnu.cmake ..
+          cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/rv64gcv-linux-gnu.cmake \
+            ${{ steps.enable_sccache.outputs.CXX_LAUNCHER }} \
+            ${{ steps.enable_sccache.outputs.C_LAUNCHER }} \
+            ..
           make -j$(nproc)
           ARGS=-V make test
       - name: Test gcc-14 VLEN=256
         run: |
           cd build; rm -rf *
           CXX=riscv64-linux-gnu-g++-14 CC=riscv64-linux-gnu-gcc-14 VLEN=256 \
-          cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/rv64gcv-linux-gnu.cmake .. -DCMAKE_BUILD_TYPE=Release
+          cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/rv64gcv-linux-gnu.cmake -DCMAKE_BUILD_TYPE=Release \
+            ${{ steps.enable_sccache.outputs.CXX_LAUNCHER }} \
+            ${{ steps.enable_sccache.outputs.C_LAUNCHER }} \
+            ..
           make -j$(nproc)
           ARGS=-V make test
       - name: Test clang-18 VLEN=512
         run: |
           cd build; rm -rf *
           CXX=clang++-18 CC=clang-18 CFLAGS=--target=riscv64-linux-gnu VLEN=512 \
-          cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/rv64gcv-linux-gnu.cmake ..
+          cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/rv64gcv-linux-gnu.cmake \
+            ${{ steps.enable_sccache.outputs.CXX_LAUNCHER }} \
+            ${{ steps.enable_sccache.outputs.C_LAUNCHER }} \
+            ..
           make -j$(nproc)
           ARGS=-V make test
       - name: Test clang-18 VLEN=1024
         run: |
           cd build; rm -rf *
           CXX=clang++-18 CC=clang-18 CFLAGS=--target=riscv64-linux-gnu VLEN=1024 \
-          cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/rv64gcv-linux-gnu.cmake .. -DCMAKE_BUILD_TYPE=Release
+          cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/Toolchains/rv64gcv-linux-gnu.cmake -DCMAKE_BUILD_TYPE=Release \
+            ${{ steps.enable_sccache.outputs.CXX_LAUNCHER }} \
+            ${{ steps.enable_sccache.outputs.C_LAUNCHER }} \
+            ..
           make -j$(nproc)
           ARGS=-V make test
+      - name: Show final sccache and build directory stats
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: scripts/ci/build-summary.sh "RVV tests" "./build/"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -149,6 +149,7 @@ jobs:
           install: |
             case "${{ matrix.distro }}" in
               ubuntu*|jessie|stretch|buster|bullseye|trixie|forky)
+                export DEBIAN_FRONTEND=noninteractive
                 apt-get update -q -y
                 apt-get install -q -y git cmake python3-mako liborc-dev libgtest-dev libfmt-dev ${{ matrix.compiler.name }}
                 ;;
@@ -198,8 +199,8 @@ jobs:
           submodules: "recursive"
       - name: dependencies
         run: |
-          sudo apt-get update >/dev/null \
-          && sudo apt-get install -y python3-mako liborc-dev libgtest-dev libfmt-dev
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update >/dev/null \
+          && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python3-mako liborc-dev libgtest-dev libfmt-dev
       - name: Install sccache
         shell: bash
         run: sudo scripts/ci/install_sccache.bash "${{ matrix.name }}"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,5 +1,6 @@
 #
 # Copyright 2020 - 2022 Free Software Foundation, Inc.
+# Copyright 2026 Marcus MÜller
 #
 # This file is part of VOLK
 #
@@ -46,16 +47,32 @@ jobs:
         with:
           submodules: "recursive"
       - name: Install dependencies
-        run: sudo apt install python3-mako liborc-dev libgtest-dev libfmt-dev ${{ matrix.compiler.name }}
+        run: sudo apt install python3-mako liborc-dev libgtest-dev libfmt-dev curl ${{ matrix.compiler.name }}
+      - name: Install sccache
+        shell: bash
+        run: sudo scripts/ci/install_sccache.bash "${{ matrix.name }}"
+        continue-on-error: true
+      - name: Prepare sccache usage
+        id: enable_sccache
+        run: scripts/ci/setup_cmake_cache_flags.bash "${{ matrix.name }}"
       - name: Configure
         env:
           CC: ${{ matrix.compiler.cc }}
           CXX: ${{ matrix.compiler.cxx }}
-        run: mkdir build && cd build && cmake -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DBUILD_EXECUTABLE=ON ..
+        run: >
+          mkdir build \
+          && cmake  \
+            -S . \
+            -B build \
+            -DCMAKE_C_FLAGS="-Werror" \
+            -DCMAKE_CXX_FLAGS="-Werror" \
+            -DBUILD_EXECUTABLE=ON \
+            ${{ steps.enable_sccache.outputs.CXX_LAUNCHER }} \
+            ${{ steps.enable_sccache.outputs.C_LAUNCHER }}
       - name: Build
         run: |
-          echo "Build with $(nproc) thread(s)"
-          cmake --build build -j$(nproc)
+          echo "Build with $(nproc)+1 thread(s)"
+          cmake --build build -j$(( $(nproc) + 1 ))
       - name: Print info
         run: |
           if [ -f ./build/cpu_features/list_cpu_features ]; then
@@ -70,12 +87,17 @@ jobs:
         run: |
           cd build
           ctest -V
+      - name: Show final sccache and build directory stats
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: scripts/ci/build-summary.sh "${{ matrix.name }}" "./build/"
 
-  build-ubuntu-arm:
+  build-distro-platform-matrix:
     # The host should always be linux
     # see: https://github.com/uraimo/run-on-arch-action
     runs-on: ubuntu-22.04
-    name: Build on ${{ matrix.distro }} ${{ matrix.arch }} ${{ matrix.compiler.name }}
+    name: Non-x86 build on ${{ matrix.distro }} ${{ matrix.arch }} ${{ matrix.compiler.name }}
 
     # Run steps on a matrix of compilers and possibly archs.
     strategy:
@@ -101,6 +123,8 @@ jobs:
         with:
           submodules: "recursive"
       - uses: uraimo/run-on-arch-action@v3
+        # Wish I gotten sccache to work in this, but the environment provided by this 
+        # action is so cursed that practically nothing works in there.
         name: Build in non-x86 container
         id: build
         with:
@@ -120,11 +144,11 @@ jobs:
             CC: ${{ matrix.compiler.cc }}
             CXX: ${{ matrix.compiler.cxx }}
 
-          shell: /bin/sh
+          shell: /bin/bash
 
           install: |
             case "${{ matrix.distro }}" in
-              ubuntu*|jessie|stretch|buster)
+              ubuntu*|jessie|stretch|buster|bullseye|trixie|forky)
                 apt-get update -q -y
                 apt-get install -q -y git cmake python3-mako liborc-dev libgtest-dev libfmt-dev ${{ matrix.compiler.name }}
                 ;;
@@ -136,10 +160,21 @@ jobs:
 
           run: |
             cd /volk
+            echo "::group::cmake"
+            cmake \
+              -DCMAKE_C_FLAGS="-Werror" \
+              -DCMAKE_CXX_FLAGS="-Werror" \
+              -DBUILD_EXECUTABLE=ON \
+              ${{ matrix.cmakeargs }} \
+              -S . \
+              -B build
+            echo "::endgroup::"
+            echo "::group::build"
+            echo "Build with $(nproc)+1 thread(s)"
+            cmake --build ./build -j$(( $(nproc) + 1 ))
+            echo "::endgroup::"
+            echo "::group::platform info"
             cd build
-            cmake -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DBUILD_EXECUTABLE=ON ${{ matrix.cmakeargs }} ..
-            echo "Build with $(nproc) thread(s)"
-            make -j$(nproc)
             if [ -f ./cpu_features/list_cpu_features ]; then
               ./cpu_features/list_cpu_features
             fi
@@ -148,7 +183,10 @@ jobs:
             ./apps/volk-config-info --all-machines
             ./apps/volk-config-info --malloc
             ./apps/volk-config-info --cc
+            echo "::endgroup::"
+            echo "::group::tests"
             ctest -V
+            echo "::endgroup::"
 
   build-ubuntu-static:
     name: Build static on ubuntu-22.04
@@ -159,9 +197,28 @@ jobs:
         with:
           submodules: "recursive"
       - name: dependencies
-        run: sudo apt install python3-mako liborc-dev libgtest-dev libfmt-dev
+        run: |
+          sudo apt-get update >/dev/null \
+          && sudo apt-get install -y python3-mako liborc-dev libgtest-dev libfmt-dev
+      - name: Install sccache
+        shell: bash
+        run: sudo scripts/ci/install_sccache.bash "${{ matrix.name }}"
+        continue-on-error: true
+      - name: Prepare sccache usage
+        id: enable_sccache
+        run: scripts/ci/setup_cmake_cache_flags.bash "${{ matrix.name }}"
       - name: configure
-        run: mkdir build && cd build && cmake -DENABLE_STATIC_LIBS=True -DCMAKE_C_FLAGS="-Werror" -DCMAKE_CXX_FLAGS="-Werror" -DBUILD_EXECUTABLE=ON ..
+        run: |
+          mkdir build \
+          && cmake \
+            -S . \
+            -B build \
+            -DENABLE_STATIC_LIBS=True \
+            -DCMAKE_C_FLAGS="-Werror" \
+            -DCMAKE_CXX_FLAGS="-Werror" \
+            -DBUILD_EXECUTABLE=ON \
+            ${{ steps.enable_sccache.outputs.CXX_LAUNCHER }} \
+            ${{ steps.enable_sccache.outputs.C_LAUNCHER }} \
       - name: build
         run: cmake --build build -j$(nproc)
       - name: Print info
@@ -174,6 +231,11 @@ jobs:
           ./build/apps/volk-config-info --cc
       - name: test
         run: cd build && ctest -V
+      - name: Show final sccache and build directory stats
+        if: always()
+        continue-on-error: true
+        shell: bash
+        run: scripts/ci/build-summary.sh "${{ matrix.name }}" "./build/"
 
   build-windows:
     runs-on: windows-latest

--- a/scripts/ci/build-summary.sh
+++ b/scripts/ci/build-summary.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright 2026 Marcus Müller
+source "$(dirname "$(realpath "$0")")/common.bash"
+builddir="$2"
+if type -p sccache > /dev/null ; then
+  stats="$(sccache -s)"
+  errors="$(printf '%s' "${stats}" | sed -n 's/\(.*\) errors[[:space:]]*\([0-9]*\)$/\1:\2/p')"
+  misses="$(printf '%s' "${stats}" | sed -n 's/Cache misses[[:space:]]*\([0-9]*\)$/\1/p')"
+  hits="$(printf '%s' "${stats}" | sed -n 's/Cache hits[[:space:]]*\([0-9]*\)$/\1/p')"
+  requests="$(printf '%s' "${stats}" | sed -n 's/Compile requests[[:space:]]*\([0-9]*\)$/\1/p')"
+  echo "sccache: ${misses} misses, ${hits} hits ${requests} compile requests"
+  printf '::group::sccache stats\n'
+  printf '%s\n' "${stats}"
+  for err_line in "${errors}"; do
+    count="$(echo "${err_line}" | head -n1 | cut -f2 -d:)"
+    if [[ count -gt 0 ]] ; then
+      gh_message "$(echo "${err_line}" | cut -f1 -d:)" "${count} errors"
+    fi
+  done
+  if [[ "${misses}" -gt 0 && -r "${SCCACHE_ERROR_LOG}" ]]; then
+    printf '::group::sccache misses (N=%d)\n' "${misses}"
+    sed -n  "s/.*sccache::compiler::compiler.* \[\(.*\)\]: *Cache miss.*$/\1/p" "${SCCACHE_ERROR_LOG}"
+    printf '\n::endgroup::\n'
+  fi
+  printf '\n::endgroup::\n'
+else
+  echo 'skipping sccache stats: sccache not found'
+fi
+
+printf '::group::build directory stats\n'
+kiB_to_MiB () {
+  python3 -c "print(f'{${1} / 1024:3.2f}')"
+}
+(
+  shopt -s dotglob globstar
+  kB_build="$( du -sk "${builddir}" | sed 's/\([^[:space:]]*\).*/\1/')"
+  kB_o_files="$( (du -ck "${builddir}"/**/*.o 2> /dev/null || echo 0) | tail -1 | sed 's/\([^[:space:]]*\).*/\1/')"
+  kB_so_files="$( (du -ck "${builddir}"/**/*.so 2> /dev/null || echo 0) | tail -1 | sed 's/\([^[:space:]]*\).*/\1/')"
+  kB_a_files="$( (du -ck "${builddir}"/**/*.a 2> /dev/null || echo 0) | tail -1 | sed 's/\([^[:space:]]*\).*/\1/')"
+  echo "Build directory size: $( kiB_to_MiB "${kB_build}" ) MiB"
+  echo "Build directory shared library (.so) files cumulative size: $( kiB_to_MiB "${kB_so_files}" ) MiB"
+  echo "Build directory object (.o) files cumulative size: $( kiB_to_MiB "${kB_o_files}" ) MiB"
+  echo "Build directory static library (.a) files cumulative size: $( kiB_to_MiB "${kB_a_files}" ) MiB"
+)
+printf '::endgroup::\n'

--- a/scripts/ci/common.bash
+++ b/scripts/ci/common.bash
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright 2026 Marcus Müller
+runname="$1"
+gh_message() {
+  printf '::notice title="%s: %s"::%s\n' "${runname}" "$1" "$2"
+}
+bail_with_message() {
+  gh_message "$1" "$2"
+  exit 0
+}
+fail_with_message() {
+  gh_message "$1" "$2"
+  exit 2
+}
+add_output() {
+  printf '%s=%s\n' "$1" "$2" >> "${GITHUB_OUTPUT}"
+}
+add_env() {
+  printf '%s=%s\n' "$1" "$2" >> "${GITHUB_ENV}"
+}
+add_mask() {
+  printf '::add-mask::%s\n' "$1"
+}

--- a/scripts/ci/common.bash
+++ b/scripts/ci/common.bash
@@ -13,10 +13,13 @@ fail_with_message() {
   exit 2
 }
 add_output() {
-  printf '%s=%s\n' "$1" "$2" >> "${GITHUB_OUTPUT}"
+  printf '%s=%s\n' "$1" "$2" >>"${GITHUB_OUTPUT}"
 }
 add_env() {
-  printf '%s=%s\n' "$1" "$2" >> "${GITHUB_ENV}"
+  # For reasons, this might not exist in the strange VOLK build container
+  mkdir -p "$(dirname "${GITHUB_ENV}")"
+  touch "${GITHUB_ENV}"
+  printf '%s=%s\n' "$1" "$2" >>"${GITHUB_ENV}"
 }
 add_mask() {
   printf '::add-mask::%s\n' "$1"

--- a/scripts/ci/install_sccache.bash
+++ b/scripts/ci/install_sccache.bash
@@ -5,91 +5,102 @@ source /etc/os-release
 export DEBIAN_FRONTEND=noninteractive
 
 check_sccache_s3() {
-  type -p sccache >/dev/null && (sccache -h | grep -q ' *S3: *true')
+	type -p sccache >/dev/null && (sccache -h | grep -q ' *S3: *true')
 }
 install_deb() {
-  apt-get install -y sccache
+	apt-get install -y sccache
 }
 
-if check_sccache_s3; then
-  echo "installed $(sccache --version) has S3 support"
-  exit 0
+check_and_exit() {
+	if check_sccache_s3; then
+		echo "installed $(sccache --version) has S3 support"
+		exit 0
+	fi
+}
+check_and_exit
+
+if [[ "$OSTYPE" = "macos" ]] && type -p brew >/dev/null; then
+	brew install sccache
+	check_and_exit
 fi
 
 if [[ "${ID}" = "ubuntu" && -n "${VERSION_ID}" ]]; then
-  ver_major="$(echo "${VERSION_ID}" | cut -f1 -d.)"
-  if [[ "${ver_major}" -ge 26 ]]; then
-    install_deb && exit 0
-  fi
+	ver_major="$(echo "${VERSION_ID}" | cut -f1 -d.)"
+	if [[ "${ver_major}" -ge 26 ]]; then
+		install_deb && check_and_exit
+	fi
 fi
 
 if [[ "${ID}" = "debian" ]]; then
-  ver_major=0
-  if [[ -n "${VERSION_ID}" ]]; then
-    ver_major="$(echo "${VERSION_ID}" | cut -f1 -d.)"
-  else
-    # non-release, um??? we know that this works for forky=14, but uuum
-    # try to install, and if that succeeds, check availability of S3,
-    # if missing, uninstall.
-    if install_deb; then
-      gh_message "speculative sccache installation" "Don't know debian ${PRETTY_NAME}, trying to install deb"
-      if check_sccache_s3; then
-        echo "using debian packaged $(sccache --version), which has S3 support"
-        exit 0
-      else
-        gh_message "insufficient debian" "available sccache $(sccache --version) has no S3 support."
-        apt-get purge -y sccache
-      fi
-    fi
-  fi
-  if [[ "${ver_major}" -ge 14 ]]; then
-    install_deb && exit 0
-  fi
+	ver_major=0
+	if [[ -n "${VERSION_ID}" ]]; then
+		ver_major="$(echo "${VERSION_ID}" | cut -f1 -d.)"
+	else
+		# non-release, um??? we know that this works for forky=14, but uuum
+		# try to install, and if that succeeds, check availability of S3,
+		# if missing, uninstall.
+		if install_deb; then
+			gh_message "speculative sccache installation" "Don't know debian ${PRETTY_NAME}, trying to install deb"
+			if check_sccache_s3; then
+				echo "using debian packaged $(sccache --version), which has S3 support"
+				exit 0
+			else
+				gh_message "insufficient debian" "available sccache $(sccache --version) has no S3 support."
+				apt-get purge -y sccache
+			fi
+		fi
+	fi
+	if [[ "${ver_major}" -ge 14 ]]; then
+		install_deb
+		check_and_exit
+	fi
 fi
 
 gh_message "sccache external download" "need to download from external source"
 
 if [[ -z "${ARCH}" ]] && type -p dpkg >/dev/null; then
-  ARCH="$(dpkg --print-architecture)"
+	ARCH="$(dpkg --print-architecture)"
 fi
 if [[ -z "${ARCH}" ]] && type -p rpm >/dev/null; then
-  ARCH="$(rpm --eval '%{_arch}')"
+	ARCH="$(rpm --eval '%{_arch}')"
 fi
 if [[ -z "${ARCH}" ]] && type -p arch >/dev/null; then
-  ARCH="$(arch)"
+	ARCH="$(arch)"
 fi
 
 sccache_release="0.15.0"
 sccache_arch="${ARCH}"
 abi_suffix=""
+libc="musl"
 case "${ARCH}" in
 "x86_64" | "amd64")
-  sccache_arch="x86_64"
-  ;;
+	sccache_arch="x86_64"
+	;;
 "arm64" | "aarch64")
-  sccache_arch="aarch64"
-  ;;
-"arm" | "armv7")
-  sccache_arch="armv7"
-  abi_suffix="eabi"
-  ;;
+	sccache_arch="aarch64"
+	;;
+"arm" | "armv7" | "armhf")
+	sccache_arch="armv7"
+	abi_suffix="eabi"
+	;;
 "x86" | "i386" | "i686" | "pentium")
-  sccache_arch="i686"
-  ;;
+	sccache_arch="i686"
+	;;
 s390*)
-  sccache_arch="s390x"
-  ;;
-risc64*)
-  sccache_arch="riscv64gc"
-  ;;
+	sccache_arch="s390x"
+	libc="gnu"
+	;;
+riscv64*)
+	sccache_arch="riscv64gc"
+	;;
 esac
-URL="https://github.com/mozilla/sccache/releases/download/v${sccache_release}/sccache-v${sccache_release}-${sccache_arch}-unknown-linux-musl${abi_suffix}.tar.gz"
+URL="https://github.com/mozilla/sccache/releases/download/v${sccache_release}/sccache-v${sccache_release}-${sccache_arch}-unknown-linux-${libc}${abi_suffix}.tar.gz"
 echo "Getting '${URL}'"
 (
-  set -e
-  cd /tmp/
-  curl -s -L "${URL}" | tar xz
-  cd sccache-*
-  cp sccache /usr/bin
-  check_sccache_s3
+	set -e
+	cd /tmp/
+	curl -s -L "${URL}" | tar xz || fail_with_message "can't download" "not possible to download sccache for ${ARCH}"
+	cd sccache-*
+	cp sccache /usr/bin
+	check_and_exit
 ) || fail_with_message "no sccache installable" "couldn't install a suitable sccache"

--- a/scripts/ci/install_sccache.bash
+++ b/scripts/ci/install_sccache.bash
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Copyright 2026 Marcus Müller
+source "$(dirname "$(realpath "$0")")/common.bash"
+source /etc/os-release
+export DEBIAN_FRONTEND=noninteractive
+
+check_sccache_s3() {
+  type -p sccache >/dev/null && (sccache -h | grep -q ' *S3: *true')
+}
+install_deb() {
+  apt-get install -y sccache
+}
+
+if check_sccache_s3; then
+  echo "installed $(sccache --version) has S3 support"
+  exit 0
+fi
+
+if [[ "${ID}" = "ubuntu" && -n "${VERSION_ID}" ]]; then
+  ver_major="$(echo "${VERSION_ID}" | cut -f1 -d.)"
+  if [[ "${ver_major}" -ge 26 ]]; then
+    install_deb && exit 0
+  fi
+fi
+
+if [[ "${ID}" = "debian" ]]; then
+  ver_major=0
+  if [[ -n "${VERSION_ID}" ]]; then
+    ver_major="$(echo "${VERSION_ID}" | cut -f1 -d.)"
+  else
+    # non-release, um??? we know that this works for forky=14, but uuum
+    # try to install, and if that succeeds, check availability of S3,
+    # if missing, uninstall.
+    if install_deb; then
+      gh_message "speculative sccache installation" "Don't know debian ${PRETTY_NAME}, trying to install deb"
+      if check_sccache_s3; then
+        echo "using debian packaged $(sccache --version), which has S3 support"
+        exit 0
+      else
+        gh_message "insufficient debian" "available sccache $(sccache --version) has no S3 support."
+        apt-get purge -y sccache
+      fi
+    fi
+  fi
+  if [[ "${ver_major}" -ge 14 ]]; then
+    install_deb && exit 0
+  fi
+fi
+
+gh_message "sccache external download" "need to download from external source"
+
+if [[ -z "${ARCH}" ]] && type -p dpkg >/dev/null; then
+  ARCH="$(dpkg --print-architecture)"
+fi
+if [[ -z "${ARCH}" ]] && type -p rpm >/dev/null; then
+  ARCH="$(rpm --eval '%{_arch}')"
+fi
+if [[ -z "${ARCH}" ]] && type -p arch >/dev/null; then
+  ARCH="$(arch)"
+fi
+
+sccache_release="0.15.0"
+sccache_arch="${ARCH}"
+abi_suffix=""
+case "${ARCH}" in
+"x86_64" | "amd64")
+  sccache_arch="x86_64"
+  ;;
+"arm64" | "aarch64")
+  sccache_arch="aarch64"
+  ;;
+"arm" | "armv7")
+  sccache_arch="armv7"
+  abi_suffix="eabi"
+  ;;
+"x86" | "i386" | "i686" | "pentium")
+  sccache_arch="i686"
+  ;;
+s390*)
+  sccache_arch="s390x"
+  ;;
+risc64*)
+  sccache_arch="riscv64gc"
+  ;;
+esac
+URL="https://github.com/mozilla/sccache/releases/download/v${sccache_release}/sccache-v${sccache_release}-${sccache_arch}-unknown-linux-musl${abi_suffix}.tar.gz"
+echo "Getting '${URL}'"
+(
+  set -e
+  cd /tmp/
+  curl -s -L "${URL}" | tar xz
+  cd sccache-*
+  cp sccache /usr/bin
+  check_sccache_s3
+) || fail_with_message "no sccache installable" "couldn't install a suitable sccache"

--- a/scripts/ci/setup_cmake_cache_flags.bash
+++ b/scripts/ci/setup_cmake_cache_flags.bash
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Copyright 2026 Marcus Müller
+source "$(dirname "$(realpath "$0")")/common.bash"
+
+type -p sccache > /dev/null || bail_with_message 'sccache' 'skipping sccache setup: sccache not found'
+# [[ -z "${SCCACHE_S3_BUCKET}" ]] && bail_with_message 'skipping sccache setup' 'S3 bucket not defined (empty/missing SCCACHE_S3_BUCKET env var)'
+
+use_default=false
+printf '::group::S3 setup\n'
+{
+  if [[ -z "${SCCACHE_S3_BUCKET}" ]] ; then
+    echo "using default S3 bucket"
+    use_default=true
+    export SCCACHE_S3_BUCKET="gr4-sccache"
+    add_env SCCACHE_S3_BUCKET "${SCCACHE_S3_BUCKET}"
+  fi
+  if [[ -z "${SCCACHE_S3_ENDPOINT}" ]] ; then
+    echo "using default S3 endpoint"
+    use_default=true
+    export SCCACHE_S3_ENDPOINT="s3.us-west-002.backblazeb2.com"
+    add_env SCCACHE_S3_ENDPOINT "${SCCACHE_S3_ENDPOINT}"
+  fi
+  if [[ -z "${SCCACHE_S3_REGION}" ]] ; then
+    echo "using default S3 region"
+    use_default=true
+    export SCCACHE_S3_REGION="auto"
+    add_env SCCACHE_S3_REGION "${SCCACHE_S3_REGION}"
+  fi
+  if [[ -z "${AWS_ACCESS_KEY_ID}" ]] ; then
+    # set up default bucket here
+    echo "AWS key ID not set. Using default read-only key ID & key"
+    use_default=true
+    export AWS_ACCESS_KEY_ID="0021090e73dcc12000000000c"
+    # Can't have a key without a key id.
+    export AWS_SECRET_ACCESS_KEY="K002P+ZeW31+o4HIhDz8CXZg6OpFI4k"
+  fi
+  add_env AWS_ACCESS_KEY_ID "${AWS_ACCESS_KEY_ID}"
+  add_env AWS_SECRET_ACCESS_KEY "${AWS_SECRET_ACCESS_KEY}"
+  # lets mask a few things in output. I bet people are scraping github action
+  # output for leaked credentials, and while there's nothing secret on that, I
+  # don't want to pay for some stupid scraper downloading the whole cache.
+  add_mask "${AWS_SECRET_ACCESS_KEY}"
+  add_mask "${AWS_ACCESS_KEY_ID}"
+}
+printf '::endgroup::'
+if [[ "${use_default}" = "true" ]] ; then
+  gh_message "sccache bucket config" "using default cache bucket, read-only!"
+fi;
+
+SCCACHE_BIN="$(type -p sccache)"
+SCCACHE_CONF_DIR="${HOME}/.config/sccache"
+SCCACHE_CONF="${SCCACHE_CONF_DIR}/config"
+add_output C_LAUNCHER   "-DCMAKE_C_COMPILER_LAUNCHER=${SCCACHE_BIN}"
+add_output CXX_LAUNCHER "-DCMAKE_CXX_COMPILER_LAUNCHER=${SCCACHE_BIN}"
+
+if [[ ! -e "${SCCACHE_CONF}" ]]; then
+  echo "Creating sccache config in ${SCCACHE_CONF_DIR}"
+  mkdir -p "${SCCACHE_CONF_DIR}"
+>> "${SCCACHE_CONF}" cat << EOF
+[cache.s3]
+endpoint = "${SCCACHE_S3_ENDPOINT}"
+bucket = "${SCCACHE_S3_BUCKET}"
+use_ssl = true
+server_side_encryption = false
+no_credentials = false
+region = "${SCCACHE_S3_REGION}"
+EOF
+fi
+
+add_output SCCACHE_CONF "${SCCACHE_CONF}"
+export SCCACHE_ERROR_LOG="/tmp/local_sccache.log"
+add_env SCCACHE_ERROR_LOG "${SCCACHE_ERROR_LOG}"
+# These could be set here, but they do spam the compile output slightly.
+# add_env SCCACHE_LOG debug
+# Instead, we just set the environment locally with debug logging on
+SCCACHE_LOG=debug sccache --start-server
+
+echo "Using ${SCCACHE_BIN} ($(${SCCACHE_BIN} --version)) as sccache binary."

--- a/scripts/ci/setup_cmake_cache_flags.bash
+++ b/scripts/ci/setup_cmake_cache_flags.bash
@@ -11,7 +11,7 @@ printf '::group::S3 setup\n'
   if [[ -z "${SCCACHE_S3_BUCKET}" ]] ; then
     echo "using default S3 bucket"
     use_default=true
-    export SCCACHE_S3_BUCKET="gr4-sccache"
+    export SCCACHE_S3_BUCKET="volk-sccache"
     add_env SCCACHE_S3_BUCKET "${SCCACHE_S3_BUCKET}"
   fi
   if [[ -z "${SCCACHE_S3_ENDPOINT}" ]] ; then
@@ -30,9 +30,9 @@ printf '::group::S3 setup\n'
     # set up default bucket here
     echo "AWS key ID not set. Using default read-only key ID & key"
     use_default=true
-    export AWS_ACCESS_KEY_ID="0021090e73dcc12000000000c"
+    export AWS_ACCESS_KEY_ID="0021090e73dcc12000000000d"
     # Can't have a key without a key id.
-    export AWS_SECRET_ACCESS_KEY="K002P+ZeW31+o4HIhDz8CXZg6OpFI4k"
+    export AWS_SECRET_ACCESS_KEY="K002v5ntyoAssltLZnAgMBzEtcJsfkw"
   fi
   add_env AWS_ACCESS_KEY_ID "${AWS_ACCESS_KEY_ID}"
   add_env AWS_SECRET_ACCESS_KEY "${AWS_SECRET_ACCESS_KEY}"


### PR DESCRIPTION
This should significantly speed up CI.

For now, uses the wrong fallback readonly repo; will fill in valid read-only credentials in a follow-up commit once this is proven to work correctly.

Then, after that, we add R/W credentials to the repo action secrets and start populating the cache.
