### PR TITLE
fmt: Switch include from core to format

### DIFF
--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -28,7 +28,7 @@
 #include <random>
 #include <vector> // for vector, _Bit_refe...
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 // Warmup time for CPU frequency scaling (ms)
 static double g_warmup_ms = 2000.0;


### PR DESCRIPTION
Fixes a breaking change introduced in fmtlib 12.2.0.

https://github.com/fmtlib/fmt/releases/tag/12.2.0

> Made the <fmt/core.h> header equivalent to <fmt/base.h> by default. Code that relied on <fmt/core.h> pulling in <fmt/format.h> must now either include <fmt/format.h> directly or define FMT_DEPRECATED_HEAVY_CORE to opt back in.

Fixes: #868 