### PR TITLE
tests: use correct fmt include

### DIFF
--- a/lib/qa_utils.cc
+++ b/lib/qa_utils.cc
@@ -28,7 +28,7 @@
 #include <random>
 #include <vector> // for vector, _Bit_refe...
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 // Warmup time for CPU frequency scaling (ms)
 static double g_warmup_ms = 2000.0;

--- a/tests/test_volk_32f_x3_sum_of_poly_32f.cc
+++ b/tests/test_volk_32f_x3_sum_of_poly_32f.cc
@@ -9,7 +9,7 @@
 
 #include "volk_test.h"
 #include <fmt/chrono.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <gtest/gtest.h>
 #include <volk/volk.h>

--- a/tests/test_volk_32fc_s32fc_x2_rotator2_32fc.cc
+++ b/tests/test_volk_32fc_s32fc_x2_rotator2_32fc.cc
@@ -9,7 +9,7 @@
 
 #include "volk_test.h"
 #include <fmt/chrono.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <gtest/gtest.h>
 #include <volk/volk.h>

--- a/tests/test_volk_32fc_x2_multiply_32fc.cc
+++ b/tests/test_volk_32fc_x2_multiply_32fc.cc
@@ -9,7 +9,7 @@
 
 #include "volk_test.h"
 #include <fmt/chrono.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <gtest/gtest-param-test.h>
 #include <gtest/gtest.h>

--- a/tests/volk_test.cc
+++ b/tests/volk_test.cc
@@ -7,8 +7,6 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-#include <fmt/core.h>
-#include <fmt/ranges.h>
 #include <gtest/gtest.h>
 #include <volk/volk.h>
 #include <algorithm>

--- a/tests/volk_test.h
+++ b/tests/volk_test.h
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <gtest/gtest.h>
 #include <volk/volk.h>


### PR DESCRIPTION
On current fmt (12.2 fmt, probably starting earlier), fmt/core.h does no
longer include fmt::format.

Crofton found this through his OE builds. Kudos.
